### PR TITLE
[CDF-23917] 🤯 Purge Asset Hierarchy

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -20,7 +20,7 @@ Changes are grouped as follows:
 ### Fixed
 
 - The `--hierarchy/-h` flag was missing from the `cdf dump timeseries` command. This is now fixed.
-- The `cdf purde dataset` now accounts for the hierarchy when deleting assets.
+- The `cdf purge dataset` now accounts for the hierarchy when deleting assets.
 
 ## [0.4.5] - 2025-02-06
 

--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -20,6 +20,7 @@ Changes are grouped as follows:
 ### Fixed
 
 - The `--hierarchy/-h` flag was missing from the `cdf dump timeseries` command. This is now fixed.
+- The `cdf purde dataset` now accounts for the hierarchy when deleting assets.
 
 ## [0.4.5] - 2025-02-06
 

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -111,7 +111,7 @@ class PurgeCommand(ToolkitCommand):
             selected_space = questionary.select(
                 "Which space are you going to purge"
                 " (delete all data models, views, containers, nodes and edges in space)?",
-                [space.space for space in spaces],
+                sorted([space.space for space in spaces]),
             ).ask()
         else:
             retrieved = client.data_modeling.spaces.retrieve(space)
@@ -205,7 +205,7 @@ class PurgeCommand(ToolkitCommand):
             datasets = client.data_sets.list(limit=-1)
             selected_dataset: str = questionary.select(
                 "Which space are you going to purge (delete all resources in dataset)?",
-                [dataset.external_id for dataset in datasets if dataset.external_id],
+                sorted([dataset.external_id for dataset in datasets if dataset.external_id]),
             ).ask()
         else:
             retrieved = client.data_sets.retrieve(external_id=external_id)

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -628,6 +628,8 @@ class PurgeCommand(ToolkitCommand):
                 if not to_delete:
                     return delete_count, set(wait_delete)
                 has_failed = True
+                for i in range(1, 11):
+                    status.update(f"Deleted {count + delete_count:,} {loader.display_name}... 😴Resting {10 - i}...")
             else:
                 if to_delete:
                     # Only update the delete count if we actually deleted something

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 import uuid
 from collections import defaultdict
 from collections.abc import Hashable
@@ -630,6 +631,7 @@ class PurgeCommand(ToolkitCommand):
                 has_failed = True
                 for i in range(1, 11):
                     status.update(f"Deleted {count + delete_count:,} {loader.display_name}... 😴Resting {10 - i}...")
+                    time.sleep(1.0)
             else:
                 if to_delete:
                     # Only update the delete count if we actually deleted something

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -116,8 +116,8 @@ class PurgeCommand(ToolkitCommand):
         if space is None:
             spaces = client.data_modeling.spaces.list(limit=-1, include_global=False)
             selected_space = questionary.select(
-                "Which space are you going to purge"
-                " (delete all data models, views, containers, nodes and edges in space)?",
+                "Which space do you want to purge"
+                " (including all data models, views, containers, nodes and edges within that space)?",
                 sorted([space.space for space in spaces]),
             ).ask()
         else:

--- a/cognite_toolkit/_cdf_tk/exceptions.py
+++ b/cognite_toolkit/_cdf_tk/exceptions.py
@@ -201,3 +201,9 @@ class AuthorizationError(ToolkitError):
 
 
 class GraphQLParseError(ToolkitError): ...
+
+
+class CDFAPIError(ToolkitError, RuntimeError):
+    """Error raised when the CDF API returns an error."""
+
+    ...

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
@@ -120,7 +120,9 @@ class AssetLoader(ResourceLoader[str, AssetWrite, Asset, AssetWriteList, AssetLi
         internal_ids, external_ids = self._split_ids(ids)
         try:
             self.client.assets.delete(id=internal_ids, external_id=external_ids)
-        except (CogniteAPIError, CogniteNotFoundError) as e:
+        except CogniteNotFoundError as e:
+            # Do a CogniteNotFoundError instead of passing 'ignore_unknown_ids=True' to the delete method
+            # to obtain an accurate list of deleted assets.
             non_existing = set(e.failed or [])
             if existing := [id_ for id_ in ids if id_ not in non_existing]:
                 internal_ids, external_ids = self._split_ids(existing)

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
@@ -23,6 +23,7 @@ from cognite.client.data_classes import (
     SequenceWriteList,
     capabilities,
 )
+from cognite.client.data_classes.assets import SortableAssetProperty
 from cognite.client.data_classes.capabilities import Capability
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
 from cognite.client.utils.useful_types import SequenceNotStr
@@ -137,7 +138,14 @@ class AssetLoader(ResourceLoader[str, AssetWrite, Asset, AssetWriteList, AssetLi
         space: str | None = None,
         parent_ids: list[Hashable] | None = None,
     ) -> Iterable[Asset]:
-        return iter(self.client.assets(data_set_external_ids=[data_set_external_id] if data_set_external_id else None))
+        return iter(
+            self.client.assets(
+                data_set_external_ids=[data_set_external_id] if data_set_external_id else None,
+                # We sort by score to ensure that leaf assets are iterated first,
+                # This is required in the cdf purge command to ensure that the leaf assets are deleted first.
+                sort=SortableAssetProperty.score,
+            )
+        )
 
     @classmethod
     @lru_cache(maxsize=1)

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
@@ -23,7 +23,6 @@ from cognite.client.data_classes import (
     SequenceWriteList,
     capabilities,
 )
-from cognite.client.data_classes.assets import SortableAssetProperty
 from cognite.client.data_classes.capabilities import Capability
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
 from cognite.client.utils.useful_types import SequenceNotStr
@@ -141,9 +140,8 @@ class AssetLoader(ResourceLoader[str, AssetWrite, Asset, AssetWriteList, AssetLi
         return iter(
             self.client.assets(
                 data_set_external_ids=[data_set_external_id] if data_set_external_id else None,
-                # We sort by score to ensure that leaf assets are iterated first,
-                # This is required in the cdf purge command to ensure that the leaf assets are deleted first.
-                sort=SortableAssetProperty.score,
+                # This is used in the purge command to delete the children before the parent.
+                aggregated_properties=["depth", "child_count", "path"],
             )
         )
 

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
@@ -117,6 +117,8 @@ class AssetLoader(ResourceLoader[str, AssetWrite, Asset, AssetWriteList, AssetLi
         return self.client.assets.update(items, mode="replace")
 
     def delete(self, ids: SequenceNotStr[str | int]) -> int:
+        if not ids:
+            return 0
         internal_ids, external_ids = self._split_ids(ids)
         try:
             self.client.assets.delete(id=internal_ids, external_id=external_ids)

--- a/cognite_toolkit/_cdf_tk/utils/collection.py
+++ b/cognite_toolkit/_cdf_tk/utils/collection.py
@@ -1,7 +1,6 @@
 import difflib
-import itertools
 from collections.abc import Collection, Iterable, Iterator
-from typing import Any, TypeVar
+from typing import Any
 
 from cognite_toolkit._cdf_tk.utils.file import yaml_safe_dump
 
@@ -42,12 +41,3 @@ def humanize_collection(collection: Collection[Any], /, *, sort: bool = True, bi
         sequence = list(strings)
 
     return f"{', '.join(sequence[:-1])} {bind_word} {sequence[-1]}"
-
-
-T_Item = TypeVar("T_Item")
-
-
-def chunker(iterable: Iterable[T_Item], size: int) -> Iterator[list[T_Item]]:
-    iterator = iter(iterable)
-    while chunk := list(itertools.islice(iterator, size)):
-        yield chunk

--- a/cognite_toolkit/_cdf_tk/utils/collection.py
+++ b/cognite_toolkit/_cdf_tk/utils/collection.py
@@ -1,6 +1,7 @@
 import difflib
+import itertools
 from collections.abc import Collection, Iterable, Iterator
-from typing import Any
+from typing import Any, TypeVar
 
 from cognite_toolkit._cdf_tk.utils.file import yaml_safe_dump
 
@@ -41,3 +42,12 @@ def humanize_collection(collection: Collection[Any], /, *, sort: bool = True, bi
         sequence = list(strings)
 
     return f"{', '.join(sequence[:-1])} {bind_word} {sequence[-1]}"
+
+
+T_Item = TypeVar("T_Item")
+
+
+def chunker(iterable: Iterable[T_Item], size: int) -> Iterator[list[T_Item]]:
+    iterator = iter(iterable)
+    while chunk := list(itertools.islice(iterator, size)):
+        yield chunk


### PR DESCRIPTION
# Description

Tested with an asset hierarchy of 100,000:
## Hierarchy
![image](https://github.com/user-attachments/assets/9d01cec6-2bf4-4c9f-a0b5-45d60bbed1f8)

## Purge command
![image](https://github.com/user-attachments/assets/8e0c18e8-b3ff-46e4-b5ab-0adba1d020df)

**Note** Ideally we should have a `cdf purge asset` command that selects an hierarchy. 

## Checklist

- [ ] Prefixed the PR title with the Jira issue number on the form `[CDF-12345]`.
- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).


[CDF-12345]: https://cognitedata.atlassian.net/browse/CDF-12345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ