### PR TITLE
[CDF-21656] 🤾Only warnings on selected

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,13 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+### Changed
+
+- The toolkit now only gives a `TemplateVariableWarning` (`Variable my_variable has value <change_me> ...`) if
+  the variable is used by `selected` in the `config.[env].yaml`. This is to avoid unnecessary warnings.
+
 ## [0.2.0b3] - 2024-06-04
 
 ### Added

--- a/cognite_toolkit/_cdf_tk/templates/data_classes/_system_yaml.py
+++ b/cognite_toolkit/_cdf_tk/templates/data_classes/_system_yaml.py
@@ -52,7 +52,7 @@ class SystemYAML(ConfigCore):
         for package, modules in self.packages.items():
             if package not in selected_packages:
                 # We do not check packages that are not selected.
-                # Typically, the user will delete the modules that are irrelevant for them,
+                # Typically, the user will delete the modules that are irrelevant for them;
                 # thus we only check the selected packages.
                 continue
             if missing := set(modules) - available_modules:


### PR DESCRIPTION
# Description

Before this PR you get this PR, even though you did not select the modules using these variables thus cluttering the warnings.

![image](https://github.com/cognitedata/toolkit/assets/60234212/7466a05b-e8cf-4f46-9c84-28f45d27a474)

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
