### PR TITLE
[CDF-21790] 🚣 Fix auth verify

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,22 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+### Improved
+
+- The command line messages have been improved to be more informative and user-friendly when running
+  `cdf-tk auth verify`.
+
+### Fixed
+
+- In the `cdf-tk auth verify` command, if the flag `--interactive` was set, the `--update-group` and `create-group`
+  flags were not ignored. This is now fixed.
+- In the `cdf-tk auth verify` command, if there was no `.env` or `--cluster` and `--project` flags, the toolkit
+  would raise an `AuthentciationError`, instead of prompting the user for cluster and project. This is now fixed.
+- In the `cdf-tk auth verify` command, the if function service was not activated, the toolkit will
+  now activate it.
+
 ## [0.2.1] - 2024-06-17
 
 ### Improved

--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -449,7 +449,7 @@ def auth_verify(
     with contextlib.redirect_stdout(None):
         # Remove the Error message from failing to load the config
         # This is verified in check_auth
-        ToolGlobals = CDFToolConfig.from_context(ctx)
+        ToolGlobals = CDFToolConfig(cluster=ctx.obj.cluster, project=ctx.obj.projec, skip_initialization=True)
     cmd.execute(ToolGlobals, dry_run, interactive, group_file, update_group, create_group, ctx.obj.verbose)
 
 

--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -403,7 +403,8 @@ def auth_verify(
         typer.Option(
             "--interactive",
             "-i",
-            help="Will run the verification in interactive mode, prompting for input. Used to bootstrap a new project.",
+            help="Will run the verification in interactive mode, prompting for input. Used to bootstrap a new project."
+            "If this mode is selected the --update-group and --create-group options will be ignored.",
         ),
     ] = False,
     group_file: Annotated[
@@ -411,7 +412,8 @@ def auth_verify(
         typer.Option(
             "--group-file",
             "-f",
-            help="Path to group yaml configuration file to use for group verification. Defaults to admin.readwrite.group.yaml from the cdf_auth_readwrite_all common module.",
+            help="Path to group yaml configuration file to use for group verification. "
+            "Defaults to admin.readwrite.group.yaml from the cdf_auth_readwrite_all common module.",
         ),
     ] = None,
     update_group: Annotated[
@@ -419,7 +421,8 @@ def auth_verify(
         typer.Option(
             "--update-group",
             "-u",
-            help="Used to update an existing group with the configurations from the configuration file. Set to the group id to update or 1 to update the default write-all group (if the tool is only member of one group).",
+            help="If --interactive is not set. Used to update an existing group with the configurations."
+            "Set to the group id or 1 to update the default write-all group.",
         ),
     ] = 0,
     create_group: Annotated[
@@ -427,7 +430,8 @@ def auth_verify(
         typer.Option(
             "--create-group",
             "-c",
-            help="Used to create a new group with the configurations from the configuration file. Set to the source id that the new group should be configured with.",
+            help="If --interactive is not set. Used to create a new group with the configurations."
+            "Set to the source id of the new group.",
         ),
     ] = None,
 ) -> None:

--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -449,7 +449,7 @@ def auth_verify(
     with contextlib.redirect_stdout(None):
         # Remove the Error message from failing to load the config
         # This is verified in check_auth
-        ToolGlobals = CDFToolConfig(cluster=ctx.obj.cluster, project=ctx.obj.projec, skip_initialization=True)
+        ToolGlobals = CDFToolConfig(cluster=ctx.obj.cluster, project=ctx.obj.project, skip_initialization=True)
     cmd.execute(ToolGlobals, dry_run, interactive, group_file, update_group, create_group, ctx.obj.verbose)
 
 

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -121,14 +121,16 @@ class AuthCommand(ToolkitCommand):
                 "The Cognite Toolkit expects the following:\n"
                 " - The principal used with the Toolkit [yellow]should[/yellow] be connected to "
                 "only ONE CDF Group.\n"
-                f" - This group [red]must[/red] be named {admin_write_group.name}.\n"
-                f" - The group {admin_write_group.name} [red]must[/red] have capabilities to "
+                f" - This group [red]must[/red] be named {admin_write_group.name!r}.\n"
+                f" - The group {admin_write_group.name!r} [red]must[/red] have capabilities to "
                 f"all resources the Toolkit is managing\n"
                 " - All he capabilities [yellow]should[/yellow] be scoped to all resources.",
                 title="Toolkit Access Group",
                 expand=False,
             )
         )
+        if interactive and not Confirm.ask("Do you want to continue?", choices=["y", "n"]):
+            return None
 
         self.check_principal_groups(principal_groups, admin_write_group)
 
@@ -321,8 +323,6 @@ class AuthCommand(ToolkitCommand):
             # Todo: New feature ask user to cleanup groups with the same name.
             #    Should compare the groups to the admin_group and ask to cleanup the groups
             #    that are not the same.
-        else:
-            print("  [bold green]OK[/] - Only one group is used for this service principal/application.")
 
         # Check for the reuse of Source ID
         unique_source_ids = set(group.source_id for group in principal_groups)

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -208,6 +208,7 @@ class AuthCommand(ToolkitCommand):
         except Exception:
             raise AuthorizationError(
                 "Not a valid authentication token. Check credentials (CDF_CLIENT_ID/CDF_CLIENT_SECRET or CDF_TOKEN)."
+                "This could also be due to the service principal/application not having access to any Groups."
             )
         return token_inspection
 

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -462,7 +462,7 @@ class AuthCommand(ToolkitCommand):
         if to_delete:
             existing_capabilities = to_delete.capabilities or []
             new_capabilities = to_create.capabilities or []
-            loosing = client.iam.compare_capabilities(existing_capabilities, new_capabilities, project=cdf_project)
+            loosing = client.iam.compare_capabilities(new_capabilities, existing_capabilities, project=cdf_project)
             for capability in loosing:
                 if len(principal_groups) > 1:
                     self.warn(

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -294,17 +294,14 @@ class AuthCommand(ToolkitCommand):
     ) -> None:
         print(f"\nChecking CDF groups access right against capabilities in {group_file_name} ...")
 
-        diff = client.iam.compare_capabilities(
+        missing_cabilities = client.iam.compare_capabilities(
             token_inspection.capabilities,
             read_write.capabilities or [],
             project=cdf_project,
         )
-        if len(diff) > 0:
-            diff_list: list[str] = []
-            for d in diff:
-                diff_list.append(str(d))
-            for s in sorted(diff_list):
-                self.warn(MissingCapabilityWarning(str(s)))
+        if missing_cabilities:
+            for s in sorted(map(str, missing_cabilities)):
+                self.warn(MissingCapabilityWarning(s))
         else:
             print("  [bold green]OK[/] - All capabilities are present in the CDF project.")
 

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -130,8 +130,8 @@ class AuthCommand(ToolkitCommand):
                 expand=False,
             )
         )
-        if interactive and not Confirm.ask("Do you want to continue?", choices=["y", "n"]):
-            return None
+        if interactive:
+            Prompt.ask("Press enter key to continue...")
 
         self.check_principal_groups(principal_groups, admin_write_group)
 

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -166,13 +166,14 @@ class AuthCommand(ToolkitCommand):
             )
             has_added_capabilities = True
 
-        must_switch_principal = created and created.id not in {group.id for group in principal_groups}
+        must_switch_principal = created and created.source_id not in {group.source_id for group in principal_groups}
         if must_switch_principal and created:
             print(
                 Panel(
-                    f"To use the Toolkit, for example, 'cdf-tk deploy', [red]you need to switch[/red]"
-                    f"to the principal with source-id{created.source_id}.",
+                    f"To use the Toolkit, for example, 'cdf-tk deploy', [red]you need to switch[/red] "
+                    f"to the principal with source-id {created.source_id!r}.",
                     title="Switch Principal",
+                    expand=False,
                 )
             )
 

--- a/cognite_toolkit/_cdf_tk/utils.py
+++ b/cognite_toolkit/_cdf_tk/utils.py
@@ -326,7 +326,7 @@ class AuthReaderValidation:
             raise RuntimeError("AuthVariables not created correctly. Contact Support") from e
 
         extra_args: dict[str, Any] = {}
-        if password is False:
+        if password is True:
             extra_args["default"] = ""
         else:
             extra_args["default"] = default

--- a/cognite_toolkit/_cdf_tk/utils.py
+++ b/cognite_toolkit/_cdf_tk/utils.py
@@ -379,7 +379,13 @@ class CDFToolConfig:
         data_set_id_by_external_id: dict[str, int] = field(default_factory=dict)
         security_categories_by_name: dict[str, int] = field(default_factory=dict)
 
-    def __init__(self, token: str | None = None, cluster: str | None = None, project: str | None = None) -> None:
+    def __init__(
+        self,
+        token: str | None = None,
+        cluster: str | None = None,
+        project: str | None = None,
+        skip_initialization: bool = False,
+    ) -> None:
         self._cache = self._Cache()
         self._environ: dict[str, str | None] = {}
         # If cluster, project, or token are passed as arguments, we override the environment variables.
@@ -410,7 +416,8 @@ class CDFToolConfig:
             return
 
         auth_vars = AuthVariables.from_env(self._environ)
-        self.initialize_from_auth_variables(auth_vars)
+        if not skip_initialization:
+            self.initialize_from_auth_variables(auth_vars)
 
     def _initialize_in_browser(self) -> None:
         try:

--- a/cognite_toolkit/cognite_modules/common/cdf_auth_readwrite_all/auth/admin.readwrite.group.yaml
+++ b/cognite_toolkit/cognite_modules/common/cdf_auth_readwrite_all/auth/admin.readwrite.group.yaml
@@ -7,8 +7,6 @@ capabilities:
       actions:
         - LIST
         - READ
-        - CREATE
-        - UPDATE
       scope:
         all: {}
   - groupsAcl:

--- a/cognite_toolkit/cognite_modules/common/cdf_auth_readwrite_all/auth/admin.readwrite.group.yaml
+++ b/cognite_toolkit/cognite_modules/common/cdf_auth_readwrite_all/auth/admin.readwrite.group.yaml
@@ -7,6 +7,7 @@ capabilities:
       actions:
         - LIST
         - READ
+        - UPDATE
       scope:
         all: {}
   - groupsAcl:

--- a/cognite_toolkit/cognite_modules/common/cdf_auth_readwrite_all/auth/admin.readwrite.group.yaml
+++ b/cognite_toolkit/cognite_modules/common/cdf_auth_readwrite_all/auth/admin.readwrite.group.yaml
@@ -7,6 +7,8 @@ capabilities:
       actions:
         - LIST
         - READ
+        - CREATE
+        - UPDATE
       scope:
         all: {}
   - groupsAcl:

--- a/tests/tests_unit/test_cli/test_build_deploy_snapshots/cdf_auth_readwrite_all.yaml
+++ b/tests/tests_unit/test_cli/test_build_deploy_snapshots/cdf_auth_readwrite_all.yaml
@@ -4,6 +4,7 @@ Group:
       actions:
       - LIST
       - READ
+      - UPDATE
       scope:
         all: {}
   - groupsAcl:


### PR DESCRIPTION
# Description

Multiple bugs in Auth Verify, `cdf-tk auth verify`

## 1
If no .env file or --cluster or --cdf-project passed in

![image](https://github.com/cognitedata/toolkit/assets/60234212/448d63b7-6437-4006-a81b-7235451c3e23)

## 2
The interactive flag is not properly respected, as you also have to input `--group-file` and `--update-group` to control the behavior of the questions being asked. Also not really sure if it is possible to get the `--update-group` path.
![image](https://github.com/cognitedata/toolkit/assets/60234212/d704a16c-34b4-439d-af17-6e1201a9d1a0)

Rewrote logic and updated information printed to the terminal.

## 3
The `client.functions.activate` call had been lost in refactorings.

## Happy Path:
```bash
$ cdf-tk auth verify --interactive
Checking current service principal/application and environment configurations...
CDF project cluster (e.g. westeurope-1)?  (bluefield): 
CDF project URL name (e.g. publicdata)?  (albert): 
CDF URL?  (https://bluefield.cognitedata.com): 
Login flow?  [client_credentials/token/interactive] (client_credentials): 
tenant id (e.g. 12345678-1234-1234-1234-123456789012)?  (7970cd77-47e3-4778-9fb0-a6747cfbae5e): 
client id (e.g. XXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX)?  (41301a1f-f4a7-430a-b34e-43eedfdbcc4f): 
You have set client secret, change it? (press Enter to keep current value) (): 
  Keeping existing client secret.
token URL?  (https://login.microsoftonline.com/7970cd77-47e3-4778-9fb0-a6747cfbae5e/oauth2/v2.0/token): 
IDP scopes?  (https://bluefield.cognitedata.com/.default): 
IDP audience?  (https://bluefield.cognitedata.com): 
WARNING: .env file already exists and values have been retrieved from it. It will be overwritten.
Do you want to save these to .env file for next time ?  [y/n]: y
  OK
Checking basic project configuration...
  OK
Checking projects that the service principal/application has access to...
  - albert
Focusing on current project albert only from here on.
Checking basic project and group manipulation access rights (projectsAcl: LIST, READ and groupsAcl: LIST, READ, CREATE, UPDATE, DELETE)...
  OK
Checking identity provider settings...
  OK: Microsoft Entra ID (aka ActiveDirectory) with tenant id (7970cd77-47e3-4778-9fb0-a6747cfbae5e).
  Matching on CDF group sourceIds will be done on any of these claims from the identity provider: ['groups', 'roles']
╭─────────────────────────────────────── Toolkit Access Group ───────────────────────────────────────╮
│ The Cognite Toolkit expects the following:                                                         │
│  - The principal used with the Toolkit should be connected to only ONE CDF Group.                  │
│  - This group must be named 'gp_admin_read_write'.                                                 │
│  - The group 'gp_admin_read_write' must have capabilities to all resources the Toolkit is managing │
│  - All he capabilities should be scoped to all resources.                                          │
╰────────────────────────────────────────────────────────────────────────────────────────────────────╯
Press enter key to continue...:
Checking CDF group memberships for the current client configured...
                      CDF Group ids, Names, and Source Ids
┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Id               ┃ Name                ┃ Source Id                            ┃
┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ 7101286974486678 │ gp_admin_read_write │ 264c9e53-6f26-4f4a-b89a-d6a6b21beb0f │
└──────────────────┴─────────────────────┴──────────────────────────────────────┘
  OK - Only one group is used for this service principal/application.
---------------------

Checking CDF groups access right against capabilities in gp_admin_read_write ...
WARNING [MEDIUM]: The principal lacks the required access capability AssetsAcl(actions=[<AssetsAcl Action.Read: 'READ'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability AssetsAcl(actions=[<AssetsAcl Action.Write: 'WRITE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability DataModelInstancesAcl(actions=[<DataModelInstancesAcl Action.Read: 'READ'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability DataModelInstancesAcl(actions=[<DataModelInstancesAcl Action.Write: 'WRITE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability DataModelsAcl(actions=[<DataModelsAcl Action.Read: 'READ'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability DataModelsAcl(actions=[<DataModelsAcl Action.Write: 'WRITE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability DataSetsAcl(actions=[<DataSetsAcl Action.Owner: 'OWNER'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability DataSetsAcl(actions=[<DataSetsAcl Action.Read: 'READ'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability DataSetsAcl(actions=[<DataSetsAcl Action.Write: 'WRITE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability ExtractionConfigsAcl(actions=[<ExtractionConfigsAcl Action.Read: 'READ'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability ExtractionConfigsAcl(actions=[<ExtractionConfigsAcl Action.Write: 'WRITE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability ExtractionPipelinesAcl(actions=[<ExtractionPipelinesAcl Action.Read: 'READ'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability ExtractionPipelinesAcl(actions=[<ExtractionPipelinesAcl Action.Write: 'WRITE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability ExtractionsRunAcl(actions=[<ExtractionsRunAcl Action.Read: 'READ'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability ExtractionsRunAcl(actions=[<ExtractionsRunAcl Action.Write: 'WRITE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability FilesAcl(actions=[<FilesAcl Action.Read: 'READ'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability FilesAcl(actions=[<FilesAcl Action.Write: 'WRITE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability FunctionsAcl(actions=[<FunctionsAcl Action.Read: 'READ'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability FunctionsAcl(actions=[<FunctionsAcl Action.Write: 'WRITE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability LabelsAcl(actions=[<LabelsAcl Action.Read: 'READ'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability LabelsAcl(actions=[<LabelsAcl Action.Write: 'WRITE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability RawAcl(actions=[<RawAcl Action.List: 'LIST'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability RawAcl(actions=[<RawAcl Action.Read: 'READ'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability RawAcl(actions=[<RawAcl Action.Write: 'WRITE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability SecurityCategoriesAcl(actions=[<SecurityCategoriesAcl Action.Create: 'CREATE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability SecurityCategoriesAcl(actions=[<SecurityCategoriesAcl Action.Delete: 'DELETE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability SecurityCategoriesAcl(actions=[<SecurityCategoriesAcl Action.List: 'LIST'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability SecurityCategoriesAcl(actions=[<SecurityCategoriesAcl Action.MemberOf: 'MEMBEROF'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability SecurityCategoriesAcl(actions=[<SecurityCategoriesAcl Action.Update: 'UPDATE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability SessionsAcl(actions=[<SessionsAcl Action.Create: 'CREATE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability SessionsAcl(actions=[<SessionsAcl Action.Delete: 'DELETE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability SessionsAcl(actions=[<SessionsAcl Action.List: 'LIST'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability TimeSeriesAcl(actions=[<TimeSeriesAcl Action.Read: 'READ'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability TimeSeriesAcl(actions=[<TimeSeriesAcl Action.Write: 'WRITE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability TimeSeriesSubscriptionsAcl(actions=[<TimeSeriesSubscriptionsAcl Action.Read: 'READ'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability TimeSeriesSubscriptionsAcl(actions=[<TimeSeriesSubscriptionsAcl Action.Write: 'WRITE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability TransformationsAcl(actions=[<TransformationsAcl Action.Read: 'READ'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability TransformationsAcl(actions=[<TransformationsAcl Action.Write: 'WRITE'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability WorkflowOrchestrationAcl(actions=[<WorkflowOrchestrationAcl Action.Read: 'READ'>], scope=AllScope()) in the CDF project
WARNING [MEDIUM]: The principal lacks the required access capability WorkflowOrchestrationAcl(actions=[<WorkflowOrchestrationAcl Action.Write: 'WRITE'>], scope=AllScope()) in the CDF project
---------------------
Do you want to update the group with name 'gp_admin_read_write' with the capabilities from the group config file? [y/n]: y
  OK - Updated new group gp_admin_read_write with 19 capabilities.
Checking function service status...
  OK - Function service has been activated.

```

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
