### PR TITLE
[CDF-21529] 🦗Warning on non required 

### DIFF
--- a/CHANGELOG.templates.md
+++ b/CHANGELOG.templates.md
@@ -24,7 +24,8 @@ Changes are grouped as follows:
 ### Removed
 
 - The parameter `fileId` is removed from all `function` configurations
-  (`cdf_functions_dummy` and `cdf_data_pipeline_files_valhall`) as it is no longer required.
+  (`cdf_functions_dummy`, `cdf_data_pipeline_files_valhall`, `cdf_data_pipeline_timeseries_valhall`,
+  and `my_example_module`) as it is no longer required.
 - In all modules with an `extraction_pipelines` resource, removed `dataSetExternalId` and `name` from all
   ExtractionPipelineConfigs as this is not used and thus only causes confusion.
 - In all modules with a `function`, renamed `externalIdDataSet` to `dataSetExternalId` to be consistent with the

--- a/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
@@ -632,6 +632,8 @@ class FunctionLoader(ResourceLoader[str, FunctionWrite, Function, FunctionWriteL
         spec = super().get_write_cls_parameter_spec()
         # Added by toolkit
         spec.add(ParameterSpec(("dataSetExternalId",), frozenset({"str"}), is_required=False, _is_nullable=False))
+        # Replaced by the toolkit
+        spec.discard(ParameterSpec(("fileId",), frozenset({"int"}), is_required=True, _is_nullable=False))
         return spec
 
 
@@ -1416,6 +1418,8 @@ class ExtractionPipelineLoader(
         spec = super().get_write_cls_parameter_spec()
         # Added by toolkit
         spec.add(ParameterSpec(("dataSetExternalId",), frozenset({"str"}), is_required=False, _is_nullable=False))
+        # Set on deploy time by toolkit
+        spec.discard(ParameterSpec(("dataSetId",), frozenset({"int"}), is_required=True, _is_nullable=False))
         return spec
 
 
@@ -2287,6 +2291,8 @@ class NodeLoader(ResourceContainerLoader[NodeId, LoadedNode, Node, LoadedNodeLis
                 _is_nullable=False,
             )
         )
+        # Not used
+        spec.discard(ParameterSpec(("apiCall",), frozenset({"dict"}), is_required=True, _is_nullable=False))
         return spec
 
 

--- a/cognite_toolkit/cognite_modules/examples/cdf_data_pipeline_files_valhall/functions/functions.yaml
+++ b/cognite_toolkit/cognite_modules/examples/cdf_data_pipeline_files_valhall/functions/functions.yaml
@@ -18,7 +18,6 @@
   dataSetExternalId: 'ds_files_{{location_name}}'
 - name: 'workflow:files:{{location_name}}:{{source_name}}:annotation'
   externalId: 'fn_workflow_files_{{location_name}}_{{source_name}}_annotation'
-  fileId: <will_be_generated>
   owner: 'Anonymous'
   description: 'Workflow scheduler for Contextualization of P&ID files creating annotations'
   metadata:

--- a/cognite_toolkit/cognite_modules/examples/cdf_data_pipeline_timeseries_valhall/functions/functions.yaml
+++ b/cognite_toolkit/cognite_modules/examples/cdf_data_pipeline_timeseries_valhall/functions/functions.yaml
@@ -2,7 +2,6 @@
 # and externalId as the function itself as defined below.
 - name: 'context:timeseries:{{location_name}}:{{source_name}}:asset'
   externalId: 'fn_context_timeseries_{{location_name}}_{{source_name}}_asset'
-  fileId: <will_be_generated>
   owner: 'Anonymous'
   description: 'Contextualization of timeseries and asset data for {{location_name}}:{{source_name}}'
   metadata:

--- a/cognite_toolkit/cognite_modules/examples/my_example_module/functions/first.function.yaml
+++ b/cognite_toolkit/cognite_modules/examples/my_example_module/functions/first.function.yaml
@@ -2,7 +2,6 @@
 # and externalId as the function itself as defined below.
 - name: 'first:example:function'
   externalId: 'fn_first_function'
-  fileId: <will_be_generated>
   owner: 'Anonymous'
   description: 'Returns the input data, secrets, and function info.'
   metadata:

--- a/tests/tests_unit/test_cdf_tk/test_load.py
+++ b/tests/tests_unit/test_cdf_tk/test_load.py
@@ -715,6 +715,9 @@ class TestResourceLoaders:
             loader_cls.resource_write_cls
         )
         resource_dump = resource.dump(camel_case=True)
+        # These two are handled by the toolkit
+        resource_dump.pop("dataSetId", None)
+        resource_dump.pop("fileId", None)
         dumped = read_parameters_from_dict(resource_dump)
         spec = loader_cls.get_write_cls_parameter_spec()
 

--- a/tests/tests_unit/test_cdf_tk/test_load.py
+++ b/tests/tests_unit/test_cdf_tk/test_load.py
@@ -53,6 +53,7 @@ from cognite_toolkit._cdf_tk.templates.data_classes import (
     SystemYAML,
 )
 from cognite_toolkit._cdf_tk.utils import CDFToolConfig, tmp_build_directory
+from cognite_toolkit._cdf_tk.validation import validate_yaml_config
 from tests.constants import REPO_ROOT
 from tests.tests_unit.approval_client import ApprovalCogniteClient
 from tests.tests_unit.data import LOAD_DATA, PYTEST_PROJECT
@@ -726,9 +727,8 @@ class TestResourceLoaders:
 
     @pytest.mark.parametrize("loader_cls, content", list(cognite_module_files_with_loader()))
     def test_write_cls_spec_against_cognite_modules(self, loader_cls: type[ResourceLoader], content: dict) -> None:
-        dumped = read_parameters_from_dict(content)
         spec = loader_cls.get_write_cls_parameter_spec()
 
-        extra = dumped - spec
+        warnings = validate_yaml_config(content, spec, Path("test.yaml"))
 
-        assert sorted(extra) == []
+        assert sorted(warnings) == []

--- a/tests/tests_unit/test_cdf_tk/test_load.py
+++ b/tests/tests_unit/test_cdf_tk/test_load.py
@@ -662,7 +662,7 @@ def test_resource_types_is_up_to_date() -> None:
     assert not extra, f"Extra {extra=}"
 
 
-def cognite_module_files_with_loader() -> Iterable:
+def cognite_module_files_with_loader() -> Iterable[ParameterSet]:
     source_path = REPO_ROOT / "cognite_toolkit"
     env = "dev"
     with tmp_build_directory() as build_dir:


### PR DESCRIPTION
# Description

In addition to bugfix, found a few unecessary `fileId= <will_be_generated>` that could be removed.

Note that this bug has not been released, so no need for an update in the changelog.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
