### PR TITLE
[CDF-22634] 🐛 Migration from 0.2.x to 0.3 alpha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -303,3 +303,4 @@ module_upgrade/cdf.toml
 my_org
 # Org used by bootcamp
 ice-cream-dataops
+module_upgrade/*.log

--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,12 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+### Fixed
+
+- Running `cdf modules upgrade` no longer raises an error when upgrading from `0.2.x`.
+
 ## [0.3.0a6] - 2024-09-20
 
 ### Added

--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -91,9 +91,10 @@ class CDFToml:
                 modules = ModulesConfig.load(raw["modules"])
             except KeyError as e:
                 raise ToolkitRequiredValueError(f"Missing required value in {cls.file_name}: {e.args}")
-
+            feature_flags = {}
             if "feature_flags" in raw:
                 feature_flags = {clean_name(k): v for k, v in raw["feature_flags"].items()}
+            plugins = {}
             if "plugins" in raw:
                 plugins = {clean_name(k): v for k, v in raw["plugins"].items()}
 

--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -95,7 +95,7 @@ class CDFToml:
             if "feature_flags" in raw:
                 feature_flags = {clean_name(k): v for k, v in raw["feature_flags"].items()}
             if "plugins" in raw:
-                plugins = {clean_name(k): v for k, v in raw["feature_flags"].items()}
+                plugins = {clean_name(k): v for k, v in raw["plugins"].items()}
 
             instance = cls(
                 cdf=cdf, modules=modules, feature_flags=feature_flags, plugins=plugins, is_loaded_from_file=True

--- a/cognite_toolkit/_cdf_tk/commands/_changes.py
+++ b/cognite_toolkit/_cdf_tk/commands/_changes.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from packaging.version import Version
 from packaging.version import parse as parse_version
 
+from cognite_toolkit._cdf_tk.constants import BUILTIN_MODULES_PATH
 from cognite_toolkit._cdf_tk.utils import iterate_modules, read_yaml_file, safe_read
 from cognite_toolkit._version import __version__
 
@@ -157,7 +158,6 @@ After:
     has_file_changes = True
 
     def do(self) -> set[Path]:
-        from cognite_toolkit._cdf_tk.commands import RepoCommand
 
         system_yaml = self._organization_dir / "_system.yaml"
         if not system_yaml.exists():
@@ -167,7 +167,7 @@ After:
         content = read_yaml_file(system_yaml)
         current_version = content.get("cdf_toolkit_version", __version__)
 
-        cdf_toml_source = RepoCommand()._repo_files / "cdf.toml"
+        cdf_toml_source = BUILTIN_MODULES_PATH / "cdf.toml"
         cdf_toml_content = cdf_toml_source.read_text()
         cdf_toml_content = cdf_toml_content.replace(f'version = "{__version__}"', f'version = "{current_version}"')
 

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -432,7 +432,7 @@ default_organization_dir = "{organization_dir.name}"''',
 
     @staticmethod
     def _get_module_version(project_path: Path) -> Version:
-        cdf_toml = CDFToml.load()
+        cdf_toml = CDFToml.load(use_singleton=False)
         # After `0.3.0` the version is in the CDF TOML file
         if cdf_toml.is_loaded_from_file and cdf_toml.modules.version:
             return parse_version(cdf_toml.modules.version)

--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -45,7 +45,7 @@ ROOT_PATH = Path(__file__).parent.parent
 COGNITE_MODULES_PATH = ROOT_PATH / COGNITE_MODULES
 MODULES_PATH = ROOT_PATH / MODULES
 BUILTIN_MODULES_PATH = ROOT_PATH / BUILTIN_MODULES
-SUPPORT_MODULE_UPGRADE_FROM_VERSION = "0.2.20"
+SUPPORT_MODULE_UPGRADE_FROM_VERSION = "0.2.0"
 # This is used in the build directory to keep track of order and flatten the
 # module directory structure with accounting for duplicated names.
 INDEX_PATTERN = re.compile("^[0-9]+\\.")

--- a/module_upgrade/run_check.py
+++ b/module_upgrade/run_check.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 
 # Hack to make the script work as running cdf modules upgrade
+original_argv = sys.argv
 sys.argv = ["cdf", "modules", "upgrade"]
 
 import yaml
@@ -48,7 +49,7 @@ logging.basicConfig(
 
 
 def run() -> None:
-    only_first = len(sys.argv) > 1 and sys.argv[1] == "--only-first"
+    only_first = len(original_argv) > 1 and original_argv[1] == "--only-first"
 
     versions = get_versions_since(SUPPORT_MODULE_UPGRADE_FROM_VERSION)
     for version in versions:

--- a/module_upgrade/run_check.py
+++ b/module_upgrade/run_check.py
@@ -55,7 +55,8 @@ logging.basicConfig(
 
 
 def run() -> None:
-    only_first = len(original_argv) > 1 and original_argv[1] == "--only-first"
+    only_earliest = len(original_argv) > 1 and original_argv[1] == "--earliest"
+    only_latest = len(original_argv) > 1 and original_argv[1] == "--latest"
 
     versions = get_versions_since(SUPPORT_MODULE_UPGRADE_FROM_VERSION)
     for version in versions:
@@ -76,8 +77,10 @@ def run() -> None:
             title="cdf-tk module upgrade",
         )
     )
-    if only_first:
+    if only_earliest:
         versions = versions[-1:]
+    elif only_latest:
+        versions = versions[:1]
     for version in versions:
         with local_tmp_project_path() as project_path, local_build_path() as build_path, tool_globals() as cdf_tool_config:
             run_modules_upgrade(version, project_path, build_path, cdf_tool_config)
@@ -178,6 +181,10 @@ def create_project_init(version: str) -> None:
 def run_modules_upgrade(
     previous_version: Version, project_path: Path, build_path: Path, cdf_tool_config: CDFToolConfig
 ) -> None:
+    if (TEST_DIR_ROOT / CDFToml.file_name).exists():
+        # Cleanup after previous run
+        (TEST_DIR_ROOT / CDFToml.file_name).unlink()
+
     project_init = PROJECT_INIT_DIR / f"project_{previous_version!s}"
     # Copy the project to a temporary location as the upgrade command modifies the project.
     shutil.copytree(project_init, project_path, dirs_exist_ok=True)

--- a/module_upgrade/run_check.py
+++ b/module_upgrade/run_check.py
@@ -175,6 +175,9 @@ def run_modules_upgrade(
     project_init = PROJECT_INIT_DIR / f"project_{previous_version!s}"
     # Copy the project to a temporary location as the upgrade command modifies the project.
     shutil.copytree(project_init, project_path, dirs_exist_ok=True)
+    if previous_version >= parse_version("0.3.0a1"):
+        # Move out the CDF.toml file to use
+        shutil.move(project_path / CDFToml.file_name, TEST_DIR_ROOT / CDFToml.file_name)
 
     with chdir(TEST_DIR_ROOT):
         modules = ModulesCommand(print_warning=False)

--- a/module_upgrade/run_check.py
+++ b/module_upgrade/run_check.py
@@ -12,6 +12,12 @@ from datetime import date
 from pathlib import Path
 from unittest.mock import patch
 
+from cognite.client.config import global_config
+
+# Do not warn the user about feature previews from the Cognite-SDK we use in Toolkit
+global_config.disable_pypi_version_check = True
+global_config.silence_feature_preview_warnings = True
+
 from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 
 # Hack to make the script work as running cdf modules upgrade


### PR DESCRIPTION
# Description

* Fixed the `python modules_upgrade/run_check.py` script. It was not testing properly and thus giving a false sense of security.
* Located the bug which is we changed `cdf.toml` location from `_repo_files` to `_builtin_modules` and forgot to update the automatic script.
* Found one more bug if you have `plugin` in your `cdf.toml`.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
