### PR TITLE
[CDF-21568, CDF-21569] 🪓Move deploy and clean

### DIFF
--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -15,8 +15,7 @@ from dotenv import load_dotenv
 from rich import print
 from rich.panel import Panel
 
-from cognite_toolkit._cdf_tk.commands import BuildCommand, CleanCommand, auth
-from cognite_toolkit._cdf_tk.commands.deploy import DeployCommand
+from cognite_toolkit._cdf_tk.commands import BuildCommand, CleanCommand, DeployCommand, auth
 from cognite_toolkit._cdf_tk.commands.describe import describe_datamodel
 from cognite_toolkit._cdf_tk.commands.dump import dump_datamodel_command
 from cognite_toolkit._cdf_tk.commands.pull import pull_command

--- a/cognite_toolkit/_cdf_tk/commands/__init__.py
+++ b/cognite_toolkit/_cdf_tk/commands/__init__.py
@@ -1,4 +1,5 @@
 from .build import BuildCommand
 from .clean import CleanCommand
+from .deploy import DeployCommand
 
-__all__ = ["BuildCommand", "CleanCommand"]
+__all__ = ["BuildCommand", "CleanCommand", "DeployCommand"]

--- a/cognite_toolkit/_cdf_tk/commands/_base.py
+++ b/cognite_toolkit/_cdf_tk/commands/_base.py
@@ -1,6 +1,15 @@
-from rich import print
+import traceback
+from pathlib import Path
 
+from cognite.client.data_classes._base import T_CogniteResourceList
+from cognite.client.utils.useful_types import SequenceNotStr
+from rich import print
+from rich.panel import Panel
+
+from cognite_toolkit._cdf_tk.load import ResourceLoader
+from cognite_toolkit._cdf_tk.load._base_loaders import T_ID
 from cognite_toolkit._cdf_tk.tk_warnings import ToolkitWarning, WarningList
+from cognite_toolkit._cdf_tk.utils import CDFToolConfig
 
 
 class ToolkitCommand:
@@ -12,3 +21,66 @@ class ToolkitCommand:
         self.warning_list.append(warning)
         if self.print_warning:
             print(warning.get_message())
+
+
+class LoaderCommand(ToolkitCommand):
+    def _load_files(
+        self,
+        loader: ResourceLoader,
+        filepaths: list[Path],
+        ToolGlobals: CDFToolConfig,
+        skip_validation: bool,
+        verbose: bool = False,
+    ) -> T_CogniteResourceList | None:
+        loaded_resources = loader.create_empty_of(loader.list_write_cls([]))
+        for filepath in filepaths:
+            try:
+                resource = loader.load_resource(filepath, ToolGlobals, skip_validation)
+            except KeyError as e:
+                # KeyError means that we are missing a required field in the yaml file.
+                print(
+                    f"[bold red]ERROR:[/] Failed to load {filepath.name} with {loader.display_name}. Missing required field: {e}."
+                    f"[bold red]ERROR:[/] Please compare with the API specification at {loader.doc_url()}."
+                )
+                return None
+            except Exception as e:
+                print(f"[bold red]ERROR:[/] Failed to load {filepath.name} with {loader.display_name}. Error: {e!r}.")
+                if verbose:
+                    print(Panel(traceback.format_exc()))
+                return None
+            if resource is None:
+                # This is intentional. It is, for example, used by the AuthLoader to skip groups with resource scopes.
+                continue
+            if isinstance(resource, loader.list_write_cls) and not resource:
+                print(f"[bold yellow]WARNING:[/] Skipping {filepath.name}. No data to load.")
+                continue
+
+            if isinstance(resource, loader.list_write_cls):
+                loaded_resources.extend(resource)
+            else:
+                loaded_resources.append(resource)
+        return loaded_resources
+
+    @staticmethod
+    def _print_ids_or_length(resource_ids: SequenceNotStr[T_ID], limit: int = 10) -> str:
+        if len(resource_ids) == 1:
+            return f"{resource_ids[0]!r}"
+        elif len(resource_ids) <= limit:
+            return f"{resource_ids}"
+        else:
+            return f"{len(resource_ids)} items"
+
+    def _remove_duplicates(
+        self, loaded_resources: T_CogniteResourceList, loader: ResourceLoader
+    ) -> tuple[T_CogniteResourceList, list[T_ID]]:
+        seen: set[T_ID] = set()
+        output = loader.create_empty_of(loaded_resources)
+        duplicates: list[T_ID] = []
+        for item in loaded_resources:
+            identifier = loader.get_id(item)
+            if identifier not in seen:
+                output.append(item)
+                seen.add(identifier)
+            else:
+                duplicates.append(identifier)
+        return output, duplicates

--- a/cognite_toolkit/_cdf_tk/commands/_base.py
+++ b/cognite_toolkit/_cdf_tk/commands/_base.py
@@ -1,15 +1,6 @@
-import traceback
-from pathlib import Path
-
-from cognite.client.data_classes._base import T_CogniteResourceList
-from cognite.client.utils.useful_types import SequenceNotStr
 from rich import print
-from rich.panel import Panel
 
-from cognite_toolkit._cdf_tk.load import ResourceLoader
-from cognite_toolkit._cdf_tk.load._base_loaders import T_ID
 from cognite_toolkit._cdf_tk.tk_warnings import ToolkitWarning, WarningList
-from cognite_toolkit._cdf_tk.utils import CDFToolConfig
 
 
 class ToolkitCommand:
@@ -21,66 +12,3 @@ class ToolkitCommand:
         self.warning_list.append(warning)
         if self.print_warning:
             print(warning.get_message())
-
-
-class LoaderCommand(ToolkitCommand):
-    def _load_files(
-        self,
-        loader: ResourceLoader,
-        filepaths: list[Path],
-        ToolGlobals: CDFToolConfig,
-        skip_validation: bool,
-        verbose: bool = False,
-    ) -> T_CogniteResourceList | None:
-        loaded_resources = loader.create_empty_of(loader.list_write_cls([]))
-        for filepath in filepaths:
-            try:
-                resource = loader.load_resource(filepath, ToolGlobals, skip_validation)
-            except KeyError as e:
-                # KeyError means that we are missing a required field in the yaml file.
-                print(
-                    f"[bold red]ERROR:[/] Failed to load {filepath.name} with {loader.display_name}. Missing required field: {e}."
-                    f"[bold red]ERROR:[/] Please compare with the API specification at {loader.doc_url()}."
-                )
-                return None
-            except Exception as e:
-                print(f"[bold red]ERROR:[/] Failed to load {filepath.name} with {loader.display_name}. Error: {e!r}.")
-                if verbose:
-                    print(Panel(traceback.format_exc()))
-                return None
-            if resource is None:
-                # This is intentional. It is, for example, used by the AuthLoader to skip groups with resource scopes.
-                continue
-            if isinstance(resource, loader.list_write_cls) and not resource:
-                print(f"[bold yellow]WARNING:[/] Skipping {filepath.name}. No data to load.")
-                continue
-
-            if isinstance(resource, loader.list_write_cls):
-                loaded_resources.extend(resource)
-            else:
-                loaded_resources.append(resource)
-        return loaded_resources
-
-    @staticmethod
-    def _print_ids_or_length(resource_ids: SequenceNotStr[T_ID], limit: int = 10) -> str:
-        if len(resource_ids) == 1:
-            return f"{resource_ids[0]!r}"
-        elif len(resource_ids) <= limit:
-            return f"{resource_ids}"
-        else:
-            return f"{len(resource_ids)} items"
-
-    def _remove_duplicates(
-        self, loaded_resources: T_CogniteResourceList, loader: ResourceLoader
-    ) -> tuple[T_CogniteResourceList, list[T_ID]]:
-        seen: set[T_ID] = set()
-        output = loader.create_empty_of(loaded_resources)
-        duplicates: list[T_ID] = []
-        for item in loaded_resources:
-            identifier = loader.get_id(item)
-            if identifier not in seen:
-                output.append(item)
-                seen.add(identifier)
-            else:
-                duplicates.append(identifier)
-        return output, duplicates

--- a/cognite_toolkit/_cdf_tk/commands/clean.py
+++ b/cognite_toolkit/_cdf_tk/commands/clean.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import traceback
 from graphlib import TopologicalSorter
 from pathlib import Path

--- a/cognite_toolkit/_cdf_tk/commands/clean.py
+++ b/cognite_toolkit/_cdf_tk/commands/clean.py
@@ -307,7 +307,8 @@ class CleanCommand(CleanBaseCommand):
             if type(loader) is DataSetsLoader:
                 self.warn(ToolkitNotSupportedWarning(feature="Dataset clean."))
                 continue
-            result = loader.clean_resources(
+            result = self.clean_resources(
+                loader,
                 build_path / loader_cls.folder_name,
                 ToolGlobals,
                 drop=True,
@@ -325,7 +326,8 @@ class CleanCommand(CleanBaseCommand):
                 raise ToolkitCleanResourceError(f"Failure to clean {loader_cls.folder_name} as expected.")
 
         if "auth" in include and (directory := (Path(build_dir) / "auth")).is_dir():
-            result = AuthLoader.create_loader(ToolGlobals, target_scopes="all").clean_resources(
+            result = self.clean_resources(
+                AuthLoader.create_loader(ToolGlobals, target_scopes="all"),
                 directory,
                 ToolGlobals,
                 drop=True,

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -1,7 +1,13 @@
+import re
+import traceback
 from graphlib import TopologicalSorter
 from pathlib import Path
+from typing import cast
 
 import typer
+from cognite.client.data_classes._base import T_CogniteResourceList
+from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError, CogniteDuplicatedError
+from cognite.client.utils.useful_types import SequenceNotStr
 from rich import print
 from rich.panel import Panel
 
@@ -16,8 +22,10 @@ from cognite_toolkit._cdf_tk.load import (
     LOADER_BY_FOLDER_NAME,
     AuthLoader,
     DeployResults,
-    ResourceLoader,
+    ResourceLoader, ResourceContainerLoader,
 )
+from cognite_toolkit._cdf_tk.load._base_loaders import T_ID
+from cognite_toolkit._cdf_tk.load.data_classes import ResourceDeployResult, ResourceContainerDeployResult
 from cognite_toolkit._cdf_tk.templates import (
     BUILD_ENVIRONMENT_FILE,
 )
@@ -166,3 +174,285 @@ class DeployCommand(ToolkitCommand):
             print(results.uploads_table())
         if ToolGlobals.failed:
             raise ToolkitDeployResourceError("Failure to deploy auth (groups) scoped to resources as expected.")
+
+    def deploy_resources(
+        self,
+        path: Path,
+        ToolGlobals: CDFToolConfig,
+        dry_run: bool = False,
+        has_done_drop: bool = False,
+        has_dropped_data: bool = False,
+        verbose: bool = False,
+    ) -> ResourceDeployResult | None:
+        self.build_path = path
+        filepaths = self.find_files(path)
+
+        def sort_key(p: Path) -> int:
+            if result := re.findall(r"^(\d+)", p.stem):
+                return int(result[0])
+            else:
+                return len(filepaths)
+
+        # In the build step, the resource files are prefixed a number that controls the order in which
+        # the resources are deployed. The custom 'sort_key' here is to get a sort on integer instead of a default string
+        # sort.
+        filepaths = sorted(filepaths, key=sort_key)
+
+        loaded_resources = self._load_files(filepaths, ToolGlobals, skip_validation=dry_run, verbose=verbose)
+        if loaded_resources is None:
+            ToolGlobals.failed = True
+            return None
+
+        # Duplicates should be handled on the build step,
+        # but in case any of them slip through, we do it here as well to
+        # avoid an error.
+        loaded_resources, duplicates = self._remove_duplicates(loaded_resources)
+
+        if not loaded_resources:
+            return ResourceDeployResult(name=self.display_name)
+
+        capabilities = self.get_required_capability(loaded_resources)
+        if capabilities:
+            ToolGlobals.verify_capabilities(capabilities)
+
+        nr_of_items = len(loaded_resources)
+        if nr_of_items == 0:
+            return ResourceDeployResult(name=self.display_name)
+
+        prefix = "Would deploy" if dry_run else "Deploying"
+        print(f"[bold]{prefix} {nr_of_items} {self.display_name} to CDF...[/]")
+        # Moved here to avoid printing before the above message.
+        for duplicate in duplicates:
+            print(f"  [bold yellow]WARNING:[/] Skipping duplicate {self.display_name} {duplicate}.")
+
+        nr_of_created = nr_of_changed = nr_of_unchanged = 0
+        to_create, to_update, unchanged = self.to_create_changed_unchanged_triple(loaded_resources)
+
+        if dry_run:
+            if (
+                self.support_drop
+                and has_done_drop
+                and (not isinstance(self, ResourceContainerLoader) or has_dropped_data)
+            ):
+                # Means the resources will be deleted and not left unchanged or changed
+                for item in unchanged:
+                    # We cannot use extents as LoadableNodes cannot be extended.
+                    to_create.append(item)
+                for item in to_update:
+                    to_create.append(item)
+                unchanged.clear()
+                to_update.clear()
+
+            nr_of_unchanged += len(unchanged)
+            nr_of_created += len(to_create)
+            nr_of_changed += len(to_update)
+        else:
+            nr_of_unchanged += len(unchanged)
+
+            if to_create:
+                created = self._create_resources(to_create, verbose)
+                if created is None:
+                    ToolGlobals.failed = True
+                    return None
+                nr_of_created += created
+
+            if to_update:
+                updated = self._update_resources(to_update, verbose)
+                if updated is None:
+                    ToolGlobals.failed = True
+                    return None
+
+                nr_of_changed += updated
+
+        if verbose:
+            self._verbose_print(to_create, to_update, unchanged, dry_run)
+
+        if isinstance(self, ResourceContainerLoader):
+            return ResourceContainerDeployResult(
+                name=self.display_name,
+                created=nr_of_created,
+                changed=nr_of_changed,
+                unchanged=nr_of_unchanged,
+                total=nr_of_items,
+                item_name=self.item_name,
+            )
+        else:
+            return ResourceDeployResult(
+                name=self.display_name,
+                created=nr_of_created,
+                changed=nr_of_changed,
+                unchanged=nr_of_unchanged,
+                total=nr_of_items,
+            )
+
+    def to_create_changed_unchanged_triple(
+        self, resources: T_CogniteResourceList
+    ) -> tuple[T_CogniteResourceList, T_CogniteResourceList, T_CogniteResourceList]:
+        """Returns a triple of lists of resources that should be created, updated, and are unchanged."""
+        resource_ids = self.get_ids(resources)
+        to_create, to_update, unchanged = (
+            self.create_empty_of(resources),
+            self.create_empty_of(resources),
+            self.create_empty_of(resources),
+        )
+        try:
+            cdf_resources = self.retrieve(resource_ids)
+        except Exception as e:
+            print(
+                f"  [bold yellow]WARNING:[/] Failed to retrieve {len(resource_ids)} of {self.display_name}. Proceeding assuming not data in CDF. Error {e}."
+            )
+            print(Panel(traceback.format_exc()))
+            cdf_resource_by_id = {}
+        else:
+            cdf_resource_by_id = {self.get_id(resource): resource for resource in cdf_resources}
+
+        for item in resources:
+            cdf_resource = cdf_resource_by_id.get(self.get_id(item))
+            # The custom compare is needed when the regular == does not work. For example, TransformationWrite
+            # have OIDC credentials that will not be returned by the retrieve method, and thus need special handling.
+            if cdf_resource and (item == cdf_resource.as_write() or self._is_equal_custom(item, cdf_resource)):
+                unchanged.append(item)
+            elif cdf_resource:
+                to_update.append(item)
+            else:
+                to_create.append(item)
+        return to_create, to_update, unchanged
+
+    def _verbose_print(
+        self,
+        to_create: T_CogniteResourceList,
+        to_update: T_CogniteResourceList,
+        unchanged: T_CogniteResourceList,
+        dry_run: bool,
+    ) -> None:
+        print_outs = []
+        prefix = "Would have " if dry_run else ""
+        if to_create:
+            print_outs.append(f"{prefix}Created {self._print_ids_or_length(self.get_ids(to_create))}")
+        if to_update:
+            print_outs.append(f"{prefix}Updated {self._print_ids_or_length(self.get_ids(to_update))}")
+        if unchanged:
+            print_outs.append(
+                f"{'Untouched' if dry_run else 'Unchanged'} {self._print_ids_or_length(self.get_ids(unchanged))}"
+            )
+        prefix_message = f" {self.display_name}: "
+        if len(print_outs) == 1:
+            print(f"{prefix_message}{print_outs[0]}")
+        elif len(print_outs) == 2:
+            print(f"{prefix_message}{print_outs[0]} and {print_outs[1]}")
+        else:
+            print(f"{prefix_message}{', '.join(print_outs[:-1])} and {print_outs[-1]}")
+
+    def _load_files(
+        self, filepaths: list[Path], ToolGlobals: CDFToolConfig, skip_validation: bool, verbose: bool = False
+    ) -> T_CogniteResourceList | None:
+        loaded_resources = self.create_empty_of(self.list_write_cls([]))
+        for filepath in filepaths:
+            try:
+                resource = self.load_resource(filepath, ToolGlobals, skip_validation)
+            except KeyError as e:
+                # KeyError means that we are missing a required field in the yaml file.
+                print(
+                    f"[bold red]ERROR:[/] Failed to load {filepath.name} with {self.display_name}. Missing required field: {e}."
+                    f"[bold red]ERROR:[/] Please compare with the API specification at {self.doc_url()}."
+                )
+                return None
+            except Exception as e:
+                print(f"[bold red]ERROR:[/] Failed to load {filepath.name} with {self.display_name}. Error: {e!r}.")
+                if verbose:
+                    print(Panel(traceback.format_exc()))
+                return None
+            if resource is None:
+                # This is intentional. It is, for example, used by the AuthLoader to skip groups with resource scopes.
+                continue
+            if isinstance(resource, self.list_write_cls) and not resource:
+                print(f"[bold yellow]WARNING:[/] Skipping {filepath.name}. No data to load.")
+                continue
+
+            if isinstance(resource, self.list_write_cls):
+                loaded_resources.extend(resource)
+            else:
+                loaded_resources.append(resource)
+        return loaded_resources
+
+    def _remove_duplicates(self, loaded_resources: T_CogniteResourceList) -> tuple[T_CogniteResourceList, list[T_ID]]:
+        seen: set[T_ID] = set()
+        output = self.create_empty_of(loaded_resources)
+        duplicates: list[T_ID] = []
+        for item in loaded_resources:
+            identifier = self.get_id(item)
+            if identifier not in seen:
+                output.append(item)
+                seen.add(identifier)
+            else:
+                duplicates.append(identifier)
+        return output, duplicates
+
+    def _delete_resources(self, loaded_resources: T_CogniteResourceList, dry_run: bool, verbose: bool) -> int:
+        nr_of_deleted = 0
+        resource_ids = self.get_ids(loaded_resources)
+        if dry_run:
+            nr_of_deleted += len(resource_ids)
+            if verbose:
+                print(f"  Would have deleted {self._print_ids_or_length(resource_ids)}.")
+            return nr_of_deleted
+
+        try:
+            nr_of_deleted += self.delete(resource_ids)
+        except CogniteAPIError as e:
+            print(f"  [bold yellow]WARNING:[/] Failed to delete {self._print_ids_or_length(resource_ids)}. Error {e}.")
+            if verbose:
+                print(Panel(traceback.format_exc()))
+        except CogniteNotFoundError:
+            if verbose:
+                print(f"  [bold]INFO:[/] {self._print_ids_or_length(resource_ids)} do(es) not exist.")
+        except Exception as e:
+            print(f"  [bold yellow]WARNING:[/] Failed to delete {self._print_ids_or_length(resource_ids)}. Error {e}.")
+            if verbose:
+                print(Panel(traceback.format_exc()))
+        else:  # Delete succeeded
+            if verbose:
+                print(f"  Deleted {self._print_ids_or_length(resource_ids)}.")
+        return nr_of_deleted
+
+    def _create_resources(self, resources: T_CogniteResourceList, verbose: bool) -> int | None:
+        try:
+            created = self.create(resources)
+        except CogniteAPIError as e:
+            if e.code == 409:
+                print("  [bold yellow]WARNING:[/] Resource(s) already exist(s), skipping creation.")
+            else:
+                print(f"[bold red]ERROR:[/] Failed to create resource(s).\n{e}")
+                return None
+        except CogniteDuplicatedError as e:
+            print(
+                f"  [bold yellow]WARNING:[/] {len(e.duplicated)} out of {len(resources)} resource(s) already exist(s). {len(e.successful or [])} resource(s) created."
+            )
+        except Exception as e:
+            print(f"[bold red]ERROR:[/] Failed to create resource(s).\n{e}")
+            if verbose:
+                print(Panel(traceback.format_exc()))
+            return None
+        else:
+            return len(created) if created is not None else 0
+        return 0
+
+    def _update_resources(self, resources: T_CogniteResourceList, verbose: bool) -> int | None:
+        try:
+            updated = self.update(resources)
+        except Exception as e:
+            print(f"  [bold yellow]Error:[/] Failed to update {self.display_name}. Error {e}.")
+            if verbose:
+                print(Panel(traceback.format_exc()))
+            return None
+        else:
+            return len(updated)
+
+    @staticmethod
+    def _print_ids_or_length(resource_ids: SequenceNotStr[T_ID], limit: int = 10) -> str:
+        if len(resource_ids) == 1:
+            return f"{resource_ids[0]!r}"
+        elif len(resource_ids) <= limit:
+            return f"{resource_ids}"
+        else:
+            return f"{len(resource_ids)} items"

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -6,11 +6,10 @@ from pathlib import Path
 import typer
 from cognite.client.data_classes._base import T_CogniteResourceList
 from cognite.client.exceptions import CogniteAPIError, CogniteDuplicatedError
-from cognite.client.utils.useful_types import SequenceNotStr
 from rich import print
 from rich.panel import Panel
 
-from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
+from cognite_toolkit._cdf_tk.commands._base import LoaderCommand
 from cognite_toolkit._cdf_tk.constants import _RUNNING_IN_BROWSER
 from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitCleanResourceError,
@@ -26,7 +25,6 @@ from cognite_toolkit._cdf_tk.load import (
     ResourceContainerLoader,
     ResourceLoader,
 )
-from cognite_toolkit._cdf_tk.load._base_loaders import T_ID
 from cognite_toolkit._cdf_tk.load.data_classes import (
     DatapointDeployResult,
     DeployResult,
@@ -47,7 +45,7 @@ from cognite_toolkit._cdf_tk.utils import (
 )
 
 
-class DeployCommand(ToolkitCommand):
+class DeployCommand(LoaderCommand):
     def execute(
         self,
         ctx: typer.Context,
@@ -372,58 +370,6 @@ class DeployCommand(ToolkitCommand):
         else:
             print(f"{prefix_message}{', '.join(print_outs[:-1])} and {print_outs[-1]}")
 
-    def _load_files(
-        self,
-        loader: ResourceLoader,
-        filepaths: list[Path],
-        ToolGlobals: CDFToolConfig,
-        skip_validation: bool,
-        verbose: bool = False,
-    ) -> T_CogniteResourceList | None:
-        loaded_resources = loader.create_empty_of(loader.list_write_cls([]))
-        for filepath in filepaths:
-            try:
-                resource = loader.load_resource(filepath, ToolGlobals, skip_validation)
-            except KeyError as e:
-                # KeyError means that we are missing a required field in the yaml file.
-                print(
-                    f"[bold red]ERROR:[/] Failed to load {filepath.name} with {loader.display_name}. Missing required field: {e}."
-                    f"[bold red]ERROR:[/] Please compare with the API specification at {loader.doc_url()}."
-                )
-                return None
-            except Exception as e:
-                print(f"[bold red]ERROR:[/] Failed to load {filepath.name} with {loader.display_name}. Error: {e!r}.")
-                if verbose:
-                    print(Panel(traceback.format_exc()))
-                return None
-            if resource is None:
-                # This is intentional. It is, for example, used by the AuthLoader to skip groups with resource scopes.
-                continue
-            if isinstance(resource, loader.list_write_cls) and not resource:
-                print(f"[bold yellow]WARNING:[/] Skipping {filepath.name}. No data to load.")
-                continue
-
-            if isinstance(resource, loader.list_write_cls):
-                loaded_resources.extend(resource)
-            else:
-                loaded_resources.append(resource)
-        return loaded_resources
-
-    def _remove_duplicates(
-        self, loaded_resources: T_CogniteResourceList, loader: ResourceLoader
-    ) -> tuple[T_CogniteResourceList, list[T_ID]]:
-        seen: set[T_ID] = set()
-        output = loader.create_empty_of(loaded_resources)
-        duplicates: list[T_ID] = []
-        for item in loaded_resources:
-            identifier = loader.get_id(item)
-            if identifier not in seen:
-                output.append(item)
-                seen.add(identifier)
-            else:
-                duplicates.append(identifier)
-        return output, duplicates
-
     def _create_resources(self, resources: T_CogniteResourceList, loader: ResourceLoader, verbose: bool) -> int | None:
         try:
             created = loader.create(resources)
@@ -456,15 +402,6 @@ class DeployCommand(ToolkitCommand):
             return None
         else:
             return len(updated)
-
-    @staticmethod
-    def _print_ids_or_length(resource_ids: SequenceNotStr[T_ID], limit: int = 10) -> str:
-        if len(resource_ids) == 1:
-            return f"{resource_ids[0]!r}"
-        elif len(resource_ids) <= limit:
-            return f"{resource_ids}"
-        else:
-            return f"{len(resource_ids)} items"
 
     def _deploy_data(
         self,

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -9,7 +9,7 @@ from cognite.client.exceptions import CogniteAPIError, CogniteDuplicatedError
 from rich import print
 from rich.panel import Panel
 
-from cognite_toolkit._cdf_tk.commands._base import LoaderCommand
+from cognite_toolkit._cdf_tk.commands.clean import CleanBaseCommand
 from cognite_toolkit._cdf_tk.constants import _RUNNING_IN_BROWSER
 from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitCleanResourceError,
@@ -45,7 +45,7 @@ from cognite_toolkit._cdf_tk.utils import (
 )
 
 
-class DeployCommand(LoaderCommand):
+class DeployCommand(CleanBaseCommand):
     def execute(
         self,
         ctx: typer.Context,

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import traceback
 from graphlib import TopologicalSorter

--- a/cognite_toolkit/_cdf_tk/load/_base_loaders.py
+++ b/cognite_toolkit/_cdf_tk/load/_base_loaders.py
@@ -30,7 +30,6 @@ from cognite_toolkit._cdf_tk.utils import CDFToolConfig, load_yaml_inject_variab
 
 from .data_classes import (
     DatapointDeployResult,
-    DeployResult,
     RawDatabaseTable,
     ResourceContainerDeployResult,
     ResourceDeployResult,
@@ -117,18 +116,6 @@ class Loader(ABC):
                 _COMPILED_PATTERN[cls.filename_pattern] = re.compile(cls.filename_pattern)
             return _COMPILED_PATTERN[cls.filename_pattern].match(file.stem) is not None
         return True
-
-    @abstractmethod
-    def deploy_resources(
-        self,
-        path: Path,
-        ToolGlobals: CDFToolConfig,
-        dry_run: bool = False,
-        has_done_drop: bool = False,
-        has_dropped_data: bool = False,
-        verbose: bool = False,
-    ) -> DeployResult | None:
-        raise NotImplementedError
 
 
 T_Loader = TypeVar("T_Loader", bound=Loader)

--- a/cognite_toolkit/_cdf_tk/load/_base_loaders.py
+++ b/cognite_toolkit/_cdf_tk/load/_base_loaders.py
@@ -503,7 +503,7 @@ class ResourceLoader(
     def _is_equal_custom(self, local: T_WriteClass, cdf_resource: T_WritableCogniteResource) -> bool:
         """This method is used to compare the local and cdf resource when the default comparison fails.
 
-        This is needed for resources that have fields that are not returned by the retrieve method, like
+        This is needed for resources that have fields that are not returned by the retrieve method, like,
         for example, the OIDC credentials in Transformations.
         """
         return False

--- a/tests/tests_integration/test_loaders/test_resource_loaders.py
+++ b/tests/tests_integration/test_loaders/test_resource_loaders.py
@@ -4,6 +4,7 @@ import pytest
 from cognite.client import CogniteClient
 from cognite.client.data_classes import Function, FunctionSchedule, FunctionScheduleWriteList
 
+from cognite_toolkit._cdf_tk.commands import DeployCommand
 from cognite_toolkit._cdf_tk.load import DataSetsLoader, FunctionScheduleLoader
 
 
@@ -12,7 +13,8 @@ class TestDataSetsLoader:
         data_sets = cognite_client.data_sets.list(limit=1, external_id_prefix="")
         loader = DataSetsLoader(client=cognite_client)
 
-        created, changed, unchanged = loader.to_create_changed_unchanged_triple(data_sets.as_write())
+        cmd = DeployCommand(print_warning=False)
+        created, changed, unchanged = cmd.to_create_changed_unchanged_triple(data_sets.as_write(), loader)
 
         assert len(unchanged) == len(data_sets)
         assert len(created) == 0

--- a/tests/tests_unit/test_cdf_tk/test_load.py
+++ b/tests/tests_unit/test_cdf_tk/test_load.py
@@ -23,7 +23,7 @@ from cognite.client.data_classes.data_modeling import Edge, Node
 from pytest import MonkeyPatch
 
 from cognite_toolkit._cdf_tk._parameters import ParameterSet, ParameterValue, read_parameters_from_dict
-from cognite_toolkit._cdf_tk.commands.build import BuildCommand
+from cognite_toolkit._cdf_tk.commands import BuildCommand, DeployCommand
 from cognite_toolkit._cdf_tk.exceptions import ToolkitYAMLFormatError
 from cognite_toolkit._cdf_tk.load import (
     LOADER_BY_FOLDER_NAME,
@@ -79,7 +79,9 @@ def test_loader_class(
     cdf_tool.client = cognite_client_approval.mock_client
     cdf_tool.data_set_id = 999
 
-    loader_cls.create_loader(cdf_tool).deploy_resources(directory, cdf_tool, dry_run=False)
+    cmd = DeployCommand(print_warning=False)
+    loader = loader_cls.create_loader(cdf_tool)
+    cmd.deploy_resources(loader, directory, cdf_tool, dry_run=False)
 
     dump = cognite_client_approval.dump()
     data_regression.check(dump, fullpath=SNAPSHOTS_DIR / f"{directory.name}.yaml")
@@ -567,7 +569,8 @@ class TestDeployResources:
         cdf_tool.verify_capabilities.return_value = cognite_client_approval.mock_client
         cdf_tool.client = cognite_client_approval.mock_client
 
-        ViewLoader.create_loader(cdf_tool).deploy_resources(BUILD_DIR, cdf_tool, dry_run=False)
+        cmd = DeployCommand(print_warning=False)
+        cmd.deploy_resources(ViewLoader.create_loader(cdf_tool), BUILD_DIR, cdf_tool, dry_run=False)
 
         views = cognite_client_approval.dump(sort=False)["View"]
 


### PR DESCRIPTION
# Description

This PR is an almost pure moving code

* Moved the `deploy_resources` and `clean_resources` from the Loader classes to their respective commands. This makes the loader classes closer to pure interfaces, and keep the responsibility of the deploy and clean operations in the command classes. 
* In addition, found a few custom warning prints, `print("    [yellow]Warning[/yellow] ...")`, which I replaced with a `self.warn` call to standardize them.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
