### PR TITLE
[CDF-22192] 👨‍✈️Handle TypeError

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_base.py
+++ b/cognite_toolkit/_cdf_tk/commands/_base.py
@@ -9,7 +9,7 @@ from typing import Any
 from cognite.client.data_classes._base import T_CogniteResourceList, T_WritableCogniteResource, T_WriteClass
 from rich import print
 
-from cognite_toolkit._cdf_tk.exceptions import ToolkitRequiredValueError, ToolkitYAMLFormatError
+from cognite_toolkit._cdf_tk.exceptions import ToolkitRequiredValueError, ToolkitTypeError, ToolkitYAMLFormatError
 from cognite_toolkit._cdf_tk.loaders import (
     ResourceLoader,
 )
@@ -88,6 +88,10 @@ class ToolkitCommand:
                     f"Failed to load {filepath.name} with {loader.display_name}. Missing required field: {e}."
                     f"\nPlease compare with the API specification at {loader.doc_url()}."
                 )
+            except TypeError as e:
+                raise ToolkitTypeError(
+                    f"Failed to load {filepath.name} with {loader.display_name}. Wrong type {e!r}"
+                ) from e
             except Exception as e:
                 raise ToolkitYAMLFormatError(
                     f"Failed to load {filepath.name} with {loader.display_name}. Error: {e!r}."

--- a/cognite_toolkit/_cdf_tk/exceptions.py
+++ b/cognite_toolkit/_cdf_tk/exceptions.py
@@ -128,6 +128,9 @@ class ToolkitValueError(ValueError, ToolkitError):
     pass
 
 
+class ToolkitTypeError(TypeError, ToolkitError): ...
+
+
 class ToolkitRequiredValueError(ToolkitError, ValueError):
     pass
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_deploy.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_deploy.py
@@ -12,7 +12,7 @@ class TestDeployCommand:
     def test_load_files(self, cdf_tool_config: CDFToolConfig) -> None:
         path = MagicMock(spec=Path)
         path.name = "my.View.yaml"
-        path.read_text.side_effect = VIEW_SOURCE_NONE
+        path.read_text.return_value = VIEW_SOURCE_NONE
         cmd = DeployCommand(print_warning=False, skip_tracking=True)
 
         with pytest.raises(TypeError) as e:
@@ -24,7 +24,6 @@ class TestDeployCommand:
 
 
 VIEW_SOURCE_NONE = """- space: dm_domain_generic
-
   externalId: Equipment
   name: Equipment
   version: v1
@@ -38,11 +37,5 @@ VIEW_SOURCE_NONE = """- space: dm_domain_generic
         list: false
         collation: ucs_basic
         type: text
-      nullable: true
-      immutable: false
-      autoIncrement: false
       source:
-      defaultValue:
-      name: id
-      description:
 """

--- a/tests/test_unit/test_cdf_tk/test_commands/test_deploy.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_deploy.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from cognite_toolkit._cdf_tk.commands import DeployCommand
+from cognite_toolkit._cdf_tk.loaders import ViewLoader
+from cognite_toolkit._cdf_tk.utils import CDFToolConfig
+
+
+class TestDeployCommand:
+    def test_load_files(self, cdf_tool_config: CDFToolConfig) -> None:
+        path = MagicMock(spec=Path)
+        path.name = "my.View.yaml"
+        path.read_text.side_effect = VIEW_SOURCE_NONE
+        cmd = DeployCommand(print_warning=False, skip_tracking=True)
+
+        with pytest.raises(TypeError) as e:
+            cmd._load_files(
+                ViewLoader.create_loader(cdf_tool_config, None), [path], cdf_tool_config, skip_validation=True
+            )
+
+        assert e.value
+
+
+VIEW_SOURCE_NONE = """- space: dm_domain_generic
+
+  externalId: Equipment
+  name: Equipment
+  version: v1
+  properties:
+    id:
+      container:
+        space: dm_domain_generic
+        externalId: Tag
+      containerPropertyIdentifier: id
+      type:
+        list: false
+        collation: ucs_basic
+        type: text
+      nullable: true
+      immutable: false
+      autoIncrement: false
+      source:
+      defaultValue:
+      name: id
+      description:
+"""


### PR DESCRIPTION
# Description

## Today
Getting an error message like this was confusing for the user.
![image](https://github.com/user-attachments/assets/d11a3c1e-7256-4b16-ad20-eb3271de8351)

This is caused by the user self by setting
```yaml
source: 
```
in a `View Property`. When you specify `source` you need to give a `ViewId`.
```yaml
source:
  space: my_space
  externalId: my_external_id
  version: 1
  type: view
```
## After this PR
Gives the correct Type of error
![image](https://github.com/user-attachments/assets/879d7a54-4573-4500-b9a0-67e5e7c2545f)

## Ways Forward
This is still not a good solution, but it is a larger effort to give a better error message. And there are multiple paths forward
1. Fix in deploy step, try to find out which part of the input is of type `ViewId` and currently set to `None`. 
2. Fix in build step, detect this at the build step and give an appropriate warning.
3. Fix in Python SDK, by handling None values.

All out of scope for what I think we should do in 0.2.x

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
