### PR TITLE
[CDF-22374] 🦈Move Feature Flag into cdf.toml

### DIFF
--- a/cdf.toml
+++ b/cdf.toml
@@ -1,6 +1,15 @@
 [cdf]
 project_dir = "cognite_toolkit"
 
+feature_flags = [
+    "graphql",
+    "asset-dump",
+    "timeseries-dump",
+    "import-cmd",
+    "modules-app"
+]
+
+
 [modules]
 # This is the version of the modules. It should not be changed manually.
 # It will be updated by the 'cdf module upgrade' command.

--- a/cdf.toml
+++ b/cdf.toml
@@ -9,7 +9,6 @@ feature_flags = [
     "modules-app"
 ]
 
-
 [modules]
 # This is the version of the modules. It should not be changed manually.
 # It will be updated by the 'cdf module upgrade' command.

--- a/cdf.toml
+++ b/cdf.toml
@@ -1,13 +1,12 @@
 [cdf]
 project_dir = "cognite_toolkit"
 
-feature_flags = [
-    "graphql",
-    "asset-dump",
-    "timeseries-dump",
-    "import-cmd",
-    "modules-app"
-]
+[cdf.feature_flags]
+graphql = true
+asset-dump = true
+timeseries-dump = true
+import-cmd = true
+modules-app = true
 
 [modules]
 # This is the version of the modules. It should not be changed manually.

--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -1150,8 +1150,9 @@ def feature_flag_main(ctx: typer.Context) -> None:
                 "\nDo not enable a flag unless you are familiar with what it does.[/]"
             )
         )
+        print("Use [bold yellow]cdf-tk features list[/] available feature flags")
         print(
-            "Use [bold yellow]cdf-tk features list[/] or [bold yellow]cdf-tk features set <flag> --enabled/--disabled[/]"
+            f"Use [bold yellow]the section cdf.feature_flags in {CDFToml.file_name!r}[/] to enable or disable feature flags."
         )
     return None
 
@@ -1161,49 +1162,7 @@ def feature_flag_list() -> None:
     """List all available feature flags."""
 
     cmd = FeatureFlagCommand()
-    cmd.run(lambda: cmd.list())
-
-
-@feature_flag_app.command("set")
-def feature_flag_set(
-    flag: Annotated[
-        str,
-        typer.Argument(
-            help="Which flag to set",
-        ),
-    ],
-    enable: Annotated[
-        bool,
-        typer.Option(
-            "--enable",
-            "-e",
-            help="Enable the flag.",
-        ),
-    ] = False,
-    disable: Annotated[
-        bool,
-        typer.Option(
-            "--disable",
-            help="Disable the flag.",
-        ),
-    ] = False,
-) -> None:
-    """Enable or disable a feature flag."""
-
-    cmd = FeatureFlagCommand()
-    if enable and disable:
-        raise ToolkitValidationError("Cannot enable and disable a flag at the same time.")
-    if not enable and not disable:
-        raise ToolkitValidationError("Must specify either --enable or --disable.")
-    cmd.run(lambda: cmd.set(flag, enable))
-
-
-@feature_flag_app.command("reset")
-def feature_flag_reset() -> None:
-    """Reset all feature flags to their default values."""
-
-    cmd = FeatureFlagCommand()
-    cmd.run(lambda: cmd.reset())
+    cmd.run(cmd.list)
 
 
 @user_app.callback(invoke_without_command=True)

--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -30,13 +30,13 @@ from cognite_toolkit._cdf_tk.commands import (
     RunFunctionCommand,
     RunTransformationCommand,
 )
-from cognite_toolkit._cdf_tk.commands.featureflag import FeatureFlag, Flags
 from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitError,
     ToolkitFileNotFoundError,
     ToolkitInvalidSettingsError,
     ToolkitValidationError,
 )
+from cognite_toolkit._cdf_tk.feature_flags import FeatureFlag, Flags
 from cognite_toolkit._cdf_tk.loaders import (
     LOADER_BY_FOLDER_NAME,
     NodeLoader,

--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any, ClassVar
 
 from cognite_toolkit import _version

--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -23,12 +23,12 @@ else:
 @dataclass
 class CLIConfig:
     project_dir: Path | None = None
-    feature_flags: list[str] = field(default_factory=list)
+    feature_flags: dict[str, bool] = field(default_factory=dict)
 
     @classmethod
     def load(cls, raw: dict[str, Any], source_dir: Path) -> CLIConfig:
         project_dir = source_dir / raw["project_dir"] if "project_dir" in raw else None
-        return cls(project_dir=project_dir, feature_flags=raw.get("feature_flags", []))
+        return cls(project_dir=project_dir, feature_flags=raw.get("feature_flags", {}))
 
     def get_root_module_paths(self, project_dir: Path | None = None) -> list[Path]:
         source_path = project_dir or self.project_dir or Path.cwd()
@@ -98,3 +98,9 @@ class CDFToml:
 
 
 _CDF_TOML: CDFToml | None = None
+
+if __name__ == "__main__":
+    from pathlib import Path
+
+    _ROOT = Path(__file__).parent.parent.parent
+    print(CDFToml.load(_ROOT))

--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, ClassVar
 
 from cognite_toolkit import _version
@@ -99,7 +100,7 @@ class CDFToml:
 _CDF_TOML: CDFToml | None = None
 
 if __name__ == "__main__":
-    from pathlib import Path
-
+    # This is a test to quickly check that the code works.
+    # also useful to check that when you change cdf.toml it is loaded correctly
     _ROOT = Path(__file__).parent.parent.parent
     print(CDFToml.load(_ROOT))

--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -23,11 +23,12 @@ else:
 @dataclass
 class CLIConfig:
     project_dir: Path | None = None
+    feature_flags: list[str] = field(default_factory=list)
 
     @classmethod
     def load(cls, raw: dict[str, Any], source_dir: Path) -> CLIConfig:
         project_dir = source_dir / raw["project_dir"] if "project_dir" in raw else None
-        return cls(project_dir=project_dir)
+        return cls(project_dir=project_dir, feature_flags=raw.get("feature_flags", []))
 
     def get_root_module_paths(self, project_dir: Path | None = None) -> list[Path]:
         source_path = project_dir or self.project_dir or Path.cwd()

--- a/cognite_toolkit/_cdf_tk/commands/featureflag.py
+++ b/cognite_toolkit/_cdf_tk/commands/featureflag.py
@@ -1,18 +1,14 @@
 from __future__ import annotations
 
-import tempfile
 from enum import Enum
 from functools import lru_cache
-from pathlib import Path
 from typing import Any, ClassVar
 
-import yaml
 from rich import print
 from rich.table import Table
 
+from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
-from cognite_toolkit._cdf_tk.exceptions import ToolkitRequiredValueError
-from cognite_toolkit._cdf_tk.utils import safe_read
 
 
 class Flags(Enum):
@@ -28,54 +24,27 @@ class Flags(Enum):
 
 class FeatureFlag:
     @staticmethod
-    def _get_file() -> Path:
-        f = Path(tempfile.gettempdir()) / "tk-ff.bin"
-        if not f.exists():
-            f.write_text("{}")
-        return f
-
-    @staticmethod
-    def load_user_settings() -> dict[str, bool]:
-        return yaml.safe_load(safe_read(FeatureFlag._get_file()))
-
-    @staticmethod
-    def save_user_settings(flag: Flags, enabled: bool) -> None:
-        settings = FeatureFlag.load_user_settings()
-        settings.update({flag.name: enabled})
-        FeatureFlag._get_file().write_text(yaml.dump(settings))
-        FeatureFlag.is_enabled.cache_clear()
-
-    @staticmethod
-    def reset_user_settings() -> None:
-        FeatureFlag._get_file().unlink()
-        FeatureFlag.is_enabled.cache_clear()
-
-    @staticmethod
     @lru_cache(typed=True)
     def is_enabled(flag: str | Flags) -> bool:
         if isinstance(flag, str):
-            fflag = FeatureFlag.to_flag(flag)
+            try:
+                fflag = Flags[flag.upper().replace("-", "_")]
+            except KeyError:
+                return False
         else:
             fflag = flag
 
         if not fflag:
             return False
 
-        user_settings = FeatureFlag.load_user_settings()
+        user_settings = CDFToml.load().cdf.feature_flags
         return user_settings.get(fflag.name, False)
-
-    @staticmethod
-    @lru_cache
-    def to_flag(flag: str) -> Flags | None:
-        try:
-            return Flags[flag.upper().replace("-", "_")]
-        except KeyError:
-            return None
 
 
 class FeatureFlagCommand(ToolkitCommand):
-    def list(self) -> None:
-        user_settings = FeatureFlag.load_user_settings()
+    @staticmethod
+    def list() -> None:
+        user_settings = CDFToml.load().cdf.feature_flags
         table = Table(title="feature flags")
         table.add_column("Name", justify="left")
         table.add_column("Description", justify="left")
@@ -91,25 +60,3 @@ class FeatureFlagCommand(ToolkitCommand):
                     style="yellow" if is_enabled else "",
                 )
         print(table)
-        self.feature_flags_warning()
-
-    def set(self, flag: str, enabled: bool) -> None:
-        fflag = FeatureFlag.to_flag(flag)
-        if not fflag:
-            raise ToolkitRequiredValueError(
-                f"Unknown flag: [bold]{flag}[/]. Use the [bold]list[/] command to see available flags"
-            )
-        FeatureFlag.save_user_settings(fflag, enabled)
-        print(f"Feature flag [bold yellow]{flag}[/] has been [bold yellow]{'enabled' if enabled else 'disabled'}[/]")
-        self.feature_flags_warning()
-
-    def feature_flags_warning(self) -> None:
-        print(
-            "[bold red]Warning[/] Feature flags are global for the user and will persist "
-            "across Toolkit installations."
-        )
-
-    def reset(self) -> None:
-        FeatureFlag.reset_user_settings()
-        print("Feature flags have been reset")
-        self.feature_flags_warning()

--- a/cognite_toolkit/_cdf_tk/commands/featureflag.py
+++ b/cognite_toolkit/_cdf_tk/commands/featureflag.py
@@ -1,44 +1,11 @@
 from __future__ import annotations
 
-from enum import Enum
-from functools import lru_cache
-from typing import Any, ClassVar
-
 from rich import print
 from rich.table import Table
 
 from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
-
-
-class Flags(Enum):
-    MODULES_CMD: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the modules management subapp"}
-    INTERNAL: ClassVar[dict[str, Any]] = {"visible": False, "description": "Does nothing"}
-    IMPORT_CMD: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the import sub application"}
-    ASSETS: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the support for loading assets"}
-    TIMESERIES_DUMP: ClassVar[dict[str, Any]] = {
-        "visible": True,
-        "description": "Enables the support to dump timeseries",
-    }
-
-
-class FeatureFlag:
-    @staticmethod
-    @lru_cache(typed=True)
-    def is_enabled(flag: str | Flags) -> bool:
-        if isinstance(flag, str):
-            try:
-                fflag = Flags[flag.upper().replace("-", "_")]
-            except KeyError:
-                return False
-        else:
-            fflag = flag
-
-        if not fflag:
-            return False
-
-        user_settings = CDFToml.load().cdf.feature_flags
-        return user_settings.get(fflag.name, False)
+from cognite_toolkit._cdf_tk.feature_flags import Flags
 
 
 class FeatureFlagCommand(ToolkitCommand):

--- a/cognite_toolkit/_cdf_tk/feature_flags.py
+++ b/cognite_toolkit/_cdf_tk/feature_flags.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from enum import Enum
+from functools import lru_cache
+from typing import Any, ClassVar
+
+from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
+
+
+class Flags(Enum):
+    MODULES_CMD: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the modules management subapp"}
+    INTERNAL: ClassVar[dict[str, Any]] = {"visible": False, "description": "Does nothing"}
+    IMPORT_CMD: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the import sub application"}
+    ASSETS: ClassVar[dict[str, Any]] = {"visible": True, "description": "Enables the support for loading assets"}
+    TIMESERIES_DUMP: ClassVar[dict[str, Any]] = {
+        "visible": True,
+        "description": "Enables the support to dump timeseries",
+    }
+
+
+class FeatureFlag:
+    @staticmethod
+    @lru_cache(typed=True)
+    def is_enabled(flag: str | Flags) -> bool:
+        if isinstance(flag, str):
+            try:
+                fflag = Flags[flag.upper().replace("-", "_")]
+            except KeyError:
+                return False
+        else:
+            fflag = flag
+
+        if not fflag:
+            return False
+
+        user_settings = CDFToml.load().cdf.feature_flags
+        return user_settings.get(fflag.name, False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,12 @@ cdf = "cognite_toolkit._cdf:app"
 show_missing = true
 
 [tool.pytest.ini_options]
+minversion = 8.0
+testpaths = [
+    "tests",
+    # In the case of doctests.
+    "cognite_toolkit",
+]
 markers = [
     "toolkit: big smoke tests",
 ]

--- a/tests/test_unit/test_cdf_tk/test_commands/test_feature_flags.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_feature_flags.py
@@ -1,14 +1,6 @@
-from cognite_toolkit._cdf_tk.commands.featureflag import FeatureFlag, Flags
+from cognite_toolkit._cdf_tk.commands.featureflag import FeatureFlag
 
 
 class TestFeatureCommand:
     def test_unknown_flag_returns_false(self):
         assert FeatureFlag.is_enabled("unknown_flag") is False
-
-    def test_user_setting_is_stored(self):
-        FeatureFlag.reset_user_settings()
-        assert FeatureFlag.is_enabled("MODULES_CMD") is False
-
-    def test_user_setting_is_read(self):
-        FeatureFlag.save_user_settings(FeatureFlag.to_flag("internal"), True)
-        assert FeatureFlag.is_enabled(Flags.INTERNAL)

--- a/tests/test_unit/test_cdf_tk/test_commands/test_feature_flags.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_feature_flags.py
@@ -1,4 +1,4 @@
-from cognite_toolkit._cdf_tk.commands.featureflag import FeatureFlag
+from cognite_toolkit._cdf_tk.feature_flags import FeatureFlag
 
 
 class TestFeatureCommand:


### PR DESCRIPTION
# Description

Feature flags are now loaded form `cdf.toml` instead of temporary file. 

Removed the commands to `cdf featureflags set` and `set featureflag reset` as they are no longer relevant as the user can set the flags directly.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
