### PR TITLE
[CDF-21949] 🫤Nice indent

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_base.py
+++ b/cognite_toolkit/_cdf_tk/commands/_base.py
@@ -41,7 +41,10 @@ class ToolkitCommand:
     def warn(self, warning: ToolkitWarning) -> None:
         self.warning_list.append(warning)
         if self.print_warning:
-            print(warning.get_message())
+            prefix = warning.severity.prefix
+            end = "\n" + " " * ((warning.severity.prefix_length + 1) // 2)
+            message = warning.get_message().replace("\n", end)
+            print(prefix, message)
 
     def _load_files(
         self,

--- a/cognite_toolkit/_cdf_tk/tk_warnings/__init__.py
+++ b/cognite_toolkit/_cdf_tk/tk_warnings/__init__.py
@@ -1,6 +1,5 @@
 from .base import (
     GeneralWarning,
-    SeverityFormat,
     SeverityLevel,
     ToolkitWarning,
     WarningList,
@@ -38,7 +37,6 @@ from .other import (
 )
 
 __all__ = [
-    "SeverityFormat",
     "SeverityLevel",
     "ToolkitWarning",
     "GeneralWarning",

--- a/cognite_toolkit/_cdf_tk/tk_warnings/base.py
+++ b/cognite_toolkit/_cdf_tk/tk_warnings/base.py
@@ -20,14 +20,22 @@ class SeverityLevel(Enum):
     MEDIUM = "yellow"
     LOW = "green"
 
+    @property
+    def prefix(self) -> str:
+        if self == SeverityLevel.ERROR:
+            return f"[bold red]ERROR [{self.name}]:[/] "
+        else:
+            return f"[bold {self.value}]WARNING [{self.name}]:[/] "
+
+    @property
+    def prefix_length(self) -> int:
+        return len(self.prefix)
+
 
 class SeverityFormat:
     @staticmethod
     def get_rich_severity_format(severity: SeverityLevel, *messages: str) -> str:
-        if severity == SeverityLevel.ERROR:
-            return f"[bold red]ERROR [{severity.name}]:[/] {' '.join(messages)}"
-        else:
-            return f"[bold {severity.value}]WARNING [{severity.name}]:[/] {' '.join(messages)}"
+        return severity.prefix + " ".join(messages)
 
     @staticmethod
     def get_rich_detail_format(message: str) -> str:
@@ -37,6 +45,8 @@ class SeverityFormat:
 @total_ordering
 @dataclass(frozen=True)
 class ToolkitWarning(ABC):
+    severity: ClassVar[SeverityLevel]
+
     def group_key(self) -> tuple[Any, ...]:
         """This is used to group warnings together when printing them out."""
         return (type(self).__name__,)

--- a/cognite_toolkit/_cdf_tk/tk_warnings/base.py
+++ b/cognite_toolkit/_cdf_tk/tk_warnings/base.py
@@ -23,23 +23,13 @@ class SeverityLevel(Enum):
     @property
     def prefix(self) -> str:
         if self == SeverityLevel.ERROR:
-            return f"[bold red]ERROR [{self.name}]:[/] "
+            return f"[bold red]ERROR [{self.name}]:[/]"
         else:
-            return f"[bold {self.value}]WARNING [{self.name}]:[/] "
+            return f"[bold {self.value}]WARNING [{self.name}]:[/]"
 
     @property
     def prefix_length(self) -> int:
-        return len(self.prefix)
-
-
-class SeverityFormat:
-    @staticmethod
-    def get_rich_severity_format(severity: SeverityLevel, *messages: str) -> str:
-        return severity.prefix + " ".join(messages)
-
-    @staticmethod
-    def get_rich_detail_format(message: str) -> str:
-        return f"{'    ' * 2}{message}"
+        return len(self.prefix.split("]", 1)[1].rsplit("[", 1)[0])
 
 
 @total_ordering

--- a/cognite_toolkit/_cdf_tk/tk_warnings/fileread.py
+++ b/cognite_toolkit/_cdf_tk/tk_warnings/fileread.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar
 
-from .base import SeverityFormat, SeverityLevel, ToolkitWarning
+from .base import SeverityLevel, ToolkitWarning
 
 
 @dataclass(frozen=True)
@@ -78,7 +78,7 @@ class UnknownResourceTypeWarning(YAMLFileWarning):
         msg = f"{type(self).__name__}: In file {self.filepath.as_posix()!r}."
         if self.suggestion:
             msg += f" Did you mean to call the file {self.suggestion!r}?"
-        return SeverityFormat.get_rich_severity_format(self.severity, msg)
+        return msg
 
 
 @dataclass(frozen=True)
@@ -108,7 +108,7 @@ class ResourceMissingIdentifierWarning(YAMLFileWarning):
 
     def get_message(self) -> str:
         message = f"The {self.resource} {self.filepath} is missing the {self.ext_id_type} field(s)."
-        return SeverityFormat.get_rich_severity_format(self.severity, message)
+        return message
 
 
 @dataclass(frozen=True)
@@ -129,10 +129,7 @@ class NamingConventionWarning(YAMLFileWarning):
             f"The {self.ext_id_type} identifier [bold]{self.external_id!r}[/bold] of the resource {self.resource} "
             f"does not follow the recommended naming convention {self.recommendation}"
         )
-        return SeverityFormat.get_rich_severity_format(
-            self.severity,
-            message,
-        )
+        return message
 
 
 @dataclass(frozen=True)
@@ -210,7 +207,7 @@ class SourceFileModifiedWarning(FileReadWarning):
             f"{type(self).__name__}: The source file {self.filepath} has been modified since the last build. "
             "Please rebuild the project."
         )
-        return SeverityFormat.get_rich_severity_format(self.severity, message)
+        return message
 
 
 @dataclass(frozen=True)
@@ -220,4 +217,4 @@ class MissingFileWarning(FileReadWarning):
 
     def get_message(self) -> str:
         message = f"{type(self).__name__}: The file {self.filepath} is missing. Cannot verify {self.attempted_check}."
-        return SeverityFormat.get_rich_severity_format(self.severity, message)
+        return message

--- a/cognite_toolkit/_cdf_tk/tk_warnings/other.py
+++ b/cognite_toolkit/_cdf_tk/tk_warnings/other.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar, Union
 
-from cognite_toolkit._cdf_tk.tk_warnings.base import GeneralWarning, SeverityFormat, SeverityLevel, ToolkitWarning
+from cognite_toolkit._cdf_tk.tk_warnings.base import GeneralWarning, SeverityLevel, ToolkitWarning
 
 
 @dataclass(frozen=True)
@@ -15,8 +15,7 @@ class UnexpectedFileLocationWarning(ToolkitWarning):
     alternative: str
 
     def get_message(self) -> str:
-        message = f"{self.filepath!r} does not exist. Using {self.alternative!r} instead."
-        return SeverityFormat.get_rich_severity_format(self.severity, message)
+        return f"{self.filepath!r} does not exist. Using {self.alternative!r} instead."
 
 
 @dataclass(frozen=True)
@@ -27,7 +26,7 @@ class ToolkitBugWarning(ToolkitWarning):
     traceback: str
 
     def get_message(self) -> str:
-        return SeverityFormat.get_rich_severity_format(self.severity, self.header, self.message, self.traceback)
+        return " ".join((self.header, self.message, self.traceback))
 
 
 @dataclass(frozen=True)
@@ -45,9 +44,7 @@ class IncorrectResourceWarning(ToolkitWarning):
                 extra_details.append(self.details)
             else:
                 extra_details.extend(self.details)
-        return SeverityFormat.get_rich_severity_format(
-            self.severity, self.location, self.message, self.resource, *extra_details
-        )
+        return " ".join((self.location, self.message, self.resource, *extra_details))
 
 
 @dataclass(frozen=True)
@@ -56,7 +53,7 @@ class LowSeverityWarning(GeneralWarning):
     message_raw: str
 
     def get_message(self) -> str:
-        return SeverityFormat.get_rich_severity_format(self.severity, self.message_raw)
+        return self.message_raw
 
 
 @dataclass(frozen=True)
@@ -65,7 +62,7 @@ class MediumSeverityWarning(GeneralWarning):
     message_raw: str
 
     def get_message(self) -> str:
-        return SeverityFormat.get_rich_severity_format(self.severity, self.message_raw)
+        return self.message_raw
 
 
 @dataclass(frozen=True)
@@ -74,7 +71,7 @@ class HighSeverityWarning(GeneralWarning):
     message_raw: str
 
     def get_message(self) -> str:
-        return SeverityFormat.get_rich_severity_format(self.severity, self.message_raw)
+        return self.message_raw
 
 
 @dataclass(frozen=True)
@@ -84,15 +81,16 @@ class ToolkitDependenciesIncludedWarning(GeneralWarning):
     dependencies: Union[None, str, list[str]]
 
     def get_message(self) -> str:
-        output = [SeverityFormat.get_rich_severity_format(self.severity, self.message)]
+        output = [self.message]
 
         if self.dependencies:
+            prefix = {"    " * 2}
             output[0] += ":"
             if isinstance(self.dependencies, str):
-                output.append(SeverityFormat.get_rich_detail_format(self.dependencies))
+                output.append(f"{prefix}{self.dependencies}")
             else:
                 for dependency in self.dependencies:
-                    output.append(SeverityFormat.get_rich_detail_format(dependency))
+                    output.append(f"{prefix}{dependency}")
         return "\n".join(output)
 
 
@@ -111,7 +109,7 @@ class ToolkitNotSupportedWarning(GeneralWarning):
                 extra_details.append(self.details)
             else:
                 extra_details.extend(self.details)
-        return SeverityFormat.get_rich_severity_format(self.severity, self.message, self.feature, *extra_details)
+        return " ".join((self.message, self.feature, *extra_details))
 
 
 @dataclass(frozen=True)
@@ -126,7 +124,7 @@ class MissingDependencyWarning(GeneralWarning):
         msg = f"{self.dependency_type} {self.identifier!r} is missing and is required by:"
         for identifier, path in self.required_by:
             msg += f"\n- {identifier!r} in {path}"
-        return SeverityFormat.get_rich_severity_format(self.severity, msg)
+        return msg
 
 
 @dataclass(frozen=True)
@@ -137,7 +135,7 @@ class MissingCapabilityWarning(GeneralWarning):
 
     def get_message(self) -> str:
         msg = f"The principal lacks the required access capability {self.capability} in the CDF project"
-        return SeverityFormat.get_rich_severity_format(self.severity, msg)
+        return msg
 
 
 @dataclass(frozen=True)
@@ -152,4 +150,4 @@ class ToolkitDeprecationWarning(ToolkitWarning, DeprecationWarning):
         if self.alternative:
             msg += f"\nUse {self.alternative!r} instead."
 
-        return SeverityFormat.get_rich_severity_format(SeverityLevel.LOW, msg)
+        return msg


### PR DESCRIPTION
# Description

## Before
![image](https://github.com/cognitedata/toolkit/assets/60234212/35b19a11-e58f-4dbc-b6b6-9c51cd1888d9)


## After this PR
![image](https://github.com/cognitedata/toolkit/assets/60234212/cdc93318-0e10-4a55-8c86-f414a969fc67)

## Motivation
Make it clear what part of the text belongs to the same warning.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
