### PR TITLE
[CDF-24233, CDF-24234] 🚶🏻Dump command wrong model issue

### DIFF
--- a/tests/test_unit/test_cli/test_packages.py
+++ b/tests/test_unit/test_cli/test_packages.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -12,51 +12,7 @@ from cognite_toolkit._cdf_tk.commands import BuildCommand, ModulesCommand
 from cognite_toolkit._cdf_tk.constants import BUILTIN_MODULES_PATH
 from cognite_toolkit._cdf_tk.data_classes import Package, Packages
 from cognite_toolkit._cdf_tk.tk_warnings import DuplicatedItemWarning, TemplateVariableWarning
-
-
-class MockQuestion:
-    def __init__(self, answer: Any, choices: list[Choice] | None = None) -> None:
-        self.answer = answer
-        self.choices = choices
-
-    def ask(self) -> Any:
-        if isinstance(self.answer, Callable):
-            return self.answer(self.choices)
-        return self.answer
-
-
-class MockQuestionary:
-    def __init__(self, module_target: str, monkeypatch: MonkeyPatch, answers: list[Any]) -> None:
-        self.module_target = module_target
-        self.answers = answers
-        self.monkeypatch = monkeypatch
-
-    def select(self, *_, choices: list[Choice], **__) -> MockQuestion:
-        return MockQuestion(self.answers.pop(0), choices)
-
-    def confirm(self, *_, **__) -> MockQuestion:
-        return MockQuestion(self.answers.pop(0))
-
-    def checkbox(self, *_, choices: list[Choice], **__) -> MockQuestion:
-        return MockQuestion(self.answers.pop(0), choices)
-
-    def text(self, *_, **__) -> MockQuestion:
-        return MockQuestion(self.answers.pop(0))
-
-    def __enter__(self):
-        for method in [self.select, self.confirm, self.checkbox, self.text]:
-            self.monkeypatch.setattr(f"{self.module_target}.questionary.{method.__name__}", method)
-        return self
-
-    def __exit__(self, *args):
-        self.monkeypatch.undo()
-        return False
-
-    @staticmethod
-    def select_all(choices: list[Choice]) -> list[str]:
-        if not choices:
-            return []
-        return [choice.value for choice in choices]
+from tests.test_unit.utils import MockQuestionary
 
 
 def get_packages() -> list[ParameterSet]:


### PR DESCRIPTION
# Description

Interactive selection of data models can lead to the selection of a model that is different than you selected. 
### Before
![image](https://github.com/user-attachments/assets/f6284fb6-5c49-423c-8346-646006b1d8f1)



## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- When running `cdf dump datamodel` in interfactive mode, the Toolkit now always dumps the selected data model. Earlier versions, depending on the choices the user made, Toolkit could end up not dumping the correct model.

## templates

No changes.
