### PR TITLE
[CDF-24288] 🪸Dump resource issue

### DIFF
--- a/tests/test_unit/test_cdf_tk/test_loaders/test_base_loaders.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_base_loaders.py
@@ -485,6 +485,29 @@ class TestResourceLoaders:
 
         assert expected_strings.issubset(sensitive_strings), f"Expected {expected_strings} but got {sensitive_strings}"
 
+    @pytest.mark.parametrize(
+        "loader_cls",
+        [
+            loader_cls
+            for loader_cls in RESOURCE_LOADER_LIST
+            if loader_cls != {HostedExtractorSourceLoader, HostedExtractorDestinationLoader}
+        ],
+    )
+    def test_dump_resource_with_local_id(
+        self, loader_cls: type[ResourceLoader], env_vars_with_client: EnvironmentVariables
+    ) -> None:
+        client = env_vars_with_client.get_client()
+        loader = loader_cls.create_loader(client)
+        resource = FakeCogniteResourceGenerator(seed=1337).create_instance(loader.resource_cls)
+        local_dict = loader.dump_id(loader.get_id(resource))
+
+        # The dump_resource method should work with the local dict only containing the
+        # identifier of the resource. This is to match the expectation of the cdf modules pull
+        # command.
+        dumped = loader.dump_resource(resource, local_dict)
+
+        assert isinstance(dumped, dict)
+
 
 class TestLoaders:
     def test_unique_display_names(self, env_vars_with_client: EnvironmentVariables):


### PR DESCRIPTION
# Description

All loaders (standardized interface to work with CDF resources) have a `dump_resource` method. In some of the loaders, this method assumes that the local representation of the resource has all required fields. This is wrong as, for example, the `cdf modules pull` only requires the identifier fields to be present. 

In the first commit, created a test that tries do dump Response/Read format of a resource together with local dict with only the identifier keys. This triggers all the implementations of the `dump_resource` were this wrong assumption is made.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- When using `cdf modues pull`, if a local resource is missing required parameters, the Toolkit no longer raises a `AttributeError` or `KeyError`. Instead, the resource is fetched from CDF and written to the local configuration YAML.

## templates

No changes.
