### PR TITLE
Removing invalid volumes mount in the default github workflow

### DIFF
--- a/cognite_toolkit/_repo_files/GitHub/.github/workflows/build.yaml
+++ b/cognite_toolkit/_repo_files/GitHub/.github/workflows/build.yaml
@@ -17,8 +17,6 @@ jobs:
         IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
         IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
         IDP_TENANT_ID: ${{ vars.IDP_TENANT_ID }}
-      volumes:
-        - :/app
     steps:
       - uses: actions/checkout@v4
       - name: Build the modules

--- a/cognite_toolkit/_repo_files/GitHub/.github/workflows/deploy.yaml
+++ b/cognite_toolkit/_repo_files/GitHub/.github/workflows/deploy.yaml
@@ -19,8 +19,6 @@ jobs:
         IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
         IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
         IDP_TENANT_ID: ${{ vars.IDP_TENANT_ID }}
-      volumes:
-        - :/app
     steps:
       - uses: actions/checkout@v4
       - name: Build the modules


### PR DESCRIPTION
# Description

The volume mounted wasn't doing anything. The build and deploy jobs work correctly without providing mount volumes.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
