### PR TITLE
[CDF-21640]🐛 Bug in checking dependent Groups

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,14 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+### Fixed
+
+- Running the build command, `cdf-tk build`, with `Group` resources scoped will read to incorrect
+  warning such as `WARNING [HIGH]: Space 'spaceIds' is missing and is required by:` and
+  `WARNING [HIGH]: DataSet 'ids' is missing and is required by:`. This is now fixed.
+
 ## [0.2.0b1] - 2024-05-20
 
 ### Added

--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -248,7 +248,7 @@ def build(
 ) -> None:
     """Build configuration files from the module templates to a local build directory."""
     cmd = BuildCommand()
-    cmd.execute(ctx, Path(source_dir), Path(build_dir), build_env_name, no_clean)
+    cmd.execute(ctx.obj.verbose, Path(source_dir), Path(build_dir), build_env_name, no_clean)
 
 
 @_app.command("deploy")

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
-import typer
 import yaml
 from cognite.client._api.functions import validate_function_folder
 from cognite.client.data_classes import FileMetadataList, FunctionList
@@ -70,9 +69,7 @@ from cognite_toolkit._cdf_tk.validation import (
 
 
 class BuildCommand(ToolkitCommand):
-    def execute(
-        self, ctx: typer.Context, source_path: Path, build_dir: Path, build_env_name: str, no_clean: bool
-    ) -> None:
+    def execute(self, verbose: bool, source_path: Path, build_dir: Path, build_env_name: str, no_clean: bool) -> None:
         if not source_path.is_dir():
             raise ToolkitNotADirectoryError(str(source_path))
 
@@ -92,7 +89,7 @@ class BuildCommand(ToolkitCommand):
             config=config,
             system_config=system_config,
             clean=not no_clean,
-            verbose=ctx.obj.verbose,
+            verbose=verbose,
         )
 
     def build_config(

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -250,10 +250,11 @@ class GroupLoader(ResourceLoader[str, GroupWrite, Group, GroupWriteList, GroupLi
                         for db_name, tables in table_ids.get("dbsToTables", {}).items():
                             yield RawDatabaseLoader, RawDatabaseTable(db_name)
                             for table in tables:
-                                yield RawDatabaseLoader, RawDatabaseTable(db_name, table)
+                                yield RawTableLoader, RawDatabaseTable(db_name, table)
                     if extraction_pipeline_ids := scope.get(capabilities.ExtractionPipelineScope._scope_name, []):
-                        for extraction_pipeline_id in extraction_pipeline_ids:
-                            yield ExtractionPipelineLoader, extraction_pipeline_id
+                        if isinstance(extraction_pipeline_ids, dict) and "ids" in extraction_pipeline_ids:
+                            for extraction_pipeline_id in extraction_pipeline_ids["ids"]:
+                                yield ExtractionPipelineLoader, extraction_pipeline_id
                     if (ids := scope.get(capabilities.IDScope._scope_name, [])) or (
                         ids := scope.get(capabilities.IDScopeLowerCase._scope_name, [])
                     ):
@@ -264,8 +265,8 @@ class GroupLoader(ResourceLoader[str, GroupWrite, Group, GroupWriteList, GroupLi
                             loader = ExtractionPipelineLoader
                         elif acl == capabilities.TimeSeriesAcl._capability_name:
                             loader = TimeSeriesLoader
-                        if loader is not None:
-                            for id_ in ids:
+                        if loader is not None and isinstance(ids, dict) and "ids" in ids:
+                            for id_ in ids["ids"]:
                                 yield loader, id_
 
     @classmethod

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -1452,6 +1452,8 @@ class TransformationLoader(
                 yield RawDatabaseLoader, RawDatabaseTable(destination["database"])
                 yield RawTableLoader, RawDatabaseTable(destination["database"], destination["table"])
             elif destination.get("type") in ("nodes", "edges") and (view := destination.get("view", {})):
+                if space := destination.get("instanceSpace"):
+                    yield SpaceLoader, space
                 if _in_dict(("space", "externalId", "version"), view):
                     yield ViewLoader, ViewId.load(view)
             elif destination.get("type") == "instances":

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -1754,9 +1754,10 @@ class ExtractionPipelineLoader(
             yield DataSetsLoader, item["dataSetExternalId"]
         if "rawTables" in item:
             for entry in item["rawTables"]:
-                if "dbName" in entry and entry["dbName"] not in seen_databases:
-                    seen_databases.add(entry["dbName"])
-                    yield RawDatabaseLoader, RawDatabaseTable(db_name=entry["dbName"])
+                if db := entry.get("dbName"):
+                    if db not in seen_databases:
+                        seen_databases.add(db)
+                        yield RawDatabaseLoader, RawDatabaseTable(db_name=db)
                     if "tableName" in entry:
                         yield RawTableLoader, RawDatabaseTable._load(entry)
 

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -1749,11 +1749,13 @@ class ExtractionPipelineLoader(
 
     @classmethod
     def get_dependent_items(cls, item: dict) -> Iterable[tuple[type[ResourceLoader], Hashable]]:
+        seen_databases: set[str] = set()
         if "dataSetExternalId" in item:
             yield DataSetsLoader, item["dataSetExternalId"]
         if "rawTables" in item:
             for entry in item["rawTables"]:
-                if "dbName" in entry:
+                if "dbName" in entry and entry["dbName"] not in seen_databases:
+                    seen_databases.add(entry["dbName"])
                     yield RawDatabaseLoader, RawDatabaseTable(db_name=entry["dbName"])
                     if "tableName" in entry:
                         yield RawTableLoader, RawDatabaseTable._load(entry)

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -239,11 +239,13 @@ class GroupLoader(ResourceLoader[str, GroupWrite, Group, GroupWriteList, GroupLi
             for acl, content in capability.items():
                 if scope := content.get("scope", {}):
                     if space_ids := scope.get(capabilities.SpaceIDScope._scope_name, []):
-                        for space_id in space_ids:
-                            yield SpaceLoader, space_id
+                        if isinstance(space_ids, dict) and "spaceIds" in space_ids:
+                            for space_id in space_ids["spaceIds"]:
+                                yield SpaceLoader, space_id
                     if data_set_ids := scope.get(capabilities.DataSetScope._scope_name, []):
-                        for data_set_id in data_set_ids:
-                            yield DataSetsLoader, data_set_id
+                        if isinstance(data_set_ids, dict) and "ids" in data_set_ids:
+                            for data_set_id in data_set_ids["ids"]:
+                                yield DataSetsLoader, data_set_id
                     if table_ids := scope.get(capabilities.TableScope._scope_name, []):
                         for db_name, tables in table_ids.get("dbsToTables", {}).items():
                             yield RawDatabaseLoader, RawDatabaseTable(db_name)

--- a/tests/tests_unit/test_cdf_tk/test_loaders.py
+++ b/tests/tests_unit/test_cdf_tk/test_loaders.py
@@ -807,6 +807,34 @@ class TestExtractionPipelineDependencies:
             assert res.deleted == 1
 
 
+class TestExtractionPipelineLoader:
+    @pytest.mark.parametrize(
+        "item, expected",
+        [
+            pytest.param(
+                {
+                    "dataSetExternalId": "ds_my_dataset",
+                    "rawTables": [
+                        {"dbName": "my_db", "tableName": "my_table"},
+                        {"dbName": "my_db", "tableName": "my_table2"},
+                    ],
+                },
+                [
+                    (DataSetsLoader, "ds_my_dataset"),
+                    (RawDatabaseLoader, RawDatabaseTable("my_db")),
+                    (RawTableLoader, RawDatabaseTable("my_db", "my_table")),
+                    (RawTableLoader, RawDatabaseTable("my_db", "my_table2")),
+                ],
+                id="Extraction pipeline to Table",
+            ),
+        ],
+    )
+    def test_get_dependent_items(self, item: dict, expected: list[tuple[type[ResourceLoader], Hashable]]) -> None:
+        actual = ExtractionPipelineLoader.get_dependent_items(item)
+
+        assert list(actual) == expected
+
+
 class TestDeployResources:
     def test_deploy_resource_order(self, cognite_client_approval: ApprovalCogniteClient):
         build_env_name = "dev"

--- a/tests/tests_unit/test_cdf_tk/test_loaders.py
+++ b/tests/tests_unit/test_cdf_tk/test_loaders.py
@@ -630,8 +630,8 @@ conflictMode: upsert
                     }
                 },
                 [
-                    (ViewLoader, dm.ViewId(space="sp_space", external_id="my_view", version="v1")),
                     (SpaceLoader, "sp_data_space"),
+                    (ViewLoader, dm.ViewId(space="sp_space", external_id="my_view", version="v1")),
                 ],
                 id="Transformation to nodes ",
             ),

--- a/tests/tests_unit/test_cdf_tk/test_loaders.py
+++ b/tests/tests_unit/test_cdf_tk/test_loaders.py
@@ -51,7 +51,7 @@ from cognite_toolkit._cdf_tk.loaders import (
     TransformationLoader,
     ViewLoader,
 )
-from cognite_toolkit._cdf_tk.loaders.data_classes import NodeAPICall, NodeApplyListWithCall
+from cognite_toolkit._cdf_tk.loaders.data_classes import NodeAPICall, NodeApplyListWithCall, RawDatabaseTable
 from cognite_toolkit._cdf_tk.templates import (
     module_from_path,
     resource_folder_from_path,
@@ -386,7 +386,7 @@ class TestGroupLoader:
                 id="SpaceId scope",
             ),
             pytest.param(
-                {"capabilities": [{"timeSeriesAcl": {"scope": {"datasetScope": {"ids": ["ds_datasest1"]}}}}]},
+                {"capabilities": [{"timeSeriesAcl": {"scope": {"datasetScope": {"ids": ["ds_dataset1"]}}}}]},
                 [
                     (DataSetsLoader, "ds_dataset1"),
                 ],
@@ -395,7 +395,7 @@ class TestGroupLoader:
             pytest.param(
                 {
                     "capabilities": [
-                        {"extractionRunsAcl": {"scope": {"extractionpiplinescope": {"ids": ["ex_my_extraction"]}}}}
+                        {"extractionRunsAcl": {"scope": {"extractionPipelineScope": {"ids": ["ex_my_extraction"]}}}}
                     ]
                 },
                 [
@@ -405,7 +405,10 @@ class TestGroupLoader:
             ),
             pytest.param(
                 {"capabilities": [{"rawAcl": {"scope": {"tableScope": {"dbsToTables": {"my_db": ["my_table"]}}}}}]},
-                [(RawDatabaseLoader, "my_db"), (RawTableLoader, "my_table")],
+                [
+                    (RawDatabaseLoader, RawDatabaseTable("my_db")),
+                    (RawTableLoader, RawDatabaseTable("my_db", "my_table")),
+                ],
                 id="Table scope",
             ),
             pytest.param(
@@ -427,7 +430,7 @@ class TestGroupLoader:
     def test_get_dependent_items(self, item: dict, expected: list[tuple[type[ResourceLoader], Hashable]]) -> None:
         actual_dependent_items = GroupLoader.get_dependent_items(item)
 
-        assert sorted(actual_dependent_items) == sorted(expected)
+        assert list(actual_dependent_items) == expected
 
 
 class TestTimeSeriesLoader:


### PR DESCRIPTION
# Description

Leads to this type of output complaining about `spaceIds` and `ids`, instead of the actual.

![image](https://github.com/cognitedata/toolkit/assets/60234212/218e9e2a-3c11-4bb7-85cc-4b3db240e3c5)

In addition, added testing for the four most complex logics `ViewLoader`, `ExtractionPipelineLoader`, `TransformationLoader` and `GroupLoader` and found a few more issues.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
