### PR TITLE
[CDF-21964] 🔻Lower bound for packaging dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -288,13 +288,13 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cognite-extractor-utils"
-version = "7.2.2"
+version = "7.2.3"
 description = "Utilities for easier development of extractors for CDF"
 optional = false
 python-versions = "<4.0.0,>=3.8.0"
 files = [
-    {file = "cognite_extractor_utils-7.2.2-py3-none-any.whl", hash = "sha256:f4955f2dcb829147bddf3b9d0dec7f7619f937468ea0d4e514717c58d2a8643a"},
-    {file = "cognite_extractor_utils-7.2.2.tar.gz", hash = "sha256:cfaab5271ad321fb282a085fe6bdbe8f639cb9f605e95c120ffb66d898b50d93"},
+    {file = "cognite_extractor_utils-7.2.3-py3-none-any.whl", hash = "sha256:492af4b4eaa0d77fc4e31c5454cbc7f5b36a81c835fef57fce834688154d5a61"},
+    {file = "cognite_extractor_utils-7.2.3.tar.gz", hash = "sha256:c1dedc73069c0d17296d850dd6d3327bc426d89b4d4789b44132994a5d772d0d"},
 ]
 
 [package.dependencies]
@@ -2039,18 +2039,18 @@ tornado = ["tornado (>=6)"]
 
 [[package]]
 name = "setuptools"
-version = "70.1.1"
+version = "70.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-70.1.1-py3-none-any.whl", hash = "sha256:a58a8fde0541dab0419750bcc521fbdf8585f6e5cb41909df3a472ef7b81ca95"},
-    {file = "setuptools-70.1.1.tar.gz", hash = "sha256:937a48c7cdb7a21eb53cd7f9b59e525503aa8abaf3584c730dc5f7a5bec3a650"},
+    {file = "setuptools-70.2.0-py3-none-any.whl", hash = "sha256:b8b8060bb426838fbe942479c90296ce976249451118ef566a5a0b7d8b78fb05"},
+    {file = "setuptools-70.2.0.tar.gz", hash = "sha256:bd63e505105011b25c3c11f753f7e3b8465ea739efddaccef8f0efac2137bac1"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "mypy (==1.10.0)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.3.2)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "mypy (==1.10.0)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.3.2)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "shellingham"
@@ -2245,4 +2245,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "b7b5d30491408dd218f8b1dfb58079e77d0318099c230444977f53a64ec220a2"
+content-hash = "1a64c1b0ac2f250eff8b617f6eb2aeea9a1b17ec05bcf5e84bb87657a08abd80"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ sentry-sdk = "^2.1.0"
 cognite-logger = "^0.6"
 questionary = "^2.0.1"
 mixpanel = "^4.10.1"
-packaging = "^24.1"
+# 22.0 was when explicit support for 3.11 was added.
+packaging = ">=22.0,<25.0"
 typing-extensions = "^4.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

## Why
`packaging` updated to `24.0` in March 2024, not all other packages have upgraded this:

![image](https://github.com/cognitedata/toolkit/assets/60234212/7c546106-3056-4230-bd0a-986c2baf90c9)

Went through the changelog of `packaging`, and in our use of it (parsing versions) it is safe to downgrade to version `22.0` 

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
