### PR TITLE
Adding 'dump timeseries' command 

### DIFF
--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -91,7 +91,9 @@ if "pytest" not in sys.modules and os.environ.get("SENTRY_ENABLED", "true").lowe
     )
 
 default_typer_kws = dict(
-    pretty_exceptions_short=False, pretty_exceptions_show_locals=False, pretty_exceptions_enable=False
+    pretty_exceptions_short=False,
+    pretty_exceptions_show_locals=False,
+    pretty_exceptions_enable=False,
 )
 try:
     typer.Typer(**default_typer_kws)  # type: ignore [arg-type]
@@ -314,7 +316,9 @@ def build(
     no_clean: Annotated[
         bool,
         typer.Option(
-            "--no-clean", "-c", help="Whether not to delete the build directory before building the configurations"
+            "--no-clean",
+            "-c",
+            help="Whether not to delete the build directory before building the configurations",
         ),
     ] = False,
     verbose: Annotated[
@@ -338,7 +342,12 @@ def build(
         print(ToolkitDeprecationWarning("cdf-tk --verbose", "cdf-tk build --verbose").get_message())
     cmd.run(
         lambda: cmd.execute(
-            verbose or ctx.obj.verbose, Path(source_dir), Path(build_dir), build_env_name, no_clean, ToolGlobals
+            verbose or ctx.obj.verbose,
+            Path(source_dir),
+            Path(build_dir),
+            build_env_name,
+            no_clean,
+            ToolGlobals,
         )
     )
 
@@ -416,7 +425,14 @@ def deploy(
         print(ToolkitDeprecationWarning("cdf-tk --verbose", "cdf-tk deploy --verbose").get_message())
     cmd.run(
         lambda: cmd.execute(
-            ToolGlobals, build_dir, build_env_name, dry_run, drop, drop_data, include, verbose or ctx.obj.verbose
+            ToolGlobals,
+            build_dir,
+            build_env_name,
+            dry_run,
+            drop,
+            drop_data,
+            include,
+            verbose or ctx.obj.verbose,
         )
     )
 
@@ -479,7 +495,16 @@ def clean(
     ToolGlobals = CDFToolConfig.from_context(ctx)
     if ctx.obj.verbose:
         print(ToolkitDeprecationWarning("cdf-tk --verbose", "cdf-tk clean --verbose").get_message())
-    cmd.run(lambda: cmd.execute(ToolGlobals, build_dir, build_env_name, dry_run, include, verbose or ctx.obj.verbose))
+    cmd.run(
+        lambda: cmd.execute(
+            ToolGlobals,
+            build_dir,
+            build_env_name,
+            dry_run,
+            include,
+            verbose or ctx.obj.verbose,
+        )
+    )
 
 
 @_app.command("collect", hidden=True)
@@ -580,7 +605,13 @@ def auth_verify(
         print(ToolkitDeprecationWarning("cdf-tk --verbose", "cdf-tk auth verify --verbose").get_message())
     cmd.run(
         lambda: cmd.execute(
-            ToolGlobals, dry_run, interactive, group_file, update_group, create_group, verbose or ctx.obj.verbose
+            ToolGlobals,
+            dry_run,
+            interactive,
+            group_file,
+            update_group,
+            create_group,
+            verbose or ctx.obj.verbose,
         )
     )
 
@@ -1045,7 +1076,10 @@ def dump_datamodel_cmd(
 
 
 if FeatureFlag.is_enabled(Flags.ASSETS):
-    from cognite_toolkit._cdf_tk.prototypes.commands import DumpAssetsCommand
+    from cognite_toolkit._cdf_tk.prototypes.commands import (
+        DumpAssetsCommand,
+        DumpTimeSeriesCommand,
+    )
 
     @dump_app.command("asset")
     def dump_asset_cmd(
@@ -1068,7 +1102,11 @@ if FeatureFlag.is_enabled(Flags.ASSETS):
         ] = None,
         interactive: Annotated[
             bool,
-            typer.Option("--interactive", "-i", help="Will prompt you to select which assets hierarchies to dump."),
+            typer.Option(
+                "--interactive",
+                "-i",
+                help="Will prompt you to select which assets hierarchies to dump.",
+            ),
         ] = False,
         output_dir: Annotated[
             Path,
@@ -1118,6 +1156,82 @@ if FeatureFlag.is_enabled(Flags.ASSETS):
             lambda: cmd.execute(
                 CDFToolConfig.from_context(ctx),
                 hierarchy,
+                data_set,
+                interactive,
+                output_dir,
+                clean_,
+                limit,
+                format_,  # type: ignore [arg-type]
+                verbose or ctx.obj.verbose,
+            )
+        )
+
+    @dump_app.command("timeseries")
+    def dump_timeseries_cmd(
+        ctx: typer.Context,
+        data_set: Annotated[
+            Optional[list[str]],
+            typer.Option(
+                "--data-set",
+                "-d",
+                help="Data set to dump.",
+            ),
+        ] = None,
+        interactive: Annotated[
+            bool,
+            typer.Option(
+                "--interactive",
+                "-i",
+                help="Will prompt you to select which timeseries to dump.",
+            ),
+        ] = False,
+        output_dir: Annotated[
+            Path,
+            typer.Argument(
+                help="Where to dump the timeseries YAML files.",
+                allow_dash=True,
+            ),
+        ] = Path("tmp"),
+        format_: Annotated[
+            str,
+            typer.Option(
+                "--format",
+                "-f",
+                help="Format to dump the timeseries in. Supported formats: yaml, csv, and parquet.",
+            ),
+        ] = "csv",
+        clean_: Annotated[
+            bool,
+            typer.Option(
+                "--clean",
+                "-c",
+                help="Delete the output directory before pulling the timeseries.",
+            ),
+        ] = False,
+        limit: Annotated[
+            Optional[int],
+            typer.Option(
+                "--limit",
+                "-l",
+                help="Limit the number of timeseries to dump.",
+            ),
+        ] = None,
+        verbose: Annotated[
+            bool,
+            typer.Option(
+                "--verbose",
+                "-v",
+                help="Turn on to get more verbose output when running the command",
+            ),
+        ] = False,
+    ) -> None:
+        """This command will dump the selected timeseries as yaml to the folder specified, defaults to /tmp."""
+        cmd = DumpTimeSeriesCommand()
+        if ctx.obj.verbose:
+            print(ToolkitDeprecationWarning("cdf-tk --verbose", "cdf-tk dump timeseries --verbose").get_message())
+        cmd.run(
+            lambda: cmd.execute(
+                CDFToolConfig.from_context(ctx),
                 data_set,
                 interactive,
                 output_dir,

--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -23,6 +23,13 @@ if FeatureFlag.is_enabled(Flags.ASSETS):
 
     setup_asset_loader.setup_asset_loader()
 
+# TODO: above my head to implement setup_asset_loader.py. Which `_modify` steps to implement?
+# if FeatureFlag.is_enabled(Flags.TIMESERIES):
+#     from cognite_toolkit._cdf_tk.prototypes import setup_timeseries_loader
+
+#     setup_timeseries_loader.setup_timeseries_loader()
+
+
 if FeatureFlag.is_enabled(Flags.MODEL_3D):
     from cognite_toolkit._cdf_tk.prototypes import setup_3D_loader
 
@@ -1076,10 +1083,7 @@ def dump_datamodel_cmd(
 
 
 if FeatureFlag.is_enabled(Flags.ASSETS):
-    from cognite_toolkit._cdf_tk.prototypes.commands import (
-        DumpAssetsCommand,
-        DumpTimeSeriesCommand,
-    )
+    from cognite_toolkit._cdf_tk.prototypes.commands import DumpAssetsCommand
 
     @dump_app.command("asset")
     def dump_asset_cmd(
@@ -1166,9 +1170,21 @@ if FeatureFlag.is_enabled(Flags.ASSETS):
             )
         )
 
+
+if FeatureFlag.is_enabled(Flags.TIMESERIES):
+    from cognite_toolkit._cdf_tk.prototypes.commands import DumpTimeSeriesCommand
+
     @dump_app.command("timeseries")
     def dump_timeseries_cmd(
         ctx: typer.Context,
+        time_series_list: Annotated[
+            Optional[list[str]],
+            typer.Option(
+                "--timeseries",
+                "-t",
+                help="Timeseries to dump.",
+            ),
+        ] = None,
         data_set: Annotated[
             Optional[list[str]],
             typer.Option(

--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -1171,7 +1171,7 @@ if FeatureFlag.is_enabled(Flags.ASSETS):
         )
 
 
-if FeatureFlag.is_enabled(Flags.TIMESERIES):
+if FeatureFlag.is_enabled(Flags.TIMESERIES_DUMP):
     from cognite_toolkit._cdf_tk.prototypes.commands import DumpTimeSeriesCommand
 
     @dump_app.command("timeseries")

--- a/cognite_toolkit/_cdf_tk/commands/featureflag.py
+++ b/cognite_toolkit/_cdf_tk/commands/featureflag.py
@@ -20,9 +20,9 @@ class Flags(Enum):
     INTERNAL: ClassVar[dict[str, Any]] = {"visible": False, "description": "Does nothing"}
     IMPORT_CMD: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the import sub application"}
     ASSETS: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the support for loading assets"}
-    TIMESERIES: ClassVar[dict[str, Any]] = {
+    TIMESERIES_DUMP: ClassVar[dict[str, Any]] = {
         "visible": True,
-        "description": "Enables the support for loading timeseries",
+        "description": "Enables the support to dump timeseries",
     }
     NO_NAMING: ClassVar[dict[str, Any]] = {"visible": True, "description": "Disables the naming convention checks"}
     ROBOTICS: ClassVar[dict[str, Any]] = {"visible": False, "description": "Enables the robotics sub application"}

--- a/cognite_toolkit/_cdf_tk/commands/featureflag.py
+++ b/cognite_toolkit/_cdf_tk/commands/featureflag.py
@@ -20,6 +20,10 @@ class Flags(Enum):
     INTERNAL: ClassVar[dict[str, Any]] = {"visible": False, "description": "Does nothing"}
     IMPORT_CMD: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the import sub application"}
     ASSETS: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the support for loading assets"}
+    TIMESERIES: ClassVar[dict[str, Any]] = {
+        "visible": True,
+        "description": "Enables the support for loading timeseries",
+    }
     NO_NAMING: ClassVar[dict[str, Any]] = {"visible": True, "description": "Disables the naming convention checks"}
     ROBOTICS: ClassVar[dict[str, Any]] = {"visible": False, "description": "Enables the robotics sub application"}
     FUN_SCHEDULE: ClassVar[dict[str, Any]] = {

--- a/cognite_toolkit/_cdf_tk/prototypes/commands/__init__.py
+++ b/cognite_toolkit/_cdf_tk/prototypes/commands/__init__.py
@@ -1,4 +1,5 @@
 from .dump_assets import DumpAssetsCommand
+from .dump_timeseries import DumpTimeSeriesCommand
 from .modules import ModulesCommand
 
-__all__ = ["ModulesCommand", "DumpAssetsCommand"]
+__all__ = ["ModulesCommand", "DumpAssetsCommand", "DumpTimeSeriesCommand"]

--- a/cognite_toolkit/_cdf_tk/prototypes/commands/dump_timeseries.py
+++ b/cognite_toolkit/_cdf_tk/prototypes/commands/dump_timeseries.py
@@ -27,11 +27,10 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitMissingResourceError,
     ToolkitValueError,
 )
-from cognite_toolkit._cdf_tk.loaders import DataSetsLoader
+from cognite_toolkit._cdf_tk.loaders import DataSetsLoader, TimeSeriesLoader
 from cognite_toolkit._cdf_tk.utils import CDFToolConfig
 
-# from cognite_toolkit._cdf_tk.prototypes.resource_loaders import TimeSeriesLoader
-TIME_SERIES_FOLDER_NAME = "timeseries"
+TIME_SERIES_FOLDER_NAME = TimeSeriesLoader.folder_name
 
 
 class DumpTimeSeriesCommand(ToolkitCommand):
@@ -205,7 +204,7 @@ class DumpTimeSeriesCommand(ToolkitCommand):
         """
         assert isinstance(choice, questionary.Choice)
         assert isinstance(choice.title, str)  # minimum external_id is set
-        return choice.title.lower()
+        return choice.title.casefold()  # superior to lower case like `ß>ss` in German
 
     def _select_data_set(
         self,

--- a/cognite_toolkit/_cdf_tk/prototypes/commands/dump_timeseries.py
+++ b/cognite_toolkit/_cdf_tk/prototypes/commands/dump_timeseries.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import pandas as pd
+import questionary
+import yaml
+from cognite.client import CogniteClient
+from cognite.client.data_classes import (
+    DataSetWrite,
+    DataSetWriteList,
+    TimeSeriesFilter,
+    TimeSeriesList,
+)
+from cognite.client.exceptions import CogniteAPIError
+from rich.progress import Progress, TaskID
+
+from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
+from cognite_toolkit._cdf_tk.exceptions import (
+    ToolkitFileExistsError,
+    ToolkitIsADirectoryError,
+    ToolkitMissingResourceError,
+    ToolkitValueError,
+)
+from cognite_toolkit._cdf_tk.loaders import DataSetsLoader, LabelLoader
+from cognite_toolkit._cdf_tk.prototypes.resource_loaders import TimeSeriesLoader
+from cognite_toolkit._cdf_tk.utils import CDFToolConfig
+
+#
+# TODO: what is the naming convention for TimeSeries, timeseries, time_series, singular or plural?
+#
+
+
+class DumpTimeSeriesCommand(ToolkitCommand):
+    # 128 MB
+    buffer_size = 128 * 1024 * 1024
+    # Note the size in memory is not the same as the size on disk,
+    # so the resulting file size will vary.
+    encoding = "utf-8"
+    newline = "\n"
+
+    def __init__(self, print_warning: bool = True, skip_tracking: bool = False):
+        super().__init__(print_warning, skip_tracking)
+        self.time_series_external_id_by_id: dict[int, str] = {}
+        self.data_set_by_id: dict[int, DataSetWrite] = {}
+        self._used_labels: set[str] = set()
+        self._used_data_sets: set[int] = set()
+        self._available_data_sets: set[str] | None = None
+
+    def execute(
+        self,
+        ToolGlobals: CDFToolConfig,
+        data_set: list[str] | None,
+        interactive: bool,
+        output_dir: Path,
+        clean: bool,
+        limit: int | None = None,
+        format_: Literal["yaml", "csv", "parquet"] = "csv",
+        verbose: bool = False,
+    ) -> None:
+        if format_ not in {"yaml", "csv", "parquet"}:
+            raise ToolkitValueError(f"Unsupported format {format_}. Supported formats are yaml, csv, parquet.")
+        if output_dir.exists() and clean:
+            shutil.rmtree(output_dir)
+        elif output_dir.exists():
+            raise ToolkitFileExistsError(f"Output directory {output_dir!s} already exists. Use --clean to remove it.")
+        elif output_dir.suffix:
+            raise ToolkitIsADirectoryError(f"Output directory {output_dir!s} is not a directory.")
+
+        data_sets = self._select_data_set(ToolGlobals.client, data_set, interactive)
+        if not data_sets:
+            raise ToolkitValueError("No data set provided")
+
+        if missing := set(data_sets) - {item.external_id for item in self.data_set_by_id.values() if item.external_id}:
+            try:
+                retrieved = ToolGlobals.client.data_sets.retrieve_multiple(external_ids=list(missing))
+            except CogniteAPIError as e:
+                raise ToolkitMissingResourceError(f"Failed to retrieve data sets {data_sets}: {e}")
+
+            self.data_set_by_id.update({item.id: item.as_write() for item in retrieved if item.id})
+
+        (output_dir / TimeSeriesLoader.folder_name).mkdir(parents=True, exist_ok=True)
+
+        total_time_series = ToolGlobals.client.time_series.aggregate_count(
+            filter=TimeSeriesFilter(
+                data_set_ids=[{"externalId": item} for item in data_sets] or None,
+            )
+        )
+        if limit:
+            total_time_series = min(total_time_series, limit)
+
+        with Progress() as progress:
+            retrieved_time_series = progress.add_task("Retrieving time_series", total=total_time_series)
+            write_to_file = progress.add_task("Writing time_series to file(s)", total=total_time_series)
+
+            time_series_iterator = ToolGlobals.client.time_series(
+                chunk_size=1000,
+                data_set_external_ids=data_sets or None,
+                limit=limit,
+            )
+            time_series_iterator = self._log_retrieved(time_series_iterator, progress, retrieved_time_series)
+            writeable = self._to_write(time_series_iterator, ToolGlobals.client, expand_metadata=True)
+
+            count = 0
+            if format_ == "yaml":
+                for time_series in writeable:
+                    file_path = output_dir / TimeSeriesLoader.folder_name / f"TimeSeries.{format_}"
+                    if file_path.exists():
+                        with file_path.open("a", encoding=self.encoding, newline=self.newline) as f:
+                            f.write("\n")
+                            f.write(yaml.safe_dump(time_series, sort_keys=False))
+                    else:
+                        with file_path.open("w", encoding=self.encoding, newline=self.newline) as f:
+                            f.write(yaml.safe_dump(time_series, sort_keys=False))
+                    count += len(time_series)
+                    progress.advance(write_to_file, advance=len(time_series))
+            elif format_ in {"csv", "parquet"}:
+                file_count: int = 0  # Counter()
+                for df in self._buffer(writeable):
+                    folder_path = output_dir / TimeSeriesLoader.folder_name
+                    folder_path.mkdir(parents=True, exist_ok=True)
+                    file_path = folder_path / f"part-{file_count:04}.TimeSeries.{format_}"
+                    if format_ == "csv":
+                        df.to_csv(
+                            file_path,
+                            index=False,
+                            encoding=self.encoding,
+                            lineterminator=self.newline,
+                        )
+                    elif format_ == "parquet":
+                        df.to_parquet(file_path, index=False)
+                    file_count += 1
+                    if verbose:
+                        print(f"Dumped {len(df):,} time_series to {file_path}")
+                    count += len(df)
+                    progress.advance(write_to_file, advance=len(df))
+            else:
+                raise ToolkitValueError(f"Unsupported format {format_}. Supported formats are yaml, csv, parquet. ")
+
+        print(f"Dumped {count:,} time_series to {output_dir}")
+
+        if self._used_labels:
+            labels = ToolGlobals.client.labels.retrieve(external_id=list(self._used_labels), ignore_unknown_ids=True)
+            if labels:
+                to_dump_dicts = labels.as_write().dump()
+                for label in to_dump_dicts:
+                    if "dataSetId" in label:
+                        data_set_id = label.pop("dataSetId")
+                        self._used_data_sets.add(data_set_id)
+                        label["dataSetExternalId"] = self._get_data_set_external_id(ToolGlobals.client, data_set_id)
+
+                file_path = output_dir / LabelLoader.folder_name / "time_series.Label.yaml"
+                file_path.parent.mkdir(parents=True, exist_ok=True)
+                if file_path.exists():
+                    with file_path.open("a", encoding=self.encoding, newline=self.newline) as f:
+                        f.write("\n")
+                        f.write(yaml.safe_dump(to_dump_dicts, sort_keys=False))
+                else:
+                    with file_path.open("w", encoding=self.encoding, newline=self.newline) as f:
+                        f.write(yaml.safe_dump(to_dump_dicts, sort_keys=False))
+
+                print(f"Dumped {len(labels):,} labels to {file_path}")
+
+        if self._used_data_sets:
+            to_dump = DataSetWriteList(
+                [self.data_set_by_id[used_dataset] for used_dataset in self._used_data_sets]
+            ).dump_yaml()
+            file_path = output_dir / DataSetsLoader.folder_name / "time_series.DataSet.yaml"
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            if file_path.exists():
+                with file_path.open("a", encoding=self.encoding, newline=self.newline) as f:
+                    f.write("\n")
+                    f.write(to_dump)
+            else:
+                with file_path.open("w", encoding=self.encoding, newline=self.newline) as f:
+                    f.write(to_dump)
+
+            print(f"Dumped {len(self.data_set_by_id):,} data sets to {file_path}")
+
+    def _buffer(self, time_series_iterator: Iterator[list[dict[str, Any]]]) -> Iterator[pd.DataFrame]:
+        """Iterates over time_series until the buffer reaches the filesize."""
+        stored_time_series: pd.DataFrame = pd.DataFrame()
+        for time_series in time_series_iterator:
+            stored_time_series = pd.concat(
+                [stored_time_series, pd.DataFrame(time_series)],
+                ignore_index=True,
+            )
+            if stored_time_series.memory_usage().sum() > self.buffer_size:
+                yield stored_time_series
+                # reset of the buffer required
+                stored_time_series = pd.DataFrame()
+        if not stored_time_series.empty:
+            yield stored_time_series
+
+    def _select_data_set(
+        self,
+        client: CogniteClient,
+        data_set: list[str] | None,
+        interactive: bool,
+    ) -> list[str]:
+        if not interactive:
+            return data_set or []
+
+        data_sets: set[str] = set()
+        while True:
+            selected = []
+            if data_sets:
+                selected.append(f"Selected data sets: {sorted(data_sets)}")
+            else:
+                selected.append("No data set selected.")
+            selected_str = "\n".join(selected)
+            what = questionary.select(
+                f"\n{selected_str}\nSelect a data set to dump",
+                choices=[
+                    "Data Set",
+                    "Done",
+                ],
+            ).ask()
+
+            if what == "Done":
+                break
+            elif what == "Data Set":
+                _available_data_sets = self._get_available_data_sets(client)
+                selected_data_set = questionary.checkbox(
+                    "Select a data set",
+                    choices=sorted(item for item in _available_data_sets if item not in data_sets),
+                ).ask()
+                if selected_data_set:
+                    data_sets.update(selected_data_set)
+                else:
+                    print("No data set selected.")
+        return list(data_sets)
+
+    def _get_available_data_sets(self, client: CogniteClient) -> set[str]:
+        if self._available_data_sets is None:
+            self.data_set_by_id.update({item.id: item.as_write() for item in client.data_sets})
+            self._available_data_sets = {item.external_id for item in self.data_set_by_id.values() if item.external_id}
+        return self._available_data_sets
+
+    def _to_write(
+        self,
+        time_series: Iterator[TimeSeriesList],
+        client: CogniteClient,
+        expand_metadata: bool,
+    ) -> Iterator[list[Any]]:
+        for time_series_list in time_series:
+            write_time_series: list[dict[str, Any]] = []
+            # TODO: how to separate `times_series` as list from `time_series` as one item?
+            for one_time_series in time_series_list:
+                write = one_time_series.as_write().dump(camel_case=True)
+                write.pop("parentId", None)
+                if "dataSetId" in write:
+                    data_set_id = write.pop("dataSetId")
+                    self._used_data_sets.add(data_set_id)
+                    write["dataSetExternalId"] = self._get_data_set_external_id(client, data_set_id)
+                if expand_metadata and "metadata" in write:
+                    metadata = write.pop("metadata")
+                    for key, value in metadata.items():
+                        write[f"metadata.{key}"] = value
+                if "rootId" in write:
+                    root_id = write.pop("rootId")
+                    write["rootExternalId"] = self._get_time_series_external_id(client, root_id)
+                if isinstance(write.get("labels"), list):
+                    write["labels"] = [label["externalId"] for label in write["labels"]]
+                    self._used_labels.update(write["labels"])
+                write_time_series.append(write)
+            yield write_time_series
+
+    def _get_time_series_external_id(self, client: CogniteClient, root_id: int) -> str:
+        if root_id in self.time_series_external_id_by_id:
+            return self.time_series_external_id_by_id[root_id]
+        try:
+            time_series = client.time_series.retrieve(id=root_id)
+        except CogniteAPIError as e:
+            raise ToolkitMissingResourceError(f"Failed to retrieve time_series {root_id}: {e}")
+        if time_series is None:
+            raise ToolkitMissingResourceError(f"TimeSeries {root_id} does not exist")
+        if not time_series.external_id:
+            raise ToolkitValueError(f"TimeSeries {root_id} does not have an external id")
+        self.time_series_external_id_by_id[root_id] = time_series.external_id
+        return time_series.external_id
+
+    def _get_data_set_external_id(self, client: CogniteClient, data_set_id: int) -> str:
+        if data_set_id in self.data_set_by_id:
+            return cast(str, self.data_set_by_id[data_set_id].external_id)
+        try:
+            data_set = client.data_sets.retrieve(id=data_set_id)
+        except CogniteAPIError as e:
+            raise ToolkitMissingResourceError(f"Failed to retrieve data set {data_set_id}: {e}")
+        if data_set is None:
+            raise ToolkitMissingResourceError(f"Data set {data_set_id} does not exist")
+        if not data_set.external_id:
+            raise ToolkitValueError(f"Data set {data_set_id} does not have an external id")
+        self.data_set_by_id[data_set_id] = data_set.as_write()
+        return data_set.external_id
+
+    @staticmethod
+    def _log_retrieved(
+        time_series_iterator: Iterator[TimeSeriesList], progress: Progress, task: TaskID
+    ) -> Iterator[TimeSeriesList]:
+        for time_series_list in time_series_iterator:
+            progress.advance(task, advance=len(time_series_list))
+            yield time_series_list

--- a/cognite_toolkit/_cdf_tk/prototypes/resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/prototypes/resource_loaders.py
@@ -17,6 +17,10 @@ from cognite.client.data_classes import (
     ThreeDModelUpdate,
     ThreeDModelWrite,
     ThreeDModelWriteList,
+    TimeSeries,
+    TimeSeriesList,
+    TimeSeriesWrite,
+    TimeSeriesWriteList,
     capabilities,
 )
 from cognite.client.data_classes.capabilities import Capability
@@ -24,9 +28,184 @@ from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
 from cognite.client.utils.useful_types import SequenceNotStr
 
 from cognite_toolkit._cdf_tk._parameters import ParameterSpec, ParameterSpecSet
-from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceContainerLoader, ResourceLoader
-from cognite_toolkit._cdf_tk.loaders._resource_loaders import DataSetsLoader, LabelLoader
+from cognite_toolkit._cdf_tk.loaders._base_loaders import (
+    ResourceContainerLoader,
+    ResourceLoader,
+)
+from cognite_toolkit._cdf_tk.loaders._resource_loaders import (
+    DataSetsLoader,
+    LabelLoader,
+)
 from cognite_toolkit._cdf_tk.utils import CDFToolConfig, load_yaml_inject_variables
+
+
+@final
+class TimeSeriesLoader(ResourceLoader[str, TimeSeriesWrite, TimeSeries, TimeSeriesWriteList, TimeSeriesList]):
+    folder_name = "timeseries"
+    filename_pattern = r"^.*\.TimeSeries$"  # Matches all yaml files whose stem ends with '.TimeSeries'.
+    filetypes = frozenset({"yaml", "yml", "csv", "parquet"})
+    resource_cls = TimeSeries
+    resource_write_cls = TimeSeriesWrite
+    list_cls = TimeSeriesList
+    list_write_cls = TimeSeriesWriteList
+    kind = "TimeSeries"
+    dependencies = frozenset({DataSetsLoader, LabelLoader})
+    _doc_url = "TimeSeries/operation/createTimeSeries"
+
+    @classmethod
+    def get_id(cls, item: TimeSeries | TimeSeriesWrite | dict) -> str:
+        if isinstance(item, dict):
+            return item["externalId"]
+        if not item.external_id:
+            raise KeyError("TimeSeries must have external_id")
+        return item.external_id
+
+    @classmethod
+    def get_required_capability(cls, items: TimeSeriesWriteList) -> Capability | list[Capability]:
+        if not items:
+            return []
+        data_set_ids = {item.data_set_id for item in items if item.data_set_id}
+        scope = (
+            capabilities.AssetsAcl.Scope.DataSet(list(data_set_ids))
+            if data_set_ids
+            else capabilities.AssetsAcl.Scope.All()
+        )
+
+        return capabilities.AssetsAcl(
+            [capabilities.AssetsAcl.Action.Read, capabilities.AssetsAcl.Action.Write],
+            scope,  # type: ignore[arg-type]
+        )
+
+    def create(self, items: TimeSeriesWriteList) -> TimeSeriesList:
+        return self.client.time_series.create(items)
+
+    def retrieve(self, ids: SequenceNotStr[str]) -> TimeSeriesList:
+        return self.client.time_series.retrieve_multiple(external_ids=ids, ignore_unknown_ids=True)
+
+    def update(self, items: TimeSeriesWriteList) -> TimeSeriesList:
+        return self.client.time_series.update(items)
+
+    def delete(self, ids: SequenceNotStr[str]) -> int:
+        try:
+            self.client.time_series.delete(external_id=ids)
+        except (CogniteAPIError, CogniteNotFoundError) as e:
+            non_existing = set(e.failed or [])
+            if existing := [id_ for id_ in ids if id_ not in non_existing]:
+                self.client.time_series.delete(external_id=existing)
+            return len(existing)
+        else:
+            return len(ids)
+
+    def iterate(self) -> Iterable[TimeSeries]:
+        return iter(self.client.time_series)
+
+    @classmethod
+    @lru_cache(maxsize=1)
+    def get_write_cls_parameter_spec(cls) -> ParameterSpecSet:
+        spec = super().get_write_cls_parameter_spec()
+        # Added by toolkit
+        spec.add(
+            ParameterSpec(
+                ("dataSetExternalId",),
+                frozenset({"str"}),
+                is_required=False,
+                _is_nullable=False,
+            )
+        )
+
+        # Should not be used, used for parentExternalId instead
+        spec.discard(ParameterSpec(("parentId",), frozenset({"int"}), is_required=False, _is_nullable=False))
+        return spec
+
+    @classmethod
+    def get_dependent_items(cls, item: dict) -> Iterable[tuple[type[ResourceLoader], Hashable]]:
+        """Returns all items that this item requires.
+
+        For example, a TimeSeries requires a DataSet, so this method would return the
+        DatasetLoader and identifier of that dataset.
+        """
+        if "dataSetExternalId" in item:
+            yield DataSetsLoader, item["dataSetExternalId"]
+        # ts doesn't support labels or parentExternalId
+        # for label in item.get("labels", []):
+        #     if isinstance(label, dict):
+        #         yield LabelLoader, label["externalId"]
+        #     elif isinstance(label, str):
+        #         yield LabelLoader, label
+        # if "parentExternalId" in item:
+        #     yield cls, item["parentExternalId"]
+
+    def load_resource(self, filepath: Path, ToolGlobals: CDFToolConfig, skip_validation: bool) -> TimeSeriesWriteList:
+        resources: list[dict[str, Any]]
+        if filepath.suffix in {".yaml", ".yml"}:
+            raw = load_yaml_inject_variables(filepath, ToolGlobals.environment_variables())
+            resources = [raw] if isinstance(raw, list) else raw  # type: ignore[assignment, list-item]
+        elif filepath.suffix == ".csv" or filepath.suffix == ".parquet":
+            if filepath.suffix == ".csv":
+                # The replacement is used to ensure that we read exactly the same file on Windows and Linux
+                file_content = filepath.read_bytes().replace(b"\r\n", b"\n").decode("utf-8")
+                data = pd.read_csv(io.StringIO(file_content))
+            else:
+                data = pd.read_parquet(filepath)
+            data.replace(pd.NA, None, inplace=True)
+            data.replace("", None, inplace=True)
+            resources = data.to_dict(orient="records")
+        else:
+            raise ValueError(f"Unsupported file type: {filepath.suffix}")
+
+        for resource in resources:
+            # Unpack metadata keys from table formats (e.g. csv, parquet)
+            metadata: dict = resource.get("metadata", {})
+            for key, value in list(resource.items()):
+                if key.startswith("metadata."):
+                    if value not in {None, float("nan")} and str(value) not in {
+                        "",
+                        " ",
+                        "nan",
+                        "null",
+                        "none",
+                    }:
+                        metadata[key.removeprefix("metadata.")] = str(value)
+                    del resource[key]
+            if metadata:
+                resource["metadata"] = metadata
+            # if "labels" in resource and isinstance(resource["labels"], str):
+            #     resource["labels"] = [
+            #         label.strip()
+            #         for label in resource["labels"]
+            #         .removeprefix("[")
+            #         .removesuffix("]")
+            #         .split(",")
+            #     ]
+
+            if resource.get("dataSetExternalId") is not None:
+                ds_external_id = resource.pop("dataSetExternalId")
+                resource["dataSetId"] = ToolGlobals.verify_dataset(
+                    ds_external_id,
+                    skip_validation,
+                    action="replace dataSetExternalId with dataSetId in time_series",
+                )
+        return TimeSeriesWriteList.load(resources)
+
+    def _are_equal(
+        self,
+        local: TimeSeriesWrite,
+        cdf_resource: TimeSeries,
+        return_dumped: bool = False,
+    ) -> bool | tuple[bool, dict[str, Any], dict[str, Any]]:
+        local_dumped = local.dump()
+        cdf_dumped = cdf_resource.as_write().dump()
+        # Dry run
+        if local_dumped.get("dataSetId") == -1 and "dataSetId" in cdf_dumped:
+            local_dumped["dataSetId"] = cdf_dumped["dataSetId"]
+        if (
+            all(s == -1 for s in local_dumped.get("securityCategories", []))
+            and "securityCategories" in cdf_dumped
+            and len(cdf_dumped["securityCategories"]) == len(local_dumped.get("securityCategories", []))
+        ):
+            local_dumped["securityCategories"] = cdf_dumped["securityCategories"]
+
+        return self._return_are_equal(local_dumped, cdf_dumped, return_dumped)
 
 
 @final
@@ -94,7 +273,14 @@ class AssetLoader(ResourceLoader[str, AssetWrite, Asset, AssetWriteList, AssetLi
     def get_write_cls_parameter_spec(cls) -> ParameterSpecSet:
         spec = super().get_write_cls_parameter_spec()
         # Added by toolkit
-        spec.add(ParameterSpec(("dataSetExternalId",), frozenset({"str"}), is_required=False, _is_nullable=False))
+        spec.add(
+            ParameterSpec(
+                ("dataSetExternalId",),
+                frozenset({"str"}),
+                is_required=False,
+                _is_nullable=False,
+            )
+        )
 
         # Should not be used, used for parentExternalId instead
         spec.discard(ParameterSpec(("parentId",), frozenset({"int"}), is_required=False, _is_nullable=False))
@@ -140,7 +326,13 @@ class AssetLoader(ResourceLoader[str, AssetWrite, Asset, AssetWriteList, AssetLi
             metadata: dict = resource.get("metadata", {})
             for key, value in list(resource.items()):
                 if key.startswith("metadata."):
-                    if value not in {None, float("nan")} and str(value) not in {"", " ", "nan", "null", "none"}:
+                    if value not in {None, float("nan")} and str(value) not in {
+                        "",
+                        " ",
+                        "nan",
+                        "null",
+                        "none",
+                    }:
                         metadata[key.removeprefix("metadata.")] = str(value)
                     del resource[key]
             if metadata:
@@ -153,7 +345,9 @@ class AssetLoader(ResourceLoader[str, AssetWrite, Asset, AssetWriteList, AssetLi
             if resource.get("dataSetExternalId") is not None:
                 ds_external_id = resource.pop("dataSetExternalId")
                 resource["dataSetId"] = ToolGlobals.verify_dataset(
-                    ds_external_id, skip_validation, action="replace dataSetExternalId with dataSetId in assets"
+                    ds_external_id,
+                    skip_validation,
+                    action="replace dataSetExternalId with dataSetId in assets",
                 )
         return AssetWriteList.load(resources)
 
@@ -286,10 +480,24 @@ class ThreeDModelLoader(
     def get_write_cls_parameter_spec(cls) -> ParameterSpecSet:
         spec = super().get_write_cls_parameter_spec()
         # Added by toolkit
-        spec.add(ParameterSpec(("dataSetExternalId",), frozenset({"str"}), is_required=False, _is_nullable=False))
+        spec.add(
+            ParameterSpec(
+                ("dataSetExternalId",),
+                frozenset({"str"}),
+                is_required=False,
+                _is_nullable=False,
+            )
+        )
 
         # Should not be used, used for dataSetExternalId instead
-        spec.discard(ParameterSpec(("dataSetId",), frozenset({"int"}), is_required=False, _is_nullable=False))
+        spec.discard(
+            ParameterSpec(
+                ("dataSetId",),
+                frozenset({"int"}),
+                is_required=False,
+                _is_nullable=False,
+            )
+        )
         return spec
 
     @classmethod
@@ -310,12 +518,17 @@ class ThreeDModelLoader(
             if resource.get("dataSetExternalId") is not None:
                 ds_external_id = resource.pop("dataSetExternalId")
                 resource["dataSetId"] = ToolGlobals.verify_dataset(
-                    ds_external_id, skip_validation, action="replace dataSetExternalId with dataSetId in 3D Model"
+                    ds_external_id,
+                    skip_validation,
+                    action="replace dataSetExternalId with dataSetId in 3D Model",
                 )
         return ThreeDModelWriteList.load(resources)
 
     def _are_equal(
-        self, local: ThreeDModelWrite, cdf_resource: ThreeDModel, return_dumped: bool = False
+        self,
+        local: ThreeDModelWrite,
+        cdf_resource: ThreeDModel,
+        return_dumped: bool = False,
     ) -> bool | tuple[bool, dict[str, Any], dict[str, Any]]:
         local_dumped = local.dump()
         cdf_dumped = cdf_resource.as_write().dump()

--- a/cognite_toolkit/_cdf_tk/prototypes/resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/prototypes/resource_loaders.py
@@ -17,10 +17,6 @@ from cognite.client.data_classes import (
     ThreeDModelUpdate,
     ThreeDModelWrite,
     ThreeDModelWriteList,
-    TimeSeries,
-    TimeSeriesList,
-    TimeSeriesWrite,
-    TimeSeriesWriteList,
     capabilities,
 )
 from cognite.client.data_classes.capabilities import Capability
@@ -28,184 +24,9 @@ from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
 from cognite.client.utils.useful_types import SequenceNotStr
 
 from cognite_toolkit._cdf_tk._parameters import ParameterSpec, ParameterSpecSet
-from cognite_toolkit._cdf_tk.loaders._base_loaders import (
-    ResourceContainerLoader,
-    ResourceLoader,
-)
-from cognite_toolkit._cdf_tk.loaders._resource_loaders import (
-    DataSetsLoader,
-    LabelLoader,
-)
+from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceContainerLoader, ResourceLoader
+from cognite_toolkit._cdf_tk.loaders._resource_loaders import DataSetsLoader, LabelLoader
 from cognite_toolkit._cdf_tk.utils import CDFToolConfig, load_yaml_inject_variables
-
-
-@final
-class TimeSeriesLoader(ResourceLoader[str, TimeSeriesWrite, TimeSeries, TimeSeriesWriteList, TimeSeriesList]):
-    folder_name = "timeseries"
-    filename_pattern = r"^.*\.TimeSeries$"  # Matches all yaml files whose stem ends with '.TimeSeries'.
-    filetypes = frozenset({"yaml", "yml", "csv", "parquet"})
-    resource_cls = TimeSeries
-    resource_write_cls = TimeSeriesWrite
-    list_cls = TimeSeriesList
-    list_write_cls = TimeSeriesWriteList
-    kind = "TimeSeries"
-    dependencies = frozenset({DataSetsLoader, LabelLoader})
-    _doc_url = "TimeSeries/operation/createTimeSeries"
-
-    @classmethod
-    def get_id(cls, item: TimeSeries | TimeSeriesWrite | dict) -> str:
-        if isinstance(item, dict):
-            return item["externalId"]
-        if not item.external_id:
-            raise KeyError("TimeSeries must have external_id")
-        return item.external_id
-
-    @classmethod
-    def get_required_capability(cls, items: TimeSeriesWriteList) -> Capability | list[Capability]:
-        if not items:
-            return []
-        data_set_ids = {item.data_set_id for item in items if item.data_set_id}
-        scope = (
-            capabilities.AssetsAcl.Scope.DataSet(list(data_set_ids))
-            if data_set_ids
-            else capabilities.AssetsAcl.Scope.All()
-        )
-
-        return capabilities.AssetsAcl(
-            [capabilities.AssetsAcl.Action.Read, capabilities.AssetsAcl.Action.Write],
-            scope,  # type: ignore[arg-type]
-        )
-
-    def create(self, items: TimeSeriesWriteList) -> TimeSeriesList:
-        return self.client.time_series.create(items)
-
-    def retrieve(self, ids: SequenceNotStr[str]) -> TimeSeriesList:
-        return self.client.time_series.retrieve_multiple(external_ids=ids, ignore_unknown_ids=True)
-
-    def update(self, items: TimeSeriesWriteList) -> TimeSeriesList:
-        return self.client.time_series.update(items)
-
-    def delete(self, ids: SequenceNotStr[str]) -> int:
-        try:
-            self.client.time_series.delete(external_id=ids)
-        except (CogniteAPIError, CogniteNotFoundError) as e:
-            non_existing = set(e.failed or [])
-            if existing := [id_ for id_ in ids if id_ not in non_existing]:
-                self.client.time_series.delete(external_id=existing)
-            return len(existing)
-        else:
-            return len(ids)
-
-    def iterate(self) -> Iterable[TimeSeries]:
-        return iter(self.client.time_series)
-
-    @classmethod
-    @lru_cache(maxsize=1)
-    def get_write_cls_parameter_spec(cls) -> ParameterSpecSet:
-        spec = super().get_write_cls_parameter_spec()
-        # Added by toolkit
-        spec.add(
-            ParameterSpec(
-                ("dataSetExternalId",),
-                frozenset({"str"}),
-                is_required=False,
-                _is_nullable=False,
-            )
-        )
-
-        # Should not be used, used for parentExternalId instead
-        spec.discard(ParameterSpec(("parentId",), frozenset({"int"}), is_required=False, _is_nullable=False))
-        return spec
-
-    @classmethod
-    def get_dependent_items(cls, item: dict) -> Iterable[tuple[type[ResourceLoader], Hashable]]:
-        """Returns all items that this item requires.
-
-        For example, a TimeSeries requires a DataSet, so this method would return the
-        DatasetLoader and identifier of that dataset.
-        """
-        if "dataSetExternalId" in item:
-            yield DataSetsLoader, item["dataSetExternalId"]
-        # ts doesn't support labels or parentExternalId
-        # for label in item.get("labels", []):
-        #     if isinstance(label, dict):
-        #         yield LabelLoader, label["externalId"]
-        #     elif isinstance(label, str):
-        #         yield LabelLoader, label
-        # if "parentExternalId" in item:
-        #     yield cls, item["parentExternalId"]
-
-    def load_resource(self, filepath: Path, ToolGlobals: CDFToolConfig, skip_validation: bool) -> TimeSeriesWriteList:
-        resources: list[dict[str, Any]]
-        if filepath.suffix in {".yaml", ".yml"}:
-            raw = load_yaml_inject_variables(filepath, ToolGlobals.environment_variables())
-            resources = [raw] if isinstance(raw, list) else raw  # type: ignore[assignment, list-item]
-        elif filepath.suffix == ".csv" or filepath.suffix == ".parquet":
-            if filepath.suffix == ".csv":
-                # The replacement is used to ensure that we read exactly the same file on Windows and Linux
-                file_content = filepath.read_bytes().replace(b"\r\n", b"\n").decode("utf-8")
-                data = pd.read_csv(io.StringIO(file_content))
-            else:
-                data = pd.read_parquet(filepath)
-            data.replace(pd.NA, None, inplace=True)
-            data.replace("", None, inplace=True)
-            resources = data.to_dict(orient="records")
-        else:
-            raise ValueError(f"Unsupported file type: {filepath.suffix}")
-
-        for resource in resources:
-            # Unpack metadata keys from table formats (e.g. csv, parquet)
-            metadata: dict = resource.get("metadata", {})
-            for key, value in list(resource.items()):
-                if key.startswith("metadata."):
-                    if value not in {None, float("nan")} and str(value) not in {
-                        "",
-                        " ",
-                        "nan",
-                        "null",
-                        "none",
-                    }:
-                        metadata[key.removeprefix("metadata.")] = str(value)
-                    del resource[key]
-            if metadata:
-                resource["metadata"] = metadata
-            # if "labels" in resource and isinstance(resource["labels"], str):
-            #     resource["labels"] = [
-            #         label.strip()
-            #         for label in resource["labels"]
-            #         .removeprefix("[")
-            #         .removesuffix("]")
-            #         .split(",")
-            #     ]
-
-            if resource.get("dataSetExternalId") is not None:
-                ds_external_id = resource.pop("dataSetExternalId")
-                resource["dataSetId"] = ToolGlobals.verify_dataset(
-                    ds_external_id,
-                    skip_validation,
-                    action="replace dataSetExternalId with dataSetId in time_series",
-                )
-        return TimeSeriesWriteList.load(resources)
-
-    def _are_equal(
-        self,
-        local: TimeSeriesWrite,
-        cdf_resource: TimeSeries,
-        return_dumped: bool = False,
-    ) -> bool | tuple[bool, dict[str, Any], dict[str, Any]]:
-        local_dumped = local.dump()
-        cdf_dumped = cdf_resource.as_write().dump()
-        # Dry run
-        if local_dumped.get("dataSetId") == -1 and "dataSetId" in cdf_dumped:
-            local_dumped["dataSetId"] = cdf_dumped["dataSetId"]
-        if (
-            all(s == -1 for s in local_dumped.get("securityCategories", []))
-            and "securityCategories" in cdf_dumped
-            and len(cdf_dumped["securityCategories"]) == len(local_dumped.get("securityCategories", []))
-        ):
-            local_dumped["securityCategories"] = cdf_dumped["securityCategories"]
-
-        return self._return_are_equal(local_dumped, cdf_dumped, return_dumped)
 
 
 @final
@@ -273,14 +94,7 @@ class AssetLoader(ResourceLoader[str, AssetWrite, Asset, AssetWriteList, AssetLi
     def get_write_cls_parameter_spec(cls) -> ParameterSpecSet:
         spec = super().get_write_cls_parameter_spec()
         # Added by toolkit
-        spec.add(
-            ParameterSpec(
-                ("dataSetExternalId",),
-                frozenset({"str"}),
-                is_required=False,
-                _is_nullable=False,
-            )
-        )
+        spec.add(ParameterSpec(("dataSetExternalId",), frozenset({"str"}), is_required=False, _is_nullable=False))
 
         # Should not be used, used for parentExternalId instead
         spec.discard(ParameterSpec(("parentId",), frozenset({"int"}), is_required=False, _is_nullable=False))
@@ -326,13 +140,7 @@ class AssetLoader(ResourceLoader[str, AssetWrite, Asset, AssetWriteList, AssetLi
             metadata: dict = resource.get("metadata", {})
             for key, value in list(resource.items()):
                 if key.startswith("metadata."):
-                    if value not in {None, float("nan")} and str(value) not in {
-                        "",
-                        " ",
-                        "nan",
-                        "null",
-                        "none",
-                    }:
+                    if value not in {None, float("nan")} and str(value) not in {"", " ", "nan", "null", "none"}:
                         metadata[key.removeprefix("metadata.")] = str(value)
                     del resource[key]
             if metadata:
@@ -345,9 +153,7 @@ class AssetLoader(ResourceLoader[str, AssetWrite, Asset, AssetWriteList, AssetLi
             if resource.get("dataSetExternalId") is not None:
                 ds_external_id = resource.pop("dataSetExternalId")
                 resource["dataSetId"] = ToolGlobals.verify_dataset(
-                    ds_external_id,
-                    skip_validation,
-                    action="replace dataSetExternalId with dataSetId in assets",
+                    ds_external_id, skip_validation, action="replace dataSetExternalId with dataSetId in assets"
                 )
         return AssetWriteList.load(resources)
 
@@ -480,24 +286,10 @@ class ThreeDModelLoader(
     def get_write_cls_parameter_spec(cls) -> ParameterSpecSet:
         spec = super().get_write_cls_parameter_spec()
         # Added by toolkit
-        spec.add(
-            ParameterSpec(
-                ("dataSetExternalId",),
-                frozenset({"str"}),
-                is_required=False,
-                _is_nullable=False,
-            )
-        )
+        spec.add(ParameterSpec(("dataSetExternalId",), frozenset({"str"}), is_required=False, _is_nullable=False))
 
         # Should not be used, used for dataSetExternalId instead
-        spec.discard(
-            ParameterSpec(
-                ("dataSetId",),
-                frozenset({"int"}),
-                is_required=False,
-                _is_nullable=False,
-            )
-        )
+        spec.discard(ParameterSpec(("dataSetId",), frozenset({"int"}), is_required=False, _is_nullable=False))
         return spec
 
     @classmethod
@@ -518,17 +310,12 @@ class ThreeDModelLoader(
             if resource.get("dataSetExternalId") is not None:
                 ds_external_id = resource.pop("dataSetExternalId")
                 resource["dataSetId"] = ToolGlobals.verify_dataset(
-                    ds_external_id,
-                    skip_validation,
-                    action="replace dataSetExternalId with dataSetId in 3D Model",
+                    ds_external_id, skip_validation, action="replace dataSetExternalId with dataSetId in 3D Model"
                 )
         return ThreeDModelWriteList.load(resources)
 
     def _are_equal(
-        self,
-        local: ThreeDModelWrite,
-        cdf_resource: ThreeDModel,
-        return_dumped: bool = False,
+        self, local: ThreeDModelWrite, cdf_resource: ThreeDModel, return_dumped: bool = False
     ) -> bool | tuple[bool, dict[str, Any], dict[str, Any]]:
         local_dumped = local.dump()
         cdf_dumped = cdf_resource.as_write().dump()


### PR DESCRIPTION
# Description

- added `DumpTimeSeriesCommand` through copy/paste search/replace approach from `DumpAssetCommand`
  - removed the `group` hierarchy-logic which caused some adoption (cannot think of a grouping feature, beside datasets?)
  - removed all `label` related code, as timeseries is not supporting labels
  - improved interactive mode 
    - listing datasets or assets with `clear-name (external_id) [count]`
    - added an "Abort" option

- TODO: (left TODO comments in code too)
  1. [x] naming convention timeseries, time_series, how to use singular vs plural [DONE]
  2. [x] assetId needs externalId replace [DONE]
    - so only storing `externalId` in `self.asset_by_id` not the whole `as_write()` object
  4. [x] ~~put it under ASSET feature flag support, let me know how to do it, maybe changing ASSETS feature to DUMP?~~
    - moved under TIMESERIES feature flag

After code-review looking into documentation, CHANGELOG, version, ..

## Checklist

- [ ] Tests added/updated.
- [x] Run Demo Job Locally.
  - [x] `dump timeseries --clean -f parquet --data-set WITSML` > 611k ts > resulted in two parquet files. Checked data in `visidata`.
  - [x]  `dump timeseries --clean -f csv --data-set WITSML --limit 1000` > checked in visidata
  - [x]  `dump timeseries --clean -f yaml --data-set WITSML --limit 1000` > checked in editor, but not loaded in total

```bash
➟  cdf-tk --env-path .env_prod_read dump timeseries --clean -f parquet --data-set WITSML
Retrieving time_series         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Writing time_series to file(s) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
Dumped 611,761 time_series to tmp
Dumped 1 data sets to tmp/data_sets/time_series.DataSet.yaml
```

- [ ] Documentation updated. > not yet, is this required for FEATURES?
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped. > not sure which one
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
