### PR TITLE
[CDF-23393] HTTP download support

### DIFF
--- a/cognite_toolkit/_builtin_modules/sourcesystem/cdf_pi/module.toml
+++ b/cognite_toolkit/_builtin_modules/sourcesystem/cdf_pi/module.toml
@@ -12,9 +12,9 @@ tags = [
 modules = []
 
 [[data]]
-repoType = "GitHub"
-repo = "cognitedata/toolkit-data"
-source = "data/publicdata/pi_timeseries.Table.csv"
+repoType = "http"
+repo = "https://apps-cdn.cogniteapp.com/toolkit"
+source = "publicdata/pi_timeseries.Table.csv"
 destination = "raw/timeseries.Table.csv"
 
 [[extra_resources]]

--- a/cognite_toolkit/_builtin_modules/sourcesystem/cdf_sap_assets/module.toml
+++ b/cognite_toolkit/_builtin_modules/sourcesystem/cdf_sap_assets/module.toml
@@ -11,10 +11,11 @@ tags = [
 modules = []
 
 [[data]]
-repoType = "GitHub"
-repo = "cognitedata/toolkit-data"
-source = "data/publicdata/assets.Table.csv"
+repoType = "http"
+repo = "https://apps-cdn.cogniteapp.com/toolkit"
+source = "publicdata/assets.Table.csv"
 destination = "raw/dump.Table.csv"
+
 
 [[extra_resources]]
 location = "cdf_common/data_sets/demo.DataSet.yaml"

--- a/cognite_toolkit/_builtin_modules/sourcesystem/cdf_sap_events/module.toml
+++ b/cognite_toolkit/_builtin_modules/sourcesystem/cdf_sap_events/module.toml
@@ -8,9 +8,9 @@ tags = [
 ]
 
 [[data]]
-repoType = "GitHub"
-repo = "cognitedata/toolkit-data"
-source = "data/publicdata/[work]*.csv"
+repoType = "http"
+repo = "https://apps-cdn.cogniteapp.com/toolkit/publicdata"
+source = "workitem.Table.csv;workorder.Table.csv;workpackage.Table.csv;worktask.Table.csv"
 destination = "raw/"
 
 [[extra_resources]]

--- a/cognite_toolkit/_builtin_modules/sourcesystem/cdf_sharepoint/module.toml
+++ b/cognite_toolkit/_builtin_modules/sourcesystem/cdf_sharepoint/module.toml
@@ -8,15 +8,15 @@ tags = [
 ]
 
 [[data]]
-repoType = "GitHub"
-repo = "cognitedata/toolkit-data"
-source = "data/publicdata/files/*.pdf"
+repoType = "http"
+repo = "https://apps-cdn.cogniteapp.com/toolkit/publicdata/files"
+source = "PH-25578-P-4110006-001.pdf;PH-25578-P-4110010-001.pdf;PH-25578-P-4110119-001.pdf;PH-ME-P-0003-001.pdf;PH-ME-P-0004-001.pdf;PH-ME-P-0151-001.pdf;PH-ME-P-0152-001.pdf;PH-ME-P-0153-001.pdf;PH-ME-P-0156-001.pdf;PH-ME-P-0156-002.pdf;PH-ME-P-0160-001.pdf;Processed-PH-25578-P-4110006-001.svg;Processed-PH-25578-P-4110010-001.svg;Processed-PH-ME-P-0152-001.svg;Processed-PH-ME-P-0153-001.svg;Processed-PH-ME-P-0156-001.svg;Processed-PH-ME-P-0156-002.svg;Processed-PH-ME-P-0160-001.svg"
 destination = "files/"
 
 [[data]]
-repoType = "GitHub"
-repo = "cognitedata/toolkit-data"
-source = "data/publicdata/valhall_file_metadata.csv"
+repoType = "http"
+repo = "https://apps-cdn.cogniteapp.com/toolkit"
+source = "publicdata/valhall_file_metadata.csv"
 destination = "raw/files.Table.csv"
 
 [[extra_resources]]

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -162,7 +162,6 @@ class ModulesCommand(ToolkitCommand):
                         if example_data.repo not in downloader_by_repo:
                             try:
                                 downloader_cls = _FILE_DOWNLOADERS_BY_TYPE[example_data.repo_type]
-                                downloader_by_repo[example_data.repo] = downloader_cls(example_data.repo)
                             except KeyError:
                                 self.warn(
                                     MediumSeverityWarning(
@@ -170,6 +169,7 @@ class ModulesCommand(ToolkitCommand):
                                     )
                                 )
                                 continue
+                            downloader_by_repo[example_data.repo] = downloader_cls(example_data.repo)
 
                         downloader = downloader_by_repo[example_data.repo]
                         downloader.copy(example_data.source, target_dir / example_data.destination)

--- a/cognite_toolkit/_cdf_tk/utils/repository.py
+++ b/cognite_toolkit/_cdf_tk/utils/repository.py
@@ -1,8 +1,10 @@
 import fnmatch
+from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from functools import lru_cache
 from pathlib import Path
-from typing import Literal
+from typing import ClassVar, Literal
+from urllib.parse import urljoin
 
 import requests
 from requests import Response
@@ -13,7 +15,21 @@ from cognite_toolkit._cdf_tk.constants import IN_BROWSER
 from cognite_toolkit._cdf_tk.tk_warnings import HTTPWarning
 
 
-class GitHubFileDownloader:
+class FileDownloader(ABC):
+    _type: ClassVar[str] = "generic"
+
+    @abstractmethod
+    def __init__(self, repo: str, errors: Literal["continue", "raise"] = "continue") -> None:
+        pass
+
+    @abstractmethod
+    def copy(self, source: str, destination: Path) -> None:
+        pass
+
+
+class GitHubFileDownloader(FileDownloader):
+    _type: ClassVar[str] = "github"
+
     api_url = "https://api.github.com"
 
     def __init__(self, repo: str, errors: Literal["continue", "raise"] = "continue") -> None:
@@ -70,3 +86,29 @@ class GitHubFileDownloader:
             destination_path = destination / source.name
         destination_path.parent.mkdir(parents=True, exist_ok=True)
         destination_path.write_bytes(response.content)
+
+
+class HttpFileDownloader(FileDownloader):
+    _type: ClassVar[str] = "http"
+
+    def __init__(self, repo: str, errors: Literal["continue", "raise"] = "raise") -> None:
+        self.repo = repo
+        self.errors = errors
+
+    def copy(self, source: str, destination: Path) -> None:
+        if not self.repo.endswith("/"):
+            self.repo += "/"
+
+        sources = source.split(";") if ";" in source else [source]
+        for source in sources:
+            file_url = urljoin(self.repo, source)
+
+            response = requests.get(file_url)
+            if response.status_code >= 400:
+                if self.errors == "raise":
+                    response.raise_for_status()
+                print(HTTPWarning("GET", response.text, response.status_code).get_message())
+                continue
+
+            location = destination if not destination.is_dir() else destination / Path(source).name
+            location.write_bytes(response.content)


### PR DESCRIPTION
# Description

New file loader supports these (in addition to GH):

```
[[data]]
repoType = "http"
repo = "https://apps-cdn.cogniteapp.com/toolkit"
source = "publicdata/valhall_file_metadata.csv"
destination = "raw/files.Table.csv"`
```

```
[[data]]
repoType = "http"
repo = "https://apps-cdn.cogniteapp.com/toolkit/publicdata/files"
source = "PH-25578-P-4110006-001.pdf;PH-25578-P-4110010-001.pdf;PH-25578-P-4110119-001.pdf;PH-ME-P-0003-001.pdf;PH-ME-P-0004-001.pdf;PH-ME-P-0151-001.pdf;PH-ME-P-0152-001.pdf;PH-ME-P-0153-001.pdf;PH-ME-P-0156-001.pdf;PH-ME-P-0156-002.pdf;PH-ME-P-0160-001.pdf;Processed-PH-25578-P-4110006-001.svg;Processed-PH-25578-P-4110010-001.svg;Processed-PH-ME-P-0152-001.svg;Processed-PH-ME-P-0153-001.svg;Processed-PH-ME-P-0156-001.svg;Processed-PH-ME-P-0156-002.svg;Processed-PH-ME-P-0160-001.svg"
destination = "files/"
```

### For discussion I
Feature or bug: repo can be any public website. Is that a problem? Should we lock the base url to CDN, 

### For discussion II
The ';' separated list of files isn't very clean, but we need to list every single resource since we can't do wildcards in http. 

We could repeat like this instead, but for many files it is a lot of toml

```
[[data]]
repoType = "http"
repo = "https://apps-cdn.cogniteapp.com/toolkit/publicdata/files"
source = "PH-25578-P-4110006-001.pdf"
destination = "files/PH-25578-P-4110006-001.pdf"

repoType = "http"
repo = "https://apps-cdn.cogniteapp.com/toolkit/publicdata/files"
source = "PH-25578-P-4110006-002.pdf"
destination = "files/PH-25578-P-4110006-002.pdf"

```






## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
