### PR TITLE
[CDF-21776]  👲Error message when wrong kind

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import difflib
 import io
 import re
 import shutil
@@ -61,7 +62,11 @@ from cognite_toolkit._cdf_tk.tk_warnings import (
     UnresolvedVariableWarning,
     WarningList,
 )
-from cognite_toolkit._cdf_tk.tk_warnings.fileread import DuplicatedItemWarning, MissingRequiredIdentifierWarning
+from cognite_toolkit._cdf_tk.tk_warnings.fileread import (
+    DuplicatedItemWarning,
+    MissingRequiredIdentifierWarning,
+    UnknownResourceTypeWarning,
+)
 from cognite_toolkit._cdf_tk.utils import (
     calculate_str_or_file_hash,
     iterate_modules,
@@ -503,7 +508,7 @@ class BuildCommand(ToolkitCommand):
                 f"YAML validation error for {destination.name} after substituting config variables: {e}"
             )
 
-        loader = self._get_loader(resource_folder, destination)
+        loader = self._get_loader(resource_folder, destination, source_path)
         if loader is None:
             return warning_list
         if not issubclass(loader, ResourceLoader):
@@ -555,16 +560,27 @@ class BuildCommand(ToolkitCommand):
             )
         return api_spec
 
-    def _get_loader(self, resource_folder: str, destination: Path) -> type[Loader] | None:
-        loaders = LOADER_BY_FOLDER_NAME.get(resource_folder, [])
-        loaders = [loader for loader in loaders if loader.is_supported_file(destination)]
-        if len(loaders) == 0:
+    def _get_loader(self, resource_folder: str, destination: Path, source_path: Path) -> type[Loader] | None:
+        folder_loaders = LOADER_BY_FOLDER_NAME.get(resource_folder, [])
+        if not folder_loaders:
             self.warn(
                 ToolkitNotSupportedWarning(
-                    f"the resource {resource_folder!r}",
+                    f"resource of type {resource_folder!r} in {source_path.name}.",
                     details=f"Available resources are: {', '.join(LOADER_BY_FOLDER_NAME.keys())}",
                 )
             )
+            return None
+
+        loaders = [loader for loader in folder_loaders if loader.is_supported_file(destination)]
+        if len(loaders) == 0:
+            suggestion: str | None = None
+            if "." in source_path.stem:
+                core, kind = source_path.stem.rsplit(".", 1)
+                match = difflib.get_close_matches(kind, [loader.kind for loader in folder_loaders])
+                if match:
+                    suggestion = f"{core}.{match[0]}{source_path.suffix}"
+            self.warn(UnknownResourceTypeWarning(source_path, suggestion))
+            return None
         elif len(loaders) > 1 and all(loader.folder_name == "raw" for loader in loaders):
             # Multiple raw loaders load from the same file.
             return RawDatabaseLoader

--- a/cognite_toolkit/_cdf_tk/tk_warnings/fileread.py
+++ b/cognite_toolkit/_cdf_tk/tk_warnings/fileread.py
@@ -69,6 +69,19 @@ class DuplicatedItemWarning(YAMLFileWarning):
 
 
 @dataclass(frozen=True)
+class UnknownResourceTypeWarning(YAMLFileWarning):
+    severity = SeverityLevel.MEDIUM
+
+    suggestion: str | None
+
+    def get_message(self) -> str:
+        msg = f"{type(self).__name__}: The resource type of file {self.filepath.as_posix()!r}."
+        if self.suggestion:
+            msg += f" Did you mean to call the file {self.suggestion!r}?"
+        return SeverityFormat.get_rich_severity_format(self.severity, msg)
+
+
+@dataclass(frozen=True)
 class UnusedParameterWarning(YAMLFileWithElementWarning):
     severity = SeverityLevel.LOW
     actual: str

--- a/cognite_toolkit/_cdf_tk/tk_warnings/fileread.py
+++ b/cognite_toolkit/_cdf_tk/tk_warnings/fileread.py
@@ -75,7 +75,7 @@ class UnknownResourceTypeWarning(YAMLFileWarning):
     suggestion: str | None
 
     def get_message(self) -> str:
-        msg = f"{type(self).__name__}: The resource type of file {self.filepath.as_posix()!r}."
+        msg = f"{type(self).__name__}: In file {self.filepath.as_posix()!r}."
         if self.suggestion:
             msg += f" Did you mean to call the file {self.suggestion!r}?"
         return SeverityFormat.get_rich_severity_format(self.severity, msg)

--- a/tests/tests_unit/test_cdf_tk/test_commands/test_build.py
+++ b/tests/tests_unit/test_cdf_tk/test_commands/test_build.py
@@ -25,7 +25,9 @@ class TestBuildCommand:
     def test_get_loader_raises_ambiguous_error(self):
         with pytest.raises(AmbiguousResourceFileError) as e:
             BuildCommand()._get_loader(
-                "transformations", destination=Path("my_module") / "transformations" / "notification.yaml"
+                "transformations",
+                destination=Path("transformation") / "notification.yaml",
+                source_path=Path("my_module") / "transformations" / "notification.yaml",
             )
         assert "Ambiguous resource file" in str(e.value)
 


### PR DESCRIPTION
# Description

Today you get:
![image](https://github.com/cognitedata/toolkit/assets/60234212/fb78e35f-4154-4905-af75-4d25f05ceb19)

Replaces it with:
![image](https://github.com/cognitedata/toolkit/assets/60234212/51988529-aa41-4ff5-affb-117f6f4bd824)

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
