### PR TITLE
[Prepare CDF-21906] 🦌Simplify Variables (Refactor) Part 1

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -175,9 +175,7 @@ class BuildCommand(ToolkitCommand):
                 "To enable them, run 'cdf-tk features set no-naming --disable'."
             )
 
-        modules = ModuleDirectories.load(source_dir, config.environment)
-
-        system_config.validate_packages(modules.available, config.environment.selected)
+        modules = ModuleDirectories.load(source_dir, config.environment, system_config.packages)
 
         selected_modules = config.get_selected_modules(system_config.packages, modules.available, source_dir, verbose)
 

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -246,18 +246,19 @@ class BuildCommand(ToolkitCommand):
                     f"Package {package} defined in {SystemYAML.file_name!s} is referring "
                     f"the following missing modules {missing}."
                 )
-        # Nothing is Selected
-        if not modules.selected:
-            raise ToolkitEnvError(
-                f"No selected modules specified in {config.filepath!s}, have you configured "
-                f"the environment ({config.environment.name})?"
-            )
 
         # Selected modules does not exists
         if missing := set(selected_modules) - modules.available:
             hint = ModuleDefinition.long(missing, source_dir)
             raise ToolkitMissingModuleError(
                 f"The following selected modules are missing, please check path: {missing}.\n{hint}"
+            )
+
+        # Nothing is Selected
+        if not modules.selected:
+            raise ToolkitEnvError(
+                f"No selected modules specified in {config.filepath!s}, have you configured "
+                f"the environment ({config.environment.name})?"
             )
 
     def process_config_files(

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -199,14 +199,14 @@ class BuildCommand(ToolkitCommand):
                 else:
                     print(f"    {MODULE_PATH_SEP.join(module)!s}")
 
-        selected_variables = self._get_selected_variables(config.variables, modules)
+        selected_variables = self._get_selected_variables(config.variables, modules.selected)
         warnings = validate_modules_variables(selected_variables, config.filepath)
         if warnings:
             self.warn(LowSeverityWarning(f"Found the following warnings in config.{config.environment.name}.yaml:"))
             for warning in warnings:
                 print(f"    {warning.get_message()}")
 
-        state = self.process_config_files(source_dir, modules, build_dir, config, verbose, ToolGlobals)
+        state = self.process_config_files(source_dir, modules.selected, build_dir, config, verbose, ToolGlobals)
 
         build_environment = config.create_build_environment(state.hash_by_source_path)
         build_environment.dump_to_file(build_dir)

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -425,10 +425,10 @@ class BuildCommand(ToolkitCommand):
     @staticmethod
     def _get_selected_variables(config_variables: dict[str, Any], modules: ModuleDirectories) -> dict[str, Any]:
         selected_paths = {
-            module.dir.parts[1:i]
+            module.relative_path.parts[1:i]
             for module in modules
-            if len(module.dir.parts) > 1
-            for i in range(2, len(module.dir.parts) + 1)
+            if len(module.relative_path.parts) > 1
+            for i in range(2, len(module.relative_path.parts) + 1)
         }
         selected_variables: dict[str, Any] = {}
         to_check: list[tuple[tuple[str, ...], dict[str, Any]]] = [(tuple(), config_variables)]

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -193,7 +193,8 @@ class BuildCommand(ToolkitCommand):
             raise ToolkitDuplicatedModuleError(
                 f"Ambiguous module selected in config.{config.environment.name}.yaml:", duplicate_modules
             )
-        system_config.validate_modules(available_modules, config.environment.selected)
+
+        system_config.validate_packages(available_modules, config.environment.selected)
 
         selected_modules = config.get_selected_modules(system_config.packages, available_modules, source_dir, verbose)
 

--- a/cognite_toolkit/_cdf_tk/data_classes/__init__.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/__init__.py
@@ -7,6 +7,7 @@ from ._config_yaml import (
     InitConfigYAML,
 )
 from ._migration_yaml import Change, MigrationYAML, VersionChanges
+from ._module_directories import ModuleDirectories, ModuleLocation
 from ._project_directory import ProjectDirectory, ProjectDirectoryInit, ProjectDirectoryUpgrade
 from ._system_yaml import SystemYAML
 
@@ -25,4 +26,6 @@ __all__ = [
     "Environment",
     "BuildEnvironment",
     "ConfigEntry",
+    "ModuleLocation",
+    "ModuleDirectories",
 ]

--- a/cognite_toolkit/_cdf_tk/data_classes/_config_yaml.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_config_yaml.py
@@ -102,6 +102,17 @@ class Environment:
             ],
         }
 
+    def get_selected_modules(
+        self, modules_by_package: dict[str, list[str | tuple[str, ...]]]
+    ) -> set[str | tuple[str, ...]]:
+        selected_modules: set[str | tuple[str, ...]] = set()
+        for selected in self.selected:
+            if selected in modules_by_package and isinstance(selected, str):
+                selected_modules.update(modules_by_package[selected])
+            else:
+                selected_modules.add(selected)
+        return selected_modules
+
 
 @dataclass
 class ConfigYAMLCore(ABC):

--- a/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
@@ -4,11 +4,10 @@ from pathlib import Path
 from typing import Literal
 
 
-@dataclass
+@dataclass(frozen=True)
 class ModuleLocation:
     """This represents the location of a module in a directory structure."""
 
-    name: str
     relative_path: Path
     root_module: Literal["cognite_modules", "custom_modules", "modules"]
     root_absolute_path: Path
@@ -17,8 +16,12 @@ class ModuleLocation:
     def path(self) -> Path:
         return self.root_absolute_path / self.relative_path
 
+    @property
+    def module_name(self) -> str:
+        return self.relative_path.name
 
-class ModulesDirectories(list, MutableSequence[ModuleLocation]):
+
+class ModuleDirectories(list, MutableSequence[ModuleLocation]):
     @classmethod
-    def load(cls, source_dir: Path) -> "ModulesDirectories":
+    def load(cls, source_dir: Path) -> "ModuleDirectories":
         raise NotImplementedError()

--- a/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
@@ -1,7 +1,15 @@
-from collections.abc import MutableSequence
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Collection, Iterable, Sequence
 from dataclasses import dataclass
+from functools import cached_property
 from pathlib import Path
-from typing import Literal
+
+from cognite_toolkit._cdf_tk.exceptions import ToolkitDuplicatedModuleError
+from cognite_toolkit._cdf_tk.utils import iterate_modules
+
+from ._config_yaml import Environment
 
 
 @dataclass(frozen=True)
@@ -9,19 +17,58 @@ class ModuleLocation:
     """This represents the location of a module in a directory structure."""
 
     relative_path: Path
-    root_module: Literal["cognite_modules", "custom_modules", "modules"]
-    root_absolute_path: Path
+    source_absolute_path: Path
 
     @property
     def path(self) -> Path:
-        return self.root_absolute_path / self.relative_path
+        return self.source_absolute_path / self.relative_path
 
     @property
     def module_name(self) -> str:
         return self.relative_path.name
 
+    @property
+    def module_references(self) -> Iterable[str | tuple[str, ...]]:
+        """Ways of selecting this module."""
+        yield self.module_name
+        module_parts = self.relative_path.parts
+        for i in range(1, len(module_parts) + 1):
+            yield module_parts[:i]
 
-class ModuleDirectories(list, MutableSequence[ModuleLocation]):
+
+@dataclass
+class ModuleDirectories(tuple, Sequence[ModuleLocation]):
+    # Subclassing tuple to make the class immutable. ModuleDirectories is expected to be initialized and
+    # then used as a read-only object.
+    def __new__(cls, collection: Collection[ModuleLocation]) -> ModuleDirectories:
+        # Need to override __new__ to as we are subclassing a tuple:
+        #   https://stackoverflow.com/questions/1565374/subclassing-tuple-with-multiple-init-arguments
+        return super().__new__(cls, tuple(collection))
+
+    def __init__(self, collection: Collection[ModuleLocation]) -> None: ...
+
+    @cached_property
+    def available_modules(self) -> set[str | tuple[str, ...]]:
+        return {ref for module_location in self for ref in module_location.module_references}
+
     @classmethod
-    def load(cls, source_dir: Path) -> "ModuleDirectories":
-        raise NotImplementedError()
+    def load(cls, source_dir: Path, environment: Environment) -> ModuleDirectories:
+        module_parts_by_name: dict[str, list[tuple[str, ...]]] = defaultdict(list)
+        module_locations: list[ModuleLocation] = []
+        for module, _ in iterate_modules(source_dir):
+            module_locations.append(ModuleLocation(module.relative_to(source_dir), source_dir))
+            module_parts_by_name[module.name].append(module.relative_to(source_dir).parts)
+
+        selected_names = {s for s in environment.selected if isinstance(s, str)}
+        if duplicate_modules := {
+            module_name: paths
+            for module_name, paths in module_parts_by_name.items()
+            if len(paths) > 1 and module_name in selected_names
+        }:
+            # If the user has selected a module by name, and there are multiple modules with that name, raise an error.
+            # Note, if the user uses a path to select a module, this error will not be raised.
+            raise ToolkitDuplicatedModuleError(
+                f"Ambiguous module selected in config.{environment.name}.yaml:", duplicate_modules
+            )
+
+        return cls(module_locations)

--- a/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
@@ -48,7 +48,7 @@ class ModuleDirectories(tuple, Sequence[ModuleLocation]):
     def __init__(self, collection: Collection[ModuleLocation]) -> None: ...
 
     @cached_property
-    def available_modules(self) -> set[str | tuple[str, ...]]:
+    def available(self) -> set[str | tuple[str, ...]]:
         return {ref for module_location in self for ref in module_location.module_references}
 
     @classmethod

--- a/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
@@ -12,7 +12,13 @@ from cognite_toolkit._cdf_tk.utils import iterate_modules
 
 @dataclass(frozen=True)
 class ModuleLocation:
-    """This represents the location of a module in a directory structure."""
+    """This represents the location of a module in a directory structure.
+    Args:
+        dir: The absolute path to the module directory.
+        source_absolute_path: The absolute path to the source directory.
+        is_selected: Whether the module is selected by the user.
+        source_paths: The paths to all files in the module.
+    """
 
     dir: Path
     source_absolute_path: Path
@@ -21,13 +27,19 @@ class ModuleLocation:
 
     @property
     def name(self) -> str:
+        """The name of the module."""
         return self.dir.name
+
+    @property
+    def relative_path(self) -> Path:
+        """The relative path to the module."""
+        return self.dir.relative_to(self.source_absolute_path)
 
     @property
     def module_references(self) -> Iterable[str | tuple[str, ...]]:
         """Ways of selecting this module."""
         yield self.name
-        module_parts = self.dir.parts
+        module_parts = self.relative_path.parts
         for i in range(1, len(module_parts) + 1):
             yield module_parts[:i]
 
@@ -63,7 +75,7 @@ class ModuleDirectories(tuple, Sequence[ModuleLocation]):
             relative_module_dir = module.relative_to(source_dir)
             module_locations.append(
                 ModuleLocation(
-                    relative_module_dir,
+                    module,
                     source_dir,
                     cls._is_selected_module(relative_module_dir, selected_modules),
                     source_paths,
@@ -85,7 +97,7 @@ class ModuleDirectories(tuple, Sequence[ModuleLocation]):
     def as_parts_by_name(self) -> dict[str, list[tuple[str, ...]]]:
         module_parts_by_name: dict[str, list[tuple[str, ...]]] = defaultdict(list)
         for module in self:
-            module_parts_by_name[module.name].append(module.dir.parts)
+            module_parts_by_name[module.name].append(module.relative_path.parts)
         return module_parts_by_name
 
     # Implemented to get correct type hints

--- a/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
@@ -59,9 +59,9 @@ class ModuleDirectories(tuple, Sequence[ModuleLocation]):
     def available(self) -> set[str | tuple[str, ...]]:
         return {ref for module_location in self for ref in module_location.module_references}
 
-    @property
-    def selected(self) -> Iterable[ModuleLocation]:
-        return (module for module in self if module.is_selected)
+    @cached_property
+    def selected(self) -> ModuleDirectories:
+        return ModuleDirectories([module for module in self if module.is_selected])
 
     @classmethod
     def load(

--- a/cognite_toolkit/_cdf_tk/data_classes/_modules_directories.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_modules_directories.py
@@ -1,0 +1,24 @@
+from collections.abc import MutableSequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+@dataclass
+class ModuleLocation:
+    """This represents the location of a module in a directory structure."""
+
+    name: str
+    relative_path: Path
+    root_module: Literal["cognite_modules", "custom_modules", "modules"]
+    root_absolute_path: Path
+
+    @property
+    def path(self) -> Path:
+        return self.root_absolute_path / self.relative_path
+
+
+class ModulesDirectories(list, MutableSequence[ModuleLocation]):
+    @classmethod
+    def load(cls, source_dir: Path) -> "ModulesDirectories":
+        raise NotImplementedError()

--- a/cognite_toolkit/_cdf_tk/data_classes/_system_yaml.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_system_yaml.py
@@ -47,7 +47,7 @@ class SystemYAML(ConfigCore):
             },
         )
 
-    def validate_modules(
+    def validate_packages(
         self, available_modules: set[str | tuple[str, ...]], selected_modules_and_packages: list[str | tuple[str, ...]]
     ) -> None:
         selected_packages = {

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -6,7 +6,7 @@ DESCRIPTIONS_FOLDER = DATA_FOLDER / "describe_data"
 AUTH_DATA = DATA_FOLDER / "auth_data"
 PROJECT_NO_COGNITE_MODULES = DATA_FOLDER / "project_no_cognite_modules"
 PROJECT_WITH_DUPLICATES = DATA_FOLDER / "project_with_duplicates"
-PYTEST_PROJECT = DATA_FOLDER / "project_for_test"
+PROJECT_FOR_TEST = DATA_FOLDER / "project_for_test"
 LOAD_DATA = DATA_FOLDER / "load_data"
 RUN_DATA = DATA_FOLDER / "run_data"
 TRANSFORMATION_CLI = DATA_FOLDER / "transformation_cli"
@@ -20,7 +20,7 @@ __all__ = [
     "AUTH_DATA",
     "PROJECT_NO_COGNITE_MODULES",
     "PROJECT_WITH_DUPLICATES",
-    "PYTEST_PROJECT",
+    "PROJECT_FOR_TEST",
     "LOAD_DATA",
     "RUN_DATA",
     "TRANSFORMATION_CLI",

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -4,7 +4,7 @@ DATA_FOLDER = Path(__file__).resolve().parent
 
 DESCRIPTIONS_FOLDER = DATA_FOLDER / "describe_data"
 AUTH_DATA = DATA_FOLDER / "auth_data"
-CUSTOM_PROJECT = DATA_FOLDER / "project_no_cognite_modules"
+PROJECT_NO_COGNITE_MODULES = DATA_FOLDER / "project_no_cognite_modules"
 PROJECT_WITH_DUPLICATES = DATA_FOLDER / "project_with_duplicates"
 PYTEST_PROJECT = DATA_FOLDER / "project_for_test"
 LOAD_DATA = DATA_FOLDER / "load_data"
@@ -18,7 +18,7 @@ __all__ = [
     "DATA_FOLDER",
     "DESCRIPTIONS_FOLDER",
     "AUTH_DATA",
-    "CUSTOM_PROJECT",
+    "PROJECT_NO_COGNITE_MODULES",
     "PROJECT_WITH_DUPLICATES",
     "PYTEST_PROJECT",
     "LOAD_DATA",

--- a/tests/data/project_no_cognite_modules/config.dev.yaml
+++ b/tests/data/project_no_cognite_modules/config.dev.yaml
@@ -15,4 +15,4 @@ variables:
       space: sp_my_space
       source: src2
       ds_something: ds_something
-
+      dict_variable: empty

--- a/tests/data/project_no_cognite_modules/config.top_level_variables.yaml
+++ b/tests/data/project_no_cognite_modules/config.top_level_variables.yaml
@@ -1,0 +1,22 @@
+environment:
+  name: dev
+  project: some-project
+  type: dev
+  selected:
+    - modules/
+
+variables:
+  ds_timeseries: ds_timeseries
+  source: src
+  location: here
+  space: sp_my_space
+  ds_something: ds_something
+  dict_variable:
+    featureConfiguration:
+      rootLocationConfigurations:
+        - assetExternalId: some_asset_ext_id
+          appDataInstanceSpace: sp_location_app_data
+          sourceDataInstanceSpace: sp_location_source_data
+    customerDataSpaceId: APM_SourceData # Space where the customer's data model lives
+    customerDataSpaceVersion: "1" # this is really the customer data model version
+    name: InRobot APM Config 2

--- a/tests/data/project_no_cognite_modules/modules/another_module/data_models/config.node.yaml
+++ b/tests/data/project_no_cognite_modules/modules/another_module/data_models/config.node.yaml
@@ -19,3 +19,13 @@ nodes:
           customerDataSpaceId: APM_SourceData # Space where the customer's data model lives
           customerDataSpaceVersion: "1" # this is really the customer data model version
           name: InRobot APM Config
+  - space: {{space}}
+    externalId: random_alert_node
+    sources:
+      - source:
+          space: {{space}}
+          externalId: Alert
+          version: 1
+          type: view
+        properties:
+          {{ dict_variable }}

--- a/tests/test_unit/test_cdf_tk/test_commands/test_build.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_build.py
@@ -77,7 +77,7 @@ class TestBuildCommand:
         cmd.execute(
             verbose=False,
             build_dir=tmp_path,
-            source_path=data.CUSTOM_PROJECT,
+            source_path=data.PROJECT_NO_COGNITE_MODULES,
             build_env_name="dev",
             no_clean=False,
         )

--- a/tests/test_unit/test_cdf_tk/test_data_classes/conftest.py
+++ b/tests/test_unit/test_cdf_tk/test_data_classes/conftest.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import pytest
 
 from cognite_toolkit._cdf_tk.data_classes import Environment
-from tests.data import PYTEST_PROJECT
+from tests.data import PROJECT_FOR_TEST
 
 
 @pytest.fixture(scope="session")
 def config_yaml() -> str:
-    return (PYTEST_PROJECT / "config.dev.yaml").read_text()
+    return (PROJECT_FOR_TEST / "config.dev.yaml").read_text()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_unit/test_cdf_tk/test_data_classes/test_build_config_yaml.py
+++ b/tests/test_unit/test_cdf_tk/test_data_classes/test_build_config_yaml.py
@@ -9,20 +9,20 @@ from cognite_toolkit._cdf_tk.commands import BuildCommand
 from cognite_toolkit._cdf_tk.data_classes import BuildConfigYAML, Environment, SystemYAML
 from cognite_toolkit._cdf_tk.loaders import LOADER_BY_FOLDER_NAME
 from cognite_toolkit._cdf_tk.utils import iterate_modules
-from tests.data import PYTEST_PROJECT
+from tests.data import PROJECT_FOR_TEST
 from tests.test_unit.test_cdf_tk.constants import BUILD_DIR
 
 
 class TestBuildConfigYAML:
     def test_build_config_create_valid_build_folder(self, config_yaml: str) -> None:
         build_env_name = "dev"
-        system_config = SystemYAML.load_from_directory(PYTEST_PROJECT, build_env_name)
-        config = BuildConfigYAML.load_from_directory(PYTEST_PROJECT, build_env_name)
-        available_modules = {module.name for module, _ in iterate_modules(PYTEST_PROJECT)}
+        system_config = SystemYAML.load_from_directory(PROJECT_FOR_TEST, build_env_name)
+        config = BuildConfigYAML.load_from_directory(PROJECT_FOR_TEST, build_env_name)
+        available_modules = {module.name for module, _ in iterate_modules(PROJECT_FOR_TEST)}
         config.environment.selected = list(available_modules)
 
         BuildCommand().build_config(
-            BUILD_DIR, PYTEST_PROJECT, config=config, system_config=system_config, clean=True, verbose=False
+            BUILD_DIR, PROJECT_FOR_TEST, config=config, system_config=system_config, clean=True, verbose=False
         )
 
         # The resulting build folder should only have subfolders that are matching the folder name

--- a/tests/test_unit/test_cdf_tk/test_data_classes/test_config_yaml.py
+++ b/tests/test_unit/test_cdf_tk/test_data_classes/test_config_yaml.py
@@ -7,7 +7,7 @@ import yaml
 
 from cognite_toolkit._cdf_tk.data_classes import ConfigEntry, Environment, InitConfigYAML
 from cognite_toolkit._cdf_tk.utils import YAMLComment, flatten_dict
-from tests.data import PYTEST_PROJECT
+from tests.data import PROJECT_FOR_TEST
 
 
 class TestConfigYAML:
@@ -19,7 +19,7 @@ class TestConfigYAML:
         # Skip all environment variables
         expected_keys = {k for k in expected_keys if not k[0] == "environment"}
 
-        config = InitConfigYAML(dummy_environment).load_defaults(PYTEST_PROJECT)
+        config = InitConfigYAML(dummy_environment).load_defaults(PROJECT_FOR_TEST)
 
         actual_keys = set(config.keys())
         missing = expected_keys - actual_keys
@@ -78,7 +78,7 @@ variable4: "value with #in it" # But a comment after
     def test_persist_variable_with_comment(self, config_yaml: str) -> None:
         custom_comment = "This is an extra comment added to the config only 'lore ipsum'"
 
-        config = InitConfigYAML.load_existing(config_yaml).load_defaults(PYTEST_PROJECT)
+        config = InitConfigYAML.load_existing(config_yaml).load_defaults(PROJECT_FOR_TEST)
 
         dumped = config.dump_yaml_with_comments()
         loaded = yaml.safe_load(dumped)
@@ -92,7 +92,7 @@ variable4: "value with #in it" # But a comment after
         # Removed = Exists in config.yaml but not in the BUILD_CONFIG directory default.config.yaml files
         existing_config_yaml["variables"]["cognite_modules"]["another_module"]["removed_variable"] = "old_value"
 
-        config = InitConfigYAML.load_existing(yaml.safe_dump(existing_config_yaml)).load_defaults(PYTEST_PROJECT)
+        config = InitConfigYAML.load_existing(yaml.safe_dump(existing_config_yaml)).load_defaults(PROJECT_FOR_TEST)
 
         removed = [v for v in config.values() if v.default_value is None]
         # There is already a custom variable in the config.yaml file
@@ -113,7 +113,7 @@ variable4: "value with #in it" # But a comment after
             ("variables", "cognite_modules", "parent_module", "child_module", "source_asset"),
         }
 
-        config = InitConfigYAML(dummy_environment).load_variables(PYTEST_PROJECT, propagate_reused_variables=True)
+        config = InitConfigYAML(dummy_environment).load_variables(PROJECT_FOR_TEST, propagate_reused_variables=True)
 
         missing = expected - set(config.keys())
         extra = set(config.keys()) - expected
@@ -146,8 +146,8 @@ variable4: "value with #in it" # But a comment after
             selected=["cognite_modules/a_module"],
         )
 
-        config_all = InitConfigYAML(environment).load_defaults(PYTEST_PROJECT)
-        config_selected = InitConfigYAML(environment).load_selected_defaults(PYTEST_PROJECT)
+        config_all = InitConfigYAML(environment).load_defaults(PROJECT_FOR_TEST)
+        config_selected = InitConfigYAML(environment).load_selected_defaults(PROJECT_FOR_TEST)
 
         assert len(config_all) > len(config_selected)
         assert ("variables", "cognite_modules", "a_module", "readonly_source_id") in config_all.keys()

--- a/tests/test_unit/test_cdf_tk/test_data_classes/tests_module_directories.py
+++ b/tests/test_unit/test_cdf_tk/test_data_classes/tests_module_directories.py
@@ -1,32 +1,31 @@
 from pathlib import Path
 
 from cognite_toolkit._cdf_tk.constants import COGNITE_MODULES
-from cognite_toolkit._cdf_tk.data_classes import ModuleDirectories, ModuleLocation
+from cognite_toolkit._cdf_tk.data_classes import Environment, ModuleDirectories, ModuleLocation
 from tests import data
 
 
 class TestModuleDirectories:
     def test_load(self):
-        cognite_modules = data.PROJECT_FOR_TEST / COGNITE_MODULES
+        cognite_modules = Path(COGNITE_MODULES)
         expected = ModuleDirectories(
             [
                 ModuleLocation(
-                    relative_path=Path("a_module"),
-                    root_module="cognite_modules",
-                    root_absolute_path=cognite_modules,
+                    relative_path=cognite_modules / Path("a_module"),
+                    source_absolute_path=data.PROJECT_FOR_TEST,
                 ),
                 ModuleLocation(
-                    relative_path=Path("another_module"),
-                    root_module="cognite_modules",
-                    root_absolute_path=cognite_modules,
+                    relative_path=cognite_modules / Path("another_module"),
+                    source_absolute_path=data.PROJECT_FOR_TEST,
                 ),
                 ModuleLocation(
-                    relative_path=Path("parent_module") / "child_module",
-                    root_module="cognite_modules",
-                    root_absolute_path=cognite_modules,
+                    relative_path=cognite_modules / Path("parent_module") / "child_module",
+                    source_absolute_path=data.PROJECT_FOR_TEST,
                 ),
             ]
         )
-        actual = ModuleDirectories.load(data.PROJECT_FOR_TEST)
+        actual = ModuleDirectories.load(
+            data.PROJECT_FOR_TEST, Environment("dev", "anders", "dev", selected=[f"{COGNITE_MODULES}/"])
+        )
 
         assert actual == expected

--- a/tests/test_unit/test_cdf_tk/test_data_classes/tests_module_directories.py
+++ b/tests/test_unit/test_cdf_tk/test_data_classes/tests_module_directories.py
@@ -6,7 +6,7 @@ from tests import data
 
 
 class TestModuleDirectories:
-    def test_load(self):
+    def test_load(self) -> None:
         cognite_modules = Path(COGNITE_MODULES)
         expected = ModuleDirectories(
             [
@@ -25,7 +25,7 @@ class TestModuleDirectories:
             ]
         )
         actual = ModuleDirectories.load(
-            data.PROJECT_FOR_TEST, Environment("dev", "anders", "dev", selected=[f"{COGNITE_MODULES}/"])
+            data.PROJECT_FOR_TEST, Environment("dev", "anders", "dev", selected=[f"{COGNITE_MODULES}/"]), {}
         )
 
         assert actual == expected

--- a/tests/test_unit/test_cdf_tk/test_data_classes/tests_module_directories.py
+++ b/tests/test_unit/test_cdf_tk/test_data_classes/tests_module_directories.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from cognite_toolkit._cdf_tk.constants import COGNITE_MODULES
-from cognite_toolkit._cdf_tk.data_classes import Environment, ModuleDirectories, ModuleLocation
+from cognite_toolkit._cdf_tk.data_classes import ModuleDirectories, ModuleLocation
 from tests import data
 
 
@@ -13,19 +13,23 @@ class TestModuleDirectories:
                 ModuleLocation(
                     relative_path=cognite_modules / Path("a_module"),
                     source_absolute_path=data.PROJECT_FOR_TEST,
+                    is_selected=True,
+                    source_paths=[],
                 ),
                 ModuleLocation(
                     relative_path=cognite_modules / Path("another_module"),
                     source_absolute_path=data.PROJECT_FOR_TEST,
+                    is_selected=True,
+                    source_paths=[],
                 ),
                 ModuleLocation(
                     relative_path=cognite_modules / Path("parent_module") / "child_module",
                     source_absolute_path=data.PROJECT_FOR_TEST,
+                    is_selected=True,
+                    source_paths=[],
                 ),
             ]
         )
-        actual = ModuleDirectories.load(
-            data.PROJECT_FOR_TEST, Environment("dev", "anders", "dev", selected=[f"{COGNITE_MODULES}/"]), {}
-        )
+        actual = ModuleDirectories.load(data.PROJECT_FOR_TEST, {("cognite_modules",)})
 
         assert actual == expected

--- a/tests/test_unit/test_cdf_tk/test_data_classes/tests_module_directories.py
+++ b/tests/test_unit/test_cdf_tk/test_data_classes/tests_module_directories.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from cognite_toolkit._cdf_tk.constants import COGNITE_MODULES
+from cognite_toolkit._cdf_tk.data_classes import ModuleDirectories, ModuleLocation
+from tests import data
+
+
+class TestModuleDirectories:
+    def test_load(self):
+        cognite_modules = data.PROJECT_FOR_TEST / COGNITE_MODULES
+        expected = ModuleDirectories(
+            [
+                ModuleLocation(
+                    relative_path=Path("a_module"),
+                    root_module="cognite_modules",
+                    root_absolute_path=cognite_modules,
+                ),
+                ModuleLocation(
+                    relative_path=Path("another_module"),
+                    root_module="cognite_modules",
+                    root_absolute_path=cognite_modules,
+                ),
+                ModuleLocation(
+                    relative_path=Path("parent_module") / "child_module",
+                    root_module="cognite_modules",
+                    root_absolute_path=cognite_modules,
+                ),
+            ]
+        )
+        actual = ModuleDirectories.load(data.PROJECT_FOR_TEST)
+
+        assert actual == expected

--- a/tests/test_unit/test_cdf_tk/test_data_classes/tests_module_directories.py
+++ b/tests/test_unit/test_cdf_tk/test_data_classes/tests_module_directories.py
@@ -11,19 +11,19 @@ class TestModuleDirectories:
         expected = ModuleDirectories(
             [
                 ModuleLocation(
-                    relative_path=cognite_modules / Path("a_module"),
+                    dir=cognite_modules / Path("a_module"),
                     source_absolute_path=data.PROJECT_FOR_TEST,
                     is_selected=True,
                     source_paths=[],
                 ),
                 ModuleLocation(
-                    relative_path=cognite_modules / Path("another_module"),
+                    dir=cognite_modules / Path("another_module"),
                     source_absolute_path=data.PROJECT_FOR_TEST,
                     is_selected=True,
                     source_paths=[],
                 ),
                 ModuleLocation(
-                    relative_path=cognite_modules / Path("parent_module") / "child_module",
+                    dir=cognite_modules / Path("parent_module") / "child_module",
                     source_absolute_path=data.PROJECT_FOR_TEST,
                     is_selected=True,
                     source_paths=[],

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_base_loaders.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_base_loaders.py
@@ -45,7 +45,7 @@ from cognite_toolkit._cdf_tk.utils import (
 )
 from cognite_toolkit._cdf_tk.validation import validate_resource_yaml
 from tests.constants import REPO_ROOT
-from tests.data import LOAD_DATA, PYTEST_PROJECT
+from tests.data import LOAD_DATA, PROJECT_FOR_TEST
 from tests.test_unit.approval_client import ApprovalCogniteClient
 from tests.test_unit.test_cdf_tk.constants import BUILD_DIR, SNAPSHOTS_DIR_ALL
 from tests.test_unit.utils import FakeCogniteResourceGenerator, mock_read_yaml_file
@@ -82,12 +82,12 @@ def test_loader_class(
 class TestDeployResources:
     def test_deploy_resource_order(self, cognite_client_approval: ApprovalCogniteClient):
         build_env_name = "dev"
-        system_config = SystemYAML.load_from_directory(PYTEST_PROJECT, build_env_name)
-        config = BuildConfigYAML.load_from_directory(PYTEST_PROJECT, build_env_name)
+        system_config = SystemYAML.load_from_directory(PROJECT_FOR_TEST, build_env_name)
+        config = BuildConfigYAML.load_from_directory(PROJECT_FOR_TEST, build_env_name)
         config.environment.selected = ["another_module"]
         build_cmd = BuildCommand()
         build_cmd.build_config(
-            BUILD_DIR, PYTEST_PROJECT, config=config, system_config=system_config, clean=True, verbose=False
+            BUILD_DIR, PROJECT_FOR_TEST, config=config, system_config=system_config, clean=True, verbose=False
         )
         expected_order = ["MyView", "MyOtherView"]
         cdf_tool = MagicMock(spec=CDFToolConfig)

--- a/tests/test_unit/test_cdf_tk/test_utils.py
+++ b/tests/test_unit/test_cdf_tk/test_utils.py
@@ -35,7 +35,7 @@ from cognite_toolkit._cdf_tk.utils import (
     module_from_path,
 )
 from cognite_toolkit._cdf_tk.validation import validate_modules_variables
-from tests.data import DATA_FOLDER, PYTEST_PROJECT
+from tests.data import DATA_FOLDER, PROJECT_FOR_TEST
 from tests.test_unit.utils import PrintCapture
 
 
@@ -397,12 +397,12 @@ class TestModuleFromPath:
 class TestIterateModules:
     def test_modules_project_for_tests(self):
         expected_modules = {
-            PYTEST_PROJECT / "cognite_modules" / "a_module",
-            PYTEST_PROJECT / "cognite_modules" / "another_module",
-            PYTEST_PROJECT / "cognite_modules" / "parent_module" / "child_module",
+            PROJECT_FOR_TEST / "cognite_modules" / "a_module",
+            PROJECT_FOR_TEST / "cognite_modules" / "another_module",
+            PROJECT_FOR_TEST / "cognite_modules" / "parent_module" / "child_module",
         }
 
-        actual_modules = {module for module, _ in iterate_modules(PYTEST_PROJECT)}
+        actual_modules = {module for module, _ in iterate_modules(PROJECT_FOR_TEST)}
 
         assert actual_modules == expected_modules
 

--- a/tests/test_unit/test_cli/test_behavior.py
+++ b/tests/test_unit/test_cli/test_behavior.py
@@ -17,7 +17,12 @@ from cognite_toolkit._cdf_tk.exceptions import ToolkitDuplicatedModuleError
 from cognite_toolkit._cdf_tk.loaders import TransformationLoader
 from cognite_toolkit._cdf_tk.prototypes import setup_robotics_loaders
 from cognite_toolkit._cdf_tk.utils import CDFToolConfig
-from tests.data import BUILD_GROUP_WITH_UNKNOWN_ACL, PROJECT_NO_COGNITE_MODULES, PROJECT_WITH_DUPLICATES, PYTEST_PROJECT
+from tests.data import (
+    BUILD_GROUP_WITH_UNKNOWN_ACL,
+    PROJECT_FOR_TEST,
+    PROJECT_NO_COGNITE_MODULES,
+    PROJECT_WITH_DUPLICATES,
+)
 from tests.test_unit.approval_client import ApprovalCogniteClient
 from tests.test_unit.utils import mock_read_yaml_file
 
@@ -293,7 +298,7 @@ def test_build_project_selecting_parent_path(
     expected_resources = {"auth", "data_models", "files", "transformations", "data_sets"}
     build(
         typer_context,
-        source_dir=str(PYTEST_PROJECT),
+        source_dir=str(PROJECT_FOR_TEST),
         build_dir=str(build_tmp_path),
         build_env_name="dev",
         no_clean=False,

--- a/tests/test_unit/test_cli/test_behavior.py
+++ b/tests/test_unit/test_cli/test_behavior.py
@@ -343,6 +343,7 @@ def test_deploy_group_with_unknown_acl(
     }
 
 
+@pytest.mark.skip("In development")
 def test_build_project_with_only_top_level_variables(
     build_tmp_path: Path,
     typer_context: typer.Context,

--- a/tests/test_unit/test_cli/test_behavior.py
+++ b/tests/test_unit/test_cli/test_behavior.py
@@ -17,7 +17,7 @@ from cognite_toolkit._cdf_tk.exceptions import ToolkitDuplicatedModuleError
 from cognite_toolkit._cdf_tk.loaders import TransformationLoader
 from cognite_toolkit._cdf_tk.prototypes import setup_robotics_loaders
 from cognite_toolkit._cdf_tk.utils import CDFToolConfig
-from tests.data import BUILD_GROUP_WITH_UNKNOWN_ACL, CUSTOM_PROJECT, PROJECT_WITH_DUPLICATES, PYTEST_PROJECT
+from tests.data import BUILD_GROUP_WITH_UNKNOWN_ACL, PROJECT_NO_COGNITE_MODULES, PROJECT_WITH_DUPLICATES, PYTEST_PROJECT
 from tests.test_unit.approval_client import ApprovalCogniteClient
 from tests.test_unit.utils import mock_read_yaml_file
 
@@ -271,7 +271,7 @@ def test_build_custom_project(
     }
     build(
         typer_context,
-        source_dir=str(CUSTOM_PROJECT),
+        source_dir=str(PROJECT_NO_COGNITE_MODULES),
         build_dir=str(build_tmp_path),
         build_env_name="dev",
         no_clean=False,
@@ -334,3 +334,18 @@ def test_deploy_group_with_unknown_acl(
             "scope": {"unknownScope": {"with": ["some", {"strange": "structure"}]}},
         }
     }
+
+
+def test_build_project_with_only_top_level_variables(
+    build_tmp_path: Path,
+    typer_context: typer.Context,
+) -> None:
+    build(
+        typer_context,
+        source_dir=str(PROJECT_NO_COGNITE_MODULES),
+        build_dir=str(build_tmp_path),
+        build_env_name="top_level_variables",
+        no_clean=False,
+    )
+
+    assert build_tmp_path.exists()

--- a/tests/test_unit/test_cli/test_behavior.py
+++ b/tests/test_unit/test_cli/test_behavior.py
@@ -74,12 +74,14 @@ def test_duplicated_modules(build_tmp_path: Path, typer_context: typer.Context) 
     config.environment = MagicMock(spec=Environment)
     config.environment.name = "dev"
     config.environment.selected = ["module1"]
+    system_yaml = MagicMock(spec=SystemYAML)
+    system_yaml.packages = {}
     with pytest.raises(ToolkitDuplicatedModuleError) as err:
         BuildCommand().build_config(
             build_dir=build_tmp_path,
             source_dir=PROJECT_WITH_DUPLICATES,
             config=config,
-            system_config=MagicMock(spec=SystemYAML),
+            system_config=system_yaml,
         )
     l1, l2, l3, l4, l5 = map(str.strip, str(err.value).splitlines())
     assert l1 == "Ambiguous module selected in config.dev.yaml:"


### PR DESCRIPTION
# Description

Introduced classes `ModuleDirectories` which is a tuple of `ModuleLocation`. This is to deal with all logic of identifying modules, which one are selected, and then have an easier way of running the validation. 

This is in preparation of rewriting variables.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
