### PR TITLE
small fix to avoid mixup between environments

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils.py
+++ b/cognite_toolkit/_cdf_tk/utils.py
@@ -505,6 +505,7 @@ class CDFToolConfig:
         token: str | None = None,
         cluster: str | None = None,
         project: str | None = None,
+        cdf_url: str | None = None,
         skip_initialization: bool = False,
     ) -> None:
         self._cache = self._Cache()
@@ -518,6 +519,8 @@ class CDFToolConfig:
             self._environ["CDF_CLUSTER"] = cluster
         if token:
             self._environ["CDF_TOKEN"] = token
+        if cdf_url:
+            self._environ["CDF_URL"] = cdf_url
 
         # ClientName is used for logging usage of the CDF-Toolkit.
         self._client_name = f"CDF-Toolkit:{__version__}"

--- a/tests/test_unit/test_cdf_tk/test_utils.py
+++ b/tests/test_unit/test_cdf_tk/test_utils.py
@@ -173,7 +173,9 @@ CDF_TOKEN=12345
 # The below variables are the defaults, they are automatically constructed unless they are set.
 CDF_URL=https://my_cluster.cognitedata.com"""
         with monkeypatch_toolkit_client() as _:
-            config = CDFToolConfig(token="12345", cluster="my_cluster", project="my_project")
+            config = CDFToolConfig(
+                token="12345", cluster="my_cluster", project="my_project", cdf_url="https://my_cluster.cognitedata.com"
+            )
             env_file = AuthVariables.from_env(config._environ).create_dotenv_file()
         not_equal = set(env_file.splitlines()) ^ set(expected.splitlines())
         assert not not_equal, "Found differences in the generated .env file: \n" + "\n".join(not_equal)


### PR DESCRIPTION
# Description

This goes into a larger problem of layers of ENVs, but is a quick fix for local tests

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
