### PR TITLE
[CDF-24076] 🏌️No unused parameter warnings for hosted extractors sources.

### DIFF
--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
@@ -613,9 +613,7 @@ class EventLoader(ResourceLoader[str, EventWrite, Event, EventWriteList, EventLi
 
         spec.add(ParameterSpec(("assetExternalIds",), frozenset({"list"}), is_required=False, _is_nullable=False))
         spec.add(
-            ParameterSpec(
-                ("assetExternalIds", ANY_INT, "externalId"), frozenset({"str"}), is_required=False, _is_nullable=False
-            )
+            ParameterSpec(("assetExternalIds", ANY_INT), frozenset({"str"}), is_required=False, _is_nullable=False)
         )
         spec.discard(ParameterSpec(("assetIds",), frozenset({"int"}), is_required=False, _is_nullable=False))
         spec.discard(ParameterSpec(("assetIds", ANY_INT), frozenset({"int"}), is_required=False, _is_nullable=False))

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/hosted_extractors.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/hosted_extractors.py
@@ -37,7 +37,7 @@ from cognite.client.data_classes.hosted_extractors.sources import (
 from cognite.client.utils.useful_types import SequenceNotStr
 from rich.console import Console
 
-from cognite_toolkit._cdf_tk._parameters import ParameterSpec, ParameterSpecSet
+from cognite_toolkit._cdf_tk._parameters import ANYTHING, ParameterSpec, ParameterSpecSet
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.exceptions import ToolkitNotSupported
 from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceLoader
@@ -115,7 +115,9 @@ class HostedExtractorSourceLoader(ResourceLoader[str, SourceWrite, Source, Sourc
     @lru_cache(maxsize=1)
     def get_write_cls_parameter_spec(cls) -> ParameterSpecSet:
         # parameterspec is highly dependent on type of source, so we accept any parameter
-        return ParameterSpecSet([])
+        return ParameterSpecSet(
+            [ParameterSpec((ANYTHING,), frozenset({"dict"}), is_required=False, _is_nullable=False)]
+        )
 
     def dump_resource(self, resource: Source, local: dict[str, Any] | None = None) -> dict[str, Any]:
         HighSeverityWarning(

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/timeseries_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/timeseries_loaders.py
@@ -21,7 +21,7 @@ from cognite.client.data_classes.capabilities import (
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
 from cognite.client.utils.useful_types import SequenceNotStr
 
-from cognite_toolkit._cdf_tk._parameters import ANY_STR, ParameterSpec, ParameterSpecSet
+from cognite_toolkit._cdf_tk._parameters import ANY_STR, ANYTHING, ParameterSpec, ParameterSpecSet
 from cognite_toolkit._cdf_tk.constants import MAX_TIMESTAMP_MS, MIN_TIMESTAMP_MS
 from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitRequiredValueError,
@@ -243,7 +243,7 @@ class DatapointSubscriptionLoader(
                 # Add extra ANY_STR layer
                 # The spec class is immutable, so we use this trick to modify it.
                 object.__setattr__(item, "path", item.path[:length] + (ANY_STR,) + item.path[length:])
-        spec.add(ParameterSpec(("filter", ANY_STR), frozenset({"dict"}), is_required=False, _is_nullable=False))
+        spec.add(ParameterSpec(("filter", ANYTHING), frozenset({"dict"}), is_required=False, _is_nullable=False))
         return spec
 
     @classmethod

--- a/tests/data/complete_org/config.dev.yaml
+++ b/tests/data/complete_org/config.dev.yaml
@@ -1,6 +1,6 @@
 environment:
   name: dev
-  project: <customer-dev>
+  project: pytest-project
   type: dev
   selected:
     - modules/

--- a/tests/data/complete_org/modules/my_example_module/data_models/instance.Space.yaml
+++ b/tests/data/complete_org/modules/my_example_module/data_models/instance.Space.yaml
@@ -1,0 +1,1 @@
+space: sp_instance

--- a/tests/data/complete_org/modules/my_example_module/timeseries/my_subscription.DatapointSubscription.yaml
+++ b/tests/data/complete_org/modules/my_example_module/timeseries/my_subscription.DatapointSubscription.yaml
@@ -2,6 +2,7 @@ externalId: my_subscription
 name: My Subscription
 description: All timeseries with externalId starting with ts_value
 partitionCount: 1
+dataSetExternalId: ds_complete_org
 filter:
   prefix:
     property:

--- a/tests/data/complete_org/modules/my_example_module/transformations/first.transformation.yaml
+++ b/tests/data/complete_org/modules/my_example_module/transformations/first.transformation.yaml
@@ -5,6 +5,7 @@ destination:
 ignoreNullFields: true
 isPublic: true
 conflictMode: upsert
+dataSetExternalId: ds_complete_org
 authentication:
   clientId: {{ cicd_clientId }}
   clientSecret: {{ cicd_clientSecret }}

--- a/tests/data/complete_org/modules/my_example_module/transformations/inline.Transformation.yaml
+++ b/tests/data/complete_org/modules/my_example_module/transformations/inline.Transformation.yaml
@@ -5,5 +5,6 @@ destination:
 ignoreNullFields: true
 isPublic: true
 conflictMode: upsert
+dataSetExternalId: ds_complete_org
 query: select "fpso_uny" as externalId, UNY as uid, UNY as description from some_database.some_table
   where UNY is not null

--- a/tests/data/complete_org/modules/my_example_module/workflows/first.Workflow.yaml
+++ b/tests/data/complete_org/modules/my_example_module/workflows/first.Workflow.yaml
@@ -1,2 +1,3 @@
 externalId: {{ workflow_external_id }}
 description: A workflow for processing data
+dataSetExternalId: ds_complete_org

--- a/tests/data/complete_org/modules/my_example_module/workflows/first.WorkflowTrigger.yaml
+++ b/tests/data/complete_org/modules/my_example_module/workflows/first.WorkflowTrigger.yaml
@@ -4,3 +4,6 @@ triggerRule:
   cronExpression: 5 4 * * *
 workflowExternalId: {{ workflow_external_id }}
 workflowVersion: '1'
+authentication:
+  clientId: {{ cicd_clientId }}
+  clientSecret: {{ cicd_clientSecret }}

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org.yaml
@@ -224,7 +224,8 @@ DataSet:
 Database:
 - name: db_complete_org
 DatapointSubscription:
-- description: All timeseries with externalId starting with ts_value
+- dataSetId: 7982613576047462211
+  description: All timeseries with externalId starting with ts_value
   externalId: my_subscription
   filter:
     prefix:
@@ -712,6 +713,7 @@ Space:
 - space: population_instance_space
 - space: population_model
 - space: sp_complete_org_files
+- space: sp_instance
 - space: sp_nodes
 - space: sp_schema
 Table:
@@ -744,6 +746,7 @@ TimeSeries:
   name: CDF Toolkit Example Timeseries 2
 Transformation:
 - conflictMode: upsert
+  dataSetId: 7982613576047462211
   destination:
     type: assets
   externalId: inlined_transformation
@@ -753,6 +756,7 @@ Transformation:
   query: select "fpso_uny" as externalId, UNY as uid, UNY as description from some_database.some_table
     where UNY is not null
 - conflictMode: upsert
+  dataSetId: 7982613576047462211
   destination:
     type: assets
   destinationOidcCredentials:
@@ -901,7 +905,8 @@ View:
   space: population_model
   version: v1
 Workflow:
-- description: A workflow for processing data
+- dataSetId: 7982613576047462211
+  description: A workflow for processing data
   externalId: baz
 WorkflowTrigger:
 - externalId: MyTrigger


### PR DESCRIPTION
# Description

Even though these parameters are used, we get `UnusedParamterWarning`s
![image](https://github.com/user-attachments/assets/fee30a53-a577-4b26-8fe3-26b157b78bc9)

**Context**: The `UnusedParamterWarning` comes from comparing the resource specification to the configuration. We obtain the resource specification by looking at the write format of the resource data class. This PR fixes mistakes in the resource spec generation for HostedExtractor Source, datapoint subscriptoin, and event write classes. 

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- When running `cdf build`, the Toolkit no longer gives `UnusedParameterWarning` for all Hosted Extractor Source parameters, the filter parameter in DatapointSubscription, and the assetExternalIds parameter for Event resources. 

## templates

No changes.
