### PR TITLE
[CDF-21717]😕 Container server vs local comparisson

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,13 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+### Fixed
+
+- When deploying `containers` resources with an index, the `cdf-tk deploy` would consider the resource as changed
+  even though it was not. This is now fixed.
+
 ## [0.2.0b4] - 2024-06-06
 
 ### Added

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -2620,10 +2620,14 @@ class ContainerLoader(
 
     def are_equal(self, local: ContainerApply, remote: Container) -> bool:
         local_dumped = local.dump(camel_case=True)
+        # 'usedFor' and 'cursorable' have default values set on the server side,
+        # but not when loading the container using the SDK. Thus, we set the default
+        # values here if they are not present.
         if "usedFor" not in local_dumped:
-            # Setting used_for to "node" as it is the default value in the CDF and will be set by
-            # the server side if it is not set.
             local_dumped["usedFor"] = "node"
+        for index in local_dumped.get("indexes", {}).values():
+            if "cursorable" not in index:
+                index["cursorable"] = False
 
         return local_dumped == remote.as_write().dump(camel_case=True)
 


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
