### PR TITLE
[CDF-21220] File id not required 🔓

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -17,6 +17,12 @@ Changes are grouped as follows:
 
 ## TBD
 
+### Fixed
+
+- In a `function` config, if you did not set `fileId` you would get an error when running `cdf-tk deploy`,
+  `Missing required field: 'fileId'.`. The `fileId` is generated automatically when the function is created,
+  so it is not necessary to set it in the config file. This is now fixed.
+
 ### Improved
 
 - Gives a more informative error message when the authentication segment of a transformation resource file is

--- a/CHANGELOG.templates.md
+++ b/CHANGELOG.templates.md
@@ -15,6 +15,13 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+### Removed
+
+- The parameter `fileId` is removed from all `function` configurations
+  (`cdf_functions_dummy` and `cdf_data_pipeline_files_valhall`) as it is no longer required.
+
 ## [0.2.0a4] - 2024-04-29
 
 ### Added

--- a/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
@@ -446,6 +446,10 @@ class FunctionLoader(ResourceLoader[str, FunctionWrite, Function, FunctionWriteL
                 self.extra_configs[func["externalId"]]["dataSetId"] = ToolGlobals.verify_dataset(
                     func.get("externalDataSetId", ""), skip_validation=skip_validation
                 )
+            if "fileId" not in func:
+                # The fileID is required for the function to be created, but in the `.create` method
+                # we first create that file and then set the fileID.
+                func["fileId"] = "<will_be_generated>"
 
         if len(functions) == 1:
             return FunctionWrite.load(functions[0])

--- a/cognite_toolkit/cognite_modules/examples/cdf_data_pipeline_files_valhall/functions/functions.yaml
+++ b/cognite_toolkit/cognite_modules/examples/cdf_data_pipeline_files_valhall/functions/functions.yaml
@@ -2,7 +2,6 @@
 # and externalId as the function itself as defined below.
 - name: 'context:files:{{location_name}}:{{source_name}}:annotation'
   externalId: 'fn_context_files_{{location_name}}_{{source_name}}_annotation'
-  fileId: <will_be_generated>
   owner: 'Anonymous'
   description: 'Contextualization of P&ID files creating annotations'
   metadata:

--- a/cognite_toolkit/cognite_modules/examples/cdf_functions_dummy/functions/functions.yaml
+++ b/cognite_toolkit/cognite_modules/examples/cdf_functions_dummy/functions/functions.yaml
@@ -2,7 +2,6 @@
 # and externalId as the function itself as defined below.
 - name: 'example:repeater'
   externalId: 'fn_example_repeater'
-  fileId: <will_be_generated>
   owner: 'Anonymous'
   description: 'Returns the input data, secrets, and function info.'
   metadata:
@@ -23,5 +22,4 @@
   externalDataSetId: 'ds_files_{{default_location}}'
 - name: 'test2'
   externalId: 'fn_test2'
-  fileId: <will_be_generated>
   functionPath: './handler.py'


### PR DESCRIPTION
# Description

This is a deviation from the API Spec of functions, but I think it is a good reason for an exception.
![image](https://github.com/cognitedata/cdf-project-templates/assets/60234212/22a7fec6-4cd4-4801-aa50-99000d7f03a3)


## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
