### PR TITLE
[CDF-21906] 🫏 Rewrite Variables Part 3

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/pull.py
+++ b/cognite_toolkit/_cdf_tk/commands/pull.py
@@ -16,7 +16,6 @@ from rich.markdown import Markdown
 from rich.panel import Panel
 
 from cognite_toolkit._cdf_tk.commands.build import BuildCommand
-from cognite_toolkit._cdf_tk.constants import COGNITE_MODULES
 from cognite_toolkit._cdf_tk.data_classes import BuildConfigYAML, SystemYAML
 from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitDuplicatedResourceError,
@@ -396,7 +395,7 @@ class PullCommand(ToolkitCommand):
             # Todo Remove once the new modules in `_cdf_tk/prototypes/_packages` are finished.
             config.variables.pop("_cdf_tk", None)
             # Use path syntax to select all modules in the source directory
-            config.environment.selected = [(COGNITE_MODULES,)]
+            config.environment.selected = [Path("")]
             print(
                 Panel.fit(
                     f"[bold]Building all modules found in {config.filepath} (not only the modules under "

--- a/cognite_toolkit/_cdf_tk/data_classes/_build_variables.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_build_variables.py
@@ -73,7 +73,13 @@ class BuildVariables(tuple, Sequence[BuildVariable]):
 
     def get_module_variables(self, module: ModuleLocation) -> BuildVariables:
         """Gets the variables for a specific module."""
-        return BuildVariables([variable for variable in self if variable.location in module.relative_parent_paths])
+        return BuildVariables(
+            [
+                variable
+                for variable in self
+                if variable.location == module.relative_path or variable.location in module.parent_relative_paths
+            ]
+        )
 
     def replace(self, content: str, file_suffix: str = ".yaml") -> str:
         for variable in self:

--- a/cognite_toolkit/_cdf_tk/data_classes/_config_yaml.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_config_yaml.py
@@ -54,7 +54,7 @@ class Environment:
     name: str
     project: str
     build_type: EnvType
-    selected: list[str | tuple[str, ...]]
+    selected: list[str | Path]
 
     def __post_init__(self) -> None:
         if self.build_type not in _AVAILABLE_ENV_TYPES:
@@ -84,10 +84,7 @@ class Environment:
             project=data["project"],
             build_type=build_type,
             selected=[
-                tuple([part for part in selected.split(MODULE_PATH_SEP) if part])
-                if MODULE_PATH_SEP in selected
-                else selected
-                for selected in data["selected"] or []
+                Path(selected) if MODULE_PATH_SEP in selected else selected for selected in data["selected"] or []
             ],
         )
 
@@ -96,16 +93,11 @@ class Environment:
             "name": self.name,
             "project": self.project,
             "type": self.build_type,
-            "selected": [
-                MODULE_PATH_SEP.join(selected) if isinstance(selected, tuple) else selected
-                for selected in self.selected
-            ],
+            "selected": [selected.as_posix() if isinstance(selected, Path) else selected for selected in self.selected],
         }
 
-    def get_selected_modules(
-        self, modules_by_package: dict[str, list[str | tuple[str, ...]]]
-    ) -> set[str | tuple[str, ...]]:
-        selected_modules: set[str | tuple[str, ...]] = set()
+    def get_selected_modules(self, modules_by_package: dict[str, list[str]]) -> set[str | Path]:
+        selected_modules: set[str | Path] = set()
         for selected in self.selected:
             if selected in modules_by_package and isinstance(selected, str):
                 selected_modules.update(modules_by_package[selected])
@@ -193,11 +185,11 @@ class BuildConfigYAML(ConfigCore, ConfigYAMLCore):
 
     def get_selected_modules(
         self,
-        modules_by_package: dict[str, list[str | tuple[str, ...]]],
-        available_modules: set[str | tuple[str, ...]],
+        modules_by_package: dict[str, list[str | Path]],
+        available_modules: set[str | Path],
         source_dir: Path,
         verbose: bool,
-    ) -> list[str | tuple[str, ...]]:
+    ) -> list[str | Path]:
         selected_packages = [
             package
             for package in self.environment.selected
@@ -228,10 +220,10 @@ class BuildConfigYAML(ConfigCore, ConfigYAMLCore):
         if verbose:
             print("  [bold green]INFO:[/] Selected modules:")
             for module in selected_modules:
-                if isinstance(module, str):
-                    print(f"    {module}")
+                if isinstance(module, Path):
+                    print(f"    {module.as_posix()}")
                 else:
-                    print(f"    {MODULE_PATH_SEP.join(module)!s}")
+                    print(f"    {module}")
         return selected_modules
 
 

--- a/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
@@ -43,8 +43,7 @@ class ModuleLocation:
     @cached_property
     def parent_relative_paths(self) -> set[Path]:
         """All relative parent paths of the module."""
-        module_parts = self.relative_path
-        return {module_parts.parents[i] for i in range(len(module_parts.parts))}
+        return set(self.relative_path.parents)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(name={self.name}, is_selected={self.is_selected}, file_count={len(self.source_paths)})"

--- a/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
@@ -38,13 +38,16 @@ class ModuleLocation:
     @property
     def module_selections(self) -> set[str | Path]:
         """Ways of selecting this module."""
-        return {self.name, *self.relative_parent_paths}
+        return {self.name, self.relative_path, *self.parent_relative_paths}
 
     @cached_property
-    def relative_parent_paths(self) -> set[Path]:
+    def parent_relative_paths(self) -> set[Path]:
         """All relative parent paths of the module."""
         module_parts = self.relative_path
         return {module_parts.parents[i] for i in range(len(module_parts.parts))}
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(name={self.name}, is_selected={self.is_selected}, file_count={len(self.source_paths)})"
 
 
 class ModuleDirectories(tuple, Sequence[ModuleLocation]):

--- a/cognite_toolkit/_cdf_tk/exceptions.py
+++ b/cognite_toolkit/_cdf_tk/exceptions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from pathlib import Path
 
 from yaml import YAMLError
 
@@ -56,16 +57,14 @@ class ToolkitDuplicatedResourceError(ToolkitError):
 
 
 class ToolkitDuplicatedModuleError(ToolkitError):
-    def __init__(self, message: str, duplicated: dict[str, list]) -> None:
+    def __init__(self, message: str, duplicated: dict[str, list[Path]]) -> None:
         super().__init__(message)
         self.duplicated = duplicated
 
     def __str__(self) -> str:
-        from cognite_toolkit._cdf_tk.constants import MODULE_PATH_SEP
-
         lines = [super().__str__()]
         for module_name, paths in self.duplicated.items():
-            locations = "\n        ".join(sorted(MODULE_PATH_SEP.join(path) for path in paths))
+            locations = "\n        ".join(sorted(path.as_posix() for path in paths))
             lines.append(f"    {module_name} exists in:\n        {locations}")
         lines.append(
             "    You can use the path syntax to disambiguate between modules with the same name. For example "

--- a/cognite_toolkit/_cdf_tk/hints.py
+++ b/cognite_toolkit/_cdf_tk/hints.py
@@ -40,7 +40,7 @@ class ModuleDefinition(Hint):
         return f"Available resource directories are {sorted(LOADER_BY_FOLDER_NAME)}. {cls._link(URL.configs)} to learn more."
 
     @classmethod
-    def long(cls, missing_modules: set[str | tuple[str, ...]] | None = None, source_dir: Path | None = None) -> str:  # type: ignore[override]
+    def long(cls, missing_modules: set[str | Path] | None = None, source_dir: Path | None = None) -> str:  # type: ignore[override]
         lines = [
             "A module is a directory with one or more resource directories in it.",
             f"Available resource directories are {sorted(LOADER_BY_FOLDER_NAME)}",

--- a/cognite_toolkit/_cdf_tk/validation.py
+++ b/cognite_toolkit/_cdf_tk/validation.py
@@ -38,7 +38,7 @@ def validate_modules_variables(variables: BuildVariables, filepath: Path) -> War
     for variable in variables:
         if isinstance(variable.value, str) and pattern.match(variable.value):
             warning_list.append(
-                TemplateVariableWarning(filepath, variable.value, variable.key, ".".join(variable.location))
+                TemplateVariableWarning(filepath, variable.value, variable.key, ".".join(variable.location.parts))
             )
     return warning_list
 

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_base_loaders.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_base_loaders.py
@@ -18,7 +18,6 @@ from pytest_regressions.data_regression import DataRegressionFixture
 
 from cognite_toolkit._cdf_tk._parameters import ParameterSet, read_parameters_from_dict
 from cognite_toolkit._cdf_tk.commands import BuildCommand, DeployCommand
-from cognite_toolkit._cdf_tk.constants import COGNITE_MODULES
 from cognite_toolkit._cdf_tk.data_classes import (
     BuildConfigYAML,
     Environment,
@@ -223,7 +222,7 @@ def cognite_module_files_with_loader() -> Iterable[ParameterSet]:
         # Todo Remove once the new modules in `_cdf_tk/prototypes/_packages` are finished.
         config.variables.pop("_cdf_tk", None)
         # Use path syntax to select all modules in the source directory
-        config.environment.selected = [(COGNITE_MODULES,)]
+        config.environment.selected = [Path()]
 
         source_by_build_path = BuildCommand().build_config(
             build_dir=build_dir,

--- a/tests/test_unit/test_cdf_tk/test_utils.py
+++ b/tests/test_unit/test_cdf_tk/test_utils.py
@@ -113,21 +113,21 @@ class TestLoadYamlInjectVariables:
     "variable, expected_warnings",
     [
         pytest.param(
-            BuildVariable("sourceId", "<change_me>", False, ()),
+            BuildVariable("sourceId", "<change_me>", False, Path()),
             [TemplateVariableWarning(Path("config.yaml"), "<change_me>", "sourceId", "")],
             id="Single warning",
         ),
         pytest.param(
-            BuildVariable("sourceId", "<change_me>", False, ("a_module",)),
+            BuildVariable("sourceId", "<change_me>", False, Path("a_module")),
             [TemplateVariableWarning(Path("config.yaml"), "<change_me>", "sourceId", "a_module")],
             id="Nested warning",
         ),
         pytest.param(
-            BuildVariable("sourceId", "<change_me>", False, ("a_super_module", "a_module")),
+            BuildVariable("sourceId", "<change_me>", False, Path("a_super_module/a_module")),
             [TemplateVariableWarning(Path("config.yaml"), "<change_me>", "sourceId", "a_super_module.a_module")],
             id="Deep nested warning",
         ),
-        pytest.param(BuildVariable("sourceId", "123", False, ("a_module",)), [], id="No warning"),
+        pytest.param(BuildVariable("sourceId", "123", False, Path("a_module")), [], id="No warning"),
     ],
 )
 def test_validate_config_yaml(variable: BuildVariable, expected_warnings: list[TemplateVariableWarning]) -> None:


### PR DESCRIPTION
# Description

Use `Path` instead of `tuble[str, ...]` to represent a path.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
