### PR TITLE
[CDF-21639, CDF-21644]🧑‍🚒Warning on valid HasData filter

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,12 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+- Running the build command, `cdf-tk build`, with a `View` resource with a `hasData` filter would print a
+  `UnusedParameterWarning: Parameter 'externalId' is not used in section ('filter', 'hasData', 0, 'externalId').`.
+  This is incorrect and is now fixed to not print this warning.
+
 ## [0.2.0b1] - 2024-05-20
 
 ### Added

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -2604,12 +2604,34 @@ class ViewLoader(ResourceLoader[ViewId, ViewApply, View, ViewApplyList, ViewList
                         _is_nullable=False,
                     ),
                     ParameterSpec(
+                        ("properties", ANY_STR, "through", "source", "type"),
+                        frozenset({"str"}),
+                        is_required=True,
+                        _is_nullable=False,
+                    ),
+                    ParameterSpec(
+                        # In the SDK this is called "property"
+                        ("properties", ANY_STR, "through", "identifier"),
+                        frozenset({"str"}),
+                        is_required=True,
+                        _is_nullable=False,
+                    ),
+                    ParameterSpec(
                         ("filter", "hasData", ANY_INT, "type"),
                         frozenset({"str"}),
                         is_required=True,
                         _is_nullable=False,
                     ),
                 }
+            )
+        )
+        spec.discard(
+            ParameterSpec(
+                # The API spec calls this "identifier", while the SDK calls it "property".
+                ("properties", ANY_STR, "through", "property"),
+                frozenset({"str"}),
+                is_required=True,
+                _is_nullable=False,
             )
         )
         return spec

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -2563,7 +2563,13 @@ class ViewLoader(ResourceLoader[ViewId, ViewApply, View, ViewApplyList, ViewList
             if len(item.path) >= length + 1 and item.path[:length] == parameter_path[:length]:
                 # Add extra ANY_STR layer
                 # The spec class is immutable, so we use this trick to modify it.
-                object.__setattr__(item, "path", item.path[:length] + (ANY_STR,) + item.path[length:])
+                is_has_data_filter = item.path[1] in ["containers", "views"]
+                if is_has_data_filter:
+                    # Special handling of the HasData filter that deviates in SDK implementation from API Spec.
+                    object.__setattr__(item, "path", item.path[:length] + (ANY_STR,) + item.path[length + 1 :])
+                else:
+                    object.__setattr__(item, "path", item.path[:length] + (ANY_STR,) + item.path[length:])
+
         spec.add(ParameterSpec(("filter", ANY_STR), frozenset({"dict"}), is_required=False, _is_nullable=False))
         # The following types are used by the SDK to load the correct class. They are not part of the init,
         # so we need to add it manually.
@@ -2593,6 +2599,12 @@ class ViewLoader(ResourceLoader[ViewId, ViewApply, View, ViewApplyList, ViewList
                     ),
                     ParameterSpec(
                         ("properties", ANY_STR, "edgeSource", "type"),
+                        frozenset({"str"}),
+                        is_required=True,
+                        _is_nullable=False,
+                    ),
+                    ParameterSpec(
+                        ("filter", "hasData", ANY_INT, "type"),
                         frozenset({"str"}),
                         is_required=True,
                         _is_nullable=False,

--- a/tests/tests_unit/test_cdf_tk/test_load.py
+++ b/tests/tests_unit/test_cdf_tk/test_load.py
@@ -154,7 +154,32 @@ class TestViewLoader:
                     }
                 },
                 id="HasData Filter",
-            )
+            ),
+            pytest.param(
+                {
+                    "properties": {
+                        "reverseDirectRelation": {
+                            "connectionType": "multi_reverse_direct_relation",
+                            "source": {
+                                "type": "view",
+                                "space": "sp_my_space",
+                                "externalId": "view_id",
+                                "version": "v42",
+                            },
+                            "through": {
+                                "source": {
+                                    "type": "view",
+                                    "space": "sp_my_space",
+                                    "externalId": "view_id",
+                                    "version": "v42",
+                                },
+                                "identifier": "view_property",
+                            },
+                        }
+                    }
+                },
+                id="Reverse Direct Relation Property",
+            ),
         ],
     )
     def test_valid_spec(self, item: dict):

--- a/tests/tests_unit/test_cdf_tk/test_load.py
+++ b/tests/tests_unit/test_cdf_tk/test_load.py
@@ -141,6 +141,30 @@ class TestDataSetsLoader:
 
 
 class TestViewLoader:
+    @pytest.mark.parametrize(
+        "item",
+        [
+            pytest.param(
+                {
+                    "filter": {
+                        "hasData": [
+                            {"type": "container", "space": "sp_my_space", "externalId": "container_id"},
+                            {"type": "view", "space": "sp_my_space", "externalId": "view_id"},
+                        ]
+                    }
+                },
+                id="HasData Filter",
+            )
+        ],
+    )
+    def test_valid_spec(self, item: dict):
+        spec = ViewLoader.get_write_cls_parameter_spec()
+        dumped = read_parameters_from_dict(item)
+
+        extra = dumped - spec
+
+        assert not extra, f"Extra keys: {extra}"
+
     def test_update_view_with_interface(self, cognite_client_approval: ApprovalCogniteClient):
         cdf_tool = MagicMock(spec=CDFToolConfig)
         cdf_tool.verify_client.return_value = cognite_client_approval.mock_client

--- a/tests/tests_unit/test_cdf_tk/test_load.py
+++ b/tests/tests_unit/test_cdf_tk/test_load.py
@@ -23,7 +23,7 @@ from cognite.client.data_classes.data_modeling import Edge, Node, NodeApply
 from pytest import MonkeyPatch
 from pytest_regressions.data_regression import DataRegressionFixture
 
-from cognite_toolkit._cdf_tk._parameters import ParameterSet, ParameterValue, read_parameters_from_dict
+from cognite_toolkit._cdf_tk._parameters import ParameterSet, read_parameters_from_dict
 from cognite_toolkit._cdf_tk.commands import BuildCommand, CleanCommand, DeployCommand
 from cognite_toolkit._cdf_tk.exceptions import ToolkitYAMLFormatError
 from cognite_toolkit._cdf_tk.loaders import (
@@ -876,7 +876,7 @@ class TestResourceLoaders:
         # The spec is calculated based on the resource class __init__ method.
         # There can be deviations in the output from the dump. If that is the case,
         # the 'get_write_cls_parameter_spec' must be updated in the loader. See, for example, the DataModelLoader.
-        assert sorted(extra) == sorted(ParameterSet[ParameterValue]({}))
+        assert sorted(extra) == []
 
     @pytest.mark.parametrize("loader_cls, content", list(cognite_module_files_with_loader()))
     def test_write_cls_spec_against_cognite_modules(self, loader_cls: type[ResourceLoader], content: dict) -> None:


### PR DESCRIPTION
# Description

![image](https://github.com/cognitedata/toolkit/assets/60234212/c3c548c2-66f9-4d54-a77a-1767b0fe8be4)

The `hasData` filter is a special case when the SDK implementation deviates from the API spec and thus needs special handling. I forgot this in the original implementation. 

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
