### PR TITLE
Missing internal ID lookup 

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/api/lookup.py
+++ b/cognite_toolkit/_cdf_tk/client/api/lookup.py
@@ -119,8 +119,8 @@ class LookUpAPI(ToolkitAPI, ABC):
         if isinstance(id, int):
             return self._get_external_id_from_cache(id)
         else:
-            ids = (self._get_external_id_from_cache(id) for id in ids)
-            return [id for id in ids if id is not None]
+            external_ids = (self._get_external_id_from_cache(id) for id in ids)
+            return [id for id in external_ids if id is not None]
 
     def _get_external_id_from_cache(self, id: int) -> str | None:
         if id == 0:
@@ -264,7 +264,7 @@ class SecurityCategoriesLookUpAPI(AllLookUpAPI):
         self._cache = {category.name: category.id for category in categories if category.name and category.id}
         self._reverse_cache = {category.id: category.name for category in categories if category.name and category.id}
 
-    def name(self, id: int | Sequence[int]) -> str | list[str]:
+    def name(self, id: int | Sequence[int]) -> str | list[str] | None:
         return self.external_id(id)
 
     def _read_acl(self) -> Capability:

--- a/cognite_toolkit/_cdf_tk/client/api/lookup.py
+++ b/cognite_toolkit/_cdf_tk/client/api/lookup.py
@@ -69,7 +69,7 @@ class LookUpAPI(ToolkitAPI, ABC):
             self._reverse_cache.update({v: k for k, v in lookup.items()})
             if len(missing) != len(lookup) and not is_dry_run:
                 raise ResourceRetrievalError(
-                    f"Failed to retrieve {self.resource_name} with external_id {missing}.Have you created it?"
+                    f"Failed to retrieve {self.resource_name} with external_id {missing}. Have you created it?"
                 )
         return (
             self._get_id_from_cache(external_id, is_dry_run, allow_empty)
@@ -116,7 +116,7 @@ class LookUpAPI(ToolkitAPI, ABC):
             self._cache.update({v: k for k, v in lookup.items()})
             if len(missing) != len(lookup):
                 raise ResourceRetrievalError(
-                    f"Failed to retrieve {self.resource_name} with id {missing}.Have you created it?"
+                    f"Failed to retrieve {self.resource_name} with id {missing}. Have you created it?"
                 )
         return (
             self._get_external_id_from_cache(id)

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/auth_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/auth_loaders.py
@@ -62,7 +62,7 @@ class _ReplaceMethod:
     lookup and replace in the ACL scoped ids"""
 
     lookup_method: Callable[[str, bool], int]
-    reverse_lookup_method: Callable[[int], str]
+    reverse_lookup_method: Callable[[int], str | None]
     id_name: str
 
 

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/auth_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/auth_loaders.py
@@ -216,9 +216,12 @@ class GroupLoader(ResourceLoader[str, GroupWrite, Group, GroupWriteList, GroupLi
                     continue
                 if ids := scope.get(scope_name, {}).get(replace_method.id_name, []):
                     if reverse:
-                        values["scope"][scope_name][replace_method.id_name] = [
+                        cdf_ids = (
                             replace_method.reverse_lookup_method(int_id) if isinstance(int_id, int) else int_id
                             for int_id in ids
+                        )
+                        values["scope"][scope_name][replace_method.id_name] = [
+                            id_ for id_ in cdf_ids if id_ is not None
                         ]
                     else:
                         values["scope"][scope_name][replace_method.id_name] = [

--- a/tests/test_integration/test_loaders/test_resource_loaders.py
+++ b/tests/test_integration/test_loaders/test_resource_loaders.py
@@ -641,7 +641,7 @@ class TestGroupLoader:
             capabilities = dumped["capabilities"]
             assert isinstance(capabilities, list)
             assert len(capabilities) == 1
-            assert capabilities[0] == {"timeSeriesAcl": {"actions": ["READ"], "scope": {"idscope": []}}}
+            assert capabilities[0] == {"timeSeriesAcl": {"actions": ["READ"], "scope": {"idscope": {"ids": []}}}}
         finally:
             toolkit_client.time_series.delete(external_id=to_delete.external_id, ignore_unknown_ids=True)
             if group_id:


### PR DESCRIPTION
# Description

We no longer raise an error when looking up external IDs from internal IDs. Instead we give a warning. The reasoning is that every time we look up an external ID from internal, it is from a resource already deployed to CDF and not a user fault in local configuration. Thus, we give warning instead.


## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- When running `cdf deploy/pull`, the Toolkit no longer raise an `ResourceRetrievalError` if a CDF resource is referencing a non-existing resource. For example, if a group has an `TimeSeriesAcl` scoped to a timeseries that no longer exists. 

## templates

No changes.
