### PR TITLE
[CDF-20808, CDF-20999] Warning on bad config ⚠

### DIFF
--- a/cognite_toolkit/_cdf_tk/_parameters/data_classes.py
+++ b/cognite_toolkit/_cdf_tk/_parameters/data_classes.py
@@ -97,9 +97,8 @@ class ParameterSet(Hashable, MutableSet, Generic[T_Parameter]):
         output = type(self)()
         for parameter in self:
             new_path = tuple(to_camel_case(name) if name not in SINGLETONS else name for name in parameter.path)
-            new_param_copy = dataclasses.replace(parameter)
             # This is because parameters are immutable
-            object.__setattr__(new_param_copy, "path", new_path)
+            new_param_copy = dataclasses.replace(parameter, path=new_path)
             output.add(new_param_copy)
         return output
 

--- a/cognite_toolkit/_cdf_tk/templates/_templates.py
+++ b/cognite_toolkit/_cdf_tk/templates/_templates.py
@@ -27,7 +27,11 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitYAMLFormatError,
 )
 from cognite_toolkit._cdf_tk.load import LOADER_BY_FOLDER_NAME, FunctionLoader, Loader, ResourceLoader
-from cognite_toolkit._cdf_tk.validation import validate_case_raw, validate_data_set_is_set, validate_modules_variables
+from cognite_toolkit._cdf_tk.validation import (
+    validate_data_set_is_set,
+    validate_modules_variables,
+    validate_yaml_config,
+)
 
 from ._constants import EXCL_INDEX_SUFFIX, PROC_TMPL_VARS_SUFFIX, ROOT_MODULES
 from ._utils import iterate_functions, iterate_modules, module_from_path, resource_folder_from_path
@@ -618,11 +622,9 @@ def validate(
                 )
 
     if isinstance(loader, ResourceLoader):
-        load_warnings = validate_case_raw(
-            parsed, loader.resource_cls, destination, identifier_key=loader.identifier_key
-        )
-        if load_warnings:
-            print(f"  [bold yellow]WARNING:[/] Found potential snake_case issues: {load_warnings!s}")
+        data_format_warning = validate_yaml_config(parsed, loader.resource_cls, source_path)
+        if data_format_warning:
+            print(f"  [bold yellow]WARNING:[/] Found potential Data Format issues: {data_format_warning!s}")
 
         data_set_warnings = validate_data_set_is_set(parsed, loader.resource_cls, source_path)
         if data_set_warnings:

--- a/cognite_toolkit/_cdf_tk/templates/_templates.py
+++ b/cognite_toolkit/_cdf_tk/templates/_templates.py
@@ -608,8 +608,10 @@ def validate(
         return
 
     if isinstance(parsed, dict):
-        parsed = [parsed]
-    for item in parsed:
+        parsed_list = [parsed]
+    else:
+        parsed_list = parsed
+    for item in parsed_list:
         if not check_yaml_semantics(
             parsed=item,
             filepath_src=source_path,
@@ -623,9 +625,9 @@ def validate(
                     f"  [bold yellow]WARNING:[/] verify file format against the API specification for {destination.parent.name!r} at {loader.doc_url()}"
                 )
 
-    if isinstance(loader, ResourceLoader):
+    if issubclass(loader, ResourceLoader):
         try:
-            data_format_warning = validate_yaml_config(parsed, loader.get_write_cls_parameter_spec(), source_path)
+            data_format_warnings = validate_yaml_config(parsed, loader.get_write_cls_parameter_spec(), source_path)
         except Exception as e:
             print(
                 f"[bold yellow]WARNING:[/] Failed to validate {destination.name} due to: {e}."
@@ -634,9 +636,9 @@ def validate(
             if verbose:
                 print(Panel(traceback.format_exc()))
         else:
-            if data_format_warning:
-                print(f"  [bold yellow]WARNING:[/] Found potential Data Format issues: {data_format_warning!s}")
+            if data_format_warnings:
+                print(f"  [bold yellow]WARNING:[/] Found potential Data Format issues: {data_format_warnings!s}")
 
-        data_set_warnings = validate_data_set_is_set(parsed, loader.resource_cls, source_path)
+        data_set_warnings = validate_data_set_is_set(parsed_list, loader.resource_cls, source_path)
         if data_set_warnings:
             print(f"  [bold yellow]WARNING:[/] Found missing data_sets: {data_set_warnings!s}")

--- a/cognite_toolkit/_cdf_tk/templates/_templates.py
+++ b/cognite_toolkit/_cdf_tk/templates/_templates.py
@@ -638,8 +638,10 @@ def validate(
                 print(Panel(traceback.format_exc()))
         else:
             if data_format_warnings:
-                print("  [bold yellow]WARNING:[/] Found potential Data Format issues:")
-                print(Markdown(f"{data_format_warnings!s}"))
+                print(
+                    "  [bold yellow]WARNING:[/] Found potential Data Format issues:",
+                    Markdown(f"{data_format_warnings!s}"),
+                )
 
         data_set_warnings = validate_data_set_is_set(parsed_list, loader.resource_cls, source_path)
         if data_set_warnings:

--- a/cognite_toolkit/_cdf_tk/templates/_templates.py
+++ b/cognite_toolkit/_cdf_tk/templates/_templates.py
@@ -18,6 +18,7 @@ from cognite.client._api.functions import validate_function_folder
 from cognite.client.data_classes.files import FileMetadataList
 from cognite.client.data_classes.functions import FunctionList
 from rich import print
+from rich.markdown import Markdown
 from rich.panel import Panel
 
 from cognite_toolkit._cdf_tk.constants import _RUNNING_IN_BROWSER
@@ -637,7 +638,8 @@ def validate(
                 print(Panel(traceback.format_exc()))
         else:
             if data_format_warnings:
-                print(f"  [bold yellow]WARNING:[/] Found potential Data Format issues: {data_format_warnings!s}")
+                print("  [bold yellow]WARNING:[/] Found potential Data Format issues:")
+                print(Markdown(f"{data_format_warnings!s}"))
 
         data_set_warnings = validate_data_set_is_set(parsed_list, loader.resource_cls, source_path)
         if data_set_warnings:

--- a/cognite_toolkit/_cdf_tk/validation/__init__.py
+++ b/cognite_toolkit/_cdf_tk/validation/__init__.py
@@ -1,3 +1,3 @@
-from .read_yaml import validate_case_raw, validate_data_set_is_set, validate_modules_variables
+from .read_yaml import validate_case_raw, validate_data_set_is_set, validate_modules_variables, validate_yaml_config
 
-__all__ = ["validate_modules_variables", "validate_data_set_is_set", "validate_case_raw"]
+__all__ = ["validate_modules_variables", "validate_data_set_is_set", "validate_case_raw", "validate_yaml_config"]

--- a/cognite_toolkit/_cdf_tk/validation/read_yaml.py
+++ b/cognite_toolkit/_cdf_tk/validation/read_yaml.py
@@ -13,6 +13,7 @@ from typing import Any, get_origin
 from cognite.client.data_classes._base import CogniteObject
 from cognite.client.utils._text import to_camel_case, to_snake_case
 
+from cognite_toolkit._cdf_tk._parameters import ParameterSpecSet
 from cognite_toolkit._cdf_tk._parameters.get_type_hints import _TypeHints
 
 from .warning import (
@@ -175,3 +176,7 @@ def validate_data_set_is_set(
     value = raw.get(identifier_key, raw.get(to_snake_case(identifier_key), f"No identifier {identifier_key}"))
     warning_list.append(DataSetMissingWarning(filepath, value, identifier_key, resource_cls.__name__))
     return warning_list
+
+
+def validate_yaml_config(content: str, spec: ParameterSpecSet, source_file: Path) -> WarningList:
+    raise NotImplementedError()

--- a/cognite_toolkit/_cdf_tk/validation/read_yaml.py
+++ b/cognite_toolkit/_cdf_tk/validation/read_yaml.py
@@ -207,6 +207,7 @@ def validate_yaml_config(content: str, spec: ParameterSpecSet, source_file: Path
         line_no = no_by_line.get(key, 0)
         warnings.append(UnusedParameterWarning(source_file, line_no, key))
 
+    # Only checking the top level for now. This can be expanded to check nested parameters.
     missing = spec.required(level=1) - actual_parameters
     for spec_param in missing:
         warnings.append(MissingRequiredParameter(source_file, 0, spec_param.key))

--- a/cognite_toolkit/_cdf_tk/validation/read_yaml.py
+++ b/cognite_toolkit/_cdf_tk/validation/read_yaml.py
@@ -201,7 +201,7 @@ def validate_yaml_config(content: str, spec: ParameterSpecSet, source_file: Path
         key = parameter.key
         line_no = no_by_line.get(key, 0)
         warnings.append(CaseTypoWarning(source_file, line_no, key, to_camel_case(key)))
-
+    unused_parameters = unused_parameters - typo_parameters
     for parameter in unused_parameters:
         key = parameter.key
         line_no = no_by_line.get(key, 0)

--- a/cognite_toolkit/_cdf_tk/validation/warning/__init__.py
+++ b/cognite_toolkit/_cdf_tk/validation/warning/__init__.py
@@ -1,4 +1,18 @@
 from ._base import ToolkitWarning, WarningList
-from .fileread import DataSetMissingWarning, SnakeCaseWarning, TemplateVariableWarning
+from .fileread import (
+    DataSetMissingWarning,
+    LinedUnusedParameterWarning,
+    SnakeCaseWarning,
+    TemplateVariableWarning,
+    UnusedParameter,
+)
 
-__all__ = ["SnakeCaseWarning", "DataSetMissingWarning", "TemplateVariableWarning", "WarningList", "ToolkitWarning"]
+__all__ = [
+    "SnakeCaseWarning",
+    "DataSetMissingWarning",
+    "TemplateVariableWarning",
+    "WarningList",
+    "ToolkitWarning",
+    "UnusedParameter",
+    "LinedUnusedParameterWarning",
+]

--- a/cognite_toolkit/_cdf_tk/validation/warning/__init__.py
+++ b/cognite_toolkit/_cdf_tk/validation/warning/__init__.py
@@ -1,10 +1,12 @@
 from ._base import ToolkitWarning, WarningList
 from .fileread import (
+    CaseTypoWarning,
     DataSetMissingWarning,
-    LinedUnusedParameterWarning,
+    MissingRequiredParameter,
     SnakeCaseWarning,
     TemplateVariableWarning,
     UnusedParameter,
+    UnusedParameterWarning,
 )
 
 __all__ = [
@@ -14,5 +16,7 @@ __all__ = [
     "WarningList",
     "ToolkitWarning",
     "UnusedParameter",
-    "LinedUnusedParameterWarning",
+    "UnusedParameterWarning",
+    "MissingRequiredParameter",
+    "CaseTypoWarning",
 ]

--- a/cognite_toolkit/_cdf_tk/validation/warning/_base.py
+++ b/cognite_toolkit/_cdf_tk/validation/warning/_base.py
@@ -46,7 +46,7 @@ class WarningList(UserList, Generic[T_Warning]):
         output = [""]
         for group_key, group in itertools.groupby(sorted(self), key=lambda w: w.group_key()):
             group_list = list(group)
-            header = type(group_list[0]).group_header(group_key)
+            header = group_list[0].group_header()
             if header:
                 output.append(header)
             for warning in group_list:

--- a/cognite_toolkit/_cdf_tk/validation/warning/_base.py
+++ b/cognite_toolkit/_cdf_tk/validation/warning/_base.py
@@ -50,5 +50,5 @@ class WarningList(UserList, Generic[T_Warning]):
             if header:
                 output.append(header)
             for warning in group_list:
-                output.append(f"{'    ' * 2}{warning!s}")
+                output.append(f"{'    ' * 2} * {warning!s}")
         return "\n".join(output)

--- a/cognite_toolkit/_cdf_tk/validation/warning/_base.py
+++ b/cognite_toolkit/_cdf_tk/validation/warning/_base.py
@@ -39,7 +39,7 @@ T_Warning = TypeVar("T_Warning", bound=ToolkitWarning)
 
 
 class WarningList(UserList, Generic[T_Warning]):
-    def __init__(self, collection: Collection[T_Warning] | None = None):
+    def __init__(self, collection: Collection[T_Warning] | None = None) -> None:
         super().__init__(collection or [])
 
     def __str__(self) -> str:

--- a/cognite_toolkit/_cdf_tk/validation/warning/fileread.py
+++ b/cognite_toolkit/_cdf_tk/validation/warning/fileread.py
@@ -89,7 +89,8 @@ class MissingRequiredParameter(YAMLFileWarning):
     expected: str
 
     def __str__(self) -> str:
-        return f"{type(self).__name__}: Missing required parameter {self.expected!r}{self._location}"
+        location = "." if self.element_no is None else f" in entry {self.element_no}"
+        return f"{type(self).__name__}: Missing required parameter {self.expected!r}{location}"
 
 
 @dataclass(frozen=True)

--- a/cognite_toolkit/_cdf_tk/validation/warning/fileread.py
+++ b/cognite_toolkit/_cdf_tk/validation/warning/fileread.py
@@ -59,13 +59,13 @@ class YAMLFileWarning(ToolkitWarning, ABC):
     @property
     def _location(self) -> str:
         if self.element_no is not None:
-            value = f" in entry {self.element_no}"
+            value = f" in entry {self.element_no} "
         else:
             value = ""
-        if len(self.path) == 0:
-            return f"{value}."
+        if len(self.path) == 1:
+            return f"{value}"
         else:
-            return f"{value} in section {self.path!r}."
+            return f"{value} in section {self.path!r}"
 
 
 @dataclass(frozen=True)
@@ -73,7 +73,7 @@ class UnusedParameterWarning(YAMLFileWarning):
     actual: str
 
     def __str__(self) -> str:
-        return f"{type(self).__name__}: Parameter {self.actual!r} is not used."
+        return f"{type(self).__name__}: Parameter {self.actual!r} is not used{self._location}."
 
 
 @dataclass(frozen=True)
@@ -81,7 +81,7 @@ class CaseTypoWarning(UnusedParameterWarning):
     expected: str
 
     def __str__(self) -> str:
-        return f"{type(self).__name__}: Got {self.actual!r}. Did you mean {self.expected!r}?"
+        return f"{type(self).__name__}: Got {self.actual!r}. Did you mean {self.expected!r}?{self._location}."
 
 
 @dataclass(frozen=True)
@@ -89,8 +89,7 @@ class MissingRequiredParameter(YAMLFileWarning):
     expected: str
 
     def __str__(self) -> str:
-        location = "." if self.element_no is None else f" in entry {self.element_no}"
-        return f"{type(self).__name__}: Missing required parameter {self.expected!r}{location}"
+        return f"{type(self).__name__}: Missing required parameter {self.expected!r}{self._location}."
 
 
 @dataclass(frozen=True)

--- a/cognite_toolkit/_cdf_tk/validation/warning/fileread.py
+++ b/cognite_toolkit/_cdf_tk/validation/warning/fileread.py
@@ -73,7 +73,7 @@ class UnusedParameterWarning(YAMLFileWarning):
     actual: str
 
     def __str__(self) -> str:
-        return f"{type(self).__name__}: Parameter {self.actual!r} is not used{self._location}"
+        return f"{type(self).__name__}: Parameter {self.actual!r} is not used."
 
 
 @dataclass(frozen=True)
@@ -81,7 +81,7 @@ class CaseTypoWarning(UnusedParameterWarning):
     expected: str
 
     def __str__(self) -> str:
-        return f"{type(self).__name__}: Got {self.actual!r}. Did you mean {self.expected!r}?{self._location}"
+        return f"{type(self).__name__}: Got {self.actual!r}. Did you mean {self.expected!r}?"
 
 
 @dataclass(frozen=True)

--- a/cognite_toolkit/_cdf_tk/validation/warning/fileread.py
+++ b/cognite_toolkit/_cdf_tk/validation/warning/fileread.py
@@ -38,6 +38,14 @@ class SnakeCaseWarning(UnusedParameter):
 
 
 @dataclass(frozen=True)
+class LinedUnusedParameterWarning(UnusedParameter):
+    line_no: int
+
+    def __str__(self) -> str:
+        return f"{type(self).__name__}: Parameter {self.actual!r} is not used in {self.filepath.name} on line {self.line_no}."
+
+
+@dataclass(frozen=True)
 class TemplateVariableWarning(FileReadWarning):
     path: str
 

--- a/cognite_toolkit/_cdf_tk/validation/warning/fileread.py
+++ b/cognite_toolkit/_cdf_tk/validation/warning/fileread.py
@@ -38,11 +38,39 @@ class SnakeCaseWarning(UnusedParameter):
 
 
 @dataclass(frozen=True)
-class LinedUnusedParameterWarning(UnusedParameter):
+class YAMLFileWarning(ToolkitWarning, ABC):
+    filepath: Path
     line_no: int
 
+    def group_key(self) -> tuple[Any, ...]:
+        return (self.filepath,)
+
+    def group_header(self) -> str:
+        return f"    In File {str(self.filepath)!r}\n"
+
+
+@dataclass(frozen=True)
+class UnusedParameterWarning(YAMLFileWarning):
+    actual: str
+
     def __str__(self) -> str:
-        return f"{type(self).__name__}: Parameter {self.actual!r} is not used in {self.filepath.name} on line {self.line_no}."
+        return f"{type(self).__name__}: Parameter {self.actual!r} is not used on line {self.line_no}."
+
+
+@dataclass(frozen=True)
+class CaseTypoWarning(UnusedParameterWarning):
+    expected: str
+
+    def __str__(self) -> str:
+        return f"{type(self).__name__}: Got {self.actual!r}. Did you mean {self.expected!r}? On line {self.line_no}."
+
+
+@dataclass(frozen=True)
+class MissingRequiredParameter(YAMLFileWarning):
+    expected: str
+
+    def __str__(self) -> str:
+        return f"{type(self).__name__}: Missing required parameter {self.expected!r} on line {self.line_no}."
 
 
 @dataclass(frozen=True)

--- a/cognite_toolkit/_cdf_tk/validation/warning/fileread.py
+++ b/cognite_toolkit/_cdf_tk/validation/warning/fileread.py
@@ -40,13 +40,32 @@ class SnakeCaseWarning(UnusedParameter):
 @dataclass(frozen=True)
 class YAMLFileWarning(ToolkitWarning, ABC):
     filepath: Path
-    line_no: int
+    # None is a dictionary, number is a list
+    element_no: int | None
+    path: tuple[str | int, ...]
 
     def group_key(self) -> tuple[Any, ...]:
-        return (self.filepath,)
+        if self.element_no is None:
+            return (self.filepath,)
+        else:
+            return self.filepath, self.element_no
 
     def group_header(self) -> str:
-        return f"    In File {str(self.filepath)!r}\n"
+        if self.element_no is None:
+            return f"    In File {str(self.filepath)!r}"
+        else:
+            return f"    In File {str(self.filepath)!r}\n    In entry {self.element_no}"
+
+    @property
+    def _location(self) -> str:
+        if self.element_no is not None:
+            value = f" in entry {self.element_no}"
+        else:
+            value = ""
+        if len(self.path) == 0:
+            return f"{value}."
+        else:
+            return f"{value} in section {self.path!r}."
 
 
 @dataclass(frozen=True)
@@ -54,7 +73,7 @@ class UnusedParameterWarning(YAMLFileWarning):
     actual: str
 
     def __str__(self) -> str:
-        return f"{type(self).__name__}: Parameter {self.actual!r} is not used on line {self.line_no}."
+        return f"{type(self).__name__}: Parameter {self.actual!r} is not used{self._location}"
 
 
 @dataclass(frozen=True)
@@ -62,7 +81,7 @@ class CaseTypoWarning(UnusedParameterWarning):
     expected: str
 
     def __str__(self) -> str:
-        return f"{type(self).__name__}: Got {self.actual!r}. Did you mean {self.expected!r}? On line {self.line_no}."
+        return f"{type(self).__name__}: Got {self.actual!r}. Did you mean {self.expected!r}?{self._location}"
 
 
 @dataclass(frozen=True)
@@ -70,7 +89,7 @@ class MissingRequiredParameter(YAMLFileWarning):
     expected: str
 
     def __str__(self) -> str:
-        return f"{type(self).__name__}: Missing required parameter {self.expected!r} on line {self.line_no}."
+        return f"{type(self).__name__}: Missing required parameter {self.expected!r}{self._location}"
 
 
 @dataclass(frozen=True)

--- a/cognite_toolkit/cognite_modules/examples/cdf_apm_simple_data_model/data_models/1.Asset.container.yaml
+++ b/cognite_toolkit/cognite_modules/examples/cdf_apm_simple_data_model/data_models/1.Asset.container.yaml
@@ -1,5 +1,4 @@
-externalId: Asset
-name: Asset
+nam: Asset
 properties:
   areaId:
     autoIncrement: false
@@ -12,7 +11,7 @@ properties:
       type: int32
   categoryId:
     autoIncrement: false
-    defaultValue: null
+    default_value: null
     description: null
     name: categoryId
     nullable: true

--- a/cognite_toolkit/cognite_modules/examples/cdf_apm_simple_data_model/data_models/1.Asset.container.yaml
+++ b/cognite_toolkit/cognite_modules/examples/cdf_apm_simple_data_model/data_models/1.Asset.container.yaml
@@ -1,4 +1,5 @@
-nam: Asset
+externalId: Asset
+name: Asset
 properties:
   areaId:
     autoIncrement: false

--- a/tests/tests_unit/test_cdf_tk/test_parameters/tests_parameters.py
+++ b/tests/tests_unit/test_cdf_tk/test_parameters/tests_parameters.py
@@ -60,7 +60,7 @@ class TestSetOperations:
                 id="Spec - Value no difference",
             ),
             pytest.param(
-                SPACE_SPEC.required,
+                SPACE_SPEC.required(),
                 ParameterSet[ParameterValue](),
                 ParameterSpecSet({ParameterSpec(("space",), frozenset({"str"}), True, False)}),
                 id="Missing required",

--- a/tests/tests_unit/test_cdf_tk/test_validation/test_read_yaml.py
+++ b/tests/tests_unit/test_cdf_tk/test_validation/test_read_yaml.py
@@ -7,13 +7,15 @@ from cognite.client.data_classes import TimeSeries
 from cognite.client.data_classes.data_modeling import ViewApply
 
 from cognite_toolkit._cdf_tk._parameters import ParameterSpecSet
-from cognite_toolkit._cdf_tk.load import SpaceLoader
+from cognite_toolkit._cdf_tk.load import ContainerLoader, SpaceLoader
 from cognite_toolkit._cdf_tk.validation import validate_case_raw, validate_data_set_is_set, validate_yaml_config
 from cognite_toolkit._cdf_tk.validation.warning import (
+    CaseTypoWarning,
     DataSetMissingWarning,
-    LinedUnusedParameterWarning,
+    MissingRequiredParameter,
     SnakeCaseWarning,
     ToolkitWarning,
+    UnusedParameterWarning,
 )
 from tests.tests_unit.data import LOAD_DATA
 
@@ -67,8 +69,34 @@ nme: My space
     yield pytest.param(
         content,
         SpaceLoader.get_write_cls_parameter_spec(),
-        [LinedUnusedParameterWarning(DUMMY_FILE, "dummy", "dummy", "nme", 2)],
+        [
+            UnusedParameterWarning(
+                DUMMY_FILE,
+                2,
+                "nme",
+            )
+        ],
         id="Unused parameter",
+    )
+    content = """externalId: Pump
+name: Pump
+usedFor: node
+properties:
+  DesignPointFlowGPM:
+    autoIncrement: false
+    default_value: null
+    nullable: true
+    type:
+      list: false
+      type: float64"""
+    yield pytest.param(
+        content,
+        ContainerLoader.get_write_cls_parameter_spec(),
+        [
+            MissingRequiredParameter(DUMMY_FILE, 0, "space"),
+            CaseTypoWarning(DUMMY_FILE, 7, "default_value", "defaultValue"),
+        ],
+        id="Valid container",
     )
 
 

--- a/tests/tests_unit/test_cdf_tk/test_validation/test_read_yaml.py
+++ b/tests/tests_unit/test_cdf_tk/test_validation/test_read_yaml.py
@@ -72,7 +72,8 @@ nme: My space
         [
             UnusedParameterWarning(
                 DUMMY_FILE,
-                2,
+                None,
+                ("nme",),
                 "nme",
             )
         ],
@@ -93,15 +94,34 @@ properties:
         content,
         ContainerLoader.get_write_cls_parameter_spec(),
         [
-            MissingRequiredParameter(DUMMY_FILE, 0, "space"),
-            CaseTypoWarning(DUMMY_FILE, 7, "default_value", "defaultValue"),
+            MissingRequiredParameter(DUMMY_FILE, None, ("space",), "space"),
+            CaseTypoWarning(
+                DUMMY_FILE, None, ("properties", "DesignPointFlowGPM", "default_value"), "default_value", "defaultValue"
+            ),
         ],
         id="Missing required and misspelling",
+    )
+    content = """
+- space: sp_my_space
+  name: First space
+- space: sp_my_space_2
+  nme: Second space
+- space: sp_my_space_3
+  nme: Third space"""
+    yield pytest.param(
+        content,
+        SpaceLoader.get_write_cls_parameter_spec(),
+        [
+            UnusedParameterWarning(DUMMY_FILE, 2, ("nme",), "nme"),
+            UnusedParameterWarning(DUMMY_FILE, 3, ("nme",), "nme"),
+        ],
+        id="Unused parameter in list",
     )
 
 
 class TestValidateYAML:
     @pytest.mark.parametrize("content, spec, expected_warnings", list(validate_yaml_config_test_cases()))
     def test_validate_yaml_config(self, content: str, spec: ParameterSpecSet, expected_warnings: list[ToolkitWarning]):
-        warnings = validate_yaml_config(content, spec, DUMMY_FILE)
+        data = yaml.safe_load(content)
+        warnings = validate_yaml_config(data, spec, DUMMY_FILE)
         assert sorted(warnings) == sorted(expected_warnings)

--- a/tests/tests_unit/test_cdf_tk/test_validation/test_read_yaml.py
+++ b/tests/tests_unit/test_cdf_tk/test_validation/test_read_yaml.py
@@ -96,7 +96,7 @@ properties:
             MissingRequiredParameter(DUMMY_FILE, 0, "space"),
             CaseTypoWarning(DUMMY_FILE, 7, "default_value", "defaultValue"),
         ],
-        id="Valid container",
+        id="Missing required and misspelling",
     )
 
 

--- a/tests/tests_unit/test_cdf_tk/test_validation/test_read_yaml.py
+++ b/tests/tests_unit/test_cdf_tk/test_validation/test_read_yaml.py
@@ -84,7 +84,7 @@ usedFor: node
 properties:
   DesignPointFlowGPM:
     autoIncrement: false
-    default_value: null
+    default_value: astring
     nullable: true
     type:
       list: false


### PR DESCRIPTION
# Description

The final goal of #525, #527, #528, #532

This implements the parameter comparison into the build step, which now gives you detailed feedback on the yaml format.

![image](https://github.com/cognitedata/toolkit/assets/60234212/dfc846a6-a5c7-4275-97c7-165b9f51b222)

In the above image, I have removed `externalId` from the container, misspelled `name` as `nam`, used snake case instead of camel case on `defaultValue`. Misspelled `list` in two different properties as `lit`.
## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
