### PR TITLE
[CDF-24289 ] extending line width when dumping yaml to avoid unwanted line breaks

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils/file.py
+++ b/cognite_toolkit/_cdf_tk/utils/file.py
@@ -300,7 +300,7 @@ class YAMLWithComments(UserDict[T_Key, T_Value]):
     def _dump_yaml_with_comments(self, indent_size: int = 2, newline_after_indent_reduction: bool = False) -> str:
         """Dump a config dictionary to a yaml string"""
         config = self.dump()
-        dumped = yaml.dump(config, sort_keys=False, indent=indent_size)
+        dumped = yaml.dump(config, sort_keys=False, indent=indent_size, width=float("inf"))
         out_lines = []
         if comments := self._get_comment(tuple()):
             for comment in comments.above:

--- a/tests/test_unit/test_cdf_tk/test_data_classes/test_config_yaml.py
+++ b/tests/test_unit/test_cdf_tk/test_data_classes/test_config_yaml.py
@@ -178,3 +178,20 @@ variable4: "value with #in it" # But a comment after
         assert ("variables", "modules", "another_module", "dataset") not in config.keys()
         assert ("variables", "modules", "another_module", "source_asset") in config.keys()
         assert ("variables", "modules", "parent_module", "child_module", "source_asset") in config.keys()
+
+    def test_allow_wide_lines(self, dummy_environment) -> None:
+        long_default_value = "value " * 20  # whitespace makes default yaml.dump split lines
+
+        config = InitConfigYAML(
+            dummy_environment,
+            {
+                ("variables", "modules", "infield", "shared_variable"): ConfigEntry(
+                    key_path=("variables", "modules", "infield", "shared_variable"),
+                    default_value=long_default_value,
+                )
+            },
+        )
+
+        dumped = config.dump_yaml_with_comments()
+        loaded = yaml.safe_load(dumped)
+        assert loaded["variables"]["modules"]["infield"]["shared_variable"] == long_default_value


### PR DESCRIPTION
# Description

Module defaults that caused long lines got unwanted line breaks: 

```
data_developer_source_id: <OBJECT ID FOR TEST/PROD DATA DEVELOPER ENTRA GROUP> # ex. xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxx
```
turned into 

```
data_developer_source_id: <OBJECT ID FOR TEST/PROD DATA DEVELOPER ENTRA  # ex. xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxx
    GROUP>
```
This is now fixed

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- Fixed a bug that caused unwanted line breaks in module default values

## templates

No changes.
