### PR TITLE
[CDF-21681, CDF-21688]😨 Fix flakey tests

### DIFF
--- a/tests/tests_integration/test_loaders/test_resource_loaders.py
+++ b/tests/tests_integration/test_loaders/test_resource_loaders.py
@@ -100,10 +100,11 @@ class TestFunctionScheduleLoader:
         retrieved = loader.retrieve([identifier])
         if not retrieved or retrieved[0].description != function_schedule.description:
             # The service can be a bit slow in returning the updated description,
-            # so we wait a bit and try again.
-            sleep(1)
+            # so we wait a bit and try again. (Eventual consistency)
+            sleep(2)
             retrieved = loader.retrieve([identifier])
 
+        assert retrieved, "Function schedule not found after update."
         assert retrieved[0].description == function_schedule.description
 
 


### PR DESCRIPTION
# Description

Increasing time to give the server more time to update.
Improved error message when the retrieve is not returned, so instead of `IndexError: list index out of range`, you will now get `Function schedule not found after update.`

![image](https://github.com/cognitedata/toolkit/assets/60234212/9b026ba6-415c-47a4-9bc7-6527a0c40b17)


## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
