### PR TITLE
[prep CDF-23388] 👷 Use new view retrieve parameter

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/dump.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump.py
@@ -96,7 +96,7 @@ class DumpCommand(ToolkitCommand):
             if suffix_version:
                 file_name = f"{file_name.removesuffix('.view.yaml')}_{view.version}.view.yaml"
             view_file = view_folder / file_name
-            view_write = view.as_write()
+            view_write = view.as_write().dump()
             safe_write(view_file, yaml_safe_dump(view_write))
             if verbose:
                 print(f"  [bold green]INFO:[/] Dumped view {view.as_id()} to {view_file!s}.")

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/datamodel_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/datamodel_loaders.py
@@ -610,7 +610,9 @@ class ViewLoader(ResourceLoader[ViewId, ViewApply, View, ViewApplyList, ViewList
         return self.client.data_modeling.views.apply(items)
 
     def retrieve(self, ids: SequenceNotStr[ViewId]) -> ViewList:
-        return self.client.data_modeling.views.retrieve(cast(Sequence, ids))
+        return self.client.data_modeling.views.retrieve(
+            cast(Sequence, ids), include_inherited_properties=False, all_versions=False
+        )
 
     def update(self, items: Sequence[ViewApply]) -> ViewList:
         return self.create(items)
@@ -628,7 +630,11 @@ class ViewLoader(ResourceLoader[ViewId, ViewApply, View, ViewApplyList, ViewList
             sleep(2)
             to_delete = existing
         else:
-            print(f"  [bold yellow]WARNING:[/] Could not delete views {to_delete} after {attempt_count} attempts.")
+            msg = f"  [bold yellow]WARNING:[/] Could not delete views {to_delete} after {attempt_count} attempts."
+            if self.console:
+                self.console.print(msg)
+            else:
+                print(msg)
         return nr_of_deleted
 
     def _iterate(

--- a/cognite_toolkit/_cdf_tk/utils/__init__.py
+++ b/cognite_toolkit/_cdf_tk/utils/__init__.py
@@ -1,5 +1,4 @@
 from .auth import AuthReader, AuthVariables, CDFToolConfig
-from .cdf import retrieve_view_ancestors
 from .cicd import get_cicd_environment
 from .collection import flatten_dict, humanize_collection, in_dict, to_diff
 from .file import (
@@ -48,7 +47,6 @@ __all__ = [
     "read_yaml_content",
     "read_yaml_file",
     "resource_folder_from_path",
-    "retrieve_view_ancestors",
     "safe_read",
     "safe_read",
     "safe_write",

--- a/cognite_toolkit/_cdf_tk/utils/cdf.py
+++ b/cognite_toolkit/_cdf_tk/utils/cdf.py
@@ -2,7 +2,7 @@ from collections.abc import Iterator
 from typing import Any, Literal, overload
 
 from cognite.client.data_classes import CreatedSession
-from cognite.client.data_classes.data_modeling import Edge, Node, View, ViewId
+from cognite.client.data_classes.data_modeling import Edge, Node
 from cognite.client.data_classes.filters import SpaceFilter
 from cognite.client.exceptions import CogniteAPIError
 from rich.console import Console
@@ -10,39 +10,6 @@ from rich.console import Console
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.testing import ToolkitClientMock
 from cognite_toolkit._cdf_tk.tk_warnings import MediumSeverityWarning
-
-
-def retrieve_view_ancestors(client: ToolkitClient, parents: list[ViewId], cache: dict[ViewId, View]) -> list[View]:
-    """Retrieves all ancestors of a view.
-
-    This will mutate the cache that is passed in, and return a list of views that are the ancestors of the views in the parents list.
-
-    Args:
-        client: The Cognite client to use for the requests
-        parents: The parents of the view to retrieve all ancestors for
-        cache: The cache to store the views in
-    """
-    parent_ids = parents
-    found: list[View] = []
-    while parent_ids:
-        to_lookup = []
-        grand_parent_ids = []
-        for parent in parent_ids:
-            if parent in cache:
-                found.append(cache[parent])
-                grand_parent_ids.extend(cache[parent].implements or [])
-            else:
-                to_lookup.append(parent)
-
-        if to_lookup:
-            looked_up = client.data_modeling.views.retrieve(to_lookup)
-            cache.update({view.as_id(): view for view in looked_up})
-            found.extend(looked_up)
-            for view in looked_up:
-                grand_parent_ids.extend(view.implements or [])
-
-        parent_ids = grand_parent_ids
-    return found
 
 
 def get_oneshot_session(client: ToolkitClient) -> CreatedSession | None:

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_view_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_view_loader.py
@@ -61,69 +61,6 @@ class TestViewLoader:
 
         assert not extra, f"Extra keys: {extra}"
 
-    def test_update_view_with_interface(
-        self, cdf_tool_mock: CDFToolConfig, toolkit_client_approval: ApprovalToolkitClient
-    ) -> None:
-        prop1 = dm.MappedProperty(
-            dm.ContainerId(space="sp_space", external_id="container_id"),
-            "prop1",
-            type=dm.Text(),
-            nullable=True,
-            auto_increment=False,
-            immutable=False,
-        )
-        interface = dm.View(
-            space="sp_space",
-            external_id="interface",
-            version="1",
-            properties={"prop1": prop1},
-            last_updated_time=1,
-            created_time=1,
-            description=None,
-            name=None,
-            filter=None,
-            implements=None,
-            writable=True,
-            used_for="node",
-            is_global=False,
-        )
-        # Note that child views always contain all properties of their parent interfaces.
-        child_cdf = dm.View(
-            space="sp_space",
-            external_id="child",
-            version="1",
-            properties={"prop1": prop1},
-            last_updated_time=1,
-            created_time=1,
-            description=None,
-            name=None,
-            filter=None,
-            implements=[interface.as_id()],
-            writable=True,
-            used_for="node",
-            is_global=False,
-        )
-        child_local = dm.ViewApply(
-            space="sp_space",
-            external_id="child",
-            version="1",
-            implements=[interface.as_id()],
-        ).dump_yaml()
-        file = MagicMock(spec=Path)
-        file.read_text.return_value = child_local
-
-        # Simulating that the interface and child_cdf are available in CDF
-        toolkit_client_approval.append(dm.View, [interface, child_cdf])
-
-        worker = ResourceWorker(ViewLoader.create_loader(cdf_tool_mock, None))
-        to_create, to_change, to_delete, unchanged, _ = worker.load_resources([file])
-        assert {
-            "create": len(to_create),
-            "change": len(to_change),
-            "delete": len(to_delete),
-            "unchanged": len(unchanged),
-        } == {"create": 0, "change": 0, "delete": 0, "unchanged": 1}
-
     def test_unchanged_view_int_version(
         self, cdf_tool_mock: CDFToolConfig, toolkit_client_approval: ApprovalToolkitClient
     ) -> None:

--- a/tests/test_unit/test_cli/test_behavior.py
+++ b/tests/test_unit/test_cli/test_behavior.py
@@ -282,14 +282,6 @@ def test_dump_datamodel(
                 auto_increment=False,
                 immutable=False,
             ),
-            "prop2": dm.MappedProperty(
-                container=container.as_id(),
-                container_property_identifier="prop2",
-                type=dm.Float64(),
-                nullable=True,
-                auto_increment=False,
-                immutable=False,
-            ),
         },
         last_updated_time=0,
         created_time=0,
@@ -305,7 +297,7 @@ def test_dump_datamodel(
         space="my_space",
         external_id="my_data_model",
         version="1",
-        views=[view, parent_view],
+        views=[view.as_id(), parent_view.as_id()],
         created_time=0,
         last_updated_time=0,
         description=None,
@@ -316,6 +308,7 @@ def test_dump_datamodel(
     toolkit_client_approval.append(dm.Container, container)
     toolkit_client_approval.append(dm.View, parent_view)
     toolkit_client_approval.append(dm.DataModel, data_model)
+    toolkit_client_approval.append(dm.View, [parent_view, view])
     app = DumpApp()
     app.dump_datamodel_cmd(
         typer_context,


### PR DESCRIPTION
# Description

The API now supports a new `includeInheritedProperties` parameter which makes the lookup of parent obsolete for converting from read to write format.

## Checklist

- [ ] Prefixed the PR title with the Jira issue number on the form `[CDF-12345]`.
- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).


[CDF-12345]: https://cognitedata.atlassian.net/browse/CDF-12345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ