### PR TITLE
[CDF-24370] 🧑‍💻Unchanged Streamlit app detected as changed

### DIFF
--- a/tests/data/complete_org/modules/my_example_module/streamlit/myapp.Streamlit.yaml
+++ b/tests/data/complete_org/modules/my_example_module/streamlit/myapp.Streamlit.yaml
@@ -3,7 +3,6 @@ name: MySuperApp
 creator: doctrino@github.com
 description: This is a super app
 published: true
-theme: Light
 thumbnail: data:image/webp;base64,....
 dataSetExternalId: ds_complete_org
 entrypoint: main.py


### PR DESCRIPTION
# Description

The StreamlitLoader (Loader = standardized interface for CDF resources) does not account for `theme=Light` set on the server side.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- When running `cdf deploy`, Streamlit apps without the parameter `theme=Light` are no longer always considered changed.

## templates

No changes.
