### PR TITLE
Feature flag to replace normal init

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -104,6 +104,20 @@
             "program": "./cognite_toolkit/cognite_modules/examples/cdf_data_pipeline_files_valhall/functions/fn_workflow_files_oid_fileshare_annotation/handler.py",
             "console": "integratedTerminal",
             "justMyCode": false
-        }
+        },
+        {
+            "name": "Python: init",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "./cdf-tk-dev.py",
+            "args": [
+                "init",
+                //"--dry-run",
+                //"--env=local",
+                //"--include=transformations"
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": false
+        },
     ]
 }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ It supports three different modes of operation:
    bundled with templates useful for getting started with Cognite Data Fusion, as well as for specific use cases
    delivered by Cognite or its partners. You can also create your own templates and share them.
 
+## Usage
+
+Install the Toolkit by running:
+
+```bash
+pip install cognite-toolkit
+```
+
+Then run `cdf-tk --help` to get started with the interactive command-line tool.
+
 ## For more information
 
 More details about the tool can be found at

--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -31,6 +31,7 @@ from cognite_toolkit._cdf_tk.load import (
     NodeLoader,
     TransformationLoader,
 )
+from cognite_toolkit._cdf_tk.prototypes import featureflag
 from cognite_toolkit._cdf_tk.templates import (
     COGNITE_MODULES,
 )
@@ -89,6 +90,10 @@ def app() -> NoReturn:
     # --- Main entry point ---
     # Users run 'app()' directly, but that doesn't allow us to control excepton handling:
     try:
+        if featureflag.enabled("FF_INTERACTIVE_INIT"):
+            from cognite_toolkit._cdf_tk.prototypes import interactive_init
+
+            _app.add_typer(interactive_init.interactive_app, name="init")
         _app()
     except ToolkitError as err:
         print(f"  [bold red]ERROR ([/][red]{type(err).__name__}[/][bold red]):[/] {err}")
@@ -453,7 +458,7 @@ def auth_verify(
         raise ToolkitValidationError("Failure to verify access rights.")
 
 
-@_app.command("init")
+@_app.command("init" if not featureflag.enabled("FF_INTERACTIVE_INIT") else "_init")
 def main_init(
     ctx: typer.Context,
     dry_run: Annotated[

--- a/cognite_toolkit/_cdf_tk/prototypes/featureflag.py
+++ b/cognite_toolkit/_cdf_tk/prototypes/featureflag.py
@@ -1,0 +1,22 @@
+import os
+from functools import lru_cache
+
+import dotenv
+
+
+@lru_cache(maxsize=128)
+def enabled(flag: str) -> bool:
+    """
+    Check if a feature flag is enabled.
+
+    Args:
+        flag (str): The feature flag to check.
+
+    Returns:
+        bool: True if the feature flag is enabled, False otherwise.
+    """
+    dotenv.load_dotenv()
+    if os.environ.get(flag, "false").lower() == "true":
+        print(f"Feature flag {flag} is enabled.")
+        return True
+    return False

--- a/cognite_toolkit/_cdf_tk/prototypes/interactive_init.py
+++ b/cognite_toolkit/_cdf_tk/prototypes/interactive_init.py
@@ -1,0 +1,59 @@
+from typing import Annotated, Optional
+
+import typer
+
+interactive_app = typer.Typer()
+
+
+@interactive_app.command("init")
+def main_init(
+    ctx: typer.Context,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            "-r",
+            help="Whether to do a dry-run, do dry-run if present.",
+        ),
+    ] = False,
+    upgrade: Annotated[
+        bool,
+        typer.Option(
+            "--upgrade",
+            "-u",
+            help="Will upgrade templates in place without overwriting existing config.yaml and other files.",
+        ),
+    ] = False,
+    git_branch: Annotated[
+        Optional[str],
+        typer.Option(
+            "--git",
+            "-g",
+            help="Will download the latest templates from the git repository branch specified. Use `main` to get the very latest templates.",
+        ),
+    ] = None,
+    no_backup: Annotated[
+        bool,
+        typer.Option(
+            "--no-backup",
+            help="Will skip making a backup before upgrading.",
+        ),
+    ] = False,
+    clean: Annotated[
+        bool,
+        typer.Option(
+            "--clean",
+            help="Will delete the new_project directory before starting.",
+        ),
+    ] = False,
+    init_dir: Annotated[
+        str,
+        typer.Argument(
+            help="Directory path to project to initialize or upgrade with templates.",
+        ),
+    ] = "new_project",
+) -> None:
+    """Initialize or upgrade a new CDF project with templates interactively."""
+
+    print("Initializing or upgrading a new CDF project with templates interactively.")
+    typer.Exit()


### PR DESCRIPTION
# Description

Taking a shot at a simple feature flag that enables an alternate init command

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
