### PR TITLE
[CDF-24130] 🍽 Improved hint for missing variables

### DIFF
--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -129,7 +129,7 @@ def app() -> NoReturn:
                     f"{HINT_LEAD_TEXT} The plugin [bold]{cmd}[/bold] is not enabled."
                     f"\nEnable it in the [bold]cdf.toml[/bold] file by setting '{cmd} = true' in the "
                     f"[bold]{escape(plugin)}[/bold] section."
-                    f"\nDocs to lean more: {Hint._link(URL.plugins, URL.plugins)}"
+                    f"\nDocs to lean more: {Hint.link(URL.plugins, URL.plugins)}"
                 )
         raise
 

--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -129,7 +129,7 @@ def app() -> NoReturn:
                     f"{HINT_LEAD_TEXT} The plugin [bold]{cmd}[/bold] is not enabled."
                     f"\nEnable it in the [bold]cdf.toml[/bold] file by setting '{cmd} = true' in the "
                     f"[bold]{escape(plugin)}[/bold] section."
-                    f"\nDocs to lean more: {Hint.link(URL.plugins, URL.plugins)}"
+                    f"\nDocs to learn more: {Hint.link(URL.plugins, URL.plugins)}"
                 )
         raise
 

--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -23,6 +23,7 @@ from cognite_toolkit._cdf_tk.constants import (
     HINT_LEAD_TEXT,
     ROOT_MODULES,
     TEMPLATE_VARS_FILE_SUFFIXES,
+    URL,
     YAML_SUFFIX,
 )
 from cognite_toolkit._cdf_tk.data_classes import (
@@ -47,7 +48,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitMissingModuleError,
     ToolkitYAMLFormatError,
 )
-from cognite_toolkit._cdf_tk.hints import ModuleDefinition, verify_module_directory
+from cognite_toolkit._cdf_tk.hints import Hint, ModuleDefinition, verify_module_directory
 from cognite_toolkit._cdf_tk.loaders import (
     ContainerLoader,
     DataLoader,
@@ -507,7 +508,10 @@ class BuildCommand(ToolkitCommand):
                     variable_str = humanize_collection(unresolved_variables)
                     source_str = variables.source_path.as_posix() if variables.source_path else "config.[ENV].yaml"
                     suffix = "s" if len(unresolved_variables) > 1 else ""
-                    message += f"\n{HINT_LEAD_TEXT}Add the following variable{suffix} to the {source_str!r} file: {variable_str!r}"
+                    message += f"\n{HINT_LEAD_TEXT}Add the following variable{suffix} to the {source_str!r} file: {variable_str!r}."
+                    message += (
+                        f"\nRead more about build variables: {Hint.link(URL.build_variables, URL.build_variables)}."
+                    )
 
                 raise ToolkitYAMLFormatError(message)
 

--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -90,3 +90,4 @@ class URL:
     configs = "https://docs.cognite.com/cdf/deploy/cdf_toolkit/references/configs"
     plugins = "https://docs.cognite.com/cdf/deploy/cdf_toolkit/guides/plugins/"
     libyaml = "https://pyyaml.org/wiki/PyYAMLDocumentation"
+    build_variables = "https://docs.cognite.com/cdf/deploy/cdf_toolkit/api/config_yaml#the-variables-section"

--- a/cognite_toolkit/_cdf_tk/hints.py
+++ b/cognite_toolkit/_cdf_tk/hints.py
@@ -40,21 +40,21 @@ class Hint:
         return cls._lead_text + f"\n{cls._indent}".join(lines)
 
     @classmethod
-    def _link(cls, url: str, text: str | None = None) -> str:
+    def link(cls, url: str, text: str | None = None) -> str:
         return f"[blue][link={url}]{text or url}[/link][/blue]"
 
 
 class ModuleDefinition(Hint):
     @classmethod
     def _short(cls) -> str:
-        return f"Available resource directories are {sorted(LOADER_BY_FOLDER_NAME)}. {cls._link(URL.configs)} to learn more."
+        return f"Available resource directories are {sorted(LOADER_BY_FOLDER_NAME)}. {cls.link(URL.configs)} to learn more."
 
     @classmethod
     def long(cls, missing_modules: set[str | Path] | None = None, organization_dir: Path | None = None) -> str:  # type: ignore[override]
         lines = [
             "A module is a directory with one or more resource directories in it.",
             f"Available resource directories are {sorted(LOADER_BY_FOLDER_NAME)}",
-            f"{cls._link(URL.configs)} to learn more",
+            f"{cls.link(URL.configs)} to learn more",
         ]
         if missing_modules and organization_dir:
             found_directory, subdirectories = find_directory_with_subdirectories(


### PR DESCRIPTION
# Description

## Before
![image](https://github.com/user-attachments/assets/60016423-fda6-4bda-842a-17745a31ec2a)

## After
![image](https://github.com/user-attachments/assets/ec3c580c-cc2e-4a8e-ba0b-c4440001f551)


## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Improved

- When running `cdf build` and missing a build variable you know get a URL to the relevant documentation.

## templates

No changes.
