### PR TITLE
[CDF-22526] 🤸‍♂️ Migration Fix

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -33,6 +33,7 @@ Changes are grouped as follows:
 
 - LocationFilter did not load subclasses properly. This is now fixed.
 - When running any command, the terminal would print warnings from the `cognite-sdk`. This is now fixed.
+- The `cdf modules init` no longer creates an invalid `cdf.toml` file when the user uses an `organization-dir`.
 
 ### Changed
 

--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -25,6 +25,7 @@ Changes are grouped as follows:
 ### Fixed
 
 - The field `default_organization_dir` was not read in the `cdf.toml` file. This is now fixed.
+- The `cdf modules upgrade` command would fail to update `0.3.0a1` and `0.3.0a2` to `0.3.0a3`. This is now fixed.
 
 ## [0.3.0a3] - 2024-09-11
 

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -138,8 +138,8 @@ class ModulesCommand(ToolkitCommand):
         if organization_dir != Path.cwd():
             cdf_toml_content = cdf_toml_content.replace(
                 "#<PLACEHOLDER>",
-                f"""
-default_organization_dir = "{organization_dir.name}""",
+                f'''
+default_organization_dir = "{organization_dir.name}"''',
             )
         else:
             cdf_toml_content = cdf_toml_content.replace("#<PLACEHOLDER>", "")

--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -44,7 +44,7 @@ ROOT_PATH = Path(__file__).parent.parent
 COGNITE_MODULES_PATH = ROOT_PATH / COGNITE_MODULES
 MODULES_PATH = ROOT_PATH / MODULES
 BUILTIN_MODULES_PATH = ROOT_PATH / BUILTIN_MODULES
-SUPPORT_MODULE_UPGRADE_FROM_VERSION = "0.1.0"
+SUPPORT_MODULE_UPGRADE_FROM_VERSION = "0.2.20"
 # This is used in the build directory to keep track of order and flatten the
 # module directory structure with accounting for duplicated names.
 INDEX_PATTERN = re.compile("^[0-9]+\\.")

--- a/module_upgrade/run_check.py
+++ b/module_upgrade/run_check.py
@@ -147,23 +147,6 @@ def create_project_init(version: str) -> None:
             print(output.stderr.decode())
             raise ValueError(f"Failed to create project init for version {version}.")
 
-        if parse_version("0.3.0a3") > version_parsed >= parse_version("0.3.0a1"):
-            cmd = [
-                str(old_version_script_dir / "cdf"),
-                "repo",
-                "init",
-                f"{PROJECT_INIT_DIR.name}/{project_init.name}",
-            ]
-            output = subprocess.run(
-                cmd,
-                capture_output=True,
-                shell=True if platform.system() == "Windows" else False,
-                env=modified_env_variables,
-            )
-            if output.returncode != 0:
-                print(output.stderr.decode())
-                raise ValueError(f"Failed to create cdf.toml for version {version}.")
-
         cdf_toml_path = TEST_DIR_ROOT / CDFToml.file_name
         if cdf_toml_path.exists():
             shutil.move(cdf_toml_path, project_init / CDFToml.file_name)

--- a/module_upgrade/run_check.py
+++ b/module_upgrade/run_check.py
@@ -118,12 +118,23 @@ def create_project_init(version: str) -> None:
     else:
         old_version_script_dir = Path(f"{environment_directory}/bin/")
     with chdir(TEST_DIR_ROOT):
-        cmd = [
-            str(old_version_script_dir / "cdf-tk"),
-            "init",
-            f"{PROJECT_INIT_DIR.name}/{project_init.name}",
-            "--clean",
-        ]
+        version_parsed = parse_version(version)
+        if version_parsed >= parse_version("0.3.0a1"):
+            cmd = [
+                str(old_version_script_dir / "cdf"),
+                "modules",
+                "init",
+                f"{PROJECT_INIT_DIR.name}/{project_init.name}",
+                "--clean",
+                "--all",
+            ]
+        else:
+            cmd = [
+                str(old_version_script_dir / "cdf-tk"),
+                "init",
+                f"{PROJECT_INIT_DIR.name}/{project_init.name}",
+            ]
+
         output = subprocess.run(
             cmd,
             capture_output=True,

--- a/module_upgrade/run_check.py
+++ b/module_upgrade/run_check.py
@@ -143,6 +143,10 @@ def create_project_init(version: str) -> None:
             shell=True if platform.system() == "Windows" else False,
             env=modified_env_variables,
         )
+        if output.returncode != 0:
+            print(output.stderr.decode())
+            raise ValueError(f"Failed to create project init for version {version}.")
+
         if parse_version("0.3.0a3") > version_parsed >= parse_version("0.3.0a1"):
             cmd = [
                 str(old_version_script_dir / "cdf"),
@@ -156,14 +160,13 @@ def create_project_init(version: str) -> None:
                 shell=True if platform.system() == "Windows" else False,
                 env=modified_env_variables,
             )
+            if output.returncode != 0:
+                print(output.stderr.decode())
+                raise ValueError(f"Failed to create cdf.toml for version {version}.")
 
         cdf_toml_path = TEST_DIR_ROOT / CDFToml.file_name
         if cdf_toml_path.exists():
             shutil.move(cdf_toml_path, project_init / CDFToml.file_name)
-
-        if output.returncode != 0:
-            print(output.stderr.decode())
-            raise ValueError(f"Failed to create project init for version {version}.")
 
     print(f"Project init for version {version} created.")
     with chdir(TEST_DIR_ROOT):

--- a/module_upgrade/run_check.py
+++ b/module_upgrade/run_check.py
@@ -10,6 +10,8 @@ from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
+from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
+
 # Hack to make the script work as running cdf modules upgrade
 sys.argv = ["cdf", "modules", "upgrade"]
 
@@ -141,6 +143,23 @@ def create_project_init(version: str) -> None:
             shell=True if platform.system() == "Windows" else False,
             env=modified_env_variables,
         )
+        if parse_version("0.3.0a3") > version_parsed >= parse_version("0.3.0a1"):
+            cmd = [
+                str(old_version_script_dir / "cdf"),
+                "repo",
+                "init",
+                f"{PROJECT_INIT_DIR.name}/{project_init.name}",
+            ]
+            output = subprocess.run(
+                cmd,
+                capture_output=True,
+                shell=True if platform.system() == "Windows" else False,
+                env=modified_env_variables,
+            )
+
+        cdf_toml_path = TEST_DIR_ROOT / CDFToml.file_name
+        if cdf_toml_path.exists():
+            shutil.move(cdf_toml_path, project_init / CDFToml.file_name)
 
         if output.returncode != 0:
             print(output.stderr.decode())


### PR DESCRIPTION
# Description

* Added missing change between `0.3.0a1` -> `0.3.0a3`.
* Upgraded `modules_upgrade/run_check.py` script to use the `modules init` for versions after `0.3.0a1`.
* Changed to only run migration from `0.2.20` and up until today. We have tested from `0.1.0` to `0.3.0a1` so we know the auto migration works.
* Found a sneaky bug in the `0.3.0a3` creation of `cdf.toml`. 

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
