### PR TITLE
[CDF-24080] 👨🏼‍🏭Pull group missing capabilities

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/pull.py
+++ b/cognite_toolkit/_cdf_tk/commands/pull.py
@@ -37,6 +37,7 @@ from cognite_toolkit._cdf_tk.loaders import (
     ExtractionPipelineConfigLoader,
     FunctionLoader,
     GraphQLLoader,
+    GroupAllScopedLoader,
     HostedExtractorDestinationLoader,
     HostedExtractorSourceLoader,
     ResourceLoader,
@@ -522,6 +523,11 @@ class PullCommand(ToolkitCommand):
                     )
                 )
                 continue
+            if isinstance(loader, GroupAllScopedLoader):
+                # We have two loaders for Groups. We skip this one and
+                # only use the GroupResourceScopedLoader
+                continue
+
             result = self._pull_resources(loader, resources, dry_run, env_vars.dump(include_os=True))
             results[loader.display_name] = result
 

--- a/cognite_toolkit/_cdf_tk/commands/pull.py
+++ b/cognite_toolkit/_cdf_tk/commands/pull.py
@@ -510,12 +510,12 @@ class PullCommand(ToolkitCommand):
             )
             if not resources:
                 continue
-            if loader in {HostedExtractorSourceLoader, HostedExtractorDestinationLoader}:
+            if isinstance(loader, HostedExtractorSourceLoader | HostedExtractorDestinationLoader):
                 self.warn(
                     LowSeverityWarning(f"Skipping {loader.display_name} as it is not supported by the pull command.")
                 )
                 continue
-            if loader in {GraphQLLoader, FunctionLoader, StreamlitLoader}:
+            if isinstance(loader, GraphQLLoader | FunctionLoader | StreamlitLoader):
                 self.warn(
                     LowSeverityWarning(
                         f"Skipping {loader.display_name} as it is not supported by the pull command due to"


### PR DESCRIPTION
# Description

This issue was caused by having two loaders (standardized interface to work with CDF resources) to work with Groups (one for all scoped and one of resource scoped). When pulling the group (retrieving the Group from CDF and writing it to the local configuration), the first loader would write correctly to the local file. While the second pass, would cause some of the capabilities disappear. Solution is to only use one of the loaders for groups.

Found a logic mistake in the if conditions for skipping unsupported loaders, so fixed that issue as well.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- Running `cdf modules pull` no longer skips capabilities for Group resources.
- Running `cdf modules pull` now correctly skips unsupported resources such as `HostedExtractor` `source` and `destination`, as well as Functions and Streamlit apps.

## templates

No changes.
