### PR TITLE
[CDF-22779] 🕵 Invalid escape sequence

### DIFF
--- a/tests/data/complete_org/modules/my_example_module/extraction_pipelines/hamburg.config.yaml
+++ b/tests/data/complete_org/modules/my_example_module/extraction_pipelines/hamburg.config.yaml
@@ -7,6 +7,7 @@ config:
     file:
       level: INFO
       path: file.log
+      user: domain\\user
   # List of databases
   databases:
   - type: odbc

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org.yaml
@@ -135,9 +135,9 @@ ExtractionPipeline:
   source: doctrino
 ExtractionPipelineConfig:
 - config: "logger:\n  console:\n    level: INFO\n  file:\n    level: INFO\n    path:\
-    \ file.log\n# List of databases\ndatabases:\n- type: odbc\n  name: postgres\n\
-    \  connection-string: DSN={MyPostgresDsn}\n# List of queries\nqueries:\n- name:\
-    \ test-postgres\n  database: postgres\n  query: SELECT\n"
+    \ file.log\n    user: domain\\\\user\n# List of databases\ndatabases:\n- type:\
+    \ odbc\n  name: postgres\n  connection-string: DSN={MyPostgresDsn}\n# List of\
+    \ queries\nqueries:\n- name: test-postgres\n  database: postgres\n  query: SELECT\n"
   description: DB extractor config reading data from Hamburg SAP
   externalId: ep_src_asset_hamburg_sap
 FileLoader:


### PR DESCRIPTION
# Description

Seems to no longer be an issue after we started to read the `config` field carefully. Extending test case to include this one.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/toolkit/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/toolkit/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
