### PR TITLE
[CDF-22341] 🏗️ modules init --all (--clean) copies all files from _builtin_modules to org_dir/modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,6 +282,7 @@ config.yaml
 demo_project/
 tests/tests_unit/pytest-project/
 my_project/
+my_organization/
 *.bck
 
 # Hide environments used for migration testing

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -164,31 +164,25 @@
       "console": "integratedTerminal",
       "justMyCode": false
     },
-
-    {
-      "name": "Python: feature flag set",
-      "type": "debugpy",
-      "request": "launch",
-      "program": "./cdf-tk-dev.py",
-      "args": ["features", "set", "modules-cmd", "--enable"],
-      "console": "integratedTerminal",
-      "justMyCode": false
-    },
-    {
-      "name": "Python: feature flags reset",
-      "type": "debugpy",
-      "request": "launch",
-      "program": "./cdf-tk-dev.py",
-      "args": ["features", "reset"],
-      "console": "integratedTerminal",
-      "justMyCode": false
-    },
     {
       "name": "Python: modules init",
       "type": "debugpy",
       "request": "launch",
       "program": "./cdf-tk-dev.py",
       "args": ["modules", "init"],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    },
+    {
+      "name": "Python: modules init --all",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "./cdf-tk-dev.py",
+      "args": [
+        "modules", 
+      "init", 
+      "--all",
+      "--clean"],
       "console": "integratedTerminal",
       "justMyCode": false
     },

--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -23,6 +23,7 @@ Changes are grouped as follows:
   `Frame`, and `Location`). These loaders were earlier available as feature preview.
 - Support for `LocationFilter` in the `locations` folder.
 - Command `cdf modules list` to list all modules.
+- Command `cdf modules init --all` bypasses interactive mode and copies all available modules.
 
 ## Changed
 

--- a/cognite_toolkit/_cdf_tk/apps/_modules_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_modules_app.py
@@ -22,7 +22,7 @@ class ModulesApp(typer.Typer):
     def main(self, ctx: typer.Context) -> None:
         """Commands to manage modules"""
         if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf-tk modules --help[/] for more information.")
+            print("Use [bold yellow]cdf modules --help[/] for more information.")
 
     def init(
         self,
@@ -39,6 +39,22 @@ class ModulesApp(typer.Typer):
                 help="Name of package to include",
             ),
         ] = None,
+        all: Annotated[
+            bool,
+            typer.Option(
+                "--all",
+                "-a",
+                help="Copy all available templates.",
+            ),
+        ] = False,
+        clean: Annotated[
+            bool,
+            typer.Option(
+                "--clean",
+                "-a",
+                help="Clean target 'modules' directory if it exists",
+            ),
+        ] = False,
     ) -> None:
         """Initialize or upgrade a new CDF project with templates interactively."""
 
@@ -47,6 +63,8 @@ class ModulesApp(typer.Typer):
             lambda: cmd.init(
                 organization_dir=organization_dir,
                 arg_package=arg_package,
+                all=all,
+                clean=clean,
             )
         )
 


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
