### PR TITLE
Fix locale for git in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.11.9-slim
 
 RUN apt-get update && apt-get install -y git gcc python3-dev procps pipx
 
+# Generate locale necessary for pre-commit and git commit
+RUN apt-get install -y --no-install-recommends locales; echo \"en_US.UTF-8 UTF-8\" >> /etc/locale.gen; locale-gen
+
 # Create the user
 RUN groupadd --gid 1000 vscode
 RUN useradd --uid 1000 --gid 1000 -m vscode --shell /bin/bash


### PR DESCRIPTION
This pull request fixes the locale for git by generating the necessary locale for pre-commit and git commit. The patch includes the installation of locales and the addition of "en_US.UTF-8 UTF-8" to /etc/locale.gen, followed by running locale-gen.