### PR TITLE
[CDF-21721] 😰Iterate modules bug

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils.py
+++ b/cognite_toolkit/_cdf_tk/utils.py
@@ -43,7 +43,7 @@ from cognite.client.testing import CogniteClientMock
 from rich import print
 from rich.prompt import Confirm, Prompt
 
-from cognite_toolkit._cdf_tk.constants import _RUNNING_IN_BROWSER
+from cognite_toolkit._cdf_tk.constants import _RUNNING_IN_BROWSER, ROOT_MODULES
 from cognite_toolkit._cdf_tk.exceptions import ToolkitError, ToolkitResourceMissingError, ToolkitYAMLFormatError
 from cognite_toolkit._version import __version__
 
@@ -1163,6 +1163,12 @@ def iterate_modules(root_dir: Path) -> Iterator[tuple[Path, list[Path]]]:
         Iterator[tuple[Path, list[Path]]]: A tuple containing the module directory and a list of all files in the module
 
     """
+    if root_dir.name not in ROOT_MODULES:
+        raise ValueError(f"Root directory {root_dir} is not a root directory for modules")
+    yield from _iterate_modules(root_dir)
+
+
+def _iterate_modules(root_dir: Path) -> Iterator[tuple[Path, list[Path]]]:
     # local import to avoid circular import
     from .constants import EXCL_FILES
     from .loaders import LOADER_BY_FOLDER_NAME
@@ -1179,7 +1185,7 @@ def iterate_modules(root_dir: Path) -> Iterator[tuple[Path, list[Path]]]:
             yield module_dir, [path for path in module_dir.rglob("*") if path.is_file() and path.name not in EXCL_FILES]
             # Stop searching for modules in subdirectories
             continue
-        yield from iterate_modules(module_dir)
+        yield from _iterate_modules(module_dir)
 
 
 @overload

--- a/cognite_toolkit/_cdf_tk/utils.py
+++ b/cognite_toolkit/_cdf_tk/utils.py
@@ -1163,9 +1163,13 @@ def iterate_modules(root_dir: Path) -> Iterator[tuple[Path, list[Path]]]:
         Iterator[tuple[Path, list[Path]]]: A tuple containing the module directory and a list of all files in the module
 
     """
-    if root_dir.name not in ROOT_MODULES:
-        raise ValueError(f"Root directory {root_dir} is not a root directory for modules")
-    yield from _iterate_modules(root_dir)
+    if root_dir.name in ROOT_MODULES:
+        yield from _iterate_modules(root_dir)
+        return
+    for root_module in ROOT_MODULES:
+        module_dir = root_dir / root_module
+        if module_dir.exists():
+            yield from _iterate_modules(module_dir)
 
 
 def _iterate_modules(root_dir: Path) -> Iterator[tuple[Path, list[Path]]]:


### PR DESCRIPTION
# Description

Currently when you call `cdf-tk build cognite_toolkit` the `iterate_modules` function searches **all** directories for modules,
including the code directories `_cdf-tk` and `_api`. Instead of just `cognite_modules`, `custom_modules` and `modules`. This goes wrong if you have a project with the `modules` folder on the root level as then `.github` folder is considered a module as it contains `workflows` subdirectory.


## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
