### PR TITLE
residue variables

### DIFF
--- a/CHANGELOG.templates.md
+++ b/CHANGELOG.templates.md
@@ -15,6 +15,12 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+### Fixed
+
+- Removed unused variables from default InRobot configuration.
+
 ## [0.3.5] - 2024-10-24
 
 ### Added

--- a/cognite_toolkit/_builtin_modules/inrobot/cdf_inrobot_common/default.config.yaml
+++ b/cognite_toolkit/_builtin_modules/inrobot/cdf_inrobot_common/default.config.yaml
@@ -1,5 +1,3 @@
 run_function_user_group_source_id: <change_me>
 run_function_client_id: <change_me>
 run_function_secret: <change_me>
-apm_datamodel_space: 'APM_SourceData'
-apm_datamodel_version: 'v1'


### PR DESCRIPTION
# Description

Variables that belong in the `cdf_apm_base` module were left in  the default.config.yaml of `cdf_inrobot_common`


## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
