### PR TITLE
[CDF-21821, CDF-21860, CDF-22355] Split auth in inti and verify

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,8 +137,6 @@ jobs:
         run: python ./demo/preproc.py --modules all
       - name: "Build the templates"
         run: cdf build --build-dir=./build --env=demo -o ./demo_project
-      - name: "Verify and create access rights"
-        run: cdf auth verify
       - name: "Test clean --dry-run"
         run: |
           cdf clean --env=demo ./build --dry-run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,8 @@ jobs:
         run: python ./demo/preproc.py --modules all
       - name: "Build the templates"
         run: cdf build --build-dir=./build --env=demo -o ./demo_project
+      - name: "Verify and create access rights"
+        run: cdf auth verify --no-prompt
       - name: "Test clean --dry-run"
         run: |
           cdf clean --env=demo ./build --dry-run

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -44,8 +44,6 @@ jobs:
 #      - name: "Delete existing resources including data"
 #        run: |
 #          cdf-tk clean --env=demo ./build --include data_models
-      - name: "Verify and create access rights"
-        run: cdf-tk auth verify
       - name: "Allow some time for data modeling to finish syncing of deletions"
         run: |
           sleep 30

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -40,13 +40,8 @@ jobs:
         run: cdf collect opt-out
       - name: "Build the templates"
         run: cdf-tk build --build-dir=./build --env=demo -o ./demo_project
-      # be careful, this works as promised
-#      - name: "Delete existing resources including data"
-#        run: |
-#          cdf-tk clean --env=demo ./build --include data_models
-      - name: "Allow some time for data modeling to finish syncing of deletions"
-        run: |
-          sleep 30
+      - name: "Verify and create access rights"
+        run: cdf auth verify --no-prompt
       - name: "Deploy the templates"
         run: |
           cdf-tk deploy --drop --env=demo ./build

--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -17,6 +17,15 @@ Changes are grouped as follows:
 
 ## TBD
 
+### Changed
+
+- [BREAKING] The command `cdf auth verify` has been split into `cdf auth init` and `cdf auth verify`. The `init` command
+  is used to initialize the authentication, and the `verify` command is used to verify the authentication. The `init`
+  command will by default run the `verify` command after the initialization unless a `--no-verify` flag is set. In
+  addition, the two commands have been reworked to be more user-friendly. They are now interactive (no longer
+  requires a `--interactive` flag) and have no longer supports passing in a custom Group file. Instead, they are
+  intended to only set up and verify a service principal for the Toolkit.
+
 ### Fixed
 
 - The `config` value of a `ExtractionPipelineConfig` is now correctly parsed as a string. Before it was parsed as YAML,

--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -20,11 +20,11 @@ Changes are grouped as follows:
 ### Changed
 
 - [BREAKING] The command `cdf auth verify` has been split into `cdf auth init` and `cdf auth verify`. The `init` command
-  is used to initialize the authentication, and the `verify` command is used to verify the authentication. The `init`
-  command will by default run the `verify` command after the initialization unless a `--no-verify` flag is set. In
-  addition, the two commands have been reworked to be more user-friendly. They are now interactive (no longer
-  requires a `--interactive` flag) and have no longer supports passing in a custom Group file. Instead, they are
-  intended to only set up and verify a service principal for the Toolkit.
+  is used to initialize the auth parameters, and the `verify` command is used to verify that required privileges are
+  set. The `init` command will by default run the `verify` command after the initialization unless a `--no-verify`
+  flag is set. In addition, the two commands have been reworked to be more user-friendly. They are now interactive
+  (no longer requires a `--interactive` flag) and have no longer supports passing in a custom Group file. Instead,
+  they are intended to only set up and verify a service principal for the Toolkit.
 
 ### Fixed
 

--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -25,7 +25,6 @@ from rich.panel import Panel
 from cognite_toolkit._cdf_tk.apps import AuthApp, LandingApp, ModulesApp, RepoApp, RunApp
 from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 from cognite_toolkit._cdf_tk.commands import (
-    AuthCommand,
     BuildCommand,
     CleanCommand,
     CollectCommand,
@@ -92,7 +91,6 @@ except AttributeError as e:
     )
 
 _app = typer.Typer(**default_typer_kws)  # type: ignore [arg-type]
-auth_app = typer.Typer(**default_typer_kws)  # type: ignore [arg-type]
 describe_app = typer.Typer(**default_typer_kws)  # type: ignore [arg-type]
 pull_app = typer.Typer(**default_typer_kws)  # type: ignore [arg-type]
 dump_app = typer.Typer(**default_typer_kws)  # type: ignore [arg-type]
@@ -511,104 +509,6 @@ def collect(
     """Collect usage information for the toolkit."""
     cmd = CollectCommand()
     cmd.run(lambda: cmd.execute(action))  # type: ignore [arg-type]
-
-
-@auth_app.callback(invoke_without_command=True)
-def auth_main(ctx: typer.Context) -> None:
-    """Test, validate, and configure authentication and authorization for CDF projects."""
-    if ctx.invoked_subcommand is None:
-        print("Use [bold yellow]cdf auth --help[/] for more information.")
-    return None
-
-
-@auth_app.command("verify")
-def auth_verify(
-    ctx: typer.Context,
-    dry_run: Annotated[
-        bool,
-        typer.Option(
-            "--dry-run",
-            "-r",
-            help="Whether to do a dry-run, do dry-run if present.",
-        ),
-    ] = False,
-    interactive: Annotated[
-        bool,
-        typer.Option(
-            "--interactive",
-            "-i",
-            help="Will run the verification in interactive mode, prompting for input. Used to bootstrap a new project."
-            "If this mode is selected the --update-group and --create-group options will be ignored.",
-        ),
-    ] = False,
-    group_file: Annotated[
-        Optional[str],
-        typer.Option(
-            "--group-file",
-            "-f",
-            help="Path to group yaml configuration file to use for group verification. "
-            "Defaults to admin.readwrite.group.yaml from the cdf_auth_readwrite_all common module.",
-        ),
-    ] = None,
-    update_group: Annotated[
-        int,
-        typer.Option(
-            "--update-group",
-            "-u",
-            help="If --interactive is not set. Used to update an existing group with the configurations."
-            "Set to the group id or 1 to update the default write-all group.",
-        ),
-    ] = 0,
-    create_group: Annotated[
-        Optional[str],
-        typer.Option(
-            "--create-group",
-            "-c",
-            help="If --interactive is not set. Used to create a new group with the configurations."
-            "Set to the source id of the new group.",
-        ),
-    ] = None,
-    verbose: Annotated[
-        bool,
-        typer.Option(
-            "--verbose",
-            "-v",
-            help="Turn on to get more verbose output when running the command",
-        ),
-    ] = False,
-) -> None:
-    """When you have the necessary information about your identity provider configuration,
-    you can use this command to configure the tool and verify that the token has the correct access rights to the project.
-    It can also create a group with the correct access rights, defaulting to write-all group
-    meant for an admin/CICD pipeline.
-
-    As a minimum, you need the CDF project name, the CDF cluster, an identity provider token URL, and a service account client ID
-    and client secret (or an OAuth2 token set in CDF_TOKEN environment variable).
-
-    Needed capabilities for bootstrapping:
-    "projectsAcl": ["LIST", "READ"],
-    "groupsAcl": ["LIST", "READ", "CREATE", "UPDATE", "DELETE"]
-
-    The default bootstrap group configuration is admin.readwrite.group.yaml from the cdf_auth_readwrite_all common module.
-    """
-    cmd = AuthCommand()
-    with contextlib.redirect_stdout(None):
-        # Remove the Error message from failing to load the config
-        # This is verified in check_auth
-        ToolGlobals = CDFToolConfig(cluster=ctx.obj.cluster, project=ctx.obj.project, skip_initialization=True)
-    if ctx.obj.verbose:
-        print(ToolkitDeprecationWarning("cdf-tk --verbose", "cdf-tk auth verify --verbose").get_message())
-    cmd.run(
-        lambda: cmd.execute(
-            ToolGlobals,
-            dry_run,
-            interactive,
-            group_file,
-            update_group,
-            create_group,
-            verbose or ctx.obj.verbose,
-        )
-    )
 
 
 @describe_app.callback(invoke_without_command=True)

--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -22,7 +22,7 @@ from dotenv import load_dotenv
 from rich import print
 from rich.panel import Panel
 
-from cognite_toolkit._cdf_tk.apps import LandingApp, ModulesApp, RepoApp, RunApp
+from cognite_toolkit._cdf_tk.apps import AuthApp, LandingApp, ModulesApp, RepoApp, RunApp
 from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 from cognite_toolkit._cdf_tk.commands import (
     AuthCommand,
@@ -101,7 +101,7 @@ user_app = typer.Typer(**default_typer_kws, hidden=True)  # type: ignore [arg-ty
 modules_app = ModulesApp(**default_typer_kws)  # type: ignore [arg-type]
 landing_app = LandingApp(**default_typer_kws)  # type: ignore [arg-type]
 
-_app.add_typer(auth_app, name="auth")
+_app.add_typer(AuthApp(**default_typer_kws), name="auth")
 _app.add_typer(describe_app, name="describe")
 _app.add_typer(RunApp(**default_typer_kws), name="run")
 _app.add_typer(RepoApp(**default_typer_kws), name="repo")

--- a/cognite_toolkit/_cdf_tk/apps/__init__.py
+++ b/cognite_toolkit/_cdf_tk/apps/__init__.py
@@ -1,6 +1,7 @@
+from ._auth_app import AuthApp
 from ._landing_app import LandingApp
 from ._modules_app import ModulesApp
 from ._repo_app import RepoApp
 from ._run import RunApp
 
-__all__ = ["LandingApp", "ModulesApp", "RunApp", "RepoApp"]
+__all__ = ["LandingApp", "ModulesApp", "RunApp", "RepoApp", "AuthApp"]

--- a/cognite_toolkit/_cdf_tk/apps/_auth_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_auth_app.py
@@ -22,6 +22,8 @@ class AuthApp(typer.Typer):
     ) -> None:
         """Creates the authorization for a user/service principal to run the CDF Toolkit commands.
 
+        This will prompt the user to log in and optionally store the credentials in a .env file.
+
         Needed capabilities for bootstrapping:
         "projectsAcl": ["LIST", "READ"],
         "groupsAcl": ["LIST", "READ", "CREATE", "UPDATE", "DELETE"]

--- a/cognite_toolkit/_cdf_tk/apps/_auth_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_auth_app.py
@@ -4,6 +4,7 @@ import typer
 from rich import print
 
 from cognite_toolkit._cdf_tk.commands import AuthCommand
+from cognite_toolkit._cdf_tk.utils import CDFToolConfig
 
 
 class AuthApp(typer.Typer):
@@ -46,6 +47,31 @@ class AuthApp(typer.Typer):
 
     def verify(
         self,
+        ctx: typer.Context,
+        dry_run: Annotated[
+            bool,
+            typer.Option(
+                "--dry-run",
+                "-r",
+                help="Whether to do a dry-run. This means that no changes to CDF will be made.",
+            ),
+        ] = False,
+        verbose: Annotated[
+            bool,
+            typer.Option(
+                "--verbose",
+                "-v",
+                help="Turn on to get more verbose output when running the command",
+            ),
+        ] = False,
     ) -> None:
         """Verify that the current user/service principal has the required capabilities to run the CDF Toolkit commands."""
-        print("Auth verify")
+        cmd = AuthCommand()
+
+        cmd.run(
+            lambda: cmd.verify(
+                CDFToolConfig.from_context(ctx),
+                dry_run=dry_run,
+                verbose=verbose,
+            )
+        )

--- a/cognite_toolkit/_cdf_tk/apps/_auth_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_auth_app.py
@@ -38,7 +38,7 @@ class AuthApp(typer.Typer):
             ),
         ] = False,
     ) -> None:
-        """Creates the authorization for a user/service principal to run the CDF Toolkit commands.
+        """Sets the OIDC parameters required to authenticate and authorize the Cognite Toolkit in Cognite Data Fusion.
 
         This will prompt the user to log in and optionally store the credentials in a .env file.
 
@@ -71,11 +71,11 @@ class AuthApp(typer.Typer):
                 "--no-prompt",
                 "-np",
                 help="Whether to skip the prompt to continue. This is useful for CI/CD pipelines."
-                "If you passe this flag, the command will exit with 1 if the user/service principal does not have the required capabilities.",
+                "If you include this flag, the execution will stop if the user or service principal does not have the required capabilities.",
             ),
         ] = False,
     ) -> None:
-        """Verify that the current user/service principal has the required capabilities to run the CDF Toolkit commands."""
+        """Verify that the current user or service principal has the required capabilities to run the CDF Toolkit commands."""
         cmd = AuthCommand()
 
         cmd.run(

--- a/cognite_toolkit/_cdf_tk/apps/_auth_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_auth_app.py
@@ -21,12 +21,20 @@ class AuthApp(typer.Typer):
 
     def init(
         self,
+        no_verify: Annotated[
+            bool,
+            typer.Option(
+                "--no-verify",
+                "-v",
+                help="Whether to skip the verification of the capabilities after the initialization.",
+            ),
+        ] = False,
         dry_run: Annotated[
             bool,
             typer.Option(
                 "--dry-run",
                 "-r",
-                help="Whether to do a dry-run. This means that no changes to CDF will be made.",
+                help="If you verify, and you pass this flag no changes to CDF will be made.",
             ),
         ] = False,
     ) -> None:
@@ -41,6 +49,7 @@ class AuthApp(typer.Typer):
         cmd = AuthCommand()
         cmd.run(
             lambda: cmd.init(
+                no_verify=no_verify,
                 dry_run=dry_run,
             )
         )

--- a/cognite_toolkit/_cdf_tk/apps/_auth_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_auth_app.py
@@ -25,7 +25,7 @@ class AuthApp(typer.Typer):
             bool,
             typer.Option(
                 "--no-verify",
-                "-v",
+                "-nv",
                 help="Whether to skip the verification of the capabilities after the initialization.",
             ),
         ] = False,
@@ -65,6 +65,15 @@ class AuthApp(typer.Typer):
                 help="Whether to do a dry-run. This means that no changes to CDF will be made.",
             ),
         ] = False,
+        no_prompt: Annotated[
+            bool,
+            typer.Option(
+                "--no-prompt",
+                "-np",
+                help="Whether to skip the prompt to continue. This is useful for CI/CD pipelines."
+                "If you passe this flag, the command will exit with 1 if the user/service principal does not have the required capabilities.",
+            ),
+        ] = False,
     ) -> None:
         """Verify that the current user/service principal has the required capabilities to run the CDF Toolkit commands."""
         cmd = AuthCommand()
@@ -73,5 +82,6 @@ class AuthApp(typer.Typer):
             lambda: cmd.verify(
                 CDFToolConfig.from_context(ctx),
                 dry_run=dry_run,
+                no_prompt=no_prompt,
             )
         )

--- a/cognite_toolkit/_cdf_tk/apps/_auth_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_auth_app.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+import typer
+from rich import print
+
+
+class AuthApp(typer.Typer):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.callback(invoke_without_command=True)(self.main)
+        self.command()(self.init)
+        self.command()(self.verify)
+
+    def main(self, ctx: typer.Context) -> None:
+        """Commands to auth setup"""
+        if ctx.invoked_subcommand is None:
+            print("Use [bold yellow]cdf auth --help[/] for more information.")
+
+    def init(
+        self,
+        verbose: bool = typer.Option(False, "-v", "--verbose", help="Verbose output"),
+    ) -> None:
+        """Creates the authorization for a user/service principal to run the CDF Toolkit commands.
+
+        Needed capabilities for bootstrapping:
+        "projectsAcl": ["LIST", "READ"],
+        "groupsAcl": ["LIST", "READ", "CREATE", "UPDATE", "DELETE"]
+        """
+        print("Auth setup")
+
+    def verify(
+        self,
+    ) -> None:
+        """Verify that the current user/service principal has the required capabilities to run the CDF Toolkit commands."""
+        print("Auth verify")

--- a/cognite_toolkit/_cdf_tk/apps/_auth_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_auth_app.py
@@ -56,14 +56,6 @@ class AuthApp(typer.Typer):
                 help="Whether to do a dry-run. This means that no changes to CDF will be made.",
             ),
         ] = False,
-        verbose: Annotated[
-            bool,
-            typer.Option(
-                "--verbose",
-                "-v",
-                help="Turn on to get more verbose output when running the command",
-            ),
-        ] = False,
     ) -> None:
         """Verify that the current user/service principal has the required capabilities to run the CDF Toolkit commands."""
         cmd = AuthCommand()
@@ -72,6 +64,5 @@ class AuthApp(typer.Typer):
             lambda: cmd.verify(
                 CDFToolConfig.from_context(ctx),
                 dry_run=dry_run,
-                verbose=verbose,
             )
         )

--- a/cognite_toolkit/_cdf_tk/apps/_auth_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_auth_app.py
@@ -1,7 +1,9 @@
-from typing import Any
+from typing import Annotated, Any
 
 import typer
 from rich import print
+
+from cognite_toolkit._cdf_tk.commands import AuthCommand
 
 
 class AuthApp(typer.Typer):
@@ -18,7 +20,14 @@ class AuthApp(typer.Typer):
 
     def init(
         self,
-        verbose: bool = typer.Option(False, "-v", "--verbose", help="Verbose output"),
+        dry_run: Annotated[
+            bool,
+            typer.Option(
+                "--dry-run",
+                "-r",
+                help="Whether to do a dry-run. This means that no changes to CDF will be made.",
+            ),
+        ] = False,
     ) -> None:
         """Creates the authorization for a user/service principal to run the CDF Toolkit commands.
 
@@ -28,7 +37,12 @@ class AuthApp(typer.Typer):
         "projectsAcl": ["LIST", "READ"],
         "groupsAcl": ["LIST", "READ", "CREATE", "UPDATE", "DELETE"]
         """
-        print("Auth setup")
+        cmd = AuthCommand()
+        cmd.run(
+            lambda: cmd.init(
+                dry_run=dry_run,
+            )
+        )
 
     def verify(
         self,

--- a/cognite_toolkit/_cdf_tk/commands/_changes.py
+++ b/cognite_toolkit/_cdf_tk/commands/_changes.py
@@ -39,6 +39,7 @@ class ManualChange(Change):
     def instructions(self, files: set[Path]) -> str:
         return ""
 
+
 class AuthVerifySplit(AutomaticChange):
     """The `cdf auth verify` has been split into `cdf auth init` and `cdf auth verify`.
 
@@ -50,6 +51,7 @@ In addition, the `cdf auth verify` command will only verify the capabilities wit
     deprecated_from = Version("0.3.0a4")
     required_from = Version("0.3.0a4")
     has_file_changes = False
+
 
 class RenamedOrganizationDirInCDFToml(AutomaticChange):
     """In the cdf.toml file, the 'organization_dir' field in the 'cdf' section has been renamed to

--- a/cognite_toolkit/_cdf_tk/commands/_changes.py
+++ b/cognite_toolkit/_cdf_tk/commands/_changes.py
@@ -39,6 +39,17 @@ class ManualChange(Change):
     def instructions(self, files: set[Path]) -> str:
         return ""
 
+class AuthVerifySplit(AutomaticChange):
+    """The `cdf auth verify` has been split into `cdf auth init` and `cdf auth verify`.
+
+The `cdf auth init` command initializes the authorization for a user/service principal to run the CDF Toolkit commands,
+it will by default also verify the capabilities after the initialization. Thus it replaces the `cdf auth verify` command.
+In addition, the `cdf auth verify` command will only verify the capabilities without initializing the authorization.
+    """
+
+    deprecated_from = Version("0.3.0a4")
+    required_from = Version("0.3.0a4")
+    has_file_changes = False
 
 class RenamedOrganizationDirInCDFToml(AutomaticChange):
     """In the cdf.toml file, the 'organization_dir' field in the 'cdf' section has been renamed to

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -49,12 +49,23 @@ from cognite_toolkit._cdf_tk.tk_warnings import (
     MediumSeverityWarning,
     MissingCapabilityWarning,
 )
-from cognite_toolkit._cdf_tk.utils import AuthVariables, CDFToolConfig, safe_read
+from cognite_toolkit._cdf_tk.utils import AuthReader, AuthVariables, CDFToolConfig, safe_read
 
 from ._base import ToolkitCommand
 
 
 class AuthCommand(ToolkitCommand):
+    def init(self, dry_run: bool = False) -> None:
+        auth_vars = AuthVariables.from_env()
+
+        reader = AuthReader(auth_vars, False)
+        auth_vars = reader.from_user()
+        if reader.messages:
+            print("\n".join(reader.messages))
+        print("  [bold green]OK[/]")
+
+        # ToolGlobals.initialize_from_auth_variables(auth_vars)
+
     def execute(
         self,
         ToolGlobals: CDFToolConfig,
@@ -182,17 +193,18 @@ class AuthCommand(ToolkitCommand):
         self.check_function_service_status(ToolGlobals.toolkit_client, dry_run, has_added_capabilities)
 
     def initialize_client(self, ToolGlobals: CDFToolConfig, interactive: bool, verbose: bool) -> AuthVariables:
-        print("[bold]Checking current service principal/application and environment configurations...[/]")
-        auth_vars = AuthVariables.from_env()
-        if interactive:
-            result = auth_vars.from_interactive_with_validation(verbose)
-        else:
-            result = auth_vars.validate(verbose)
-        if result.messages:
-            print("\n".join(result.messages))
-        print("  [bold green]OK[/]")
-        ToolGlobals.initialize_from_auth_variables(auth_vars)
-        return auth_vars
+        raise NotImplementedError()
+        # print("[bold]Checking current service principal/application and environment configurations...[/]")
+        # auth_vars = AuthVariables.from_env()
+        # if interactive:
+        #     result = auth_vars.from_interactive_with_validation(verbose)
+        # else:
+        #     result = auth_vars.validate(verbose)
+        # if result.messages:
+        #     print("\n".join(result.messages))
+        # print("  [bold green]OK[/]")
+        # ToolGlobals.initialize_from_auth_variables(auth_vars)
+        # return auth_vars
 
     def check_has_any_access(self, ToolGlobals: CDFToolConfig) -> TokenInspection:
         print("Checking basic project configuration...")

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -59,12 +59,11 @@ class AuthCommand(ToolkitCommand):
         auth_vars = AuthVariables.from_env()
 
         reader = AuthReader(auth_vars, False)
-        auth_vars = reader.from_user()
+        _ = reader.from_user()
         if reader.messages:
-            print("\n".join(reader.messages))
+            for message in reader.messages:
+                self.warn(MediumSeverityWarning(message))
         print("  [bold green]OK[/]")
-
-        # ToolGlobals.initialize_from_auth_variables(auth_vars)
 
     def execute(
         self,

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -151,17 +151,9 @@ class AuthCommand(ToolkitCommand):
                         to_create.capabilities,  # type: ignore[arg-type]
                         project=cdf_project,
                     )
-                    removing = ToolGlobals.toolkit_client.iam.compare_capabilities(
-                        to_create.capabilities,  # type: ignore[arg-type]
-                        to_delete.capabilities,  # type: ignore[arg-type]
-                        project=cdf_project,
-                    )
-                    print(adding)
-                    print(removing)
-                    print(
-                        f"Would have updated group {to_create.name} "
-                        f"with {len(adding)} new capabilities and removing {len(removing)} capabilities."
-                    )
+                    adding = self._merge_capabilities(adding)
+                    capability_str = "capabilities" if len(adding) > 1 else "capability"
+                    print(f"Would have updated group {to_create.name} with {len(adding)} new {capability_str}.")
             elif to_create:
                 created = self.upsert_group(
                     ToolGlobals.toolkit_client, to_create, to_delete, principal_groups, True, cdf_project
@@ -579,8 +571,8 @@ class AuthCommand(ToolkitCommand):
             # We need to recalculate the missing capabilities as the missing capabilities for service principal
             # (if it has access to multiple groups) may be different from the ones missing in this group
             missing_capabilities = client.iam.compare_capabilities(
-                admin_group.capabilities or [],
                 update_group.capabilities or [],
+                admin_group.capabilities or [],
                 project=cdf_project,
             )
             missing_capabilities = self._merge_capabilities(missing_capabilities)
@@ -697,7 +689,7 @@ class AuthCommand(ToolkitCommand):
                     f"such that you don't have a duplicated group in your CDF project."
                 )
         print(
-            f"  [bold green]OK[/] - {action.capitalize()}d new group {created.name} with {len(created.capabilities or [])} capabilities."
+            f"  [bold green]OK[/] - {action.capitalize()}d new group {created.name}. It now has {len(created.capabilities or [])} capabilities."
         )
         return created
 

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -51,7 +51,7 @@ from ._base import ToolkitCommand
 
 
 class AuthCommand(ToolkitCommand):
-    def init(self, dry_run: bool = False) -> None:
+    def init(self, no_verify: bool = False, dry_run: bool = False) -> None:
         auth_vars = AuthVariables.from_env()
 
         reader = AuthReader(auth_vars, False)
@@ -59,9 +59,10 @@ class AuthCommand(ToolkitCommand):
         if reader.messages:
             for message in reader.messages:
                 self.warn(MediumSeverityWarning(message))
-        ToolGlobals = CDFToolConfig(skip_initialization=True)
-        ToolGlobals.initialize_from_auth_variables(auth_vars)
-        self.verify(ToolGlobals, dry_run)
+        if not no_verify:
+            ToolGlobals = CDFToolConfig(skip_initialization=True)
+            ToolGlobals.initialize_from_auth_variables(auth_vars)
+            self.verify(ToolGlobals, dry_run)
 
     def verify(
         self,

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -63,7 +63,14 @@ class AuthCommand(ToolkitCommand):
         if reader.messages:
             for message in reader.messages:
                 self.warn(MediumSeverityWarning(message))
-        print("  [bold green]OK[/]")
+
+    def verify(
+        self,
+        ToolGlobals: CDFToolConfig,
+        dry_run: bool,
+        verbose: bool,
+    ) -> None:
+        raise NotImplementedError()
 
     def execute(
         self,

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -68,7 +68,10 @@ class AuthCommand(ToolkitCommand):
         self,
         ToolGlobals: CDFToolConfig,
         dry_run: bool,
+        no_prompt: bool = False,
     ) -> None:
+        # More readable variable in the code
+        is_interactive = not no_prompt
         if ToolGlobals.project is None:
             raise AuthorizationError("CDF_PROJECT is not set.")
         cdf_project = ToolGlobals.project
@@ -113,7 +116,8 @@ class AuthCommand(ToolkitCommand):
                 expand=False,
             )
         )
-        Prompt.ask("Press enter key to continue...")
+        if is_interactive:
+            Prompt.ask("Press enter key to continue...")
 
         self.check_principal_groups(principal_groups, admin_write_group)
 
@@ -127,7 +131,12 @@ class AuthCommand(ToolkitCommand):
         )
         print("---------------------")
         has_added_capabilities = False
-        if missing_capabilities:
+        if missing_capabilities and not is_interactive:
+            raise AuthorizationError(
+                "The service principal/application does not have the required capabilities to run the Toolkit with "
+                "all resources supported by Toolkit"
+            )
+        elif missing_capabilities:
             to_create, to_delete = self.upsert_toolkit_group_interactive(
                 principal_groups, admin_write_group, ToolGlobals.toolkit_client, cdf_project
             )

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -133,8 +133,7 @@ class AuthCommand(ToolkitCommand):
         has_added_capabilities = False
         if missing_capabilities and not is_interactive:
             raise AuthorizationError(
-                "The service principal/application does not have the required capabilities to run the Toolkit with "
-                "all resources supported by Toolkit"
+                "The service principal/application does not have the required capabilities for the Toolkit to function properly"
             )
         elif missing_capabilities:
             to_create, to_delete = self.upsert_toolkit_group_interactive(

--- a/cognite_toolkit/_cdf_tk/loaders/_base_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_base_loaders.py
@@ -164,7 +164,7 @@ class ResourceLoader(
 
     @classmethod
     @abstractmethod
-    def get_required_capability(cls, items: T_CogniteResourceList) -> Capability | list[Capability]:
+    def get_required_capability(cls, items: T_CogniteResourceList | None) -> Capability | list[Capability]:
         raise NotImplementedError(f"get_required_capability must be implemented for {cls.__name__}.")
 
     @abstractmethod

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/asset_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/asset_loaders.py
@@ -49,15 +49,15 @@ class AssetLoader(ResourceLoader[str, AssetWrite, Asset, AssetWriteList, AssetLi
         return {"externalId": id}
 
     @classmethod
-    def get_required_capability(cls, items: AssetWriteList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: AssetWriteList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
-        data_set_ids = {item.data_set_id for item in items if item.data_set_id}
-        scope = (
-            capabilities.AssetsAcl.Scope.DataSet(list(data_set_ids))
-            if data_set_ids
-            else capabilities.AssetsAcl.Scope.All()
+        scope: capabilities.AssetsAcl.Scope.All | capabilities.AssetsAcl.Scope.DataSet = (
+            capabilities.AssetsAcl.Scope.All()
         )
+        if items:
+            if data_set_ids := {item.data_set_id for item in items if item.data_set_id}:
+                scope = capabilities.AssetsAcl.Scope.DataSet(list(data_set_ids))
 
         return capabilities.AssetsAcl(
             [capabilities.AssetsAcl.Action.Read, capabilities.AssetsAcl.Action.Write],

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/asset_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/asset_loaders.py
@@ -52,7 +52,7 @@ class AssetLoader(ResourceLoader[str, AssetWrite, Asset, AssetWriteList, AssetLi
     def get_required_capability(cls, items: AssetWriteList | None) -> Capability | list[Capability]:
         if not items and items is not None:
             return []
-        scope: capabilities.AssetsAcl.Scope.All | capabilities.AssetsAcl.Scope.DataSet = (
+        scope: capabilities.AssetsAcl.Scope.All | capabilities.AssetsAcl.Scope.DataSet = (  # type: ignore[valid-type]
             capabilities.AssetsAcl.Scope.All()
         )
         if items:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/auth_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/auth_loaders.py
@@ -102,10 +102,16 @@ class GroupLoader(ResourceLoader[str, GroupWrite, Group, GroupWriteList, GroupLi
 
     @classmethod
     def get_required_capability(cls, items: GroupWriteList | None) -> Capability | list[Capability]:
-        if not items:
+        if not items and items is not None:
             return []
         return GroupsAcl(
-            [GroupsAcl.Action.Read, GroupsAcl.Action.List, GroupsAcl.Action.Create, GroupsAcl.Action.Delete],
+            [
+                GroupsAcl.Action.Read,
+                GroupsAcl.Action.List,
+                GroupsAcl.Action.Create,
+                GroupsAcl.Action.Delete,
+                GroupsAcl.Action.Update,
+            ],
             GroupsAcl.Scope.All(),
         )
 

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/auth_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/auth_loaders.py
@@ -101,7 +101,7 @@ class GroupLoader(ResourceLoader[str, GroupWrite, Group, GroupWriteList, GroupLi
         return cls(ToolGlobals.toolkit_client, build_dir)
 
     @classmethod
-    def get_required_capability(cls, items: GroupWriteList) -> Capability | list[Capability]:
+    def get_required_capability(cls, items: GroupWriteList | None) -> Capability | list[Capability]:
         if not items:
             return []
         return GroupsAcl(
@@ -417,7 +417,7 @@ class SecurityCategoryLoader(
         return {"name": id}
 
     @classmethod
-    def get_required_capability(cls, items: SecurityCategoryWriteList) -> Capability | list[Capability]:
+    def get_required_capability(cls, items: SecurityCategoryWriteList | None) -> Capability | list[Capability]:
         if not items:
             return []
         return SecurityCategoriesAcl(

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/auth_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/auth_loaders.py
@@ -418,7 +418,7 @@ class SecurityCategoryLoader(
 
     @classmethod
     def get_required_capability(cls, items: SecurityCategoryWriteList | None) -> Capability | list[Capability]:
-        if not items:
+        if not items and items is not None:
             return []
         return SecurityCategoriesAcl(
             actions=[

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/data_organization_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/data_organization_loaders.py
@@ -68,7 +68,7 @@ class DataSetsLoader(ResourceLoader[str, DataSetWrite, DataSet, DataSetWriteList
         if not items and items is not None:
             return []
         return DataSetsAcl(
-            [DataSetsAcl.Action.Read, DataSetsAcl.Action.Write],
+            [DataSetsAcl.Action.Read, DataSetsAcl.Action.Write, DataSetsAcl.Action.Owner],
             DataSetsAcl.Scope.All(),
         )
 

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/data_organization_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/data_organization_loaders.py
@@ -183,7 +183,7 @@ class LabelLoader(
     def get_required_capability(cls, items: LabelDefinitionWriteList | None) -> Capability | list[Capability]:
         if not items and items is not None:
             return []
-        scope: capabilities.LabelsAcl.Scope.All | capabilities.LabelsAcl.Scope.DataSet = (
+        scope: capabilities.LabelsAcl.Scope.All | capabilities.LabelsAcl.Scope.DataSet = (  # type: ignore[valid-type]
             capabilities.LabelsAcl.Scope.All()
         )
         if items:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/data_organization_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/data_organization_loaders.py
@@ -65,7 +65,7 @@ class DataSetsLoader(ResourceLoader[str, DataSetWrite, DataSet, DataSetWriteList
 
     @classmethod
     def get_required_capability(cls, items: DataSetWriteList | None) -> Capability | list[Capability]:
-        if not items:
+        if not items and items is not None:
             return []
         return DataSetsAcl(
             [DataSetsAcl.Action.Read, DataSetsAcl.Action.Write],

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/data_organization_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/data_organization_loaders.py
@@ -64,7 +64,7 @@ class DataSetsLoader(ResourceLoader[str, DataSetWrite, DataSet, DataSetWriteList
     _doc_url = "Data-sets/operation/createDataSets"
 
     @classmethod
-    def get_required_capability(cls, items: DataSetWriteList) -> Capability | list[Capability]:
+    def get_required_capability(cls, items: DataSetWriteList | None) -> Capability | list[Capability]:
         if not items:
             return []
         return DataSetsAcl(
@@ -180,15 +180,15 @@ class LabelLoader(
         return {"externalId": id}
 
     @classmethod
-    def get_required_capability(cls, items: LabelDefinitionWriteList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: LabelDefinitionWriteList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
-        data_set_ids = {item.data_set_id for item in items if item.data_set_id}
-        scope = (
-            capabilities.LabelsAcl.Scope.DataSet(list(data_set_ids))
-            if data_set_ids
-            else capabilities.LabelsAcl.Scope.All()
+        scope: capabilities.LabelsAcl.Scope.All | capabilities.LabelsAcl.Scope.DataSet = (
+            capabilities.LabelsAcl.Scope.All()
         )
+        if items:
+            if data_set_ids := {item.data_set_id for item in items if item.data_set_id}:
+                scope = capabilities.LabelsAcl.Scope.DataSet(list(data_set_ids))
 
         return capabilities.LabelsAcl(
             [capabilities.LabelsAcl.Action.Read, capabilities.LabelsAcl.Action.Write],

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/datamodel_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/datamodel_loaders.py
@@ -113,8 +113,8 @@ class SpaceLoader(ResourceContainerLoader[str, SpaceApply, Space, SpaceApplyList
         return "spaces"
 
     @classmethod
-    def get_required_capability(cls, items: SpaceApplyList) -> list[Capability] | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: SpaceApplyList | None) -> list[Capability] | list[Capability]:
+        if not items and items is not None:
             return []
         return [
             DataModelsAcl(
@@ -225,12 +225,14 @@ class ContainerLoader(
         return "containers"
 
     @classmethod
-    def get_required_capability(cls, items: ContainerApplyList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: ContainerApplyList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
         return DataModelsAcl(
             [DataModelsAcl.Action.Read, DataModelsAcl.Action.Write],
-            DataModelsAcl.Scope.SpaceID(list({item.space for item in items})),
+            DataModelsAcl.Scope.SpaceID(list({item.space for item in items}))
+            if items is not None
+            else DataModelsAcl.Scope.All(),
         )
 
     @classmethod
@@ -440,12 +442,14 @@ class ViewLoader(ResourceLoader[ViewId, ViewApply, View, ViewApplyList, ViewList
         return "views"
 
     @classmethod
-    def get_required_capability(cls, items: ViewApplyList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: ViewApplyList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
         return DataModelsAcl(
             [DataModelsAcl.Action.Read, DataModelsAcl.Action.Write],
-            DataModelsAcl.Scope.SpaceID(list({item.space for item in items})),
+            DataModelsAcl.Scope.SpaceID(list({item.space for item in items}))
+            if items is not None
+            else DataModelsAcl.Scope.All(),
         )
 
     @classmethod
@@ -670,12 +674,14 @@ class DataModelLoader(ResourceLoader[DataModelId, DataModelApply, DataModel, Dat
         return "data models"
 
     @classmethod
-    def get_required_capability(cls, items: DataModelApplyList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: DataModelApplyList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
         return DataModelsAcl(
             [DataModelsAcl.Action.Read, DataModelsAcl.Action.Write],
-            DataModelsAcl.Scope.SpaceID(list({item.space for item in items})),
+            DataModelsAcl.Scope.SpaceID(list({item.space for item in items}))
+            if items is not None
+            else DataModelsAcl.Scope.All(),
         )
 
     @classmethod
@@ -809,12 +815,14 @@ class NodeLoader(ResourceContainerLoader[NodeId, NodeApply, Node, NodeApplyListW
         return "nodes"
 
     @classmethod
-    def get_required_capability(cls, items: NodeApplyListWithCall) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: NodeApplyListWithCall | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
         return DataModelInstancesAcl(
             [DataModelInstancesAcl.Action.Read, DataModelInstancesAcl.Action.Write],
-            DataModelInstancesAcl.Scope.SpaceID(list({item.space for item in items})),
+            DataModelInstancesAcl.Scope.SpaceID(list({item.space for item in items}))
+            if items is not None
+            else DataModelInstancesAcl.Scope.All(),
         )
 
     @classmethod
@@ -1002,12 +1010,14 @@ class GraphQLLoader(
         return id.dump(include_type=False)
 
     @classmethod
-    def get_required_capability(cls, items: GraphQLDataModelWriteList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: GraphQLDataModelWriteList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
         return DataModelsAcl(
             [DataModelsAcl.Action.Read, DataModelsAcl.Action.Write],
-            DataModelsAcl.Scope.SpaceID(list({item.space for item in items})),
+            DataModelsAcl.Scope.SpaceID(list({item.space for item in items}))
+            if items is not None
+            else DataModelsAcl.Scope.All(),
         )
 
     @classmethod

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/extraction_pipeline_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/extraction_pipeline_loaders.py
@@ -80,7 +80,7 @@ class ExtractionPipelineLoader(
     def get_required_capability(cls, items: ExtractionPipelineWriteList | None) -> Capability | list[Capability]:
         if not items:
             return []
-        scope: ExtractionPipelinesAcl.Scope.All | ExtractionPipelinesAcl.Scope.DataSet = (
+        scope: ExtractionPipelinesAcl.Scope.All | ExtractionPipelinesAcl.Scope.DataSet = (  # type: ignore[valid-type]
             ExtractionPipelinesAcl.Scope.All()
         )
         if items is not None:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/extraction_pipeline_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/extraction_pipeline_loaders.py
@@ -26,6 +26,7 @@ from cognite.client.data_classes import (
 )
 from cognite.client.data_classes.capabilities import (
     Capability,
+    ExtractionConfigsAcl,
     ExtractionPipelinesAcl,
 )
 from cognite.client.data_classes.extractionpipelines import (
@@ -226,9 +227,15 @@ class ExtractionPipelineConfigLoader(
 
     @classmethod
     def get_required_capability(cls, items: ExtractionPipelineConfigWriteList | None) -> list[Capability]:
-        # Access for extraction pipeline configs is checked by the extraction pipeline that is deployed
-        # first, so we don't need to check for any capabilities here.
-        return []
+        if not items and items is not None:
+            return []
+
+        return [
+            ExtractionConfigsAcl(
+                [ExtractionConfigsAcl.Action.Read, ExtractionConfigsAcl.Action.Write],
+                ExtractionConfigsAcl.Scope.All(),
+            )
+        ]
 
     @classmethod
     def get_id(cls, item: ExtractionPipelineConfig | ExtractionPipelineConfigWrite | dict) -> str:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/extraction_pipeline_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/extraction_pipeline_loaders.py
@@ -77,16 +77,15 @@ class ExtractionPipelineLoader(
     _doc_url = "Extraction-Pipelines/operation/createExtPipes"
 
     @classmethod
-    def get_required_capability(cls, items: ExtractionPipelineWriteList) -> Capability | list[Capability]:
+    def get_required_capability(cls, items: ExtractionPipelineWriteList | None) -> Capability | list[Capability]:
         if not items:
             return []
-        data_set_id = {item.data_set_id for item in items if item.data_set_id}
-
-        scope = (
-            ExtractionPipelinesAcl.Scope.DataSet(list(data_set_id))
-            if data_set_id
-            else ExtractionPipelinesAcl.Scope.All()
+        scope: ExtractionPipelinesAcl.Scope.All | ExtractionPipelinesAcl.Scope.DataSet = (
+            ExtractionPipelinesAcl.Scope.All()
         )
+        if items is not None:
+            if data_set_id := {item.data_set_id for item in items if item.data_set_id}:
+                scope = ExtractionPipelinesAcl.Scope.DataSet(list(data_set_id))
 
         return ExtractionPipelinesAcl(
             [ExtractionPipelinesAcl.Action.Read, ExtractionPipelinesAcl.Action.Write],
@@ -226,7 +225,7 @@ class ExtractionPipelineConfigLoader(
         return "extraction_pipeline.config"
 
     @classmethod
-    def get_required_capability(cls, items: ExtractionPipelineConfigWriteList) -> list[Capability]:
+    def get_required_capability(cls, items: ExtractionPipelineConfigWriteList | None) -> list[Capability]:
         # Access for extraction pipeline configs is checked by the extraction pipeline that is deployed
         # first, so we don't need to check for any capabilities here.
         return []

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/extraction_pipeline_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/extraction_pipeline_loaders.py
@@ -78,7 +78,7 @@ class ExtractionPipelineLoader(
 
     @classmethod
     def get_required_capability(cls, items: ExtractionPipelineWriteList | None) -> Capability | list[Capability]:
-        if not items:
+        if not items and items is not None:
             return []
         scope: ExtractionPipelinesAcl.Scope.All | ExtractionPipelinesAcl.Scope.DataSet = (  # type: ignore[valid-type]
             ExtractionPipelinesAcl.Scope.All()

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/file_loader.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/file_loader.py
@@ -71,12 +71,13 @@ class FileMetadataLoader(
         return "file_metadata"
 
     @classmethod
-    def get_required_capability(cls, items: FileMetadataWriteList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: FileMetadataWriteList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
-        data_set_ids = {item.data_set_id for item in items if item.data_set_id}
-
-        scope = FilesAcl.Scope.DataSet(list(data_set_ids)) if data_set_ids else FilesAcl.Scope.All()
+        scope: FilesAcl.Scope.All | FilesAcl.Scope.DataSet = FilesAcl.Scope.All()
+        if items:
+            if data_set_ids := {item.data_set_id for item in items if item.data_set_id}:
+                scope = FilesAcl.Scope.DataSet(list(data_set_ids))
 
         return FilesAcl([FilesAcl.Action.Read, FilesAcl.Action.Write], scope)  # type: ignore[arg-type]
 

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/file_loader.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/file_loader.py
@@ -74,7 +74,7 @@ class FileMetadataLoader(
     def get_required_capability(cls, items: FileMetadataWriteList | None) -> Capability | list[Capability]:
         if not items and items is not None:
             return []
-        scope: FilesAcl.Scope.All | FilesAcl.Scope.DataSet = FilesAcl.Scope.All()
+        scope: FilesAcl.Scope.All | FilesAcl.Scope.DataSet = FilesAcl.Scope.All()  # type: ignore[valid-type]
         if items:
             if data_set_ids := {item.data_set_id for item in items if item.data_set_id}:
                 scope = FilesAcl.Scope.DataSet(list(data_set_ids))

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/function_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/function_loaders.py
@@ -78,8 +78,8 @@ class FunctionLoader(ResourceLoader[str, FunctionWrite, Function, FunctionWriteL
         secret_hash = "cdf-toolkit-secret-hash"
 
     @classmethod
-    def get_required_capability(cls, items: FunctionWriteList) -> list[Capability] | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: FunctionWriteList | None) -> list[Capability] | list[Capability]:
+        if not items and items is not None:
             return []
         return [
             FunctionsAcl([FunctionsAcl.Action.Read, FunctionsAcl.Action.Write], FunctionsAcl.Scope.All()),
@@ -279,8 +279,8 @@ class FunctionScheduleLoader(
         return "function.schedules"
 
     @classmethod
-    def get_required_capability(cls, items: FunctionScheduleWriteList) -> list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: FunctionScheduleWriteList | None) -> list[Capability]:
+        if not items and items is not None:
             return []
         return [
             FunctionsAcl([FunctionsAcl.Action.Read, FunctionsAcl.Action.Write], FunctionsAcl.Scope.All()),

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/location_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/location_loaders.py
@@ -41,8 +41,8 @@ class LocationFilterLoader(
     subfilter_names = ("assets", "events", "files", "timeseries", "sequences")
 
     @classmethod
-    def get_required_capability(cls, items: LocationFilterWriteList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: LocationFilterWriteList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
         # Todo: Specify space ID scopes:
         return LocationFiltersAcl(

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/raw_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/raw_loaders.py
@@ -71,7 +71,7 @@ class RawDatabaseLoader(
 
             scope = RawAcl.Scope.Table(dict(tables_by_database)) if tables_by_database else RawAcl.Scope.All()  # type: ignore[arg-type]
 
-        return RawAcl([RawAcl.Action.Read, RawAcl.Action.Write], scope)  # type: ignore[arg-type]
+        return RawAcl([RawAcl.Action.Read, RawAcl.Action.Write, RawAcl.Action.List], scope)  # type: ignore[arg-type]
 
     @classmethod
     def get_id(cls, item: RawDatabaseTable | dict) -> RawDatabaseTable:
@@ -189,7 +189,7 @@ class RawTableLoader(
 
             scope = RawAcl.Scope.Table(dict(tables_by_database)) if tables_by_database else RawAcl.Scope.All()  # type: ignore[arg-type]
 
-        return RawAcl([RawAcl.Action.Read, RawAcl.Action.Write], scope)  # type: ignore[arg-type]
+        return RawAcl([RawAcl.Action.Read, RawAcl.Action.Write, RawAcl.Action.List], scope)  # type: ignore[arg-type]
 
     @classmethod
     def get_id(cls, item: RawDatabaseTable | dict) -> RawDatabaseTable:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/raw_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/raw_loaders.py
@@ -60,14 +60,16 @@ class RawDatabaseLoader(
         return "raw.databases"
 
     @classmethod
-    def get_required_capability(cls, items: RawTableList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: RawTableList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
-        tables_by_database = defaultdict(list)
-        for item in items:
-            tables_by_database[item.db_name].append(item.table_name)
+        scope: RawTableList.All | RawTableList.Table = RawTableList.All()
+        if items:
+            tables_by_database = defaultdict(list)
+            for item in items:
+                tables_by_database[item.db_name].append(item.table_name)
 
-        scope = RawAcl.Scope.Table(dict(tables_by_database)) if tables_by_database else RawAcl.Scope.All()  # type: ignore[arg-type]
+            scope = RawAcl.Scope.Table(dict(tables_by_database)) if tables_by_database else RawAcl.Scope.All()  # type: ignore[arg-type]
 
         return RawAcl([RawAcl.Action.Read, RawAcl.Action.Write], scope)  # type: ignore[arg-type]
 
@@ -176,14 +178,16 @@ class RawTableLoader(
         return "raw.tables"
 
     @classmethod
-    def get_required_capability(cls, items: RawTableList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: RawTableList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
-        tables_by_database = defaultdict(list)
-        for item in items:
-            tables_by_database[item.db_name].append(item.table_name)
+        scope: RawTableList.All | RawTableList.Table = RawTableList.All()
+        if items:
+            tables_by_database = defaultdict(list)
+            for item in items:
+                tables_by_database[item.db_name].append(item.table_name)
 
-        scope = RawAcl.Scope.Table(dict(tables_by_database)) if tables_by_database else RawAcl.Scope.All()  # type: ignore[arg-type]
+            scope = RawAcl.Scope.Table(dict(tables_by_database)) if tables_by_database else RawAcl.Scope.All()  # type: ignore[arg-type]
 
         return RawAcl([RawAcl.Action.Read, RawAcl.Action.Write], scope)  # type: ignore[arg-type]
 

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/raw_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/raw_loaders.py
@@ -63,7 +63,7 @@ class RawDatabaseLoader(
     def get_required_capability(cls, items: RawTableList | None) -> Capability | list[Capability]:
         if not items and items is not None:
             return []
-        scope: RawTableList.All | RawTableList.Table = RawTableList.All()
+        scope: RawAcl.Scope.All | RawAcl.Scope.Table = RawAcl.Scope.All()  # type: ignore[valid-type]
         if items:
             tables_by_database = defaultdict(list)
             for item in items:
@@ -181,7 +181,7 @@ class RawTableLoader(
     def get_required_capability(cls, items: RawTableList | None) -> Capability | list[Capability]:
         if not items and items is not None:
             return []
-        scope: RawTableList.All | RawTableList.Table = RawTableList.All()
+        scope: RawAcl.Scope.All | RawAcl.Scope.Table = RawAcl.Scope.All()  # type: ignore[valid-type]
         if items:
             tables_by_database = defaultdict(list)
             for item in items:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/robotics_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/robotics_loaders.py
@@ -124,8 +124,8 @@ class RoboticFrameLoader(ResourceLoader[str, FrameWrite, Frame, FrameWriteList, 
         return {"externalId": id}
 
     @classmethod
-    def get_required_capability(cls, items: FrameWriteList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: FrameWriteList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
         return capabilities.RoboticsAcl(
             [

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/robotics_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/robotics_loaders.py
@@ -63,8 +63,8 @@ class RoboticMapLoader(ResourceLoader[str, MapWrite, Map, MapWriteList, MapList]
         return {"externalId": id}
 
     @classmethod
-    def get_required_capability(cls, items: MapWriteList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: MapWriteList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
         return capabilities.RoboticsAcl(
             [
@@ -185,8 +185,8 @@ class RoboticLocationLoader(ResourceLoader[str, LocationWrite, Location, Locatio
         return {"externalId": id}
 
     @classmethod
-    def get_required_capability(cls, items: LocationWriteList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: LocationWriteList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
         return capabilities.RoboticsAcl(
             [
@@ -250,8 +250,8 @@ class RoboticsDataPostProcessingLoader(
         return {"externalId": id}
 
     @classmethod
-    def get_required_capability(cls, items: DataPostProcessingWriteList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: DataPostProcessingWriteList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
         return capabilities.RoboticsAcl(
             [
@@ -325,8 +325,8 @@ class RobotCapabilityLoader(
         return {"externalId": id}
 
     @classmethod
-    def get_required_capability(cls, items: RobotCapabilityWriteList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: RobotCapabilityWriteList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
         return capabilities.RoboticsAcl(
             [

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/three_d_model_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/three_d_model_loaders.py
@@ -54,7 +54,7 @@ class ThreeDModelLoader(
     def get_required_capability(cls, items: ThreeDModelWriteList | None) -> Capability | list[Capability]:
         if not items and items is not None:
             return []
-        scope: capabilities.ThreeDAcl.Scope.All | capabilities.ThreeDAcl.Scope.DataSet = (
+        scope: capabilities.ThreeDAcl.Scope.All | capabilities.ThreeDAcl.Scope.DataSet = (  # type: ignore[valid-type]
             capabilities.ThreeDAcl.Scope.All()
         )
         if items:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/three_d_model_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/three_d_model_loaders.py
@@ -54,12 +54,12 @@ class ThreeDModelLoader(
     def get_required_capability(cls, items: ThreeDModelWriteList | None) -> Capability | list[Capability]:
         if not items and items is not None:
             return []
-        data_set_ids = {item.data_set_id for item in items or [] if item.data_set_id}
-        scope = (
-            capabilities.ThreeDAcl.Scope.DataSet(list(data_set_ids))
-            if data_set_ids
-            else capabilities.ThreeDAcl.Scope.All()
+        scope: capabilities.ThreeDAcl.Scope.All | capabilities.ThreeDAcl.Scope.DataSet = (
+            capabilities.ThreeDAcl.Scope.All()
         )
+        if items:
+            if data_set_ids := {item.data_set_id for item in items or [] if item.data_set_id}:
+                scope = capabilities.ThreeDAcl.Scope.DataSet(list(data_set_ids))
 
         return capabilities.ThreeDAcl(
             [

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/timeseries_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/timeseries_loaders.py
@@ -84,7 +84,7 @@ class TimeSeriesLoader(ResourceContainerLoader[str, TimeSeriesWrite, TimeSeries,
     def get_required_capability(cls, items: TimeSeriesWriteList | None) -> Capability | list[Capability]:
         if not items and items is not None:
             return []
-        scope: TimeSeriesAcl.Scope.All | TimeSeriesAcl.Scope.DataSet = TimeSeriesAcl.Scope.All()
+        scope: TimeSeriesAcl.Scope.All | TimeSeriesAcl.Scope.DataSet = TimeSeriesAcl.Scope.All()  # type: ignore[valid-type]
         if items:
             if dataset_ids := {item.data_set_id for item in items if item.data_set_id}:
                 scope = TimeSeriesAcl.Scope.DataSet(list(dataset_ids))
@@ -294,7 +294,7 @@ class DatapointSubscriptionLoader(
     def get_required_capability(cls, items: DatapointSubscriptionWriteList | None) -> Capability | list[Capability]:
         if not items and items is not None:
             return []
-        scope: TimeSeriesSubscriptionsAcl.Scope.All | TimeSeriesSubscriptionsAcl.Scope.DataSet = (
+        scope: TimeSeriesSubscriptionsAcl.Scope.All | TimeSeriesSubscriptionsAcl.Scope.DataSet = (  # type: ignore[valid-type]
             TimeSeriesSubscriptionsAcl.Scope.All()
         )
         if items:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/timeseries_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/timeseries_loaders.py
@@ -81,13 +81,13 @@ class TimeSeriesLoader(ResourceContainerLoader[str, TimeSeriesWrite, TimeSeries,
     _doc_url = "Time-series/operation/postTimeSeries"
 
     @classmethod
-    def get_required_capability(cls, items: TimeSeriesWriteList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: TimeSeriesWriteList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
-
-        dataset_ids = {item.data_set_id for item in items if item.data_set_id}
-
-        scope = TimeSeriesAcl.Scope.DataSet(list(dataset_ids)) if dataset_ids else TimeSeriesAcl.Scope.All()
+        scope: TimeSeriesAcl.Scope.All | TimeSeriesAcl.Scope.DataSet = TimeSeriesAcl.Scope.All()
+        if items:
+            if dataset_ids := {item.data_set_id for item in items if item.data_set_id}:
+                scope = TimeSeriesAcl.Scope.DataSet(list(dataset_ids))
 
         return TimeSeriesAcl(
             [TimeSeriesAcl.Action.Read, TimeSeriesAcl.Action.Write],
@@ -291,15 +291,16 @@ class DatapointSubscriptionLoader(
             yield TimeSeriesLoader, timeseries_id
 
     @classmethod
-    def get_required_capability(cls, items: DatapointSubscriptionWriteList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: DatapointSubscriptionWriteList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
-        data_set_ids = {item.data_set_id for item in items if item.data_set_id}
-        scope = (
-            TimeSeriesSubscriptionsAcl.Scope.DataSet(list(data_set_ids))
-            if data_set_ids
-            else TimeSeriesSubscriptionsAcl.Scope.All()
+        scope: TimeSeriesSubscriptionsAcl.Scope.All | TimeSeriesSubscriptionsAcl.Scope.DataSet = (
+            TimeSeriesSubscriptionsAcl.Scope.All()
         )
+        if items:
+            if data_set_ids := {item.data_set_id for item in items if item.data_set_id}:
+                scope = TimeSeriesSubscriptionsAcl.Scope.DataSet(list(data_set_ids))
+
         return TimeSeriesSubscriptionsAcl(
             [TimeSeriesSubscriptionsAcl.Action.Read, TimeSeriesSubscriptionsAcl.Action.Write],
             scope,  # type: ignore[arg-type]

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/transformation_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/transformation_loaders.py
@@ -99,12 +99,13 @@ class TransformationLoader(
     _doc_url = "Transformations/operation/createTransformations"
 
     @classmethod
-    def get_required_capability(cls, items: TransformationWriteList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: TransformationWriteList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
-        data_set_ids = {item.data_set_id for item in items if item.data_set_id}
-
-        scope = TransformationsAcl.Scope.DataSet(list(data_set_ids)) if data_set_ids else TransformationsAcl.Scope.All()
+        scope: TransformationsAcl.Scope.All | TransformationsAcl.Scope.DataSet = TransformationsAcl.Scope.All()
+        if items is not None:
+            if data_set_ids := {item.data_set_id for item in items if item.data_set_id}:
+                scope = TransformationsAcl.Scope.DataSet(list(data_set_ids))
 
         return TransformationsAcl(
             [TransformationsAcl.Action.Read, TransformationsAcl.Action.Write],
@@ -340,7 +341,7 @@ class TransformationScheduleLoader(
         return "transformation.schedules"
 
     @classmethod
-    def get_required_capability(cls, items: TransformationScheduleWriteList) -> list[Capability]:
+    def get_required_capability(cls, items: TransformationScheduleWriteList | None) -> list[Capability]:
         # Access for transformations schedules is checked by the transformation that is deployed
         # first, so we don't need to check for any capabilities here.
         return []
@@ -446,7 +447,9 @@ class TransformationNotificationLoader(
         }
 
     @classmethod
-    def get_required_capability(cls, items: TransformationNotificationWriteList) -> Capability | list[Capability]:
+    def get_required_capability(
+        cls, items: TransformationNotificationWriteList | None
+    ) -> Capability | list[Capability]:
         # Access for transformation notification is checked by the transformation that is deployed
         # first, so we don't need to check for any capabilities here.
         return []

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/transformation_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/transformation_loaders.py
@@ -102,7 +102,7 @@ class TransformationLoader(
     def get_required_capability(cls, items: TransformationWriteList | None) -> Capability | list[Capability]:
         if not items and items is not None:
             return []
-        scope: TransformationsAcl.Scope.All | TransformationsAcl.Scope.DataSet = TransformationsAcl.Scope.All()
+        scope: TransformationsAcl.Scope.All | TransformationsAcl.Scope.DataSet = TransformationsAcl.Scope.All()  # type: ignore[valid-type]
         if items is not None:
             if data_set_ids := {item.data_set_id for item in items if item.data_set_id}:
                 scope = TransformationsAcl.Scope.DataSet(list(data_set_ids))

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/workflow_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/workflow_loaders.py
@@ -80,8 +80,8 @@ class WorkflowLoader(ResourceLoader[str, WorkflowUpsert, Workflow, WorkflowUpser
     _doc_url = "Workflows/operation/CreateOrUpdateWorkflow"
 
     @classmethod
-    def get_required_capability(cls, items: WorkflowUpsertList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: WorkflowUpsertList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
         return WorkflowOrchestrationAcl(
             [WorkflowOrchestrationAcl.Action.Read, WorkflowOrchestrationAcl.Action.Write],
@@ -162,8 +162,8 @@ class WorkflowVersionLoader(
         return "workflow.versions"
 
     @classmethod
-    def get_required_capability(cls, items: WorkflowVersionUpsertList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: WorkflowVersionUpsertList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
         return WorkflowOrchestrationAcl(
             [WorkflowOrchestrationAcl.Action.Read, WorkflowOrchestrationAcl.Action.Write],
@@ -297,8 +297,8 @@ class WorkflowTriggerLoader(
         return {"externalId": id}
 
     @classmethod
-    def get_required_capability(cls, items: WorkflowTriggerCreateList) -> Capability | list[Capability]:
-        if not items:
+    def get_required_capability(cls, items: WorkflowTriggerCreateList | None) -> Capability | list[Capability]:
+        if not items and items is not None:
             return []
         return WorkflowOrchestrationAcl(
             [WorkflowOrchestrationAcl.Action.Read, WorkflowOrchestrationAcl.Action.Write],

--- a/cognite_toolkit/_cdf_tk/utils.py
+++ b/cognite_toolkit/_cdf_tk/utils.py
@@ -338,14 +338,15 @@ class AuthReader:
         if Path(".env").exists():
             existing = Path(".env").read_text()
             if existing == new_env_file:
-                print("No changes to .env file.")
-            print(MediumSeverityWarning(".env file already exists").get_message())
+                print("Identical '.env' file already exist.")
+                return auth_vars
+            MediumSeverityWarning("'.env' file already exists").print_warning()
             filename = next(f"backup_{no}.env" for no in itertools.count() if not Path(f"backup_{no}.env").exists())
 
             if questionary.confirm(
-                f"Do you want to overwrite the existing .env file? the existing will be renamed to {filename}",
+                f"Do you want to overwrite the existing '.env' file? The existing will be renamed to {filename}",
                 default=False,
-            ):
+            ).ask():
                 shutil.move(".env", filename)
                 Path(".env").write_text(new_env_file)
         elif questionary.confirm("Do you want to save these to .env file for next time?", default=True).ask():

--- a/poetry.lock
+++ b/poetry.lock
@@ -54,13 +54,13 @@ test = ["dateparser (==1.*)", "pre-commit", "pytest", "pytest-cov", "pytest-mock
 
 [[package]]
 name = "azure-core"
-version = "1.30.2"
+version = "1.31.0"
 description = "Microsoft Azure Core Library for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "azure-core-1.30.2.tar.gz", hash = "sha256:a14dc210efcd608821aa472d9fb8e8d035d29b68993819147bc290a8ac224472"},
-    {file = "azure_core-1.30.2-py3-none-any.whl", hash = "sha256:cf019c1ca832e96274ae85abd3d9f752397194d9fea3b41487290562ac8abe4a"},
+    {file = "azure_core-1.31.0-py3-none-any.whl", hash = "sha256:22954de3777e0250029360ef31d80448ef1be13b80a459bff80ba7073379e2cd"},
+    {file = "azure_core-1.31.0.tar.gz", hash = "sha256:656a0dd61e1869b1506b7c6a3b31d62f15984b1a573d6326f6aa2f3e4123284b"},
 ]
 
 [package.dependencies]
@@ -379,20 +379,20 @@ python-json-logger = ">=2.0.7,<3.0.0"
 
 [[package]]
 name = "cognite-sdk"
-version = "7.60.0"
+version = "7.60.4"
 description = "Cognite Python SDK"
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "cognite_sdk-7.60.0-py3-none-any.whl", hash = "sha256:1c637da8a5536a365532c99650ab51803278632596401e9f7d54d03e3dda5aed"},
-    {file = "cognite_sdk-7.60.0.tar.gz", hash = "sha256:3eda19a582696884b5b83c224ecb5901b98da7575562e814d350648b4ad1d3c0"},
+    {file = "cognite_sdk-7.60.4-py3-none-any.whl", hash = "sha256:e178e5722f526fa13e72d7ba8a666294696dc31b726628fcd6cd33be72037b49"},
+    {file = "cognite_sdk-7.60.4.tar.gz", hash = "sha256:78462ee1d8be57e7a3a4d6327d931e6ff0420462a0eb53595209bb47a180b15f"},
 ]
 
 [package.dependencies]
 msal = ">=1,<2"
 pandas = {version = ">=2.1", optional = true, markers = "python_version >= \"3.9\" and (extra == \"pandas\" or extra == \"all\")"}
 protobuf = ">=4"
-requests = ">=2,<3"
+requests = ">=2.27,<3.0"
 requests_oauthlib = ">=1,<2"
 typing_extensions = ">=4"
 
@@ -769,6 +769,7 @@ files = [
     {file = "fastparquet-2024.5.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5626fc72204001b7e82fedb4b02174ecb4e2d4143b38b4ea8d2f9eb65f6b000e"},
     {file = "fastparquet-2024.5.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c8b2e86fe6488cce0e3d41263bb0296ef9bbb875a2fca09d67d7685640017a66"},
     {file = "fastparquet-2024.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2a951106782d51e5ab110beaad29c4aa0537f045711bb0bf146f65aeaed14174"},
+    {file = "fastparquet-2024.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:cd3473d3e299bfb04c0ac7726cca5d13ee450cc2387ee7fd70587ca150647315"},
     {file = "fastparquet-2024.5.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:47695037fdc534ef4247f25ccf17dcbd8825be6ecb70c54ca54d588a794f4a6d"},
     {file = "fastparquet-2024.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fc3d35ff8341cd65baecac71062e9d73393d7afda207b3421709c1d3f4baa194"},
     {file = "fastparquet-2024.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:691348cc85890663dd3c0bb02544d38d4c07a0c3d68837324dc01007301150b5"},
@@ -929,13 +930,13 @@ files = [
 
 [[package]]
 name = "identify"
-version = "2.6.0"
+version = "2.6.1"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "identify-2.6.0-py2.py3-none-any.whl", hash = "sha256:e79ae4406387a9d300332b5fd366d8994f1525e8414984e1a59e058b2eda2dd0"},
-    {file = "identify-2.6.0.tar.gz", hash = "sha256:cb171c685bdc31bcc4c1734698736a7d5b6c8bf2e0c15117f4d469c8640ae5cf"},
+    {file = "identify-2.6.1-py2.py3-none-any.whl", hash = "sha256:53863bcac7caf8d2ed85bd20312ea5dcfc22226800f6d6881f232d861db5a8f0"},
+    {file = "identify-2.6.1.tar.gz", hash = "sha256:91478c5fb7c3aac5ff7bf9b4344f803843dc586832d5f110d672b19aa1984c98"},
 ]
 
 [package.extras]
@@ -943,14 +944,17 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.8"
+version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "idna-3.8-py3-none-any.whl", hash = "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac"},
-    {file = "idna-3.8.tar.gz", hash = "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"},
+    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
+    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
 ]
+
+[package.extras]
+all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "importlib-metadata"
@@ -1439,6 +1443,7 @@ optional = false
 python-versions = ">=3.9"
 files = [
     {file = "pandas-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:90c6fca2acf139569e74e8781709dccb6fe25940488755716d1d354d6bc58bce"},
+    {file = "pandas-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c7adfc142dac335d8c1e0dcbd37eb8617eac386596eb9e1a1b77791cf2498238"},
     {file = "pandas-2.2.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4abfe0be0d7221be4f12552995e58723c7422c80a659da13ca382697de830c08"},
     {file = "pandas-2.2.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8635c16bf3d99040fdf3ca3db669a7250ddf49c55dc4aa8fe0ae0fa8d6dcc1f0"},
     {file = "pandas-2.2.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:40ae1dffb3967a52203105a077415a86044a2bea011b5f321c6aa64b379a3f51"},
@@ -1459,6 +1464,7 @@ files = [
     {file = "pandas-2.2.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:43498c0bdb43d55cb162cdc8c06fac328ccb5d2eabe3cadeb3529ae6f0517c32"},
     {file = "pandas-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:d187d355ecec3629624fccb01d104da7d7f391db0311145817525281e2804d23"},
     {file = "pandas-2.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0ca6377b8fca51815f382bd0b697a0814c8bda55115678cbc94c30aacbb6eff2"},
+    {file = "pandas-2.2.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9057e6aa78a584bc93a13f0a9bf7e753a5e9770a30b4d758b8d5f2a62a9433cd"},
     {file = "pandas-2.2.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:001910ad31abc7bf06f49dcc903755d2f7f3a9186c0c040b827e522e9cef0863"},
     {file = "pandas-2.2.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66b479b0bd07204e37583c191535505410daa8df638fd8e75ae1b383851fe921"},
     {file = "pandas-2.2.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a77e9d1c386196879aa5eb712e77461aaee433e54c68cf253053a73b7e49c33a"},
@@ -1518,13 +1524,13 @@ testing = ["pytest", "pytest-cov", "wheel"]
 
 [[package]]
 name = "platformdirs"
-version = "4.3.2"
+version = "4.3.3"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.3.2-py3-none-any.whl", hash = "sha256:eb1c8582560b34ed4ba105009a4badf7f6f85768b30126f351328507b2beb617"},
-    {file = "platformdirs-4.3.2.tar.gz", hash = "sha256:9e5e27a08aa095dd127b9f2e764d74254f482fef22b0970773bfba79d091ab8c"},
+    {file = "platformdirs-4.3.3-py3-none-any.whl", hash = "sha256:50a5450e2e84f44539718293cbb1da0a0885c9d14adf21b77bae4e66fc99d9b5"},
+    {file = "platformdirs-4.3.3.tar.gz", hash = "sha256:d4e0b7d8ec176b341fb03cb11ca12d0276faa8c485f9cd218f613840463fc2c0"},
 ]
 
 [package.extras]
@@ -2326,13 +2332,13 @@ tornado = ["tornado (>=6)"]
 
 [[package]]
 name = "setuptools"
-version = "74.1.2"
+version = "74.1.3"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-74.1.2-py3-none-any.whl", hash = "sha256:5f4c08aa4d3ebcb57a50c33b1b07e94315d7fc7230f7115e47fc99776c8ce308"},
-    {file = "setuptools-74.1.2.tar.gz", hash = "sha256:95b40ed940a1c67eb70fc099094bd6e99c6ee7c23aa2306f4d2697ba7916f9c6"},
+    {file = "setuptools-74.1.3-py3-none-any.whl", hash = "sha256:1cfd66bfcf197bce344da024c8f5b35acc4dcb7ca5202246a75296b4883f6851"},
+    {file = "setuptools-74.1.3.tar.gz", hash = "sha256:fbb126f14b0b9ffa54c4574a50ae60673bbe8ae0b1645889d10b3b14f5891d28"},
 ]
 
 [package.extras]
@@ -2543,13 +2549,13 @@ files = [
 
 [[package]]
 name = "zipp"
-version = "3.20.1"
+version = "3.20.2"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "zipp-3.20.1-py3-none-any.whl", hash = "sha256:9960cd8967c8f85a56f920d5d507274e74f9ff813a0ab8889a5b5be2daf44064"},
-    {file = "zipp-3.20.1.tar.gz", hash = "sha256:c22b14cc4763c5a5b04134207736c107db42e9d3ef2d9779d465f5f1bcba572b"},
+    {file = "zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350"},
+    {file = "zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29"},
 ]
 
 [package.extras]

--- a/tests/test_unit/test_cdf_tk/test_commands/test_auth.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_auth.py
@@ -101,7 +101,7 @@ class TestAuthCommand:
         cdf_tool_config.toolkit_client = auth_cognite_approval_client.mock_client
         cmd = AuthCommand(print_warning=False)
 
-        cmd.verify(cdf_tool_config, False)
+        cmd.verify(cdf_tool_config, False, no_prompt=True)
 
         assert list(cmd.warning_list) == []
 
@@ -126,7 +126,7 @@ class TestAuthCommand:
         cdf_tool_config.toolkit_client = auth_cognite_approval_client.mock_client
         cmd = AuthCommand(print_warning=False)
 
-        cmd.verify(cdf_tool_config, False)
+        cmd.verify(cdf_tool_config, False, no_prompt=True)
 
         assert len(cmd.warning_list) == len(expected_warnings)
         assert set(cmd.warning_list) == set(expected_warnings)
@@ -148,7 +148,7 @@ class TestAuthCommand:
         # the approval_client
         cdf_tool_config.toolkit_client = auth_cognite_approval_client.mock_client
         cmd = AuthCommand(print_warning=False)
-        cmd.verify(cdf_tool_config, False)
+        cmd.verify(cdf_tool_config, False, no_prompt=True)
 
         assert len(cmd.warning_list) == 1
         assert set(cmd.warning_list) == {
@@ -180,7 +180,7 @@ class TestAuthCommand:
         cdf_tool_config.verify_authorization.side_effect = mock_verify_client
         cmd = AuthCommand(print_warning=False)
         with pytest.raises(AuthorizationError) as e:
-            cmd.verify(cdf_tool_config, False)
+            cmd.verify(cdf_tool_config, False, no_prompt=True)
 
         assert len(cmd.warning_list) == 1
         assert set(cmd.warning_list) == {


### PR DESCRIPTION
# Description

## Init
![image](https://github.com/user-attachments/assets/a7d8d068-9ef0-489f-b219-1fcddb5c6e7e)

## Verify
More or less the same as the old `auth verify`, but based on the required loaders capabilities and not the admin group.  Thus, a simpler interface of only one flag `--dry-run`


### Listing Resources that requires the capabilities

![image](https://github.com/user-attachments/assets/81ad1e7d-9196-4b44-8873-e8490b4bd0c3)

### Merging Capabilities
![image](https://github.com/user-attachments/assets/6baca8dc-7ca5-413a-a977-f1b40de0871a)

### Fix
The previous `cdf auth verify` could end up removing existing capabilities, the new version ensures it is only adding.


### Note
As the commands are interactive the testing is outdated. I have done manually testing and set the existing tests to skip. Suggest we move this to the backlog as rewriting the tests to work with interactive is a significant effort. In addition, there is more refactoring that can be done as interactive is now an assumption, but trying to limit the scope of this PR to not do more changes than necessary.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
