### PR TITLE
[CDF-21507] 🗨 Support node types

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,12 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+### Added
+
+- Support
+
 ## [0.2.0a5] - 2024-05-28
 
 ### Added

--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -19,7 +19,8 @@ Changes are grouped as follows:
 
 ### Added
 
-- Support
+- Support for loading `nodes` with `APICall` arguments. The typical use case is when `node types` are part of a
+  data model, and the default `APICall` arguments are sufficient for all nodes
 
 ## [0.2.0a5] - 2024-05-28
 

--- a/cognite_toolkit/_cdf_tk/_parameters/data_classes.py
+++ b/cognite_toolkit/_cdf_tk/_parameters/data_classes.py
@@ -173,9 +173,10 @@ class ParameterSet(Hashable, MutableSet, Generic[T_Parameter]):
 
 
 class ParameterSpecSet(ParameterSet[ParameterSpec]):
-    def __init__(self, iterable: Iterable[ParameterSpec] = ()) -> None:
+    def __init__(self, iterable: Iterable[ParameterSpec] = (), spec_name: str | None = None) -> None:
         super().__init__(iterable)
         self.is_complete = True
+        self.spec_name = spec_name
 
     def required(self, level: int | None = None) -> ParameterSet[ParameterSpec]:
         if level is None:

--- a/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
@@ -2704,6 +2704,10 @@ class NodeLoader(ResourceContainerLoader[NodeId, NodeApply, Node, NodeApplyListW
                 elif identifier.get("type") == "container" and _in_dict(("space", "externalId"), identifier):
                     yield ContainerLoader, ContainerId(identifier["space"], identifier["externalId"])
 
+    @classmethod
+    def create_empty_of(cls, items: NodeApplyListWithCall) -> NodeApplyListWithCall:
+        return NodeApplyListWithCall([], items.api_call)
+
     def are_equal(self, local: NodeApply, cdf_resource: Node) -> bool:
         """Comparison for nodes to include properties in the comparison
 

--- a/cognite_toolkit/_cdf_tk/load/data_classes.py
+++ b/cognite_toolkit/_cdf_tk/load/data_classes.py
@@ -24,12 +24,11 @@ from typing import Any, Literal
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes._base import (
-    CogniteResource,
     CogniteResourceList,
     WriteableCogniteResource,
     WriteableCogniteResourceList,
 )
-from cognite.client.data_classes.data_modeling import NodeApply, NodeApplyList, NodeId
+from cognite.client.data_classes.data_modeling import NodeApply, NodeApplyList
 from rich.table import Table
 
 
@@ -119,15 +118,6 @@ class NodeAPICall:
         if self.replace is not None:
             output["replace"] = self.replace
         return output
-
-
-@dataclass
-class LoadedNode(CogniteResource):
-    api_call: NodeAPICall | None
-    node: NodeApply
-
-    def as_id(self) -> NodeId:
-        return self.node.as_id()
 
 
 class NodeApplyListWithCall(CogniteResourceList[NodeApply]):

--- a/cognite_toolkit/_cdf_tk/load/data_classes.py
+++ b/cognite_toolkit/_cdf_tk/load/data_classes.py
@@ -94,9 +94,9 @@ class RawTableList(WriteableCogniteResourceList[RawDatabaseTable, RawDatabaseTab
 
 @dataclass(frozen=True, order=True)
 class NodeAPICall:
-    auto_create_direct_relations: bool
-    skip_on_version_conflict: bool
-    replace: bool
+    auto_create_direct_relations: bool | None
+    skip_on_version_conflict: bool | None
+    replace: bool | None
 
     @classmethod
     def load(cls, resource: dict[str, Any]) -> NodeAPICall:
@@ -118,7 +118,7 @@ class NodeAPICall:
 
 @dataclass
 class LoadedNode(CogniteResource):
-    api_call: NodeAPICall
+    api_call: NodeAPICall | None
     node: NodeApply
 
     def as_id(self) -> NodeId:

--- a/cognite_toolkit/_cdf_tk/load/data_classes.py
+++ b/cognite_toolkit/_cdf_tk/load/data_classes.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from abc import ABC
 from collections import UserDict
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable
 from dataclasses import dataclass
 from functools import total_ordering
 from typing import Any, Literal
@@ -101,19 +101,24 @@ class NodeAPICall:
     @classmethod
     def load(cls, resource: dict[str, Any]) -> NodeAPICall:
         return cls(
-            auto_create_direct_relations=resource["autoCreateDirectRelations"],
-            skip_on_version_conflict=resource["skipOnVersionConflict"],
-            replace=resource["replace"],
+            auto_create_direct_relations=resource.get("autoCreateDirectRelations"),
+            skip_on_version_conflict=resource.get("skipOnVersionConflict"),
+            replace=resource.get("replace"),
         )
 
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
-        return {
-            (
-                "autoCreateDirectRelations" if camel_case else "auto_create_direct_relations"
-            ): self.auto_create_direct_relations,
-            "skipOnVersionConflict" if camel_case else "skip_on_version_conflict": self.skip_on_version_conflict,
-            "replace": self.replace,
-        }
+        output: dict[str, Any] = {}
+        if self.auto_create_direct_relations is not None:
+            output["autoCreateDirectRelations" if camel_case else "auto_create_direct_relations"] = (
+                self.auto_create_direct_relations
+            )
+        if self.skip_on_version_conflict is not None:
+            output["skipOnVersionConflict" if camel_case else "skip_on_version_conflict"] = (
+                self.skip_on_version_conflict
+            )
+        if self.replace is not None:
+            output["replace"] = self.replace
+        return output
 
 
 @dataclass
@@ -125,16 +130,42 @@ class LoadedNode(CogniteResource):
         return self.node.as_id()
 
 
-class LoadedNodeList(CogniteResourceList[LoadedNode]):
-    _RESOURCE = LoadedNode
+class NodeApplyListWithCall(CogniteResourceList[NodeApply]):
+    _RESOURCE = NodeApply
+
+    def __init__(self, resources: Collection[Any], api_call: NodeAPICall | None = None) -> None:
+        super().__init__(resources, cognite_client=None)
+        self.api_call = api_call
 
     @classmethod
     def _load(  # type: ignore[override]
-        cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None
-    ) -> LoadedNodeList:
-        api_call = NodeAPICall.load(resource)
-        nodes = NodeApplyList.load(resource["nodes"])
-        return cls([LoadedNode(api_call, node) for node in nodes])
+        cls, resource: dict[str, Any] | list[dict[str, Any]], cognite_client: CogniteClient | None = None
+    ) -> NodeApplyListWithCall:
+        api_call: NodeAPICall | None = None
+        if isinstance(resource, dict) and ("nodes" in resource or "node" in resource):
+            api_call = NodeAPICall.load(resource)
+
+        if api_call and isinstance(resource, dict) and "nodes" in resource:
+            nodes = NodeApplyList.load(resource["nodes"])
+        elif api_call and isinstance(resource, dict) and "node" in resource:
+            nodes = NodeApplyList([NodeApply.load(resource["node"])])
+        elif isinstance(resource, list):
+            nodes = NodeApplyList.load(resource)
+        elif isinstance(resource, dict):
+            nodes = NodeApplyList([NodeApply.load(resource)])
+        else:
+            raise ValueError("Invalid input for NodeApplyListWithCall")
+        return cls(nodes, api_call)
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any] | list[dict[str, Any]]:  # type: ignore[override]
+        nodes = [resource.dump(camel_case) for resource in self.data]
+        if self.api_call is not None:
+            if len(nodes) == 1:
+                return {**self.api_call.dump(camel_case), "node": nodes[0]}
+            else:
+                return {**self.api_call.dump(camel_case), "nodes": nodes}
+        else:
+            return nodes
 
 
 @total_ordering

--- a/cognite_toolkit/_cdf_tk/validation.py
+++ b/cognite_toolkit/_cdf_tk/validation.py
@@ -9,6 +9,7 @@ from cognite.client.data_classes._base import CogniteObject
 from cognite.client.utils._text import to_camel_case, to_snake_case
 
 from cognite_toolkit._cdf_tk._parameters import ParameterSpecSet, read_parameters_from_dict
+from cognite_toolkit._cdf_tk.load import NodeLoader
 from cognite_toolkit._cdf_tk.tk_warnings import (
     CaseTypoWarning,
     DataSetMissingWarning,
@@ -71,10 +72,27 @@ def validate_data_set_is_set(
 def validate_resource_yaml(
     data: dict | list, spec: ParameterSpecSet, source_file: Path, element: int | None = None
 ) -> WarningList:
+    if spec.spec_name == NodeLoader.__name__:
+        # Special case for NodeLoader as it has options for API call parameters
+        if isinstance(data, list):
+            return _validate_resource_yaml(data, spec, source_file)
+        elif isinstance(data, dict) and "node" in data:
+            return _validate_resource_yaml(data["node"], spec, source_file)
+        elif isinstance(data, dict) and "nodes" in data:
+            return _validate_resource_yaml(data["nodes"], spec, source_file)
+        else:
+            return _validate_resource_yaml(data, spec, source_file)
+    else:
+        return _validate_resource_yaml(data, spec, source_file, element)
+
+
+def _validate_resource_yaml(
+    data: dict | list, spec: ParameterSpecSet, source_file: Path, element: int | None = None
+) -> WarningList:
     warnings: WarningList = WarningList()
     if isinstance(data, list):
         for no, item in enumerate(data, 1):
-            warnings.extend(validate_resource_yaml(item, spec, source_file, no))
+            warnings.extend(_validate_resource_yaml(item, spec, source_file, no))
         return warnings
     elif not isinstance(data, dict):
         raise NotImplementedError("Note: This function only supports top-level and lists dictionaries.")

--- a/tests/tests_unit/test_cdf_tk/test_load.py
+++ b/tests/tests_unit/test_cdf_tk/test_load.py
@@ -596,12 +596,12 @@ nodes:
         self,
         yamL_raw: str,
         expected: NodeApplyListWithCall,
-        cdf_tool_config_real: CDFToolConfig,
+        cdf_tool_config: CDFToolConfig,
         monkeypatch: MonkeyPatch,
     ) -> None:
-        loader = NodeLoader.create_loader(cdf_tool_config_real, None)
+        loader = NodeLoader.create_loader(cdf_tool_config, None)
         mock_read_yaml_file({"my_node.yaml": yaml.safe_load(yamL_raw)}, monkeypatch)
-        loaded = loader.load_resource(Path("my_node.yaml"), cdf_tool_config_real, skip_validation=True)
+        loaded = loader.load_resource(Path("my_node.yaml"), cdf_tool_config, skip_validation=True)
 
         assert loaded.dump() == expected.dump()
 


### PR DESCRIPTION
# Description

Added support for giving nodes as a single dict or list with and without API call parameters
```yaml
space: my_space
externalId: my_node_id
```

```yaml
- space: my_space
  externalId: reservoir_type
``` 

Refactoring:
* Did a simplification were I store the APICall parameter on the list instead of the individual nodes, removing the need for the  
   `LoadedNode` class, in favor of the more explicitly named `NodeApplyListWithCall`.


## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
