### PR TITLE
[CDF-21480] 🏂Better build message

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -81,7 +81,7 @@ class BuildCommand(ToolkitCommand):
         config = BuildConfigYAML.load_from_directory(source_path, build_env_name, self.warn)
         sources = [module_dir for root_module in ROOT_MODULES if (module_dir := source_path / root_module).exists()]
         if not sources:
-            directories = "\n".join(f"   ┣ 📂 {name}" for name in ROOT_MODULES[:-1])
+            directories = "\n".join(f"   ┣ {name}" for name in ROOT_MODULES[:-1])
             raise ToolkitMissingModulesError(
                 f"Could not find the source modules directory.\nExpected to find one of the following directories\n"
                 f"📦{source_path.name}\n{directories}\n   ┗ 📂 {ROOT_MODULES[-1]}"

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -87,7 +87,7 @@ class BuildCommand(ToolkitCommand):
                 f"📦{source_path.name}\n{directories}\n   ┗ 📂 {ROOT_MODULES[-1]}"
             )
         directory_name = "current directory" if source_path == Path(".") else f"project '{source_path!s}'"
-        module_locations = "\n".join(f"  - Module directory -'{source!s}'" for source in sources)
+        module_locations = "\n".join(f"  - Module directory '{source!s}'" for source in sources)
         print(
             Panel(
                 f"Building {directory_name}:\n  - Environment {build_env_name!r}\n  - Config '{config.filepath!s}'"

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -84,7 +84,7 @@ class BuildCommand(ToolkitCommand):
             directories = "\n".join(f"   ┣ {name}" for name in ROOT_MODULES[:-1])
             raise ToolkitMissingModulesError(
                 f"Could not find the source modules directory.\nExpected to find one of the following directories\n"
-                f"📦{source_path.name}\n{directories}\n   ┗ 📂 {ROOT_MODULES[-1]}"
+                f"{source_path.name}\n{directories}\n   ┗  {ROOT_MODULES[-1]}"
             )
         directory_name = "current directory" if source_path == Path(".") else f"project '{source_path!s}'"
         module_locations = "\n".join(f"  - Module directory '{source!s}'" for source in sources)

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -34,6 +34,7 @@ from cognite_toolkit._cdf_tk.data_classes import (
 from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitDuplicatedModuleError,
     ToolkitFileExistsError,
+    ToolkitMissingModulesError,
     ToolkitNotADirectoryError,
     ToolkitValidationError,
     ToolkitYAMLFormatError,
@@ -78,10 +79,19 @@ class BuildCommand(ToolkitCommand):
 
         system_config = SystemYAML.load_from_directory(source_path, build_env_name, self.warn)
         config = BuildConfigYAML.load_from_directory(source_path, build_env_name, self.warn)
+        sources = [module_dir for root_module in ROOT_MODULES if (module_dir := source_path / root_module).exists()]
+        if not sources:
+            directories = "\n┣ 📂".join(ROOT_MODULES[:-1])
+            raise ToolkitMissingModulesError(
+                f"Could not find the source modules directory.\nExpected to find one\n"
+                f"{source_path.name}\n{directories}\n ┗ 📂{ROOT_MODULES[-1]}"
+            )
+
         print(
             Panel(
                 f"[bold]Building config files from templates into {build_dir!s} for environment {build_env_name} using {source_path!s} as sources...[/bold]"
-                f"\n[bold]Config file:[/] '{config.filepath.absolute()!s}'"
+                f"\n[bold]Config file:[/] '{config.filepath.absolute()!s}'",
+                expand=False,
             )
         )
         config.set_environment_variables()

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -86,14 +86,16 @@ class BuildCommand(ToolkitCommand):
                 f"Could not find the source modules directory.\nExpected to find one of the following directories\n"
                 f"📦{source_path.name}\n{directories}\n   ┗ 📂 {ROOT_MODULES[-1]}"
             )
-
+        directory_name = "current directory" if source_path == Path(".") else f"project '{source_path!s}'"
+        module_locations = "\n".join(f"  - Module directory -'{source!s}'" for source in sources)
         print(
             Panel(
-                f"[bold]Building config files from templates into {build_dir!s} for environment {build_env_name} using {source_path!s} as sources...[/bold]"
-                f"\n[bold]Config file:[/] '{config.filepath.absolute()!s}'",
+                f"Building {directory_name}:\n  - Environment {build_env_name!r}\n  - Config '{config.filepath!s}'"
+                f"\n{module_locations}",
                 expand=False,
             )
         )
+
         config.set_environment_variables()
 
         self.build_config(

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -81,10 +81,10 @@ class BuildCommand(ToolkitCommand):
         config = BuildConfigYAML.load_from_directory(source_path, build_env_name, self.warn)
         sources = [module_dir for root_module in ROOT_MODULES if (module_dir := source_path / root_module).exists()]
         if not sources:
-            directories = "\n┣ 📂".join(ROOT_MODULES[:-1])
+            directories = "\n".join(f"   ┣ 📂 {name}" for name in ROOT_MODULES[:-1])
             raise ToolkitMissingModulesError(
-                f"Could not find the source modules directory.\nExpected to find one\n"
-                f"{source_path.name}\n{directories}\n ┗ 📂{ROOT_MODULES[-1]}"
+                f"Could not find the source modules directory.\nExpected to find one of the following directories\n"
+                f"📦{source_path.name}\n{directories}\n   ┗ 📂 {ROOT_MODULES[-1]}"
             )
 
         print(

--- a/cognite_toolkit/_cdf_tk/exceptions.py
+++ b/cognite_toolkit/_cdf_tk/exceptions.py
@@ -47,6 +47,10 @@ class ToolkitMissingModuleError(ToolkitError):
     pass
 
 
+class ToolkitMissingModulesError(ToolkitError):
+    pass
+
+
 class ToolkitDuplicatedResourceError(ToolkitError):
     pass
 


### PR DESCRIPTION
# Description
If not source modules are found:
![image](https://github.com/cognitedata/toolkit/assets/60234212/339fe60f-fb14-497a-a6e7-25b0c33d1ed5)

And instead of the following when running the `cdf-tk build`
![image](https://github.com/cognitedata/toolkit/assets/60234212/c52ee8bd-f116-466e-9ba0-3d316382052a)

with this one
![image](https://github.com/cognitedata/toolkit/assets/60234212/730cd9e4-e109-4e62-9875-d530b7779d22)



## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
