### PR TITLE
🔨 Fixing flaky tests

### DIFF
--- a/tests/tests_integration/test_loaders/test_resource_container_loaders.py
+++ b/tests/tests_integration/test_loaders/test_resource_container_loaders.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 import pandas as pd
 import pytest
 from cognite.client import CogniteClient
@@ -106,6 +108,7 @@ class TestContainerLoader:
             if updated[0].description != write_container.description:
                 # The API is not always consistent in returning the updated description,
                 # so we need to retrieve the container to verify the update
+                sleep(1)
                 updated = loader.retrieve([node_container.as_id()])
             assert updated[0].description == write_container.description
         finally:
@@ -158,6 +161,7 @@ class TestContainerLoader:
             if updated[0].description != write_container.description:
                 # The API is not always consistent in returning the updated description,
                 # so we need to retrieve the container to verify the update
+                sleep(1)
                 updated = loader.retrieve([write_container.as_id()])
             assert updated[0].description == write_container.description
         finally:

--- a/tests/tests_integration/test_loaders/test_resource_loaders.py
+++ b/tests/tests_integration/test_loaders/test_resource_loaders.py
@@ -82,7 +82,7 @@ class TestFunctionScheduleLoader:
         loader.update(FunctionScheduleWriteList([function_schedule]))
 
         retrieved = loader.retrieve([identifier])
-        if retrieved[0].description != function_schedule.description:
+        if not retrieved or retrieved[0].description != function_schedule.description:
             # The service can be a bit slow in returning the updated description,
             # so we wait a bit and try again.
             sleep(1)

--- a/tests/tests_integration/test_loaders/test_resource_loaders.py
+++ b/tests/tests_integration/test_loaders/test_resource_loaders.py
@@ -1,3 +1,5 @@
+from asyncio import sleep
+
 import pytest
 from cognite.client import CogniteClient
 from cognite.client.data_classes import Function, FunctionSchedule, FunctionScheduleWriteList
@@ -80,5 +82,10 @@ class TestFunctionScheduleLoader:
         loader.update(FunctionScheduleWriteList([function_schedule]))
 
         retrieved = loader.retrieve([identifier])
+        if retrieved[0].description != function_schedule.description:
+            # The service can be a bit slow in returning the updated description,
+            # so we wait a bit and try again.
+            sleep(1)
+            retrieved = loader.retrieve([identifier])
 
         assert retrieved[0].description == function_schedule.description


### PR DESCRIPTION
# Description

I think this should take care of the flaky test. 

Note since we now run tests in a parallel adding some extra sleep is unlikely to have any impact on the overall time it takes to run the test suite.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
