### PR TITLE
🐛fix: pick up default org in cdm.toml

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,12 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+### Fixed
+
+- The field `default_organization_dir` was not read in the `cdf.toml` file. This is now fixed.
+
 ## [0.3.0a3] - 2024-09-11
 
 ### Fixed

--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -27,7 +27,9 @@ class CLIConfig:
 
     @classmethod
     def load(cls, raw: dict[str, Any], cwd: Path) -> CLIConfig:
-        default_organization_dir = cwd / raw["default_organization_dir"] if "organization_dir" in raw else Path.cwd()
+        default_organization_dir = (
+            cwd / raw["default_organization_dir"] if "default_organization_dir" in raw else Path.cwd()
+        )
         return cls(
             default_organization_dir=default_organization_dir,
             default_env=raw.get("default_env", "dev"),


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
