### PR TITLE
[CDF-21946] 🤷Turn off naming convention

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -17,6 +17,11 @@ Changes are grouped as follows:
 
 ## TBD
 
+### Added
+
+- [Feature Preview] Option to turn off semantic naming checks for resources. Turn on the feature by running
+  `cdf-tk features set no-naming --enable`.
+
 ### Fixed
 
 - When running `cdf-tk run function --local`, the toolkit would raise an `ToolkitValidationError`. This is now fixed.

--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -22,6 +22,11 @@ if FeatureFlag.is_enabled(Flags.ASSETS):
 
     setup_asset_loader.setup_asset_loader()
 
+if FeatureFlag.is_enabled(Flags.NO_NAMING):
+    from cognite_toolkit._cdf_tk.prototypes import turn_off_naming_check
+
+    turn_off_naming_check.do()
+
 from cognite_toolkit._cdf_tk.commands import (
     AuthCommand,
     BuildCommand,

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -88,6 +88,8 @@ from cognite_toolkit._cdf_tk.validation import (
 )
 from cognite_toolkit._version import __version__
 
+from .featureflag import FeatureFlag, Flags
+
 
 class BuildCommand(ToolkitCommand):
     def execute(self, verbose: bool, source_path: Path, build_dir: Path, build_env_name: str, no_clean: bool) -> None:
@@ -135,18 +137,24 @@ class BuildCommand(ToolkitCommand):
             shutil.rmtree(build_dir)
             build_dir.mkdir()
             if not _RUNNING_IN_BROWSER:
-                print(f"  [bold green]INFO:[/] Cleaned existing build directory {build_dir!s}.")
+                print(f"[bold green]INFO:[/] Cleaned existing build directory {build_dir!s}.")
         elif is_populated and not _RUNNING_IN_BROWSER:
             self.warn(
                 LowSeverityWarning("Build directory is not empty. Run without --no-clean to remove existing files.")
             )
         elif build_dir.exists() and not _RUNNING_IN_BROWSER:
-            print("  [bold green]INFO:[/] Build directory does already exist and is empty. No need to create it.")
+            print("[bold green]INFO:[/] Build directory does already exist and is empty. No need to create it.")
         else:
             build_dir.mkdir(exist_ok=True)
 
         if issue := config.validate_environment():
             self.warn(issue)
+
+        if FeatureFlag.is_enabled(Flags.NO_NAMING):
+            print(
+                "[bold green]INFO:[/] Naming convention warnings have been disabled. "
+                "To enable them, run 'cdf-tk features set no-naming --disable'."
+            )
 
         module_parts_by_name: dict[str, list[tuple[str, ...]]] = defaultdict(list)
         available_modules: set[str | tuple[str, ...]] = set()

--- a/cognite_toolkit/_cdf_tk/commands/featureflag.py
+++ b/cognite_toolkit/_cdf_tk/commands/featureflag.py
@@ -19,7 +19,7 @@ class Flags(Enum):
     INTERNAL: ClassVar[dict[str, Any]] = {"visible": False, "description": "Does nothing"}
     IMPORT_CMD: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the import sub application"}
     ASSETS: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the support for loading assets"}
-    NAMING: ClassVar[dict[str, Any]] = {"visible": True, "description": "Disables the naming convention checks"}
+    NO_NAMING: ClassVar[dict[str, Any]] = {"visible": True, "description": "Disables the naming convention checks"}
 
 
 class FeatureFlag:

--- a/cognite_toolkit/_cdf_tk/commands/featureflag.py
+++ b/cognite_toolkit/_cdf_tk/commands/featureflag.py
@@ -17,8 +17,9 @@ from cognite_toolkit._cdf_tk.exceptions import ToolkitRequiredValueError
 class Flags(Enum):
     MODULES_CMD: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the modules management subapp"}
     INTERNAL: ClassVar[dict[str, Any]] = {"visible": False, "description": "Does nothing"}
-    IMPORT_CMD: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the import sup application"}
+    IMPORT_CMD: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the import sub application"}
     ASSETS: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the support for loading assets"}
+    NAMING: ClassVar[dict[str, Any]] = {"visible": True, "description": "Disables the naming convention checks"}
 
 
 class FeatureFlag:

--- a/cognite_toolkit/_cdf_tk/prototypes/turn_off_naming_check.py
+++ b/cognite_toolkit/_cdf_tk/prototypes/turn_off_naming_check.py
@@ -5,9 +5,8 @@ from cognite_toolkit._cdf_tk.loaders import RESOURCE_LOADER_LIST, GroupLoader
 from cognite_toolkit._cdf_tk.tk_warnings import WarningList, YAMLFileWarning
 
 
-def do() -> None:
-    def no_op(cls: type, identifier: Hashable, filepath: Path, verbose: bool) -> WarningList[YAMLFileWarning]:
-        return WarningList[YAMLFileWarning]()
+def no_op(cls: type, identifier: Hashable, filepath: Path, verbose: bool) -> WarningList[YAMLFileWarning]:
+    return WarningList[YAMLFileWarning]()
 
 
 def do() -> None:

--- a/cognite_toolkit/_cdf_tk/prototypes/turn_off_naming_check.py
+++ b/cognite_toolkit/_cdf_tk/prototypes/turn_off_naming_check.py
@@ -1,0 +1,16 @@
+from collections.abc import Hashable
+from pathlib import Path
+
+from cognite_toolkit._cdf_tk.loaders import (
+    RESOURCE_LOADER_LIST,
+)
+from cognite_toolkit._cdf_tk.tk_warnings import WarningList, YAMLFileWarning
+
+
+def do() -> None:
+    def no_op(cls: type, identifier: Hashable, filepath: Path, verbose: bool) -> WarningList[YAMLFileWarning]:
+        """This should be overwritten in subclasses to check the semantics of the identifier."""
+        return WarningList[YAMLFileWarning]()
+
+    for loader in RESOURCE_LOADER_LIST:
+        loader.check_identifier_semantics = classmethod(no_op)  # type: ignore[method-assign, assignment, arg-type]

--- a/cognite_toolkit/_cdf_tk/prototypes/turn_off_naming_check.py
+++ b/cognite_toolkit/_cdf_tk/prototypes/turn_off_naming_check.py
@@ -1,9 +1,7 @@
 from collections.abc import Hashable
 from pathlib import Path
 
-from cognite_toolkit._cdf_tk.loaders import (
-    RESOURCE_LOADER_LIST,
-)
+from cognite_toolkit._cdf_tk.loaders import RESOURCE_LOADER_LIST, GroupLoader
 from cognite_toolkit._cdf_tk.tk_warnings import WarningList, YAMLFileWarning
 
 
@@ -11,5 +9,7 @@ def do() -> None:
     def no_op(cls: type, identifier: Hashable, filepath: Path, verbose: bool) -> WarningList[YAMLFileWarning]:
         return WarningList[YAMLFileWarning]()
 
-    for loader in RESOURCE_LOADER_LIST:
-        loader.check_identifier_semantics = classmethod(no_op)  # type: ignore[method-assign, assignment, arg-type]
+
+def do() -> None:
+    for loader in [*RESOURCE_LOADER_LIST, GroupLoader]:
+        loader.check_identifier_semantics = classmethod(no_op)  # type: ignore[attr-defined]

--- a/cognite_toolkit/_cdf_tk/prototypes/turn_off_naming_check.py
+++ b/cognite_toolkit/_cdf_tk/prototypes/turn_off_naming_check.py
@@ -9,7 +9,6 @@ from cognite_toolkit._cdf_tk.tk_warnings import WarningList, YAMLFileWarning
 
 def do() -> None:
     def no_op(cls: type, identifier: Hashable, filepath: Path, verbose: bool) -> WarningList[YAMLFileWarning]:
-        """This should be overwritten in subclasses to check the semantics of the identifier."""
         return WarningList[YAMLFileWarning]()
 
     for loader in RESOURCE_LOADER_LIST:


### PR DESCRIPTION
# Description

## Today
![image](https://github.com/cognitedata/toolkit/assets/60234212/36370e2d-a570-4e0a-8031-8fad43180bc6)

## After no more warning about naming convention

![image](https://github.com/cognitedata/toolkit/assets/60234212/9a40a146-db95-474f-8aae-b0ebac516b40)



## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
