### PR TITLE
🏠 Build Command to Class with Standardized Warnings Part 1

### DIFF
--- a/cognite_toolkit/_api/modules_api.py
+++ b/cognite_toolkit/_api/modules_api.py
@@ -13,8 +13,9 @@ from cognite.client.utils.useful_types import SequenceNotStr
 
 from cognite_toolkit._api.data_classes import _DUMMY_ENVIRONMENT, ModuleMeta, ModuleMetaList
 from cognite_toolkit._cdf import Common, clean, deploy
+from cognite_toolkit._cdf_tk.build import BuildCommand
 from cognite_toolkit._cdf_tk.load import ResourceTypes
-from cognite_toolkit._cdf_tk.templates import COGNITE_MODULES, COGNITE_MODULES_PATH, build_config, iterate_modules
+from cognite_toolkit._cdf_tk.templates import COGNITE_MODULES, COGNITE_MODULES_PATH, iterate_modules
 from cognite_toolkit._cdf_tk.templates.data_classes import BuildConfigYAML, Environment, InitConfigYAML, SystemYAML
 
 
@@ -82,7 +83,7 @@ class ModulesAPI:
             filepath=Path(""),
             variables=variables,
         )
-        build_config(
+        BuildCommand().build_config(
             self._build_dir,
             self._source_dir().parent,
             config,

--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -17,6 +17,7 @@ from rich import print
 from rich.panel import Panel
 
 from cognite_toolkit._cdf_tk import auth
+from cognite_toolkit._cdf_tk.build import BuildCommand
 from cognite_toolkit._cdf_tk.clean import CleanCommand
 from cognite_toolkit._cdf_tk.constants import _RUNNING_IN_BROWSER
 from cognite_toolkit._cdf_tk.describe import describe_datamodel
@@ -43,14 +44,11 @@ from cognite_toolkit._cdf_tk.run import run_function, run_local_function, run_tr
 from cognite_toolkit._cdf_tk.templates import (
     BUILD_ENVIRONMENT_FILE,
     COGNITE_MODULES,
-    build_config,
 )
 from cognite_toolkit._cdf_tk.templates.data_classes import (
-    BuildConfigYAML,
     BuildEnvironment,
     ProjectDirectoryInit,
     ProjectDirectoryUpgrade,
-    SystemYAML,
 )
 from cognite_toolkit._cdf_tk.utils import (
     CDFToolConfig,
@@ -257,28 +255,8 @@ def build(
     ] = False,
 ) -> None:
     """Build configuration files from the module templates to a local build directory."""
-    source_path = Path(source_dir)
-    if not source_path.is_dir():
-        raise ToolkitNotADirectoryError(str(source_path))
-
-    system_config = SystemYAML.load_from_directory(source_path, build_env_name)
-    config = BuildConfigYAML.load_from_directory(source_path, build_env_name)
-    print(
-        Panel(
-            f"[bold]Building config files from templates into {build_dir!s} for environment {build_env_name} using {source_path!s} as sources...[/bold]"
-            f"\n[bold]Config file:[/] '{config.filepath.absolute()!s}'"
-        )
-    )
-    config.set_environment_variables()
-
-    build_config(
-        build_dir=Path(build_dir),
-        source_dir=source_path,
-        config=config,
-        system_config=system_config,
-        clean=not no_clean,
-        verbose=ctx.obj.verbose,
-    )
+    cmd = BuildCommand()
+    cmd.execute(ctx, Path(source_dir), Path(build_dir), build_env_name, no_clean)
 
 
 @_app.command("deploy")

--- a/cognite_toolkit/_cdf_tk/build.py
+++ b/cognite_toolkit/_cdf_tk/build.py
@@ -34,7 +34,6 @@ from .templates._constants import PROC_TMPL_VARS_SUFFIX
 from .templates._templates import (
     create_file_name,
     create_local_config,
-    process_config_files,
     process_files_directory,
     process_function_directory,
     replace_variables,
@@ -125,7 +124,7 @@ class BuildCommand(ToolkitCommand):
             for warning in warnings:
                 print(f"    {warning.get_message()}")
 
-        source_by_build_path = process_config_files(source_dir, selected_modules, build_dir, config, verbose)
+        source_by_build_path = self.process_config_files(source_dir, selected_modules, build_dir, config, verbose)
 
         build_environment = config.create_build_environment()
         build_environment.dump_to_file(build_dir)

--- a/cognite_toolkit/_cdf_tk/build.py
+++ b/cognite_toolkit/_cdf_tk/build.py
@@ -25,8 +25,8 @@ class BuildCommand(ToolkitCommand):
         if not source_path.is_dir():
             raise ToolkitNotADirectoryError(str(source_path))
 
-        system_config = SystemYAML.load_from_directory(source_path, build_env_name)
-        config = BuildConfigYAML.load_from_directory(source_path, build_env_name)
+        system_config = SystemYAML.load_from_directory(source_path, build_env_name, self.warn)
+        config = BuildConfigYAML.load_from_directory(source_path, build_env_name, self.warn)
         print(
             Panel(
                 f"[bold]Building config files from templates into {build_dir!s} for environment {build_env_name} using {source_path!s} as sources...[/bold]"

--- a/cognite_toolkit/_cdf_tk/build.py
+++ b/cognite_toolkit/_cdf_tk/build.py
@@ -1,0 +1,4 @@
+from ._commands import ToolkitCommand
+
+
+class BuildCommand(ToolkitCommand): ...

--- a/cognite_toolkit/_cdf_tk/build.py
+++ b/cognite_toolkit/_cdf_tk/build.py
@@ -1,21 +1,48 @@
+from __future__ import annotations
+
+import datetime
+import io
+import re
+import shutil
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
 from pathlib import Path
 
+import pandas as pd
 import typer
 from rich import print
 from rich.panel import Panel
 
+from cognite_toolkit._cdf_tk.constants import _RUNNING_IN_BROWSER
 from cognite_toolkit._cdf_tk.exceptions import (
+    ToolkitDuplicatedModuleError,
     ToolkitNotADirectoryError,
 )
-from cognite_toolkit._cdf_tk.templates import (
-    build_config,
-)
+from cognite_toolkit._cdf_tk.templates._utils import iterate_modules
 from cognite_toolkit._cdf_tk.templates.data_classes import (
     BuildConfigYAML,
     SystemYAML,
 )
+from cognite_toolkit._cdf_tk.validation import (
+    validate_modules_variables,
+)
 
 from ._commands import ToolkitCommand
+from .load import FunctionLoader
+from .templates._constants import PROC_TMPL_VARS_SUFFIX
+from .templates._templates import (
+    create_file_name,
+    create_local_config,
+    process_config_files,
+    process_files_directory,
+    process_function_directory,
+    replace_variables,
+    resource_folder_from_path,
+    split_config,
+    validate,
+)
+from .user_warnings import HighSeverityWarning, LowSeverityWarning
 
 
 class BuildCommand(ToolkitCommand):
@@ -35,11 +62,213 @@ class BuildCommand(ToolkitCommand):
         )
         config.set_environment_variables()
 
-        build_config(
-            build_dir=Path(build_dir),
+        self.build_config(
+            build_dir=build_dir,
             source_dir=source_path,
             config=config,
             system_config=system_config,
             clean=not no_clean,
             verbose=ctx.obj.verbose,
         )
+
+    def build_config(
+        self,
+        build_dir: Path,
+        source_dir: Path,
+        config: BuildConfigYAML,
+        system_config: SystemYAML,
+        clean: bool = False,
+        verbose: bool = False,
+    ) -> dict[Path, Path]:
+        is_populated = build_dir.exists() and any(build_dir.iterdir())
+        if is_populated and clean:
+            shutil.rmtree(build_dir)
+            build_dir.mkdir()
+            if not _RUNNING_IN_BROWSER:
+                print(f"  [bold green]INFO:[/] Cleaned existing build directory {build_dir!s}.")
+        elif is_populated and not _RUNNING_IN_BROWSER:
+            self.warn(
+                LowSeverityWarning("Build directory is not empty. Run without --no-clean to remove existing files.")
+            )
+        elif build_dir.exists() and not _RUNNING_IN_BROWSER:
+            print("  [bold green]INFO:[/] Build directory does already exist and is empty. No need to create it.")
+        else:
+            build_dir.mkdir(exist_ok=True)
+
+        config.validate_environment()
+
+        module_parts_by_name: dict[str, list[tuple[str, ...]]] = defaultdict(list)
+        available_modules: set[str | tuple[str, ...]] = set()
+        for module, _ in iterate_modules(source_dir):
+            available_modules.add(module.name)
+            module_parts = module.relative_to(source_dir).parts
+            for i in range(1, len(module_parts) + 1):
+                available_modules.add(module_parts[:i])
+
+            module_parts_by_name[module.name].append(module.relative_to(source_dir).parts)
+
+        if duplicate_modules := {
+            module_name: paths
+            for module_name, paths in module_parts_by_name.items()
+            if len(paths) > 1 and module_name in config.environment.selected_modules_and_packages
+        }:
+            raise ToolkitDuplicatedModuleError(
+                f"Ambiguous module selected in config.{config.environment.name}.yaml:", duplicate_modules
+            )
+        system_config.validate_modules(available_modules, config.environment.selected_modules_and_packages)
+
+        selected_modules = config.get_selected_modules(system_config.packages, available_modules, verbose)
+
+        warnings = validate_modules_variables(config.variables, config.filepath)
+        if warnings:
+            self.warn(LowSeverityWarning(f"Found the following warnings in config.{config.environment.name}.yaml:"))
+            for warning in warnings:
+                print(f"    {warning.get_message()}")
+
+        source_by_build_path = process_config_files(source_dir, selected_modules, build_dir, config, verbose)
+
+        build_environment = config.create_build_environment()
+        build_environment.dump_to_file(build_dir)
+        if not _RUNNING_IN_BROWSER:
+            print(f"  [bold green]INFO:[/] Build complete. Files are located in {build_dir!s}/")
+        return source_by_build_path
+
+    def process_config_files(
+        self,
+        project_config_dir: Path,
+        selected_modules: list[str | tuple[str, ...]],
+        build_dir: Path,
+        config: BuildConfigYAML,
+        verbose: bool = False,
+    ) -> dict[Path, Path]:
+        source_by_build_path: dict[Path, Path] = {}
+        printed_function_warning = False
+        configs = split_config(config.variables)
+        modules_by_variables = defaultdict(list)
+        for module_path, variables in configs.items():
+            for variable in variables:
+                modules_by_variables[variable].append(module_path)
+        number_by_resource_type: dict[str, int] = defaultdict(int)
+
+        for module_dir, filepaths in iterate_modules(project_config_dir):
+            module_parts = module_dir.relative_to(project_config_dir).parts
+            is_in_selected_modules = module_dir.name in selected_modules or module_parts in selected_modules
+            is_parent_in_selected_modules = any(
+                parent in selected_modules for parent in (module_parts[:i] for i in range(1, len(module_parts)))
+            )
+            if not is_in_selected_modules and not is_parent_in_selected_modules:
+                continue
+            if verbose:
+                print(f"  [bold green]INFO:[/] Processing module {module_dir.name}")
+            local_config = create_local_config(configs, module_dir)
+
+            # Sort to support 1., 2. etc prefixes
+            def sort_key(p: Path) -> int:
+                if result := re.findall(r"^(\d+)", p.stem):
+                    return int(result[0])
+                else:
+                    return len(filepaths)
+
+            # The builder of a module can control the order that resources are deployed by prefixing a number
+            # The custom key 'sort_key' is to get the sort on integer and not the string.
+            filepaths = sorted(filepaths, key=sort_key)
+
+            @dataclass
+            class ResourceFiles:
+                resource_files: list[Path] = field(default_factory=list)
+                other_files: list[Path] = field(default_factory=list)
+
+            # Initialise for auth, other resource folders will be added as they are found
+            files_by_resource_folder: dict[str, ResourceFiles] = defaultdict(ResourceFiles)
+            for filepath in filepaths:
+                try:
+                    resource_folder = resource_folder_from_path(filepath)
+                except ValueError:
+                    if verbose:
+                        print(
+                            f"      [bold green]INFO:[/] The file {filepath.name} is not in a resource directory, skipping it..."
+                        )
+                    continue
+                if filepath.suffix.lower() in PROC_TMPL_VARS_SUFFIX:
+                    files_by_resource_folder[resource_folder].resource_files.append(filepath)
+                else:
+                    files_by_resource_folder[resource_folder].other_files.append(filepath)
+
+            for resource_folder in files_by_resource_folder:
+                for filepath in files_by_resource_folder[resource_folder].resource_files:
+                    # We only want to process the yaml files for functions as the function code is handled separately.
+                    if resource_folder == "functions" and filepath.suffix.lower() != ".yaml":
+                        continue
+                    if verbose:
+                        print(f"    [bold green]INFO:[/] Processing {filepath.name}")
+                    content = filepath.read_text()
+                    content = replace_variables(content, local_config)
+                    filename = create_file_name(filepath, number_by_resource_type)
+                    destination = build_dir / resource_folder / filename
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    destination.write_text(content)
+                    validate(content, destination, filepath, modules_by_variables, verbose)
+                    source_by_build_path[destination] = filepath
+
+                    # If we have a function definition, we want to process the directory.
+                    if (
+                        resource_folder == "functions"
+                        and filepath.suffix.lower() == ".yaml"
+                        and re.match(FunctionLoader.filename_pattern, filepath.stem)
+                    ):
+                        if not printed_function_warning and sys.version_info >= (3, 12):
+                            self.warn(
+                                HighSeverityWarning(
+                                    "The functions API does not support Python 3.12. "
+                                    "It is recommended that you use Python 3.11 or 3.10 to develop functions locally."
+                                )
+                            )
+                            printed_function_warning = True
+                        process_function_directory(
+                            yaml_source_path=filepath,
+                            yaml_dest_path=destination,
+                            module_dir=module_dir,
+                            build_dir=build_dir,
+                            verbose=verbose,
+                        )
+                        files_by_resource_folder[resource_folder].other_files = []
+                    if resource_folder == "files":
+                        process_files_directory(
+                            files=files_by_resource_folder[resource_folder].other_files,
+                            yaml_dest_path=destination,
+                            module_dir=module_dir,
+                            build_dir=build_dir,
+                            verbose=verbose,
+                        )
+                        files_by_resource_folder[resource_folder].other_files = []
+
+                if resource_folder == "timeseries_datapoints":
+                    # Process all csv files
+                    for filepath in files_by_resource_folder["timeseries_datapoints"].other_files:
+                        if filepath.suffix.lower() != ".csv":
+                            continue
+                        # Special case for timeseries datapoints, we want to timeshift datapoints
+                        # if the file is a csv file and we have been instructed to.
+                        # The replacement is used to ensure that we read exactly the same file on Windows and Linux
+                        file_content = filepath.read_bytes().replace(b"\r\n", b"\n").decode("utf-8")
+                        data = pd.read_csv(io.StringIO(file_content), parse_dates=True, index_col=0)
+                        destination = build_dir / resource_folder / filename
+                        destination.parent.mkdir(parents=True, exist_ok=True)
+                        if "timeshift_" in data.index.name:
+                            print(
+                                "      [bold green]INFO:[/] Found 'timeshift_' in index name, timeshifting datapoints up to today..."
+                            )
+                            data.index.name = data.index.name.replace("timeshift_", "")
+                            data.index = pd.DatetimeIndex(data.index)
+                            periods = datetime.datetime.today() - data.index[-1]
+                            data.index = pd.DatetimeIndex.shift(data.index, periods=periods.days, freq="D")
+                        destination.write_text(data.to_csv())
+                for filepath in files_by_resource_folder[resource_folder].other_files:
+                    if verbose:
+                        print(f"    [bold green]INFO:[/] Found unrecognized file {filepath}. Copying in untouched...")
+                    # Copy the file as is, not variable replacement
+                    destination = build_dir / filepath.parent.name / filepath.name
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copyfile(filepath, destination)
+
+        return source_by_build_path

--- a/cognite_toolkit/_cdf_tk/build.py
+++ b/cognite_toolkit/_cdf_tk/build.py
@@ -1,4 +1,45 @@
+from pathlib import Path
+
+import typer
+from rich import print
+from rich.panel import Panel
+
+from cognite_toolkit._cdf_tk.exceptions import (
+    ToolkitNotADirectoryError,
+)
+from cognite_toolkit._cdf_tk.templates import (
+    build_config,
+)
+from cognite_toolkit._cdf_tk.templates.data_classes import (
+    BuildConfigYAML,
+    SystemYAML,
+)
+
 from ._commands import ToolkitCommand
 
 
-class BuildCommand(ToolkitCommand): ...
+class BuildCommand(ToolkitCommand):
+    def execute(
+        self, ctx: typer.Context, source_path: Path, build_dir: Path, build_env_name: str, no_clean: bool
+    ) -> None:
+        if not source_path.is_dir():
+            raise ToolkitNotADirectoryError(str(source_path))
+
+        system_config = SystemYAML.load_from_directory(source_path, build_env_name)
+        config = BuildConfigYAML.load_from_directory(source_path, build_env_name)
+        print(
+            Panel(
+                f"[bold]Building config files from templates into {build_dir!s} for environment {build_env_name} using {source_path!s} as sources...[/bold]"
+                f"\n[bold]Config file:[/] '{config.filepath.absolute()!s}'"
+            )
+        )
+        config.set_environment_variables()
+
+        build_config(
+            build_dir=Path(build_dir),
+            source_dir=source_path,
+            config=config,
+            system_config=system_config,
+            clean=not no_clean,
+            verbose=ctx.obj.verbose,
+        )

--- a/cognite_toolkit/_cdf_tk/pull.py
+++ b/cognite_toolkit/_cdf_tk/pull.py
@@ -15,6 +15,7 @@ from rich import print
 from rich.markdown import Markdown
 from rich.panel import Panel
 
+from cognite_toolkit._cdf_tk.build import BuildCommand
 from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitDuplicatedResourceError,
     ToolkitMissingResourceError,
@@ -22,7 +23,6 @@ from cognite_toolkit._cdf_tk.exceptions import (
 )
 from cognite_toolkit._cdf_tk.load import ResourceLoader
 from cognite_toolkit._cdf_tk.load._base_loaders import T_ID, T_WritableCogniteResourceList
-from cognite_toolkit._cdf_tk.templates import build_config
 from cognite_toolkit._cdf_tk.templates.data_classes import BuildConfigYAML, SystemYAML
 from cognite_toolkit._cdf_tk.utils import CDFToolConfig, YAMLComment, YAMLWithComments, tmp_build_directory
 
@@ -395,7 +395,7 @@ def pull_command(
                 f"'selected_modules_and_packages') from {source_path}...[/]"
             )
         )
-        source_by_build_path = build_config(
+        source_by_build_path = BuildCommand().build_config(
             build_dir=build_dir,
             source_dir=source_path,
             config=config,

--- a/cognite_toolkit/_cdf_tk/run.py
+++ b/cognite_toolkit/_cdf_tk/run.py
@@ -17,10 +17,10 @@ from cognite.client.data_classes.transformations.common import NonceCredentials
 from rich import print
 from rich.table import Table
 
+from cognite_toolkit._cdf_tk.build import BuildCommand
 from cognite_toolkit._cdf_tk.constants import _RUNNING_IN_BROWSER
 from cognite_toolkit._cdf_tk.load import FunctionLoader, FunctionScheduleLoader
 from cognite_toolkit._cdf_tk.templates import (
-    build_config,
     module_from_path,
 )
 from cognite_toolkit._cdf_tk.templates.data_classes import BuildConfigYAML, SystemYAML
@@ -199,7 +199,7 @@ def run_local_function(
     if not found:
         print(f"  [bold red]ERROR:[/] Could not find function with external id {external_id}, exiting.")
         return False
-    build_config(
+    BuildCommand().build_config(
         build_dir=Path(build_dir),
         source_dir=source_path,
         config=config,

--- a/cognite_toolkit/_cdf_tk/templates/__init__.py
+++ b/cognite_toolkit/_cdf_tk/templates/__init__.py
@@ -6,7 +6,7 @@ from ._constants import (
     ROOT_MODULES,
     ROOT_PATH,
 )
-from ._templates import build_config, check_yaml_semantics, create_local_config, split_config
+from ._templates import check_yaml_semantics, create_local_config, split_config
 from ._utils import flatten_dict, iterate_modules, module_from_path, resource_folder_from_path
 
 __all__ = [
@@ -18,7 +18,6 @@ __all__ = [
     "ROOT_PATH",
     "ROOT_MODULES",
     "COGNITE_MODULES_PATH",
-    "build_config",
     "BUILD_ENVIRONMENT_FILE",
     "split_config",
     "create_local_config",

--- a/cognite_toolkit/_cdf_tk/templates/_templates.py
+++ b/cognite_toolkit/_cdf_tk/templates/_templates.py
@@ -31,23 +31,8 @@ from cognite_toolkit._cdf_tk.validation import (
 
 from ._constants import EXCL_INDEX_SUFFIX, ROOT_MODULES
 from ._utils import iterate_functions, module_from_path, resource_folder_from_path
-from .data_classes import BuildConfigYAML, SystemYAML
 
 WARN_YELLOW = "[bold yellow]WARNING:[/]"
-
-
-def build_config(
-    build_dir: Path,
-    source_dir: Path,
-    config: BuildConfigYAML,
-    system_config: SystemYAML,
-    clean: bool = False,
-    verbose: bool = False,
-) -> dict[Path, Path]:
-    from cognite_toolkit._cdf_tk.build import BuildCommand
-
-    cmd = BuildCommand()
-    return cmd.build_config(build_dir, source_dir, config, system_config, clean, verbose)
 
 
 class Resource(Enum):

--- a/cognite_toolkit/_cdf_tk/user_warnings.py
+++ b/cognite_toolkit/_cdf_tk/user_warnings.py
@@ -92,6 +92,17 @@ class GeneralWarning(ToolkitWarning, ABC):
 
 
 @dataclass(frozen=True)
+class UnexpectedFileLocationWarning(ToolkitWarning):
+    severity: ClassVar[SeverityLevel] = SeverityLevel.LOW
+    filepath: str
+    alternative: str
+
+    def get_message(self) -> str:
+        message = f"{self.filepath!r} does not exist. Using {self.alternative!r} instead."
+        return SeverityFormat.get_rich_severity_format(self.severity, message)
+
+
+@dataclass(frozen=True)
 class ToolkitDependenciesIncludedWarning(GeneralWarning):
     severity: ClassVar[SeverityLevel] = SeverityLevel.LOW
     message: ClassVar[str] = "Some resources were added due to dependencies."

--- a/cognite_toolkit/_cdf_tk/user_warnings.py
+++ b/cognite_toolkit/_cdf_tk/user_warnings.py
@@ -103,6 +103,33 @@ class UnexpectedFileLocationWarning(ToolkitWarning):
 
 
 @dataclass(frozen=True)
+class LowSeverityWarning(GeneralWarning):
+    severity: ClassVar[SeverityLevel] = SeverityLevel.LOW
+    message_raw: str
+
+    def get_message(self) -> str:
+        return SeverityFormat.get_rich_severity_format(self.severity, self.message_raw)
+
+
+@dataclass(frozen=True)
+class MediumSeverityWarning(GeneralWarning):
+    severity: ClassVar[SeverityLevel] = SeverityLevel.MEDIUM
+    message_raw: str
+
+    def get_message(self) -> str:
+        return SeverityFormat.get_rich_severity_format(self.severity, self.message_raw)
+
+
+@dataclass(frozen=True)
+class HighSeverityWarning(GeneralWarning):
+    severity: ClassVar[SeverityLevel] = SeverityLevel.HIGH
+    message_raw: str
+
+    def get_message(self) -> str:
+        return SeverityFormat.get_rich_severity_format(self.severity, self.message_raw)
+
+
+@dataclass(frozen=True)
 class ToolkitDependenciesIncludedWarning(GeneralWarning):
     severity: ClassVar[SeverityLevel] = SeverityLevel.LOW
     message: ClassVar[str] = "Some resources were added due to dependencies."

--- a/tests/tests_unit/test_cdf_tk/test_load.py
+++ b/tests/tests_unit/test_cdf_tk/test_load.py
@@ -23,6 +23,7 @@ from cognite.client.data_classes.data_modeling import Edge, Node
 from pytest import MonkeyPatch
 
 from cognite_toolkit._cdf_tk._parameters import ParameterSet, ParameterValue, read_parameters_from_dict
+from cognite_toolkit._cdf_tk.build import BuildCommand
 from cognite_toolkit._cdf_tk.exceptions import ToolkitYAMLFormatError
 from cognite_toolkit._cdf_tk.load import (
     LOADER_BY_FOLDER_NAME,
@@ -42,7 +43,6 @@ from cognite_toolkit._cdf_tk.load import (
     ViewLoader,
 )
 from cognite_toolkit._cdf_tk.templates import (
-    build_config,
     module_from_path,
     resource_folder_from_path,
 )
@@ -556,7 +556,10 @@ class TestDeployResources:
         system_config = SystemYAML.load_from_directory(PYTEST_PROJECT, build_env_name)
         config = BuildConfigYAML.load_from_directory(PYTEST_PROJECT, build_env_name)
         config.environment.selected_modules_and_packages = ["another_module"]
-        build_config(BUILD_DIR, PYTEST_PROJECT, config=config, system_config=system_config, clean=True, verbose=False)
+        build_cmd = BuildCommand()
+        build_cmd.build_config(
+            BUILD_DIR, PYTEST_PROJECT, config=config, system_config=system_config, clean=True, verbose=False
+        )
         expected_order = ["MyView", "MyOtherView"]
         cdf_tool = MagicMock(spec=CDFToolConfig)
         cdf_tool.verify_client.return_value = cognite_client_approval.mock_client
@@ -674,7 +677,8 @@ def cognite_module_files_with_loader() -> Iterable:
         config = config_init.as_build_config()
         config.set_environment_variables()
         config.environment.selected_modules_and_packages = config.available_modules
-        source_by_build_path = build_config(
+
+        source_by_build_path = BuildCommand().build_config(
             build_dir=build_dir,
             source_dir=source_path,
             config=config,

--- a/tests/tests_unit/test_cdf_tk/test_templates.py
+++ b/tests/tests_unit/test_cdf_tk/test_templates.py
@@ -7,9 +7,9 @@ from typing import Any
 import pytest
 import yaml
 
+from cognite_toolkit._cdf_tk.build import BuildCommand
 from cognite_toolkit._cdf_tk.load import LOADER_BY_FOLDER_NAME, RESOURCE_LOADER_LIST
 from cognite_toolkit._cdf_tk.templates import (
-    build_config,
     check_yaml_semantics,
     create_local_config,
     flatten_dict,
@@ -340,7 +340,9 @@ class TestBuildConfigYAML:
         available_modules = {module.name for module, _ in iterate_modules(PYTEST_PROJECT)}
         config.environment.selected_modules_and_packages = list(available_modules)
 
-        build_config(BUILD_DIR, PYTEST_PROJECT, config=config, system_config=system_config, clean=True, verbose=False)
+        BuildCommand().build_config(
+            BUILD_DIR, PYTEST_PROJECT, config=config, system_config=system_config, clean=True, verbose=False
+        )
 
         # The resulting build folder should only have subfolders that are matching the folder name
         # used by the loaders.

--- a/tests/tests_unit/test_cli/test_behavior.py
+++ b/tests/tests_unit/test_cli/test_behavior.py
@@ -9,9 +9,9 @@ from cognite.client.data_classes import Transformation, TransformationWrite
 from pytest import MonkeyPatch
 
 from cognite_toolkit._cdf import build, deploy, dump_datamodel_cmd, pull_transformation_cmd
+from cognite_toolkit._cdf_tk.build import BuildCommand
 from cognite_toolkit._cdf_tk.exceptions import ToolkitDuplicatedModuleError
 from cognite_toolkit._cdf_tk.load import TransformationLoader
-from cognite_toolkit._cdf_tk.templates import build_config
 from cognite_toolkit._cdf_tk.templates.data_classes import BuildConfigYAML, Environment, SystemYAML
 from cognite_toolkit._cdf_tk.utils import CDFToolConfig
 from tests.tests_unit.approval_client import ApprovalCogniteClient
@@ -67,7 +67,7 @@ def test_duplicated_modules(build_tmp_path: Path, typer_context: typer.Context) 
     config.environment.name = "dev"
     config.environment.selected_modules_and_packages = ["module1"]
     with pytest.raises(ToolkitDuplicatedModuleError) as err:
-        build_config(
+        BuildCommand().build_config(
             build_dir=build_tmp_path,
             source_dir=PROJECT_WITH_DUPLICATES,
             config=config,


### PR DESCRIPTION
# Description

* Created `build.py` module with `BuildCommand` class
* Moved the two functions `build_config` and `process_config_files` from `cognite_toolkit._cdf_tk.templates._templates`, so they can take advantage of the `self.warn` method in the `BuildCommand` class.
* Introduced three generic warnings intended for one-time use.

This is a part 1, will make a Part 2 standardizing and moving the remaining relevant functions from `cognite_toolkit._cdf_tk.templates._templates` into the `build.py` module.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
