### PR TITLE
[CDF-24185] 🚓 Allow CDF auth provider

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils/auth.py
+++ b/cognite_toolkit/_cdf_tk/utils/auth.py
@@ -111,7 +111,7 @@ class EnvironmentVariables:
                 "entra_id": "https://login.microsoftonline.com/{IDP_TENANT_ID}/oauth2/v2.0/token",
                 "auth0": "https://<my_auth_url>/oauth/token",
             },
-            required=all_providers(flow="client_credentials", exclude="entra_id"),
+            required=all_providers(flow="client_credentials", exclude={"entra_id", "cdf"}),
             optional=frozenset([("entra_id", "client_credentials")]),
         ),
     )
@@ -134,7 +134,7 @@ class EnvironmentVariables:
                 "auth0": "https: //{CDF_PROJECT}.fusion.cognite.com/{CDF_PROJECT}",
                 "other": "https://{CDF_CLUSTER}.cognitedata.com",
             },
-            required=all_providers(flow="client_credentials", exclude={"entra_id", "auth0"}),
+            required=all_providers(flow="client_credentials", exclude={"entra_id", "auth0", "cdf"}),
             optional=frozenset([("entra_id", "client_credentials"), ("auth0", "client_credentials")]),
         ),
     )

--- a/cognite_toolkit/_cdf_tk/utils/auth.py
+++ b/cognite_toolkit/_cdf_tk/utils/auth.py
@@ -147,7 +147,7 @@ class EnvironmentVariables:
                 "entra_id": "https://{CDF_CLUSTER}.cognitedata.com/.default",
                 "auth0": "IDENTITY,user_impersonation",
             },
-            optional=frozenset([*all_providers("client_credentials"), (None, "interactive")]),
+            optional=frozenset([*all_providers("client_credentials", exclude="cdf"), (None, "interactive")]),
         ),
     )
     IDP_AUTHORITY_URL: str | None = field(

--- a/cognite_toolkit/_cdf_tk/utils/auth.py
+++ b/cognite_toolkit/_cdf_tk/utils/auth.py
@@ -21,7 +21,7 @@ from cognite_toolkit._cdf_tk.exceptions import AuthenticationError, ToolkitKeyEr
 from cognite_toolkit._cdf_tk.utils import humanize_collection
 from cognite_toolkit._version import __version__
 
-Provider: TypeAlias = Literal["entra_id", "auth0", "other"]
+Provider: TypeAlias = Literal["entra_id", "auth0", "cdf", "other"]
 LoginFlow: TypeAlias = Literal["client_credentials", "token", "device_code", "interactive"]
 VALID_PROVIDERS = get_args(Provider)
 VALID_LOGIN_FLOWS = get_args(LoginFlow)
@@ -30,7 +30,7 @@ CLIENT_NAME = f"CDF-Toolkit:{__version__}"
 PROVIDER_DESCRIPTION = {
     "entra_id": "Use Microsoft Entra ID to authenticate",
     "auth0": "Use Auth0 to authenticate",
-    # "cdf": "Use Cognite IDP to authenticate",
+    "cdf": "Use Cognite IDP to authenticate",
     "other": "Use other IDP to authenticate",
 }
 LOGIN_FLOW_DESCRIPTION = {
@@ -443,7 +443,9 @@ def prompt_user_environment_variables(current: EnvironmentVariables | None = Non
         "Choose the provider (Who authenticates you?)",
         choices=[
             Choice(title=f"{provider}: {description}", value=provider)
+            # We CDF as a provider is not yet out of alpha, so we hide it from the user.
             for provider, description in PROVIDER_DESCRIPTION.items()
+            if provider != "cdf"
         ],
         default=current.PROVIDER if current else "entra_id",
     ).ask()

--- a/tests/test_unit/test_cdf_tk/test_utils/test_auth.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_auth.py
@@ -71,6 +71,16 @@ class TestEnvironmentVariables:
                 },
                 id="device other",
             ),
+            pytest.param(
+                {
+                    **PROJECT_AND_CLUSTER,
+                    "LOGIN_FLOW": "client_credentials",
+                    "PROVIDER": "cdf",
+                    "IDP_CLIENT_ID": "my-identifier",
+                    "IDP_CLIENT_SECRET": "my-secret",
+                },
+                id="client-credentials cdf",
+            ),
         ],
     )
     def test_get_valid_config(self, args: dict[str, Any]) -> None:


### PR DESCRIPTION
# Description

## Before
There were no way to set ENV variables to authenticate with CDF as the provider.

## After
You can use CDF as the provider if you set your env file to 
```env
LOGIN_FLOW=client_credentials
PROVIDER=cdf
CDF_CLUSTER=
CDF_PROJECT=
IDP_CLIENT_ID=
IDP_CLIENT_SECRET=
```

We are not exposing this to the end user as this is only in private alpha used by GSS.

## Checklist

- [ ] Prefixed the PR title with the Jira issue number on the form `[CDF-12345]`.
- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/toolkit/blob/main/CHANGELOG.templates.md).


[CDF-12345]: https://cognitedata.atlassian.net/browse/CDF-12345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ