### PR TITLE
[CDF-21496] Fix dependencies for Workflows.

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,12 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+### Fixed
+
+- The toolkit now ensures `Transformations` and `Functions` are deployed before `Workflows`
+
 ## [0.2.0b2] - 2024-06-03
 
 ### Fixed

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -2901,6 +2901,8 @@ class WorkflowLoader(ResourceLoader[str, WorkflowUpsert, Workflow, WorkflowUpser
     dependencies = frozenset(
         {
             GroupAllScopedLoader,
+            TransformationLoader,
+            FunctionLoader,
         }
     )
     _doc_base_url = "https://api-docs.cognite.com/20230101-beta/tag/"

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -2966,7 +2966,7 @@ class WorkflowVersionLoader(
     ]
 ):
     folder_name = "workflows"
-    filename_pattern = r"^.*\.?(WorkflowVersion)$"
+    filename_pattern = r"^.*WorkflowVersion$"
     resource_cls = WorkflowVersion
     resource_write_cls = WorkflowVersionUpsert
     list_cls = WorkflowVersionList

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -2893,12 +2893,16 @@ class NodeLoader(ResourceContainerLoader[NodeId, NodeApply, Node, NodeApplyListW
 @final
 class WorkflowLoader(ResourceLoader[str, WorkflowUpsert, Workflow, WorkflowUpsertList, WorkflowList]):
     folder_name = "workflows"
-    filename_pattern = r"^.*\.Workflow$"
+    filename_pattern = r"^.*Workflow$"
     resource_cls = Workflow
     resource_write_cls = WorkflowUpsert
     list_cls = WorkflowList
     list_write_cls = WorkflowUpsertList
-    dependencies = frozenset({GroupAllScopedLoader})
+    dependencies = frozenset(
+        {
+            GroupAllScopedLoader,
+        }
+    )
     _doc_base_url = "https://api-docs.cognite.com/20230101-beta/tag/"
     _doc_url = "Workflows/operation/CreateOrUpdateWorkflow"
 


### PR DESCRIPTION
# Description

In addition, fix the filename pattern such that the `.` is not required, meaning `Workflow.yaml` and `WorkflowVersion.yaml` are acceptable.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
