### PR TITLE
[CDF-22527] 🧑‍🤝‍🧑Userfriendly message if modules and config not found.

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,12 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+### Fixed
+
+- The field `default_organization_dir` was not read in the `cdf.toml` file. This is now fixed.
+
 ## [0.3.0a3] - 2024-09-11
 
 ### Fixed

--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -6,9 +6,8 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 from cognite_toolkit import _version
-from cognite_toolkit._cdf_tk.constants import ROOT_MODULES, clean_name
+from cognite_toolkit._cdf_tk.constants import clean_name
 from cognite_toolkit._cdf_tk.exceptions import (
-    ToolkitMissingModulesError,
     ToolkitRequiredValueError,
     ToolkitVersionError,
 )
@@ -35,19 +34,6 @@ class CLIConfig:
             default_env=raw.get("default_env", "dev"),
             feature_flags={clean_name(k): v for k, v in raw.get("feature_flags", {}).items()},
         )
-
-    def get_root_module_paths(self, organization_dir: Path | None) -> list[Path]:
-        organization_dir = organization_dir or self.default_organization_dir
-        sources = [
-            module_dir for root_module in ROOT_MODULES if (module_dir := organization_dir / root_module).exists()
-        ]
-        if not sources:
-            directories = "\n".join(f"   ┣ {name}" for name in ROOT_MODULES[:-1])
-            raise ToolkitMissingModulesError(
-                f"Could not find the modules directory.\nExpected to find one of the following directories inside {organization_dir.name}\n"
-                f"{organization_dir.name}\n{directories}\n   ┗ {ROOT_MODULES[-1]}"
-            )
-        return sources
 
 
 @dataclass

--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -27,7 +27,9 @@ class CLIConfig:
 
     @classmethod
     def load(cls, raw: dict[str, Any], cwd: Path) -> CLIConfig:
-        default_organization_dir = cwd / raw["default_organization_dir"] if "organization_dir" in raw else Path.cwd()
+        default_organization_dir = (
+            cwd / raw["default_organization_dir"] if "default_organization_dir" in raw else Path.cwd()
+        )
         return cls(
             default_organization_dir=default_organization_dir,
             default_env=raw.get("default_env", "dev"),

--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -23,16 +23,17 @@ class CLIConfig:
     default_organization_dir: Path
     default_env: str = "dev"
     feature_flags: dict[str, bool] = field(default_factory=dict)
+    has_user_set_default_org: bool = False
 
     @classmethod
     def load(cls, raw: dict[str, Any], cwd: Path) -> CLIConfig:
-        default_organization_dir = (
-            cwd / raw["default_organization_dir"] if "default_organization_dir" in raw else Path.cwd()
-        )
+        has_user_set_default_org = "default_organization_dir" in raw
+        default_organization_dir = cwd / raw["default_organization_dir"] if has_user_set_default_org else Path.cwd()
         return cls(
             default_organization_dir=default_organization_dir,
             default_env=raw.get("default_env", "dev"),
             feature_flags={clean_name(k): v for k, v in raw.get("feature_flags", {}).items()},
+            has_user_set_default_org=has_user_set_default_org,
         )
 
 

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -125,7 +125,7 @@ class BuildCommand(ToolkitCommand):
         cdf_toml = CDFToml.load()
         if not cdf_toml.is_loaded_from_file:
             raise ToolkitError(
-                "No 'cdf.toml' file found in the current directory. " "Please run 'cdf repo init' to create it"
+                "No 'cdf.toml' file found in the current directory. Please run 'cdf repo init' to create it"
             )
 
         sources = cdf_toml.cdf.get_root_module_paths(organization_dir)

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -52,7 +52,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitNotADirectoryError,
     ToolkitYAMLFormatError,
 )
-from cognite_toolkit._cdf_tk.hints import ModuleDefinition
+from cognite_toolkit._cdf_tk.hints import ModuleDefinition, verify_module_directory
 from cognite_toolkit._cdf_tk.loaders import (
     LOADER_BY_FOLDER_NAME,
     ContainerLoader,
@@ -119,8 +119,9 @@ class BuildCommand(ToolkitCommand):
         no_clean: bool,
         ToolGlobals: CDFToolConfig | None = None,
     ) -> None:
-        if not organization_dir.is_dir():
-            raise ToolkitNotADirectoryError(str(organization_dir))
+        if organization_dir in {Path("."), Path("./")}:
+            organization_dir = Path.cwd()
+        verify_module_directory(organization_dir, build_env_name)
 
         cdf_toml = CDFToml.load()
         if not cdf_toml.is_loaded_from_file:

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -28,6 +28,7 @@ from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
 from cognite_toolkit._cdf_tk.constants import (
     _RUNNING_IN_BROWSER,
     INDEX_PATTERN,
+    ROOT_MODULES,
     TEMPLATE_VARS_FILE_SUFFIXES,
 )
 from cognite_toolkit._cdf_tk.data_classes import (
@@ -129,11 +130,13 @@ class BuildCommand(ToolkitCommand):
                 "No 'cdf.toml' file found in the current directory. Please run 'cdf repo init' to create it"
             )
 
-        sources = cdf_toml.cdf.get_root_module_paths(organization_dir)
         config = BuildConfigYAML.load_from_directory(organization_dir, build_env_name)
 
         directory_name = "current directory" if organization_dir == Path(".") else f"project '{organization_dir!s}'"
-        module_locations = "\n".join(f"  - Module directory '{source!s}'" for source in sources)
+        root_modules = [
+            module_dir for root_module in ROOT_MODULES if (module_dir := organization_dir / root_module).exists()
+        ]
+        module_locations = "\n".join(f"  - Module directory '{root_module!s}'" for root_module in root_modules)
         print(
             Panel(
                 f"Building {directory_name}:\n  - Toolkit Version '{__version__!s}'\n"

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -43,6 +43,7 @@ from cognite_toolkit._cdf_tk.data_classes import (
     Packages,
 )
 from cognite_toolkit._cdf_tk.exceptions import ToolkitRequiredValueError
+from cognite_toolkit._cdf_tk.hints import verify_module_directory
 from cognite_toolkit._cdf_tk.tk_warnings import MediumSeverityWarning
 from cognite_toolkit._cdf_tk.utils import read_yaml_file
 from cognite_toolkit._version import __version__
@@ -430,6 +431,9 @@ default_organization_dir = "{organization_dir.name}""",
         return parse_version(content.get("cdf_toolkit_version", "0.0.0"))
 
     def list(self, organization_dir: Path, build_env_name: str) -> None:
+        if organization_dir in {Path("."), Path("./")}:
+            organization_dir = Path.cwd()
+        verify_module_directory(organization_dir, build_env_name)
         modules = ModuleResources(organization_dir, build_env_name)
 
         table = Table(title=f"{build_env_name} {organization_dir.name} modules")

--- a/cognite_toolkit/_cdf_tk/commands/run.py
+++ b/cognite_toolkit/_cdf_tk/commands/run.py
@@ -30,6 +30,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitNotADirectoryError,
     ToolkitNotSupported,
 )
+from cognite_toolkit._cdf_tk.hints import verify_module_directory
 from cognite_toolkit._cdf_tk.loaders import FunctionLoader, FunctionScheduleLoader
 from cognite_toolkit._cdf_tk.loaders.data_classes import FunctionScheduleID
 from cognite_toolkit._cdf_tk.tk_warnings import MediumSeverityWarning
@@ -104,6 +105,10 @@ if __name__ == "__main__":
         schedule: str | None = None,
         wait: bool = False,
     ) -> bool:
+        if organization_dir in {Path("."), Path("./")}:
+            organization_dir = Path.cwd()
+        verify_module_directory(organization_dir, build_env_name)
+
         resources = ModuleResources(organization_dir, build_env_name)
         is_interactive = external_id is None
         external_id = self._get_function(external_id, resources).identifier
@@ -245,6 +250,11 @@ if __name__ == "__main__":
             if _RUNNING_IN_BROWSER:
                 raise ToolkitNotSupported("This functionality is not supported in a browser environment.")
             raise
+
+        if organization_dir in {Path("."), Path("./")}:
+            organization_dir = Path.cwd()
+        verify_module_directory(organization_dir, build_env_name)
+
         resources = ModuleResources(organization_dir, build_env_name)
         function_build = self._get_function(external_id, resources)
 

--- a/cognite_toolkit/_cdf_tk/hints.py
+++ b/cognite_toolkit/_cdf_tk/hints.py
@@ -135,7 +135,7 @@ def verify_module_directory(organization_dir: Path, build_env_name: str) -> None
         cdf_toml = CDFToml.load()
         if not cdf_toml.cdf.has_user_set_default_org:
             print(
-                f"{Hint._lead_text} You can specify a default_organization_dir = ...' in the [cdf] section of your "
+                f"{Hint._lead_text} You can specify a 'default_organization_dir = ...' in the '\[cdf]' section of your "
                 f"'{CDFToml.file_name}' file to avoid using the -o/--organization-dir argument"
             )
 

--- a/cognite_toolkit/_cdf_tk/hints.py
+++ b/cognite_toolkit/_cdf_tk/hints.py
@@ -4,7 +4,11 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Any
 
-from .constants import URL
+from rich import print
+from rich.panel import Panel
+
+from .constants import MODULES, ROOT_MODULES, URL
+from .exceptions import ToolkitFileNotFoundError, ToolkitNotADirectoryError
 from .loaders import LOADER_BY_FOLDER_NAME
 from .utils import find_directory_with_subdirectories
 
@@ -56,3 +60,40 @@ class ModuleDefinition(Hint):
                     f"subdirectories are resource directories. The subdirectories found are: {subdirectories}",
                 ]
         return cls._to_hint(lines)
+
+
+def verify_module_directory(organization_dir: Path, build_env_name: str) -> None:
+    from .data_classes import BuildConfigYAML
+
+    config_file = BuildConfigYAML.get_filename(build_env_name)
+
+    if organization_dir != Path.cwd():
+        panel = Panel(
+            f"Toolkit expects the following structure:\n"
+            f"{organization_dir!s}/\n"
+            f"  ┣ {MODULES}/\n"
+            f"  ┗ {config_file}\n",
+            expand=False,
+        )
+    else:
+        panel = Panel(
+            f"Toolkit expects the following structure:\n" f"  {MODULES}/\n" f"  {config_file}\n",
+            expand=False,
+        )
+    if not organization_dir.is_dir():
+        print(panel)
+        raise ToolkitNotADirectoryError(f"{organization_dir.as_posix()!r} is not a directory.")
+
+    root_modules = [
+        module_dir for root_module in ROOT_MODULES if (module_dir := organization_dir / root_module).exists()
+    ]
+    config_path = organization_dir / config_file
+    if root_modules and config_path.is_file():
+        return
+    if root_modules or config_path.is_file():
+        print(panel)
+        if not root_modules:
+            raise ToolkitNotADirectoryError(f"Could not find the {(organization_dir/ MODULES).as_posix()!r} directory.")
+        raise ToolkitFileNotFoundError(f"Could not find the {config_path.as_posix()!r} file.")
+
+    raise ValueError()

--- a/cognite_toolkit/_cdf_tk/hints.py
+++ b/cognite_toolkit/_cdf_tk/hints.py
@@ -8,6 +8,8 @@ from typing import Any
 from rich import print
 from rich.panel import Panel
 
+from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
+
 from .constants import MODULES, ROOT_MODULES, URL
 from .exceptions import ToolkitFileNotFoundError, ToolkitNotADirectoryError
 from .loaders import LOADER_BY_FOLDER_NAME
@@ -130,4 +132,11 @@ def verify_module_directory(organization_dir: Path, build_env_name: str) -> None
             suggestion.append(f"-o {candidate_rel}")
 
         print(f"{Hint._lead_text} Did you mean to use the command: '{' '.join(suggestion)}'?")
+        cdf_toml = CDFToml.load()
+        if not cdf_toml.cdf.has_user_set_default_org:
+            print(
+                f"{Hint._lead_text} You can specify a default_organization_dir = ...' in the [cdf] section of your "
+                f"'{CDFToml.file_name}' file to avoid using the -o/--organization-dir argument"
+            )
+
     raise ToolkitNotADirectoryError(f"Could not find the {(organization_dir/ MODULES).as_posix()!r} directory.")


### PR DESCRIPTION
# Description

**Note**: `cognite_modules` and `custom_modules` are still valid, but not mentioned in the hints any more. This is for clarity. 

## Missing config file
![image](https://github.com/user-attachments/assets/44cd403d-45be-45f4-b680-b30a0723c68e)

## Missing config and modules director
And if the modules folder is found in a subdirectory

![image](https://github.com/user-attachments/assets/4b7e7b71-a8ee-40f0-81f1-c6cc12b19181)


## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
