### PR TITLE
[CDF-21690] 🕸Handle empty items when checking capabilities

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,13 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+### Fixed
+
+- When running `cdf-tk clean` or `cdf-tk deploy --drop --drop-data` there was an edge case that triggered the bug
+  `ValueError: No capabilities given`. This is now fixed.
+
 ## [0.2.0b4] - 2024-06-06
 
 ### Added

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -645,10 +645,19 @@ class LabelLoader(
         return item.external_id
 
     @classmethod
-    def get_required_capability(cls, items: T_CogniteResourceList) -> Capability | list[Capability]:
+    def get_required_capability(cls, items: LabelDefinitionWriteList) -> Capability | list[Capability]:
+        if not items:
+            return []
+        data_set_ids = {item.data_set_id for item in items if item.data_set_id}
+        scope = (
+            capabilities.LabelsAcl.Scope.DataSet(list(data_set_ids))
+            if data_set_ids
+            else capabilities.LabelsAcl.Scope.All()
+        )
+
         return capabilities.LabelsAcl(
             [capabilities.LabelsAcl.Action.Read, capabilities.LabelsAcl.Action.Write],
-            capabilities.LabelsAcl.Scope.All(),
+            scope,  # type: ignore[arg-type]
         )
 
     def create(self, items: LabelDefinitionWriteList) -> LabelDefinitionList:
@@ -1067,7 +1076,9 @@ class RawDatabaseLoader(
         return "raw.databases"
 
     @classmethod
-    def get_required_capability(cls, items: RawTableList) -> Capability:
+    def get_required_capability(cls, items: RawTableList) -> Capability | list[Capability]:
+        if not items:
+            return []
         tables_by_database = defaultdict(list)
         for item in items:
             tables_by_database[item.db_name].append(item.table_name)
@@ -1173,7 +1184,9 @@ class RawTableLoader(
         return "raw.tables"
 
     @classmethod
-    def get_required_capability(cls, items: RawTableList) -> Capability:
+    def get_required_capability(cls, items: RawTableList) -> Capability | list[Capability]:
+        if not items:
+            return []
         tables_by_database = defaultdict(list)
         for item in items:
             tables_by_database[item.db_name].append(item.table_name)
@@ -1294,7 +1307,10 @@ class TimeSeriesLoader(ResourceContainerLoader[str, TimeSeriesWrite, TimeSeries,
     _doc_url = "Time-series/operation/postTimeSeries"
 
     @classmethod
-    def get_required_capability(cls, items: TimeSeriesWriteList) -> Capability:
+    def get_required_capability(cls, items: TimeSeriesWriteList) -> Capability | list[Capability]:
+        if not items:
+            return []
+
         dataset_ids = {item.data_set_id for item in items if item.data_set_id}
 
         scope = TimeSeriesAcl.Scope.DataSet(list(dataset_ids)) if dataset_ids else TimeSeriesAcl.Scope.All()
@@ -1457,9 +1473,17 @@ class DatapointSubscriptionLoader(
 
     @classmethod
     def get_required_capability(cls, items: DatapointSubscriptionWriteList) -> Capability | list[Capability]:
+        if not items:
+            return []
+        data_set_ids = {item.data_set_id for item in items if item.data_set_id}
+        scope = (
+            TimeSeriesSubscriptionsAcl.Scope.DataSet(list(data_set_ids))
+            if data_set_ids
+            else TimeSeriesSubscriptionsAcl.Scope.All()
+        )
         return TimeSeriesSubscriptionsAcl(
             [TimeSeriesSubscriptionsAcl.Action.Read, TimeSeriesSubscriptionsAcl.Action.Write],
-            TimeSeriesSubscriptionsAcl.Scope.All(),
+            scope,  # type: ignore[arg-type]
         )
 
     def create(self, items: DatapointSubscriptionWriteList) -> DatapointSubscriptionList:
@@ -1531,7 +1555,9 @@ class TransformationLoader(
     _doc_url = "Transformations/operation/createTransformations"
 
     @classmethod
-    def get_required_capability(cls, items: TransformationWriteList) -> Capability:
+    def get_required_capability(cls, items: TransformationWriteList) -> Capability | list[Capability]:
+        if not items:
+            return []
         data_set_ids = {item.data_set_id for item in items if item.data_set_id}
 
         scope = TransformationsAcl.Scope.DataSet(list(data_set_ids)) if data_set_ids else TransformationsAcl.Scope.All()
@@ -1941,7 +1967,9 @@ class ExtractionPipelineLoader(
     _doc_url = "Extraction-Pipelines/operation/createExtPipes"
 
     @classmethod
-    def get_required_capability(cls, items: ExtractionPipelineWriteList) -> Capability:
+    def get_required_capability(cls, items: ExtractionPipelineWriteList) -> Capability | list[Capability]:
+        if not items:
+            return []
         data_set_id = {item.data_set_id for item in items if item.data_set_id}
 
         scope = (
@@ -2214,7 +2242,9 @@ class FileMetadataLoader(
         return "file_metadata"
 
     @classmethod
-    def get_required_capability(cls, items: FileMetadataWriteList) -> Capability:
+    def get_required_capability(cls, items: FileMetadataWriteList) -> Capability | list[Capability]:
+        if not items:
+            return []
         data_set_ids = {item.data_set_id for item in items if item.data_set_id}
 
         scope = FilesAcl.Scope.DataSet(list(data_set_ids)) if data_set_ids else FilesAcl.Scope.All()
@@ -2383,7 +2413,9 @@ class SpaceLoader(ResourceContainerLoader[str, SpaceApply, Space, SpaceApplyList
         return "spaces"
 
     @classmethod
-    def get_required_capability(cls, items: SpaceApplyList) -> list[Capability]:
+    def get_required_capability(cls, items: SpaceApplyList) -> list[Capability] | list[Capability]:
+        if not items:
+            return []
         return [
             DataModelsAcl(
                 [DataModelsAcl.Action.Read, DataModelsAcl.Action.Write],
@@ -2511,7 +2543,9 @@ class ContainerLoader(
         return "containers"
 
     @classmethod
-    def get_required_capability(cls, items: ContainerApplyList) -> Capability:
+    def get_required_capability(cls, items: ContainerApplyList) -> Capability | list[Capability]:
+        if not items:
+            return []
         return DataModelsAcl(
             [DataModelsAcl.Action.Read, DataModelsAcl.Action.Write],
             DataModelsAcl.Scope.SpaceID(list({item.space for item in items})),
@@ -2701,7 +2735,9 @@ class ViewLoader(ResourceLoader[ViewId, ViewApply, View, ViewApplyList, ViewList
         return "views"
 
     @classmethod
-    def get_required_capability(cls, items: ViewApplyList) -> Capability:
+    def get_required_capability(cls, items: ViewApplyList) -> Capability | list[Capability]:
+        if not items:
+            return []
         return DataModelsAcl(
             [DataModelsAcl.Action.Read, DataModelsAcl.Action.Write],
             DataModelsAcl.Scope.SpaceID(list({item.space for item in items})),
@@ -2890,7 +2926,9 @@ class DataModelLoader(ResourceLoader[DataModelId, DataModelApply, DataModel, Dat
         return "data models"
 
     @classmethod
-    def get_required_capability(cls, items: DataModelApplyList) -> Capability:
+    def get_required_capability(cls, items: DataModelApplyList) -> Capability | list[Capability]:
+        if not items:
+            return []
         return DataModelsAcl(
             [DataModelsAcl.Action.Read, DataModelsAcl.Action.Write],
             DataModelsAcl.Scope.SpaceID(list({item.space for item in items})),
@@ -2976,7 +3014,9 @@ class NodeLoader(ResourceContainerLoader[NodeId, NodeApply, Node, NodeApplyListW
         return "nodes"
 
     @classmethod
-    def get_required_capability(cls, items: NodeApplyListWithCall) -> Capability:
+    def get_required_capability(cls, items: NodeApplyListWithCall) -> Capability | list[Capability]:
+        if not items:
+            return []
         return DataModelInstancesAcl(
             [DataModelInstancesAcl.Action.Read, DataModelInstancesAcl.Action.Write],
             DataModelInstancesAcl.Scope.SpaceID(list({item.space for item in items})),
@@ -3131,7 +3171,9 @@ class WorkflowLoader(ResourceLoader[str, WorkflowUpsert, Workflow, WorkflowUpser
     _doc_url = "Workflows/operation/CreateOrUpdateWorkflow"
 
     @classmethod
-    def get_required_capability(cls, items: WorkflowUpsertList) -> Capability:
+    def get_required_capability(cls, items: WorkflowUpsertList) -> Capability | list[Capability]:
+        if not items:
+            return []
         return WorkflowOrchestrationAcl(
             [WorkflowOrchestrationAcl.Action.Read, WorkflowOrchestrationAcl.Action.Write],
             WorkflowOrchestrationAcl.Scope.All(),

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -233,6 +233,8 @@ class GroupLoader(ResourceLoader[str, GroupWrite, Group, GroupWriteList, GroupLi
 
     @classmethod
     def get_required_capability(cls, items: GroupWriteList) -> Capability | list[Capability]:
+        if not items:
+            return []
         return GroupsAcl(
             [GroupsAcl.Action.Read, GroupsAcl.Action.List, GroupsAcl.Action.Create, GroupsAcl.Action.Delete],
             GroupsAcl.Scope.All(),
@@ -489,6 +491,8 @@ class SecurityCategoryLoader(
 
     @classmethod
     def get_required_capability(cls, items: SecurityCategoryWriteList) -> Capability | list[Capability]:
+        if not items:
+            return []
         return SecurityCategoriesAcl(
             actions=[
                 SecurityCategoriesAcl.Action.Create,
@@ -537,7 +541,9 @@ class DataSetsLoader(ResourceLoader[str, DataSetWrite, DataSet, DataSetWriteList
     _doc_url = "Data-sets/operation/createDataSets"
 
     @classmethod
-    def get_required_capability(cls, items: DataSetWriteList) -> Capability:
+    def get_required_capability(cls, items: DataSetWriteList) -> Capability | list[Capability]:
+        if not items:
+            return []
         return DataSetsAcl(
             [DataSetsAcl.Action.Read, DataSetsAcl.Action.Write],
             DataSetsAcl.Scope.All(),
@@ -730,7 +736,9 @@ class FunctionLoader(ResourceLoader[str, FunctionWrite, Function, FunctionWriteL
     _doc_url = "Functions/operation/postFunctions"
 
     @classmethod
-    def get_required_capability(cls, items: FunctionWriteList) -> list[Capability]:
+    def get_required_capability(cls, items: FunctionWriteList) -> list[Capability] | list[Capability]:
+        if not items:
+            return []
         return [
             FunctionsAcl([FunctionsAcl.Action.Read, FunctionsAcl.Action.Write], FunctionsAcl.Scope.All()),
             FilesAcl(
@@ -941,6 +949,8 @@ class FunctionScheduleLoader(
 
     @classmethod
     def get_required_capability(cls, items: FunctionScheduleWriteList) -> list[Capability]:
+        if not items:
+            return []
         return [
             FunctionsAcl([FunctionsAcl.Action.Read, FunctionsAcl.Action.Write], FunctionsAcl.Scope.All()),
             SessionsAcl(
@@ -3245,7 +3255,9 @@ class WorkflowVersionLoader(
         return "workflow.versions"
 
     @classmethod
-    def get_required_capability(cls, items: WorkflowVersionUpsertList) -> Capability:
+    def get_required_capability(cls, items: WorkflowVersionUpsertList) -> Capability | list[Capability]:
+        if not items:
+            return []
         return WorkflowOrchestrationAcl(
             [WorkflowOrchestrationAcl.Action.Read, WorkflowOrchestrationAcl.Action.Write],
             WorkflowOrchestrationAcl.Scope.All(),

--- a/tests/tests_unit/test_cdf_tk/test_loaders.py
+++ b/tests/tests_unit/test_cdf_tk/test_loaders.py
@@ -1174,6 +1174,14 @@ class TestResourceLoaders:
 
         assert sorted(warnings) == []
 
+    @pytest.mark.parametrize("loader_cls", RESOURCE_LOADER_LIST)
+    def test_empty_required_capabilities_when_no_items(
+        self, loader_cls: type[ResourceLoader], cdf_tool_config: CDFToolConfig
+    ):
+        actual = loader_cls.get_required_capability(loader_cls.list_write_cls([]))
+
+        assert actual == []
+
 
 class TestLoaders:
     def test_unique_display_names(self, cdf_tool_config: CDFToolConfig):


### PR DESCRIPTION
# Description

In the NodeLoader you can get a situation where you create a capability with no SpaceIds in the scope, which is interpreted as no capabilities. And you get an error mesasge `ValueError: No capabilities given`

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
