### PR TITLE
🎾fix: wrong default in dumping containers

### DIFF
--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/datamodel_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/datamodel_loaders.py
@@ -319,7 +319,7 @@ class ContainerLoader(
             if prop_id not in local_prop_by_id:
                 continue
             local_prop = local_prop_by_id[prop_id]
-            for key, default in [("immutable", False), ("autoIncrement", False), ("nullable", False)]:
+            for key, default in [("immutable", False), ("autoIncrement", False), ("nullable", True)]:
                 if cdf_prop.get(key) is default and key not in local_prop:
                     cdf_prop.pop(key, None)
             cdf_type = cdf_prop.get("type", {})


### PR DESCRIPTION
# Description

I did some experimenting on a case, and ended up having to delete and recreate the test containers. This triggered the following bug, which is currently causing the tests on the main branch to fail.

**Risk Reviewer** As this is currently blocking all other PRs it would be nice to get some speed on this one. 

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- A container with the `nullable` property not set will no longer always be considered changed when running `cdf deploy`.

## templates

No changes.
