### PR TITLE
Retrieval error

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,12 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+### Fixed
+
+- An IndexError was reported when instances.nodes was an empty list. This is now fixed.
+
 ## [0.4.1] - 2025-02-03
 
 ### Added

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/datamodel_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/datamodel_loaders.py
@@ -944,18 +944,11 @@ class NodeLoader(ResourceContainerLoader[NodeId, NodeApply, Node, NodeApplyList,
         # CDF resource does not have properties set, so we need to do a lookup
         local = local or {}
         sources = [ViewId.load(source["source"]) for source in local.get("sources", []) if "source" in source]
+
         if sources:
-            try:
-                cdf_resource_with_properties = self.client.data_modeling.instances.retrieve(
-                    nodes=resource.as_id(), sources=sources
-                ).nodes[0]
-            except CogniteAPIError:
-                # View does not exist
-                dumped = resource.as_write().dump()
-            else:
-                dumped = cdf_resource_with_properties.as_write().dump()
+            res = self.client.data_modeling.instances.retrieve(nodes=resource.as_id(), sources=sources)
+            dumped = res.nodes[0].as_write().dump() if len(res.nodes) > 0 else resource.as_write().dump()
         else:
-            # No sources, so we can just dump the resource.
             dumped = resource.as_write().dump()
 
         if "existingVersion" not in local:


### PR DESCRIPTION
# Description

User would get a IndexError, not an APIError if there were no matching nodes. 

```
File "/Users/yevhen.tanchik/Library/Caches/pypoetry/virtualenvs/cdf-configuration-8esxaXpu-py3.11/lib/python3.11/site-packages/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/datamodel_loaders.py", line 935, in _are_equal
    cdf_resource_with_properties = self.client.data_modeling.instances.retrieve(
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yevhen.tanchik/Library/Caches/pypoetry/virtualenvs/cdf-configuration-8esxaXpu-py3.11/lib/python3.11/site-packages/cognite/client/data_classes/_base.py", line 292, in __getitem__
    value = self.data[item]
            ~~~~~~~~~^^^^^^
IndexError: list index out of range

```

## Checklist

- [ ] Prefixed the PR title with the Jira issue number on the form `[CDF-12345]`.
- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).
