### PR TITLE
[CDF-21917]🕵️‍♂️ Fix diffs deploy --dry-run

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -20,6 +20,9 @@ Changes are grouped as follows:
 ### Fixed
 
 - When running `cdf-tk run function --local`, the toolkit would raise an `ToolkitValidationError`. This is now fixed.
+- When running `cdf-tk deploy --dry-run`, if any resource was referencing a `DataSet`, `SecurityCategory`,
+  or `ExtractionPipeline`, it would incorrectly be classified as changed. This is now fixed. This applied to
+  `ExtractionPipeline`, `FileMetadata`, `Function`, `Group`, `Label`, `TimeSeries`, and `Transformation` resources.
 
 ## [0.2.7] - 2024-06-28
 

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders.py
@@ -1509,10 +1509,11 @@ class TimeSeriesLoader(ResourceContainerLoader[str, TimeSeriesWrite, TimeSeries,
         if (
             all(s == -1 for s in local_dumped.get("securityCategories", []))
             and "securityCategories" in cdf_dumped
-            and len(cdf_dumped["securityCategories"]) == len(local_dumped["securityCategories"])
+            and len(cdf_dumped["securityCategories"]) == len(local_dumped.get("securityCategories", []))
         ):
             local_dumped["securityCategories"] = cdf_dumped["securityCategories"]
-
+        if local_dumped.get("assetId") == -1 and "assetId" in cdf_dumped:
+            local_dumped["assetId"] = cdf_dumped["assetId"]
         return self._return_are_equal(local_dumped, cdf_dumped, return_dumped)
 
     def create(self, items: TimeSeriesWriteList) -> TimeSeriesList:
@@ -2560,9 +2561,15 @@ class FileMetadataLoader(
         if (
             all(s == -1 for s in local_dumped.get("securityCategories", []))
             and "securityCategories" in cdf_dumped
-            and len(cdf_dumped["securityCategories"]) == len(local_dumped["securityCategories"])
+            and len(cdf_dumped["securityCategories"]) == len(local_dumped.get("securityCategories", []))
         ):
             local_dumped["securityCategories"] = cdf_dumped["securityCategories"]
+        if (
+            all(a == -1 for a in local_dumped.get("assetIds", []))
+            and "assetIds" in cdf_dumped
+            and len(cdf_dumped["assetIds"]) == len(local_dumped.get("assetIds", []))
+        ):
+            local_dumped["assetIds"] = cdf_dumped["assetIds"]
 
         return self._return_are_equal(local_dumped, cdf_dumped, return_dumped)
 

--- a/cognite_toolkit/_cdf_tk/prototypes/resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/prototypes/resource_loaders.py
@@ -153,7 +153,7 @@ class AssetLoader(ResourceLoader[str, AssetWrite, Asset, AssetWriteList, AssetLi
         if (
             all(s == -1 for s in local_dumped.get("securityCategories", []))
             and "securityCategories" in cdf_dumped
-            and len(cdf_dumped["securityCategories"]) == len(local_dumped["securityCategories"])
+            and len(cdf_dumped["securityCategories"]) == len(local_dumped.get("securityCategories", []))
         ):
             local_dumped["securityCategories"] = cdf_dumped["securityCategories"]
 

--- a/cognite_toolkit/_cdf_tk/prototypes/resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/prototypes/resource_loaders.py
@@ -141,3 +141,20 @@ class AssetLoader(ResourceLoader[str, AssetWrite, Asset, AssetWriteList, AssetLi
                     ds_external_id, skip_validation, action="replace dataSetExternalId with dataSetId in assets"
                 )
         return AssetWriteList.load(resources)
+
+    def _are_equal(
+        self, local: AssetWrite, cdf_resource: Asset, return_dumped: bool = False
+    ) -> bool | tuple[bool, dict[str, Any], dict[str, Any]]:
+        local_dumped = local.dump()
+        cdf_dumped = cdf_resource.as_write().dump()
+        # Dry run
+        if local_dumped.get("dataSetId") == -1 and "dataSetId" in cdf_dumped:
+            local_dumped["dataSetId"] = cdf_dumped["dataSetId"]
+        if (
+            all(s == -1 for s in local_dumped.get("securityCategories", []))
+            and "securityCategories" in cdf_dumped
+            and len(cdf_dumped["securityCategories"]) == len(local_dumped["securityCategories"])
+        ):
+            local_dumped["securityCategories"] = cdf_dumped["securityCategories"]
+
+        return self._return_are_equal(local_dumped, cdf_dumped, return_dumped)


### PR DESCRIPTION
# Description

## Bug
![image](https://github.com/cognitedata/toolkit/assets/60234212/2fe431a0-bbae-4024-88ab-6b03cc28e3fe)

## Discussion
The `.load_resource` and `_are_equal` can likely be made generic. This will save a lot of code lines, ensure consistent implementations, but will add an extra abstraction layer and thus causing obfuscation. I chose thus to do this the repetitive way

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
