### PR TITLE
[CDF-21621] 😕 Fixes in printout and demo deployment

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -29,6 +29,8 @@ Changes are grouped as follows:
   if `datapoints subscription` was failing the error message would be `Failure to load/deploy timeseries as expected`,
   now it is `Failure to load/deploy timeseries.subscription as expected`.
 - Unique display names for all resource types.
+- Fixed bug when deploying extraction pipeline config, when none existed from before:
+  `There is no config stored for the extraction pipeline`.
 
 ## [0.2.0a5] - 2024-05-28
 

--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -20,7 +20,14 @@ Changes are grouped as follows:
 ### Added
 
 - Support for loading `nodes` with `APICall` arguments. The typical use case is when `node types` are part of a
-  data model, and the default `APICall` arguments are sufficient for all nodes
+  data model, and the default `APICall` arguments works well.
+
+### Fixed
+
+- Error message displayed to console on failed `cdf-tk deploy` command could be modified. This is now fixed.
+- Using display name instead of folder name on a failed `cdf-tk deploy` or `cdf-tk clean` command. For example,
+  if `datapoints subscription` was failing the error message would be `Failure to load/deploy timeseries as expected`,
+  now it is `Failure to load/deploy timeseries.subscription as expected`.
 
 ## [0.2.0a5] - 2024-05-28
 

--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -28,6 +28,7 @@ Changes are grouped as follows:
 - Using display name instead of folder name on a failed `cdf-tk deploy` or `cdf-tk clean` command. For example,
   if `datapoints subscription` was failing the error message would be `Failure to load/deploy timeseries as expected`,
   now it is `Failure to load/deploy timeseries.subscription as expected`.
+- Unique display names for all resource types.
 
 ## [0.2.0a5] - 2024-05-28
 

--- a/CHANGELOG.templates.md
+++ b/CHANGELOG.templates.md
@@ -15,6 +15,13 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+### Fixed
+
+- Removed illegal characters from `DatapointSubscriptoin` description in
+  `cognite_modules/examples/my_example_module`.
+
 ## [0.2.0a5] - 2024-05-28
 
 ### Added

--- a/cognite_toolkit/_cdf_tk/commands/clean.py
+++ b/cognite_toolkit/_cdf_tk/commands/clean.py
@@ -282,7 +282,7 @@ class CleanCommand(ToolkitCommand):
                     print(results.counts_table())
                 if results and results.has_uploads:
                     print(results.uploads_table())
-                raise ToolkitCleanResourceError(f"Failure to clean {loader_cls.folder_name} as expected.")
+                raise ToolkitCleanResourceError(f"Failure to clean {loader.display_name} as expected.")
         if results.has_counts:
             print(results.counts_table())
         if results.has_uploads:

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -366,7 +366,8 @@ class DeployCommand(ToolkitCommand):
             if e.code == 409:
                 self.warn(LowSeverityWarning("Resource(s) already exist(s), skipping creation."))
             else:
-                print(f"[bold red]ERROR:[/] Failed to create resource(s).\n{e}")
+                print("[bold red]ERROR:[/] Failed to create resource(s).\n")
+                print(e)
                 return None
         except CogniteDuplicatedError as e:
             self.warn(

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -149,8 +149,9 @@ class DeployCommand(ToolkitCommand):
         if drop or drop_data:
             print(Panel("[bold]DEPLOYING resources...[/]"))
         for loader_cls in ordered_loaders:
+            loader_instance = loader_cls.create_loader(ToolGlobals, build_dir)
             result = self.deploy_resources(
-                loader_cls.create_loader(ToolGlobals, build_dir),
+                loader_instance,
                 ToolGlobals=ToolGlobals,
                 dry_run=dry_run,
                 has_done_drop=drop,
@@ -162,7 +163,7 @@ class DeployCommand(ToolkitCommand):
                     print(results.counts_table())
                 if results and results.has_uploads:
                     print(results.uploads_table())
-                raise ToolkitDeployResourceError(f"Failure to load/deploy {loader_cls.folder_name} as expected.")
+                raise ToolkitDeployResourceError(f"Failure to load/deploy {loader_instance.display_name} as expected.")
             if result:
                 results[result.name] = result
             if ctx.obj.verbose:

--- a/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
@@ -2427,8 +2427,6 @@ class ViewLoader(ResourceLoader[ViewId, ViewApply, View, ViewApplyList, ViewList
     list_cls = ViewList
     list_write_cls = ViewApplyList
     dependencies = frozenset({SpaceLoader, ContainerLoader})
-
-    _display_name = "views"
     _doc_url = "Views/operation/ApplyViews"
 
     def __init__(self, client: CogniteClient, build_dir: Path) -> None:

--- a/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
@@ -1913,7 +1913,10 @@ class ExtractionPipelineConfigLoader(
         for item in items:
             if not item.external_id:
                 raise ToolkitRequiredValueError("ExtractionPipelineConfig must have external_id set.")
-            latest = self.client.extraction_pipelines.config.retrieve(item.external_id)
+            try:
+                latest = self.client.extraction_pipelines.config.retrieve(item.external_id)
+            except CogniteAPIError:
+                latest = None
             if latest and self.are_equal(item, latest):
                 updated.append(latest)
                 continue

--- a/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
@@ -2251,9 +2251,11 @@ class ContainerLoader(
     list_cls = ContainerList
     list_write_cls = ContainerApplyList
     dependencies = frozenset({SpaceLoader})
-
-    _display_name = "containers"
     _doc_url = "Containers/operation/ApplyContainers"
+
+    @property
+    def display_name(self) -> str:
+        return "containers"
 
     @classmethod
     def get_required_capability(cls, items: ContainerApplyList) -> Capability:
@@ -2433,6 +2435,10 @@ class ViewLoader(ResourceLoader[ViewId, ViewApply, View, ViewApplyList, ViewList
         super().__init__(client, build_dir)
         # Caching to avoid multiple lookups on the same interfaces.
         self._interfaces_by_id: dict[ViewId, View] = {}
+
+    @property
+    def display_name(self) -> str:
+        return "views"
 
     @classmethod
     def get_required_capability(cls, items: ViewApplyList) -> Capability:

--- a/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
@@ -1865,7 +1865,7 @@ class ExtractionPipelineConfigLoader(
 
     @property
     def display_name(self) -> str:
-        return "extraction_pipeline_config"
+        return "extraction_pipeline.config"
 
     @classmethod
     def get_required_capability(cls, items: ExtractionPipelineConfigWriteList) -> list[Capability]:

--- a/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
@@ -824,6 +824,10 @@ class FunctionScheduleLoader(
     dependencies = frozenset({FunctionLoader})
     _doc_url = "Function-schedules/operation/postFunctionSchedules"
 
+    @property
+    def display_name(self) -> str:
+        return "function.schedules"
+
     @classmethod
     def get_required_capability(cls, items: FunctionScheduleWriteList) -> list[Capability]:
         return [
@@ -956,6 +960,10 @@ class RawDatabaseLoader(
         super().__init__(client, build_dir)
         self._loaded_db_names: set[str] = set()
 
+    @property
+    def display_name(self) -> str:
+        return "raw.databases"
+
     @classmethod
     def get_required_capability(cls, items: RawTableList) -> Capability:
         tables_by_database = defaultdict(list)
@@ -1057,6 +1065,10 @@ class RawTableLoader(
     def __init__(self, client: CogniteClient, build_dir: Path):
         super().__init__(client, build_dir)
         self._printed_warning = False
+
+    @property
+    def display_name(self) -> str:
+        return "raw.tables"
 
     @classmethod
     def get_required_capability(cls, items: RawTableList) -> Capability:
@@ -1633,6 +1645,10 @@ class TransformationScheduleLoader(
     dependencies = frozenset({TransformationLoader})
     _doc_url = "Transformation-Schedules/operation/createTransformationSchedules"
 
+    @property
+    def display_name(self) -> str:
+        return "transformation.schedules"
+
     @classmethod
     def get_required_capability(cls, items: TransformationScheduleWriteList) -> list[Capability]:
         # Access for transformations schedules is checked by the transformation that is deployed
@@ -1846,6 +1862,10 @@ class ExtractionPipelineConfigLoader(
     list_write_cls = ExtractionPipelineConfigWriteList
     dependencies = frozenset({ExtractionPipelineLoader})
     _doc_url = "Extraction-Pipelines-Config/operation/createExtPipeConfig"
+
+    @property
+    def display_name(self) -> str:
+        return "extraction_pipeline_config"
 
     @classmethod
     def get_required_capability(cls, items: ExtractionPipelineConfigWriteList) -> list[Capability]:
@@ -2897,6 +2917,10 @@ class WorkflowVersionLoader(
 
     _doc_base_url = "https://api-docs.cognite.com/20230101-beta/tag/"
     _doc_url = "Workflow-versions/operation/CreateOrUpdateWorkflowVersion"
+
+    @property
+    def display_name(self) -> str:
+        return "workflow.versions"
 
     @classmethod
     def get_required_capability(cls, items: WorkflowVersionUpsertList) -> Capability:

--- a/cognite_toolkit/cognite_modules/examples/my_example_module/timeseries/my_subscription.DatapointSubscription.yaml
+++ b/cognite_toolkit/cognite_modules/examples/my_example_module/timeseries/my_subscription.DatapointSubscription.yaml
@@ -1,6 +1,6 @@
 externalId: my_subscription
 name: My Subscription
-description: All timeseries with externalId starting with 'ts_value'
+description: All timeseries with externalId starting with ts_value
 partitionCount: 1
 filter:
   prefix:

--- a/tests/tests_unit/test_cdf_tk/test_load.py
+++ b/tests/tests_unit/test_cdf_tk/test_load.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+from collections import Counter
 from collections.abc import Iterable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -884,3 +885,14 @@ class TestResourceLoaders:
         warnings = validate_resource_yaml(content, spec, Path("test.yaml"))
 
         assert sorted(warnings) == []
+
+
+class TestLoaders:
+    def test_unique_display_names(self, cdf_tool_config: CDFToolConfig):
+        name_by_count = Counter(
+            [loader_cls.create_loader(cdf_tool_config, None).display_name for loader_cls in LOADER_LIST]
+        )
+
+        duplicates = {name: count for name, count in name_by_count.items() if count > 1}
+
+        assert not duplicates, f"Duplicate display names: {duplicates}"

--- a/tests/tests_unit/test_cli/test_build_deploy_snapshots/my_example_module.yaml
+++ b/tests/tests_unit/test_cli/test_build_deploy_snapshots/my_example_module.yaml
@@ -6,7 +6,7 @@ DataSet:
   name: Example dataset.
   writeProtected: false
 DatapointSubscription:
-- description: All timeseries with externalId starting with 'ts_value'
+- description: All timeseries with externalId starting with ts_value
   externalId: my_subscription
   filter:
     prefix:


### PR DESCRIPTION
# Description
Turns out rich print actually modifies the input strings, I got the following error message:
![image](https://github.com/cognitedata/toolkit/assets/60234212/d6555a4d-3689-4111-b8d7-60f6c8fe99d6)

Which is now fixed to give the actual correct error message:
![image](https://github.com/cognitedata/toolkit/assets/60234212/d38ee0da-820b-4b1c-adaa-6b5bd8658ec1)

Also fixed the issue in the datapoint subscription. 

And also fixed this to not give the folder name, but the display name of the loader
![image](https://github.com/cognitedata/toolkit/assets/60234212/ddf091ae-9642-4e99-aee5-21258d7f52ae)

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
