### PR TITLE
[CDF-21945] 😫Less Warnings on Functions

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -21,6 +21,11 @@ Changes are grouped as follows:
 
 - When running `cdf-tk run function --local`, the toolkit would raise an `ToolkitValidationError`. This is now fixed.
 
+### Changed
+
+- Function configurations for multiple functions can now be in multiple files in the function directory. Before
+  all had to be listed in the same YAML file.
+
 ## [0.2.7] - 2024-06-28
 
 ### Fixed

--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -27,7 +27,7 @@ Changes are grouped as follows:
 ### Changed
 
 - Function configurations for multiple functions can now be in multiple files in the function directory. Before
-  all had to be listed in the same YAML file.
+  all configurations had to be listed in the same YAML file.
 
 ## [0.2.7] - 2024-06-28
 

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -273,7 +273,7 @@ class BuildCommand(ToolkitCommand):
                 required_location = module_dir / FunctionLoader.folder_name / yaml_source_path.name
                 self.warn(
                     LowSeverityWarning(
-                        f"The required Function resource configuration file " 
+                        f"The required Function resource configuration file "
                         f"was not found in {required_location.as_posix()!r}. "
                         f"The file {yaml_source_path.as_posix()!r} is currently "
                         f"considered part of the Function's artifacts and "

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -17,7 +17,6 @@ from typing import Any
 import pandas as pd
 import yaml
 from cognite.client._api.functions import validate_function_folder
-from cognite.client.data_classes import FunctionList
 from rich import print
 from rich.panel import Panel
 
@@ -25,9 +24,10 @@ from cognite_toolkit._cdf_tk._parameters import ParameterSpecSet
 from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
 from cognite_toolkit._cdf_tk.constants import (
     _RUNNING_IN_BROWSER,
+    CONFIGURATION_FILE_SUFFIXES,
     EXCL_INDEX_SUFFIX,
-    PROC_TMPL_VARS_SUFFIX,
     ROOT_MODULES,
+    TEMPLATE_VARS_FILE_SUFFIXES,
 )
 from cognite_toolkit._cdf_tk.data_classes import (
     BuildConfigYAML,
@@ -207,82 +207,104 @@ class BuildCommand(ToolkitCommand):
 
             state.update_local_variables(module_dir)
 
-            files_by_resource_folder = self._to_files_by_resource_folder(source_paths, module_dir)
+            files_by_resource_directory = self._to_files_by_resource_directory(source_paths, module_dir)
 
-            for resource_folder in files_by_resource_folder:
-                for source_path in files_by_resource_folder[resource_folder].resource_files:
-                    if verbose:
-                        print(f"    [bold green]INFO:[/] Processing {source_path.name}")
-                    destination = build_dir / resource_folder / state.create_file_name(source_path)
-                    destination.parent.mkdir(parents=True, exist_ok=True)
-
-                    is_function_non_yaml = resource_folder == FunctionLoader.folder_name and (
-                        source_path.suffix.lower() != ".yaml" or source_path.parent.name != FunctionLoader.folder_name
+            for resource_directory_name, directory_files in files_by_resource_directory.items():
+                build_folder: list[Path] = []
+                for source_path in directory_files.resource_files:
+                    destination = self._replace_variables_validate_to_build_directory(
+                        source_path, resource_directory_name, state, build_dir, verbose
                     )
-                    # We only want to process the yaml files for functions as the function code is handled separately.
-                    # Note that yaml files that are NOT in the root function folder are considered function code.
-                    content = ""
-                    if not is_function_non_yaml:
-                        content = source_path.read_text()
-                        state.hash_by_source_path[source_path] = calculate_str_or_file_hash(content)
-                        content = state.replace_variables(content, source_path.suffix)
-                        destination.write_text(content)
-                        state.source_by_build_path[destination] = source_path
-                        file_warnings = self.validate(content, source_path, destination, state, verbose)
-                        if file_warnings:
-                            self.warning_list.extend(file_warnings)
-                            # Here we do not use the self.warn method as we want to print the warnings as a group.
-                            if self.print_warning:
-                                print(str(file_warnings))
+                    build_folder.append(destination)
 
-                    is_function_yaml = (
-                        resource_folder == FunctionLoader.folder_name
-                        and source_path.suffix.lower() == ".yaml"
-                        and re.match(FunctionLoader.filename_pattern, source_path.stem)
+                if resource_directory_name == FunctionLoader.folder_name:
+                    self._validate_function_directory(state, directory_files, module_dir)
+                    self.validate_and_copy_function_directory_to_build(
+                        resource_files_build_folder=build_folder,
+                        state=state,
+                        module_dir=module_dir,
+                        build_dir=build_dir,
                     )
-                    if is_function_yaml:
-                        if not state.printed_function_warning and sys.version_info >= (3, 12):
-                            self.warn(
-                                HighSeverityWarning(
-                                    "The functions API does not support Python 3.12. "
-                                    "It is recommended that you use Python 3.11 or 3.10 to develop functions locally."
+                elif resource_directory_name == FileLoader.folder_name:
+                    self.copy_files_to_upload_to_build_directory(
+                        file_to_upload=directory_files.other_files,
+                        resource_files_build_folder=build_folder,
+                        module_dir=module_dir,
+                        build_dir=build_dir,
+                        verbose=verbose,
+                    )
+                else:
+                    for source_path in directory_files.other_files:
+                        destination = build_dir / resource_directory_name / source_path.name
+                        destination.parent.mkdir(parents=True, exist_ok=True)
+                        if (
+                            resource_directory_name == DatapointsLoader.folder_name
+                            and source_path.suffix.lower() == ".csv"
+                        ):
+                            self._copy_and_timeshift_csv_files(source_path, destination)
+                        else:
+                            if verbose:
+                                print(
+                                    f"    [bold green]INFO:[/] Found unrecognized file {source_path}. Copying in untouched..."
                                 )
-                            )
-                            state.printed_function_warning = True
-                        self.process_function_directory(
-                            yaml_source_path=source_path,
-                            yaml_dest_path=destination,
-                            module_dir=module_dir,
-                            build_dir=build_dir,
-                            verbose=verbose,
-                        )
-                        files_by_resource_folder[resource_folder].other_files = []
-
-                    if resource_folder == FileLoader.folder_name:
-                        self.copy_files_to_upload_to_build_directory(
-                            file_to_upload=files_by_resource_folder[resource_folder].other_files,
-                            config_content=content,
-                            module_dir=module_dir,
-                            build_dir=build_dir,
-                            verbose=verbose,
-                        )
-                        files_by_resource_folder[resource_folder].other_files.clear()
-
-                for source_path in files_by_resource_folder[resource_folder].other_files:
-                    destination = build_dir / DatapointsLoader.folder_name / source_path.name
-                    destination.parent.mkdir(parents=True, exist_ok=True)
-                    if resource_folder == DatapointsLoader.folder_name and source_path.suffix.lower() == ".csv":
-                        self._copy_and_timeshift_csv_files(source_path, destination)
-                    else:
-                        if verbose:
-                            print(
-                                f"    [bold green]INFO:[/] Found unrecognized file {source_path}. Copying in untouched..."
-                            )
-                        # Copy the file as is, not variable replacement
-                        shutil.copyfile(source_path, destination)
+                            # Copy the file as is, not variable replacement
+                            shutil.copyfile(source_path, destination)
 
         self._check_missing_dependencies(state, project_config_dir)
         return state
+
+    def _validate_function_directory(
+        self, state: _BuildState, directory_files: ResourceDirectory, module_dir: Path
+    ) -> None:
+        if not state.printed_function_warning and sys.version_info >= (3, 12):
+            self.warn(
+                HighSeverityWarning(
+                    "The functions API does not support Python 3.12. "
+                    "It is recommended that you use Python 3.11 or 3.10 to develop functions locally."
+                )
+            )
+            state.printed_function_warning = True
+
+        has_config_files = any(
+            file.suffix.lower() in CONFIGURATION_FILE_SUFFIXES for file in directory_files.resource_files
+        )
+        config_files_misplaced = [
+            file for file in directory_files.resource_files if file.suffix.lower() in CONFIGURATION_FILE_SUFFIXES
+        ]
+
+        if not has_config_files and config_files_misplaced:
+            for yaml_source_path in config_files_misplaced:
+                required_location = module_dir / FunctionLoader.folder_name / yaml_source_path.name
+                self.warn(
+                    LowSeverityWarning(
+                        f"The file {yaml_source_path.as_posix()!r} is considered part of the Function's code and "
+                        f"will not be processed as a CDF resource. "
+                        f"If this is a function configuration please move it to {required_location.as_posix()!r}."
+                    )
+                )
+
+    def _replace_variables_validate_to_build_directory(
+        self, source_path: Path, resource_directory: str, state: _BuildState, build_dir: Path, verbose: bool
+    ) -> Path:
+        if verbose:
+            print(f"    [bold green]INFO:[/] Processing {source_path.name}")
+        destination = build_dir / resource_directory / state.create_file_name(source_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+
+        content = source_path.read_text()
+        state.hash_by_source_path[source_path] = calculate_str_or_file_hash(content)
+
+        content = state.replace_variables(content, source_path.suffix)
+        destination.write_text(content)
+        state.source_by_build_path[destination] = source_path
+
+        file_warnings = self.validate(content, source_path, destination, state, verbose)
+        if file_warnings:
+            self.warning_list.extend(file_warnings)
+            # Here we do not use the self.warn method as we want to print the warnings as a group.
+            if self.print_warning:
+                print(str(file_warnings))
+        return destination
 
     def _check_missing_dependencies(self, state: _BuildState, project_config_dir: Path) -> None:
         existing = {(resource_cls, id_) for resource_cls, ids in state.ids_by_resource_type.items() for id_ in ids}
@@ -342,7 +364,7 @@ class BuildCommand(ToolkitCommand):
         )
         return is_parent_in_selected_modules or is_in_selected_modules
 
-    def _to_files_by_resource_folder(self, filepaths: list[Path], module_dir: Path) -> dict[str, _ResourceFiles]:
+    def _to_files_by_resource_directory(self, filepaths: list[Path], module_dir: Path) -> dict[str, ResourceDirectory]:
         # Sort to support 1., 2. etc prefixes
         def sort_key(p: Path) -> int:
             if result := re.findall(r"^(\d+)", p.stem):
@@ -354,27 +376,42 @@ class BuildCommand(ToolkitCommand):
         # The custom key 'sort_key' is to get the sort on integer and not the string.
         filepaths = sorted(filepaths, key=sort_key)
 
-        files_by_resource_folder: dict[str, _ResourceFiles] = defaultdict(_ResourceFiles)
+        files_by_resource_directory: dict[str, ResourceDirectory] = defaultdict(ResourceDirectory)
         not_resource_directory: set[str] = set()
         for filepath in filepaths:
             try:
-                resource_folder = resource_folder_from_path(filepath)
+                resource_directory = resource_folder_from_path(filepath)
             except ValueError:
                 relative_to_module = filepath.relative_to(module_dir)
-                if relative_to_module.parts[0] != filepath.name:
+                is_file_in_resource_folder = relative_to_module.parts[0] == filepath.name
+                if not is_file_in_resource_folder:
                     not_resource_directory.add(relative_to_module.parts[0])
                 continue
-            if filepath.suffix.lower() in PROC_TMPL_VARS_SUFFIX:
-                files_by_resource_folder[resource_folder].resource_files.append(filepath)
+
+            if filepath.suffix.lower() in TEMPLATE_VARS_FILE_SUFFIXES and not self._is_exception_file(
+                filepath, resource_directory
+            ):
+                files_by_resource_directory[resource_directory].resource_files.append(filepath)
             else:
-                files_by_resource_folder[resource_folder].other_files.append(filepath)
+                files_by_resource_directory[resource_directory].other_files.append(filepath)
+
         if not_resource_directory:
             self.warn(
                 LowSeverityWarning(
                     f"Module {module_dir.name!r} has non-resource directories: {sorted(not_resource_directory)}. {ModuleDefinition.short()}"
                 )
             )
-        return files_by_resource_folder
+        return files_by_resource_directory
+
+    @staticmethod
+    def _is_exception_file(filepath: Path, resource_directory: str) -> bool:
+        # In the 'functions' resource directories, all `.yaml` files must be in the root of the directory
+        # This is to allow for function code to include arbitrary yaml files.
+        return (
+            resource_directory == FunctionLoader.folder_name
+            and filepath.suffix.lower() in {".yaml", ".yml"}
+            and filepath.parent.name != FunctionLoader.folder_name
+        )
 
     @staticmethod
     def _copy_and_timeshift_csv_files(csv_file: Path, destination: Path) -> None:
@@ -395,82 +432,127 @@ class BuildCommand(ToolkitCommand):
             data.index = pd.DatetimeIndex.shift(data.index, periods=periods.days, freq="D")
         destination.write_text(data.to_csv())
 
-    def process_function_directory(
+    def validate_and_copy_function_directory_to_build(
         self,
-        yaml_source_path: Path,
-        yaml_dest_path: Path,
+        resource_files_build_folder: list[Path],
+        state: _BuildState,
         module_dir: Path,
         build_dir: Path,
-        verbose: bool = False,
     ) -> None:
-        if yaml_source_path.parent.name != FunctionLoader.folder_name:
-            self.warn(
-                LowSeverityWarning(
-                    f"The file {yaml_source_path.as_posix()!r} is considered part of the Function's code and will not be processed as a CDF resource. If this is a "
-                    f"function config please move it to {FunctionLoader.folder_name} folder."
+        function_directory_by_name = {
+            dir_.name: dir_ for dir_ in (module_dir / FunctionLoader.folder_name).iterdir() if dir_.is_dir()
+        }
+        external_id_by_function_path = self._read_function_path_by_external_id(
+            resource_files_build_folder, function_directory_by_name, state
+        )
+
+        for external_id, function_path in external_id_by_function_path.items():
+            # Function directory already validated to exist in read function
+            function_dir = function_directory_by_name[external_id]
+            destination = build_dir / FunctionLoader.folder_name / external_id
+            if destination.exists():
+                raise ToolkitFileExistsError(
+                    f"Function {external_id!r} is duplicated. If this is unexpected, ensure you have a clean build directory."
                 )
-            )
-            return None
-        try:
-            functions: FunctionList = FunctionList.load(yaml.safe_load(yaml_dest_path.read_text()))
-        except (KeyError, yaml.YAMLError) as e:
-            raise ToolkitYAMLFormatError(f"Failed to load function file {yaml_source_path} due to: {e}")
+            shutil.copytree(function_dir, destination)
+            if function_path:
+                try:
+                    # Run validations on the function using the SDK's validation function
+                    validate_function_folder(
+                        root_path=destination.as_posix(),
+                        function_path=function_path,
+                        skip_folder_validation=False,
+                    )
+                except Exception as e:
+                    raise ToolkitValidationError(
+                        f"Failed to package function {external_id} at {function_dir.as_posix()!r}, python module is not loadable "
+                        f"due to: {type(e)}({e}). Note that you need to have any requirements your function uses "
+                        "installed in your current, local python environment."
+                    ) from e
 
-        for func in functions:
-            found = False
-            for function_subdirs in self.iterate_functions(module_dir):
-                for function_dir in function_subdirs:
-                    if (fn_xid := func.external_id) == function_dir.name:
-                        found = True
-                        if verbose:
-                            print(f"      [bold green]INFO:[/] Found function {fn_xid}")
-                        destination = build_dir / "functions" / fn_xid
-                        if destination.exists():
-                            raise ToolkitFileExistsError(
-                                f"Function {fn_xid} is duplicated. If this is unexpected, you may want to use '--clean'."
-                            )
-                        shutil.copytree(function_dir, destination)
+            # Clean up cache files
+            for subdir in destination.iterdir():
+                if subdir.is_dir():
+                    shutil.rmtree(subdir / "__pycache__", ignore_errors=True)
+            shutil.rmtree(destination / "__pycache__", ignore_errors=True)
 
-                        # Run validations on the function using the SDK's validation function
-                        try:
-                            if func.function_path:
-                                validate_function_folder(
-                                    root_path=destination.as_posix(),
-                                    function_path=func.function_path,
-                                    skip_folder_validation=False,
-                                )
-                            else:
-                                self.warn(
-                                    MediumSeverityWarning(
-                                        f"Function {fn_xid} in {yaml_source_path} has no function_path defined."
-                                    )
-                                )
-                        except Exception as e:
-                            raise ToolkitValidationError(
-                                f"Failed to package function {fn_xid} at {function_dir}, python module is not loadable "
-                                f"due to: {type(e)}({e}). Note that you need to have any requirements your function uses "
-                                "installed in your current, local python environment."
-                            ) from e
-                        # Clean up cache files
-                        for subdir in destination.iterdir():
-                            if subdir.is_dir():
-                                shutil.rmtree(subdir / "__pycache__", ignore_errors=True)
-                        shutil.rmtree(destination / "__pycache__", ignore_errors=True)
-            if not found:
-                raise ToolkitNotADirectoryError(
-                    f"Function directory not found for externalId {func.external_id} defined in {yaml_source_path}."
-                )
+    def _read_function_path_by_external_id(
+        self, resource_files_build_folder: list[Path], function_directory_by_name: dict[str, Path], state: _BuildState
+    ) -> dict[str, str | None]:
+        function_path_by_external_id: dict[str, str | None] = {}
+        configuration_files = [
+            file for file in resource_files_build_folder if file.suffix.lower() in CONFIGURATION_FILE_SUFFIXES
+        ]
+        for config_file in configuration_files:
+            source_file = state.source_by_build_path[config_file]
 
+            try:
+                raw_content = read_yaml_content(config_file.read_text())
+            except yaml.YAMLError as e:
+                raise ToolkitYAMLFormatError(f"Failed to load function files {source_file.as_posix()!r} due to: {e}")
+            raw_functions = raw_content if isinstance(raw_content, list) else [raw_content]
+            for raw_function in raw_functions:
+                external_id = raw_function.get("externalId")
+                function_path = raw_function.get("functionPath")
+                if not external_id:
+                    self.warn(
+                        HighSeverityWarning(
+                            f"Function in {source_file.as_posix()!r} has no externalId defined. "
+                            f"This is used to match the function to the function directory."
+                        )
+                    )
+                    continue
+                elif external_id not in function_directory_by_name:
+                    raise ToolkitNotADirectoryError(
+                        f"Function directory not found for externalId {external_id} defined in {source_file.as_posix()!r}."
+                    )
+                if not function_path:
+                    self.warn(
+                        MediumSeverityWarning(
+                            f"Function {external_id} in {source_file.as_posix()!r} has no function_path defined."
+                        )
+                    )
+                function_path_by_external_id[external_id] = function_path
+
+        return function_path_by_external_id
+
+    @staticmethod
     def copy_files_to_upload_to_build_directory(
-        self,
         file_to_upload: list[Path],
-        config_content: str,
+        resource_files_build_folder: list[Path],
         module_dir: Path,
         build_dir: Path,
         verbose: bool = False,
     ) -> None:
-        if len(file_to_upload) == 0 or not config_content:
+        """This function copies the file to upload to the build directory.
+
+        It also checks the resource configuration files for a file template definition and renames the
+        file to upload if a template is found.
+        """
+        if len(file_to_upload) == 0:
             return
+
+        template_name = BuildCommand._get_file_template_name(resource_files_build_folder, module_dir, verbose)
+
+        for filepath in file_to_upload:
+            destination_stem = filepath.stem
+            if template_name:
+                destination_stem = template_name.replace(FileMetadataLoader.template_pattern, filepath.stem)
+            destination = build_dir / FileLoader.folder_name / f"{destination_stem}{filepath.suffix}"
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(filepath, destination)
+
+    @staticmethod
+    def _get_file_template_name(resource_files_build_folder: list[Path], module_dir: Path, verbose: bool) -> str | None:
+        # We only support one file template definition per module.
+        configuration_files = [
+            file for file in resource_files_build_folder if file.suffix.lower() in CONFIGURATION_FILE_SUFFIXES
+        ]
+        if len(configuration_files) != 1:
+            # Multiple configuration files, then there is no template
+            return None
+
+        config_content = configuration_files[0].read_text()
         try:
             raw_files = read_yaml_content(config_content)
         except yaml.YAMLError as e:
@@ -481,25 +563,21 @@ class BuildCommand(ToolkitCommand):
             and len(raw_files) == 1
             and FileMetadataLoader.template_pattern in raw_files[0].get("externalId", "")
         )
-        # We only support one file template definition per module.
-        template_name: str | None = None
-        if is_file_template and isinstance(raw_files, list):
-            template = raw_files[0]
-            if "name" in template and FileMetadataLoader.template_pattern in template["name"]:
-                template_name = template["name"]
-                if verbose:
-                    print(
-                        f"      [bold green]INFO:[/] Detected file template name {template_name!r} in "
-                        f"{module_dir}/{FileMetadataLoader.folder_name}, renaming files..."
-                    )
+        if not is_file_template:
+            return None
 
-        for filepath in file_to_upload:
-            destination_stem = filepath.stem
-            if template_name:
-                destination_stem = template_name.replace(FileMetadataLoader.template_pattern, filepath.stem)
-            destination = build_dir / FileLoader.folder_name / f"{destination_stem}{filepath.suffix}"
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copyfile(filepath, destination)
+        # MyPy is not able to infer the type of raw_files here, so we need to use ignore
+        template = raw_files[0]  # type: ignore[index]
+        has_template_name = "name" in template and FileMetadataLoader.template_pattern in template["name"]
+        if not has_template_name:
+            return None
+        template_name = template["name"]
+        if verbose:
+            print(
+                f"      [bold green]INFO:[/] Detected file template name {template_name!r} in "
+                f"{module_dir}/{FileMetadataLoader.folder_name}, renaming files..."
+            )
+        return template_name
 
     def validate(
         self,
@@ -666,6 +744,7 @@ class _BuildState:
     dependencies_by_required: dict[tuple[type[ResourceLoader], Hashable], list[tuple[Hashable, Path]]] = field(
         default_factory=lambda: defaultdict(list)
     )
+
     _local_variables: Mapping[str, str] = field(default_factory=dict)
 
     @property
@@ -705,7 +784,14 @@ class _BuildState:
 
 
 @dataclass
-class _ResourceFiles:
+class ResourceDirectory:
+    """The files in a Resource Directory.
+
+    Args:
+        resource_files: The files that are considered resources, which will be preformed variable replacement on
+        other_files: Files that are not considered resources, and will be copied as is.
+    """
+
     resource_files: list[Path] = field(default_factory=list)
     other_files: list[Path] = field(default_factory=list)
 

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -481,7 +481,9 @@ class BuildCommand(ToolkitCommand):
     ) -> dict[str, str | None]:
         function_path_by_external_id: dict[str, str | None] = {}
         configuration_files = [
-            file for file in resource_files_build_folder if file.suffix.lower() in CONFIGURATION_FILE_SUFFIXES
+            file
+            for file in resource_files_build_folder
+            if file.suffix.lower() in CONFIGURATION_FILE_SUFFIXES and FunctionLoader.is_supported_file(file)
         ]
         for config_file in configuration_files:
             source_file = state.source_by_build_path[config_file]

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -273,9 +273,11 @@ class BuildCommand(ToolkitCommand):
                 required_location = module_dir / FunctionLoader.folder_name / yaml_source_path.name
                 self.warn(
                     LowSeverityWarning(
-                        f"The file {yaml_source_path.as_posix()!r} is considered part of the Function's code and "
-                        f"will not be processed as a CDF resource. "
-                        f"If this is a function configuration please move it to {required_location.as_posix()!r}."
+                        f"The required Function resource configuration file " 
+                        f"was not found in {required_location.as_posix()!r}. "
+                        f"The file {yaml_source_path.as_posix()!r} is currently "
+                        f"considered part of the Function's artifacts and "
+                        f"will not be processed by the Toolkit."
                     )
                 )
 

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -406,7 +406,7 @@ class BuildCommand(ToolkitCommand):
         if yaml_source_path.parent.name != FunctionLoader.folder_name:
             self.warn(
                 LowSeverityWarning(
-                    f"The file {yaml_source_path} is considered part of the Function's code and will not be processed as a CDF resource. If this is a "
+                    f"The file {yaml_source_path.as_posix()!r} is considered part of the Function's code and will not be processed as a CDF resource. If this is a "
                     f"function config please move it to {FunctionLoader.folder_name} folder."
                 )
             )

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -9,7 +9,7 @@ import shutil
 import sys
 import traceback
 from collections import ChainMap, defaultdict
-from collections.abc import Hashable, Iterator, Mapping, Sequence
+from collections.abc import Hashable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -268,7 +268,6 @@ class BuildCommand(ToolkitCommand):
         config_files_misplaced = [
             file for file in directory_files.other_files if FunctionLoader.is_supported_file(file)
         ]
-
         if not has_config_files and config_files_misplaced:
             for yaml_source_path in config_files_misplaced:
                 required_location = module_dir / FunctionLoader.folder_name / yaml_source_path.name
@@ -709,15 +708,6 @@ class BuildCommand(ToolkitCommand):
             )
 
         return loaders[0]
-
-    @staticmethod
-    def iterate_functions(module_dir: Path) -> Iterator[list[Path]]:
-        for function_dir in module_dir.glob(f"**/{FunctionLoader.folder_name}"):
-            if not function_dir.is_dir():
-                continue
-            function_directories = [path for path in function_dir.iterdir() if path.is_dir()]
-            if function_directories:
-                yield function_directories
 
 
 @dataclass

--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -31,8 +31,12 @@ EXCL_FILES = ["README.md", DEFAULT_CONFIG_FILE]
 EXCL_INDEX_SUFFIX = frozenset([".sql", ".csv", ".parquet"])
 # Files to search for variables.
 SEARCH_VARIABLES_SUFFIX = frozenset([".yaml", "yml", ".sql", ".csv"])
-# Which suffixes to process for template variable replacement
-PROC_TMPL_VARS_SUFFIX = frozenset([".yaml", ".yml", ".sql", ".csv", ".parquet", ".json", ".txt", ".md", ".html", ".py"])
+# Which files to process for template variable replacement
+TEMPLATE_VARS_FILE_SUFFIXES = frozenset(
+    [".yaml", ".yml", ".sql", ".csv", ".parquet", ".json", ".txt", ".md", ".html", ".py"]
+)
+# Configuration files contains the specification for a CDF Resource
+CONFIGURATION_FILE_SUFFIXES = frozenset({".yaml", ".yml"})
 
 ROOT_PATH = Path(__file__).parent.parent
 COGNITE_MODULES_PATH = ROOT_PATH / COGNITE_MODULES

--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -35,9 +35,6 @@ SEARCH_VARIABLES_SUFFIX = frozenset([".yaml", "yml", ".sql", ".csv"])
 TEMPLATE_VARS_FILE_SUFFIXES = frozenset(
     [".yaml", ".yml", ".sql", ".csv", ".parquet", ".json", ".txt", ".md", ".html", ".py"]
 )
-# Configuration files contains the specification for a CDF Resource
-CONFIGURATION_FILE_SUFFIXES = frozenset({".yaml", ".yml"})
-
 ROOT_PATH = Path(__file__).parent.parent
 COGNITE_MODULES_PATH = ROOT_PATH / COGNITE_MODULES
 

--- a/tests/data/run_data/cognite_modules/examples/run_local_functions/functions/fn_test2/part_of_code.yaml
+++ b/tests/data/run_data/cognite_modules/examples/run_local_functions/functions/fn_test2/part_of_code.yaml
@@ -1,0 +1,1 @@
+this: is used in fn_test2

--- a/tests/data/run_data/cognite_modules/examples/run_local_functions/functions/functions.yaml
+++ b/tests/data/run_data/cognite_modules/examples/run_local_functions/functions/functions.yaml
@@ -1,6 +1,5 @@
 - name: 'test2'
   externalId: 'fn_test2'
-  fileId: <will_be_generated>
   owner: 'Anonymous'
   description: 'Returns the input data, secrets, and function info.'
   metadata:

--- a/tests/data/run_data/config.dev.yaml
+++ b/tests/data/run_data/config.dev.yaml
@@ -2,8 +2,8 @@ environment:
   name: dev
   project: <my-project>
   type: dev
-  selected_modules_and_packages:
-  - cdf_functions_dummy
+  selected:
+  - run_local_functions
 
 variables:
   cognite_modules:

--- a/tests/tests_integration/test_loaders/test_resource_container_loaders.py
+++ b/tests/tests_integration/test_loaders/test_resource_container_loaders.py
@@ -80,7 +80,7 @@ def edge_container(cognite_client: CogniteClient, integration_space: dm.Space) -
 
 class TestContainerLoader:
     # The DMS service is fairly unstable, so we need to rerun the tests if they fail.
-    @pytest.mark.flaky(reruns=3, reruns_delay=10, only_rerun=["AssertionError"])
+    @pytest.mark.flaky(reruns=3, reruns_delay=10, only_rerun=["AssertionError", "CogniteAPIError"])
     def test_populate_count_drop_data_node_container(
         self, node_container: dm.Container, cognite_client: CogniteClient
     ) -> None:
@@ -117,7 +117,7 @@ class TestContainerLoader:
             loader.drop_data(container_id)
 
     # The DMS service is fairly unstable, so we need to rerun the tests if they fail.
-    @pytest.mark.flaky(reruns=3, reruns_delay=10, only_rerun=["AssertionError"])
+    @pytest.mark.flaky(reruns=3, reruns_delay=10, only_rerun=["AssertionError", "CogniteAPIError"])
     def test_populate_count_drop_data_edge_container(
         self, edge_container: dm.Container, cognite_client: CogniteClient
     ) -> None:


### PR DESCRIPTION
# Description

## Today
![image](https://github.com/cognitedata/toolkit/assets/60234212/ba34e451-4db4-4976-ab8d-3d959d02e29c)

Now removed as there is already a config for this function.

## Note
This PR contains a larger refactoring in addition to the change above. The motivation for this is that to implement the logic required to figure out whether to give that warning or not, you cannot just look at an individual file as was done before. I realized that the way file and function files were processed did not make sense, so restructured. Notice that a side effect is that you can now have function config in different files, which you could not do before. 



## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
