### PR TITLE
[CDF-21903]🦸Diffs

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -21,6 +21,7 @@ Changes are grouped as follows:
 
 - The `--verbose` flag is now moved to the end of the command. For example, instead of `cdf-tk --verbose build`,
   you should now write `cdf-tk build --verbose`. The old syntax is still supported but will raise a deprecation warning.
+- When running `cdf-tk deploy --verbose` you will now get a detailed output for each resource that has changed.
 
 ### Fixed
 

--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -29,6 +29,8 @@ Changes are grouped as follows:
   This is now fixed by not validating the details of `View.filters`. The motivation is that `View.filters` is a complex
   structure, and it is likely that you will get a false warning. The users that starts to use `View.filters` are
   expected to know what they are doing.
+- If you run `cdf-tk deploy` and you had a child view that overrides a property from a parent view, the Toolkit would
+  log it as changed even though it was not. This is now fixed.
 
 ## [0.2.5] - 2024-06-25
 

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -310,7 +310,7 @@ class DeployCommand(ToolkitCommand):
         for item in resources:
             cdf_resource = cdf_resource_by_id.get(loader.get_id(item))
             try:
-                are_equal = cdf_resource and loader.are_equal(item, cdf_resource)
+                are_equal = cdf_resource and loader._are_equal(item, cdf_resource)
             except CogniteAPIError as e:
                 self.warn(
                     MediumSeverityWarning(

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -4,6 +4,7 @@ import re
 import traceback
 from graphlib import TopologicalSorter
 from pathlib import Path
+from typing import Any
 
 from cognite.client.data_classes._base import T_CogniteResourceList
 from cognite.client.exceptions import CogniteAPIError, CogniteDuplicatedError
@@ -46,6 +47,7 @@ from cognite_toolkit._cdf_tk.tk_warnings.other import (
 from cognite_toolkit._cdf_tk.utils import (
     CDFToolConfig,
     read_yaml_file,
+    to_diff,
 )
 
 from ._utils import _print_ids_or_length, _remove_duplicates
@@ -230,7 +232,7 @@ class DeployCommand(ToolkitCommand):
             self.warn(LowSeverityWarning(f"Skipping duplicate {loader.display_name} {duplicate}."))
 
         nr_of_created = nr_of_changed = nr_of_unchanged = 0
-        to_create, to_update, unchanged = self.to_create_changed_unchanged_triple(loaded_resources, loader)
+        to_create, to_update, unchanged = self.to_create_changed_unchanged_triple(loaded_resources, loader, verbose)
 
         if dry_run:
             if (
@@ -286,6 +288,7 @@ class DeployCommand(ToolkitCommand):
         self,
         resources: T_CogniteResourceList,
         loader: ResourceLoader,
+        verbose: bool = False,
     ) -> tuple[T_CogniteResourceList, T_CogniteResourceList, T_CogniteResourceList]:
         """Returns a triple of lists of resources that should be created, updated, and are unchanged."""
         resource_ids = loader.get_ids(resources)
@@ -309,19 +312,25 @@ class DeployCommand(ToolkitCommand):
 
         for item in resources:
             cdf_resource = cdf_resource_by_id.get(loader.get_id(item))
-            try:
-                are_equal = cdf_resource and loader._are_equal(item, cdf_resource)
-            except CogniteAPIError as e:
-                self.warn(
-                    MediumSeverityWarning(
-                        f"Failed to compare {loader.display_name} {loader.get_id(item)} for equality. Proceeding assuming not data in CDF. Error {e}."
+            local_dumped: dict[str, Any] = {}
+            cdf_dumped: dict[str, Any] = {}
+            are_equal = False
+            if cdf_resource:
+                try:
+                    are_equal, local_dumped, cdf_dumped = loader.are_equal(item, cdf_resource, return_dumped=True)
+                except CogniteAPIError as e:
+                    self.warn(
+                        MediumSeverityWarning(
+                            f"Failed to compare {loader.display_name} {loader.get_id(item)} for equality. Proceeding assuming not data in CDF. Error {e}."
+                        )
                     )
-                )
-                print(Panel(traceback.format_exc()))
-                are_equal = False
+                    print(Panel(traceback.format_exc()))
+
             if are_equal:
                 unchanged.append(item)
             elif cdf_resource:
+                if verbose:
+                    print(Panel("\n".join(to_diff(local_dumped, cdf_dumped))))
                 to_update.append(item)
             else:
                 to_create.append(item)

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -311,7 +311,8 @@ class DeployCommand(ToolkitCommand):
             cdf_resource_by_id = {loader.get_id(resource): resource for resource in cdf_resources}
 
         for item in resources:
-            cdf_resource = cdf_resource_by_id.get(loader.get_id(item))
+            identifier = loader.get_id(item)
+            cdf_resource = cdf_resource_by_id.get(identifier)
             local_dumped: dict[str, Any] = {}
             cdf_dumped: dict[str, Any] = {}
             are_equal = False
@@ -330,7 +331,13 @@ class DeployCommand(ToolkitCommand):
                 unchanged.append(item)
             elif cdf_resource:
                 if verbose:
-                    print(Panel("\n".join(to_diff(local_dumped, cdf_dumped))))
+                    print(
+                        Panel(
+                            "\n".join(to_diff(cdf_dumped, local_dumped)),
+                            title=f"{loader.display_name}: {identifier}",
+                            expand=False,
+                        )
+                    )
                 to_update.append(item)
             else:
                 to_create.append(item)

--- a/cognite_toolkit/_cdf_tk/loaders/_base_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_base_loaders.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Hashable, Iterable, Sequence, Sized
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Literal, TypeVar, overload
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes._base import (
@@ -234,13 +234,42 @@ class ResourceLoader(
         """
         return resource.dump(), {}
 
-    def are_equal(self, local: T_WriteClass, cdf_resource: T_WritableCogniteResource) -> bool:
+    @overload
+    def are_equal(
+        self, local: T_WriteClass, cdf_resource: T_WritableCogniteResource, return_dumped: Literal[False] = False
+    ) -> bool: ...
+
+    @overload
+    def are_equal(
+        self, local: T_WriteClass, cdf_resource: T_WritableCogniteResource, return_dumped: Literal[True]
+    ) -> tuple[bool, dict[str, Any], dict[str, Any]]: ...
+
+    def are_equal(
+        self, local: T_WriteClass, cdf_resource: T_WritableCogniteResource, return_dumped: bool = False
+    ) -> bool | tuple[bool, dict[str, Any], dict[str, Any]]:
+        return self._are_equal(local, cdf_resource, return_dumped)
+
+    # Private to avoid having to overload in all subclasses
+    def _are_equal(
+        self, local: T_WriteClass, cdf_resource: T_WritableCogniteResource, return_dumped: bool = False
+    ) -> bool | tuple[bool, dict[str, Any], dict[str, Any]]:
         """This can be overwritten in subclasses that require special comparison logic.
 
         For example, TransformationWrite has OIDC credentials that will not be returned
         by the retrieve method, and thus needs special handling.
         """
-        return local == cdf_resource.as_write()
+        local_dumped = local.dump()
+        cdf_dumped = cdf_resource.as_write().dump()
+        return self._return_are_equal(local_dumped, cdf_dumped, return_dumped)
+
+    @staticmethod
+    def _return_are_equal(
+        local_dumped: dict[str, Any], cdf_dumped: dict[str, Any], return_dumped: bool
+    ) -> bool | tuple[bool, dict[str, Any], dict[str, Any]]:
+        if return_dumped:
+            return local_dumped == cdf_dumped, local_dumped, cdf_dumped
+        else:
+            return local_dumped == cdf_dumped
 
     # Helper method
     @classmethod

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -2897,13 +2897,13 @@ class ViewLoader(ResourceLoader[ViewId, ViewApply, View, ViewApplyList, ViewList
             parents = retrieve_view_ancestors(self.client, cdf_resource.implements or [], self._interfaces_by_id)
             cdf_properties = cdf_dumped["properties"]
             for parent in parents:
-                for prop_name, prop in parent.properties.items():
-                    is_overidden = prop_name in cdf_properties and cdf_properties[prop_name] != prop.dump()
+                for prop_name, parent_prop in (parent.as_write().properties or {}).items():
+                    is_overidden = prop_name in cdf_properties and cdf_properties[prop_name] != parent_prop.dump()
                     if is_overidden:
                         continue
                     cdf_properties.pop(prop_name, None)
 
-        if not cdf_properties:
+        if not cdf_dumped["properties"]:
             # All properties were removed, so we remove the properties key.
             cdf_dumped.pop("properties", None)
         if "properties" in local_dumped and not local_dumped["properties"]:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -2895,11 +2895,11 @@ class ViewLoader(ResourceLoader[ViewId, ViewApply, View, ViewApplyList, ViewList
             # We need to remove these properties to compare with the local view.
             # Unless the local view has overridden the properties.
             parents = retrieve_view_ancestors(self.client, cdf_resource.implements or [], self._interfaces_by_id)
+            cdf_properties = cdf_dumped["properties"]
             for parent in parents:
                 for prop_name, prop in parent.properties.items():
-                    if (prop_name not in cdf_dumped["properties"]) or (
-                        cdf_dumped["properties"][prop_name] != prop.dump()
-                    ):
+                    is_overidden = prop_name in cdf_properties and cdf_properties[prop_name] != prop.dump()
+                    if is_overidden:
                         continue
                     cdf_dumped["properties"].pop(prop_name, None)
 

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -2893,9 +2893,14 @@ class ViewLoader(ResourceLoader[ViewId, ViewApply, View, ViewApplyList, ViewList
         if cdf_resource.properties:
             # All read version of views have all the properties of their parent views.
             # We need to remove these properties to compare with the local view.
+            # Unless the local view has overridden the properties.
             parents = retrieve_view_ancestors(self.client, cdf_resource.implements or [], self._interfaces_by_id)
             for parent in parents:
-                for prop_name in parent.properties.keys():
+                for prop_name, prop in parent.properties.items():
+                    if (prop_name not in cdf_dumped["properties"]) or (
+                        cdf_dumped["properties"][prop_name] != prop.dump()
+                    ):
+                        continue
                     cdf_dumped["properties"].pop(prop_name, None)
 
         if not cdf_dumped["properties"]:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -2901,9 +2901,9 @@ class ViewLoader(ResourceLoader[ViewId, ViewApply, View, ViewApplyList, ViewList
                     is_overidden = prop_name in cdf_properties and cdf_properties[prop_name] != prop.dump()
                     if is_overidden:
                         continue
-                    cdf_dumped["properties"].pop(prop_name, None)
+                    cdf_properties.pop(prop_name, None)
 
-        if not cdf_dumped["properties"]:
+        if not cdf_properties:
             # All properties were removed, so we remove the properties key.
             cdf_dumped.pop("properties", None)
         if "properties" in local_dumped and not local_dumped["properties"]:

--- a/cognite_toolkit/_cdf_tk/utils.py
+++ b/cognite_toolkit/_cdf_tk/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import difflib
 import hashlib
 import json
 import logging
@@ -1275,3 +1276,10 @@ def to_directory_compatible(text: str) -> str:
     cleaned = _ILLEGAL_CHARACTERS.sub("_", text)
     # Replace multiple underscores with a single one
     return re.sub(r"_+", "_", cleaned)
+
+
+def to_diff(a: dict[str, Any], b: dict[str, Any]) -> Iterator[str]:
+    a_str = yaml.safe_dump(a, sort_keys=True)
+    b_str = yaml.safe_dump(b, sort_keys=True)
+
+    return difflib.unified_diff(a_str.splitlines(), b_str.splitlines())


### PR DESCRIPTION
# Description

When running `cdf-tk deploy --verbose` gives a detailed output

![image](https://github.com/cognitedata/toolkit/assets/60234212/8b528b11-28da-4324-919e-b6e04ba09f0c)

Note that this PR makes it clear that there are more bugs in the change logic, which appears when you run in `--dry-run` mode.

![image](https://github.com/cognitedata/toolkit/assets/60234212/f86aaff2-7661-4859-98d5-5f220ea78136)

Creating a separate issue for that.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
