### PR TITLE
[CDF-21088] 🐫 Warning on duplicated resources

### DIFF
--- a/cognite_toolkit/_cdf_tk/tk_warnings/__init__.py
+++ b/cognite_toolkit/_cdf_tk/tk_warnings/__init__.py
@@ -8,6 +8,7 @@ from .base import (
 from .fileread import (
     CaseTypoWarning,
     DataSetMissingWarning,
+    DuplicatedItemWarning,
     FileReadWarning,
     MissingRequiredParameterWarning,
     NamespacingConventionWarning,
@@ -42,6 +43,7 @@ __all__ = [
     "UnresolvedVariableWarning",
     "PrefixConventionWarning",
     "NamespacingConventionWarning",
+    "DuplicatedItemWarning",
     "UnusedParameterWarning",
     "MissingRequiredParameterWarning",
     "YAMLFileWarning",

--- a/cognite_toolkit/_cdf_tk/tk_warnings/fileread.py
+++ b/cognite_toolkit/_cdf_tk/tk_warnings/fileread.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Hashable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar
@@ -52,6 +53,19 @@ class YAMLFileWithElementWarning(YAMLFileWarning, ABC):
             return f"{value}"
         else:
             return f"{value} in section {self.path!r}"
+
+
+@dataclass(frozen=True)
+class DuplicatedItemWarning(YAMLFileWarning):
+    severity = SeverityLevel.MEDIUM
+    identifier: Hashable
+    first_location: Path
+
+    def get_message(self) -> str:
+        return (
+            f"{type(self).__name__}: Duplicated item with identifier "
+            f"{self.identifier!r} first seen in {self.first_location.name}."
+        )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
# Description

I chose not to skip duplicates in the build step, and instead leave that for the deploy step. The reason is that skipping becomes complicated as a single YAML file can contain multiple resources, and thus if one of them is a duplicate, what do you do with the rest? It gets complicated to just partially skip a file. 

This is simpler in the deploy step, as there you load all items from all files, and then remove the duplicates. I think just a warning is sufficient for the build step.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
