### PR TITLE
[CDF-21798] 🤓Do not include prototype variables in old init

### DIFF
--- a/cognite_toolkit/_cdf_tk/data_classes/_config_yaml.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_config_yaml.py
@@ -18,6 +18,7 @@ from cognite_toolkit._cdf_tk.constants import (
     BUILD_ENVIRONMENT_FILE,
     DEFAULT_CONFIG_FILE,
     MODULE_PATH_SEP,
+    ROOT_MODULES,
     SEARCH_VARIABLES_SUFFIX,
 )
 from cognite_toolkit._cdf_tk.exceptions import ToolkitEnvError, ToolkitMissingModuleError
@@ -352,9 +353,17 @@ class InitConfigYAML(YAMLWithComments[tuple[str, ...], ConfigEntry], ConfigYAMLC
         return self._load_defaults(cognite_root_module, relevant_defaults)
 
     def load_defaults(self, cognite_root_module: Path) -> InitConfigYAML:
-        default_files = sorted(
-            cognite_root_module.glob(f"**/{DEFAULT_CONFIG_FILE}"), key=lambda f: f.relative_to(cognite_root_module)
+        """Loads all default.config.yaml files in the cognite root module."""
+
+        default_files_iterable = itertools.chain(
+            *[
+                (cognite_root_module / root_module).glob(f"**/{DEFAULT_CONFIG_FILE}")
+                for root_module in ROOT_MODULES
+                if (cognite_root_module / root_module).exists()
+            ]
         )
+
+        default_files = sorted(default_files_iterable, key=lambda f: f.relative_to(cognite_root_module))
         return self._load_defaults(cognite_root_module, default_files)
 
     def _load_defaults(self, cognite_root_module: Path, defaults_files: list[Path]) -> InitConfigYAML:

--- a/cognite_toolkit/_cdf_tk/data_classes/_config_yaml.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_config_yaml.py
@@ -5,7 +5,7 @@ import os
 import re
 from abc import ABC
 from collections import UserDict, defaultdict
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
@@ -355,13 +355,17 @@ class InitConfigYAML(YAMLWithComments[tuple[str, ...], ConfigEntry], ConfigYAMLC
     def load_defaults(self, cognite_root_module: Path) -> InitConfigYAML:
         """Loads all default.config.yaml files in the cognite root module."""
 
-        default_files_iterable = itertools.chain(
-            *[
-                (cognite_root_module / root_module).glob(f"**/{DEFAULT_CONFIG_FILE}")
-                for root_module in ROOT_MODULES
-                if (cognite_root_module / root_module).exists()
-            ]
-        )
+        default_files_iterable: Iterable[Path]
+        if cognite_root_module.name in ROOT_MODULES:
+            default_files_iterable = cognite_root_module.glob(f"**/{DEFAULT_CONFIG_FILE}")
+        else:
+            default_files_iterable = itertools.chain(
+                *[
+                    (cognite_root_module / root_module).glob(f"**/{DEFAULT_CONFIG_FILE}")
+                    for root_module in ROOT_MODULES
+                    if (cognite_root_module / root_module).exists()
+                ]
+            )
 
         default_files = sorted(default_files_iterable, key=lambda f: f.relative_to(cognite_root_module))
         return self._load_defaults(cognite_root_module, default_files)


### PR DESCRIPTION
# Description
If you run the old init, no feature flags, you include the prototype variables in the `config.<env>.yaml`. This fixes it.
![image](https://github.com/cognitedata/toolkit/assets/60234212/8101dd03-3d10-4ed3-b2ca-6e9dc7e002f9)


## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
