### PR TITLE
Release 0.5.0

### DIFF
--- a/cdf.toml
+++ b/cdf.toml
@@ -9,10 +9,6 @@ module-repeat = true
 dump-extended = true
 populate = true
 strict-validation = true
-# Setting this to true wil change all snapshots for WorkflowTriggers/FunctionSchedules.
-# For simplicity, (avoid keeping track of two sets of snapshots), we keep this to false in development.
-credentials-hash = false
-dump-dm-global = true
 
 [plugins]
 run = true

--- a/cdf.toml
+++ b/cdf.toml
@@ -6,9 +6,7 @@ default_organization_dir = "cognite_toolkit"
 graphql = true
 import-cmd = true
 module-repeat = true
-dump-extended = true
 populate = true
-strict-validation = true
 
 [plugins]
 run = true

--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -19,7 +19,6 @@ from cognite_toolkit._cdf_tk.commands.dump_resource import (
     WorkflowFinder,
 )
 from cognite_toolkit._cdf_tk.exceptions import ToolkitRequiredValueError
-from cognite_toolkit._cdf_tk.feature_flags import Flags
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 
 
@@ -32,11 +31,10 @@ class DumpApp(typer.Typer):
         self.command("asset")(self.dump_asset_cmd)
         self.command("timeseries")(self.dump_timeseries_cmd)
 
-        if Flags.DUMP_EXTENDED.is_enabled():
-            self.command("workflow")(self.dump_workflow)
-            self.command("transformation")(self.dump_transformation)
-            self.command("group")(self.dump_group)
-            self.command("node")(self.dump_node)
+        self.command("workflow")(self.dump_workflow)
+        self.command("transformation")(self.dump_transformation)
+        self.command("group")(self.dump_group)
+        self.command("node")(self.dump_node)
 
     def dump_main(self, ctx: typer.Context) -> None:
         """Commands to dump resource configurations from CDF into a temporary directory."""

--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -27,10 +27,8 @@ class DumpApp(typer.Typer):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.callback(invoke_without_command=True)(self.dump_main)
-        if Flags.DUMP_DM_GLOBAL:
-            self.command("datamodel")(self.dump_datamodel_cmd_v5)
-        else:
-            self.command("datamodel")(self.dump_datamodel_cmd)
+        self.command("datamodel")(self.dump_datamodel_cmd)
+
         self.command("asset")(self.dump_asset_cmd)
         self.command("timeseries")(self.dump_timeseries_cmd)
 
@@ -48,63 +46,6 @@ class DumpApp(typer.Typer):
 
     @staticmethod
     def dump_datamodel_cmd(
-        ctx: typer.Context,
-        data_model_id: Annotated[
-            Optional[list[str]],
-            typer.Argument(
-                help="Data model ID to dump. Format: space external_id version. Example: 'my_space my_external_id v1'. "
-                "Note that version is optional and defaults to the latest published version. If nothing is provided,"
-                "an interactive prompt will be shown to select the data model.",
-            ),
-        ] = None,
-        output_dir: Annotated[
-            Path,
-            typer.Option(
-                "--output-dir",
-                "-o",
-                help="Where to dump the datamodel files.",
-                allow_dash=True,
-            ),
-        ] = Path("tmp"),
-        clean: Annotated[
-            bool,
-            typer.Option(
-                "--clean",
-                "-c",
-                help="Delete the output directory before dumping the datamodel.",
-            ),
-        ] = False,
-        verbose: Annotated[
-            bool,
-            typer.Option(
-                "--verbose",
-                "-v",
-                help="Turn on to get more verbose output when running the command",
-            ),
-        ] = False,
-    ) -> None:
-        """This command will dump the selected data model as yaml to the folder specified, defaults to /tmp."""
-        selected_data_model: Union[DataModelId, None] = None
-        if data_model_id is not None:
-            if len(data_model_id) < 2:
-                raise ToolkitRequiredValueError(
-                    "Data model ID must have at least 2 parts: space, external_id, and, optionally, version."
-                )
-            selected_data_model = DataModelId(*data_model_id)
-        client = EnvironmentVariables.create_from_environment().get_client()
-
-        cmd = DumpResourceCommand()
-        cmd.run(
-            lambda: cmd.dump_to_yamls(
-                DataModelFinder(client, selected_data_model, include_global=True),
-                output_dir=output_dir,
-                clean=clean,
-                verbose=verbose,
-            )
-        )
-
-    @staticmethod
-    def dump_datamodel_cmd_v5(
         ctx: typer.Context,
         data_model_id: Annotated[
             Optional[list[str]],

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -347,7 +347,7 @@ class NodeFinder(ResourceFinder[dm.ViewId]):
             count = self.client.data_modeling.instances.aggregate(
                 self.identifier, dm.aggregations.Count("externalId"), instance_type="node"
             ).value
-            if count == 0:
+            if count == 0 or count is None:
                 raise ToolkitMissingResourceError(f"No nodes found in {self.identifier}")
             elif count > 50:
                 if not questionary.confirm(

--- a/cognite_toolkit/_cdf_tk/feature_flags.py
+++ b/cognite_toolkit/_cdf_tk/feature_flags.py
@@ -28,10 +28,6 @@ class Flags(Enum):
         "visible": True,
         "description": "Enables support for the populate command",
     }
-    STRICT_VALIDATION: ClassVar[dict[str, Any]] = {  # type: ignore[misc]
-        "visible": True,
-        "description": "For Workflow/Transformations/Function do not fallback to Toolkit credentials when validation-type != 'dev'",
-    }
 
     def is_enabled(self) -> bool:
         return FeatureFlag.is_enabled(self)

--- a/cognite_toolkit/_cdf_tk/feature_flags.py
+++ b/cognite_toolkit/_cdf_tk/feature_flags.py
@@ -37,12 +37,6 @@ class Flags(Enum):
         "description": "Stores a hash of the credentials of Workflow/Transformation/Function in the resources such that"
         " the resource is updated when the credentials change",
     }
-    DUMP_DM_GLOBAL: ClassVar[dict[str, Any]] = {  # type: ignore[misc]
-        "visible": True,
-        "description": "Changes the behavior of the cdf dump datamodel command to skip all"
-        " resources that are global (in a system space). You can get the original behavior"
-        "by using the --include-global flag",
-    }
 
     def is_enabled(self) -> bool:
         return FeatureFlag.is_enabled(self)

--- a/cognite_toolkit/_cdf_tk/feature_flags.py
+++ b/cognite_toolkit/_cdf_tk/feature_flags.py
@@ -20,10 +20,6 @@ class Flags(Enum):
         "visible": True,
         "description": "Enables the support for repeating modules in the config file",
     }
-    DUMP_EXTENDED: ClassVar[dict[str, Any]] = {  # type: ignore[misc]
-        "visible": True,
-        "description": "Enables support for dump workflow/transformation/group/node",
-    }
     POPULATE: ClassVar[dict[str, Any]] = {  # type: ignore[misc]
         "visible": True,
         "description": "Enables support for the populate command",

--- a/cognite_toolkit/_cdf_tk/feature_flags.py
+++ b/cognite_toolkit/_cdf_tk/feature_flags.py
@@ -32,11 +32,6 @@ class Flags(Enum):
         "visible": True,
         "description": "For Workflow/Transformations/Function do not fallback to Toolkit credentials when validation-type != 'dev'",
     }
-    CREDENTIALS_HASH: ClassVar[dict[str, Any]] = {  # type: ignore[misc]
-        "visible": True,
-        "description": "Stores a hash of the credentials of Workflow/Transformation/Function in the resources such that"
-        " the resource is updated when the credentials change",
-    }
 
     def is_enabled(self) -> bool:
         return FeatureFlag.is_enabled(self)

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/function_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/function_loaders.py
@@ -35,7 +35,6 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ResourceCreationError,
     ToolkitRequiredValueError,
 )
-from cognite_toolkit._cdf_tk.feature_flags import Flags
 from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceLoader
 from cognite_toolkit._cdf_tk.tk_warnings import HighSeverityWarning, LowSeverityWarning
 from cognite_toolkit._cdf_tk.utils import (
@@ -414,19 +413,18 @@ class FunctionScheduleLoader(
             identifier = self.get_id(resource)
             credentials = read_auth(identifier, resource, self.client, "function schedule", self.console)
             self.authentication_by_id[identifier] = credentials
-            if Flags.CREDENTIALS_HASH.is_enabled():
-                auth_hash = calculate_secure_hash(credentials.dump(camel_case=True), shorten=True)
-                extra_str = f" {self._hash_key}: {auth_hash}"
-                if "description" not in resource:
-                    resource["description"] = extra_str[1:]
-                elif len(resource["description"]) + len(extra_str) < self._description_character_limit:
-                    resource["description"] += f"{extra_str}"
-                else:
-                    LowSeverityWarning(
-                        f"Description is too long for schedule {identifier!r}. Truncating..."
-                    ).print_warning(console=self.console)
-                    truncation = self._description_character_limit - len(extra_str) - 3
-                    resource["description"] = f"{resource['description'][:truncation]}...{extra_str}"
+            auth_hash = calculate_secure_hash(credentials.dump(camel_case=True), shorten=True)
+            extra_str = f" {self._hash_key}: {auth_hash}"
+            if "description" not in resource:
+                resource["description"] = extra_str[1:]
+            elif len(resource["description"]) + len(extra_str) < self._description_character_limit:
+                resource["description"] += f"{extra_str}"
+            else:
+                LowSeverityWarning(f"Description is too long for schedule {identifier!r}. Truncating...").print_warning(
+                    console=self.console
+                )
+                truncation = self._description_character_limit - len(extra_str) - 3
+                resource["description"] = f"{resource['description'][:truncation]}...{extra_str}"
         return resources
 
     def load_resource(self, resource: dict[str, Any], is_dry_run: bool = False) -> FunctionScheduleWrite:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/function_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/function_loaders.py
@@ -417,6 +417,9 @@ class FunctionScheduleLoader(
             extra_str = f" {self._hash_key}: {auth_hash}"
             if "description" not in resource:
                 resource["description"] = extra_str[1:]
+            elif resource["description"].endswith(extra_str[1:]):
+                # The hash is already in the description
+                ...
             elif len(resource["description"]) + len(extra_str) < self._description_character_limit:
                 resource["description"] += f"{extra_str}"
             else:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/transformation_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/transformation_loaders.py
@@ -245,7 +245,9 @@ class TransformationLoader(
             if auth_dict:
                 auth_hash = calculate_secure_hash(auth_dict, shorten=True)
                 if "query" in item:
-                    item["query"] = f"{self._hash_key}: {auth_hash}\n{item['query']}"
+                    hash_str = f"{self._hash_key}: {auth_hash}"
+                    if not item["query"].startswith(self._hash_key):
+                        item["query"] = f"{hash_str}\n{item['query']}"
         return raw_list
 
     def load_resource(self, resource: dict[str, Any], is_dry_run: bool = False) -> TransformationWrite:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/transformation_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/transformation_loaders.py
@@ -72,7 +72,6 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitTypeError,
     ToolkitYAMLFormatError,
 )
-from cognite_toolkit._cdf_tk.feature_flags import Flags
 from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceLoader
 from cognite_toolkit._cdf_tk.utils import (
     calculate_secure_hash,
@@ -233,21 +232,20 @@ class TransformationLoader(
             elif query_file:
                 item["query"] = safe_read(query_file)
 
-            if Flags.CREDENTIALS_HASH.is_enabled():
-                auth_dict: dict[str, Any] = {}
-                for key in [
-                    "authentication",
-                    "sourceOidcCredentials",
-                    "destinationOidcCredentials",
-                    "sourceNonce",
-                    "destinationNonce",
-                ]:
-                    if key in item:
-                        auth_dict[key] = item[key]
-                if auth_dict:
-                    auth_hash = calculate_secure_hash(auth_dict, shorten=True)
-                    if "query" in item:
-                        item["query"] = f"{self._hash_key}: {auth_hash}\n{item['query']}"
+            auth_dict: dict[str, Any] = {}
+            for key in [
+                "authentication",
+                "sourceOidcCredentials",
+                "destinationOidcCredentials",
+                "sourceNonce",
+                "destinationNonce",
+            ]:
+                if key in item:
+                    auth_dict[key] = item[key]
+            if auth_dict:
+                auth_hash = calculate_secure_hash(auth_dict, shorten=True)
+                if "query" in item:
+                    item["query"] = f"{self._hash_key}: {auth_hash}\n{item['query']}"
         return raw_list
 
     def load_resource(self, resource: dict[str, Any], is_dry_run: bool = False) -> TransformationWrite:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/workflow_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/workflow_loaders.py
@@ -657,9 +657,9 @@ class WorkflowTriggerLoader(
             self._authentication_by_id[identifier] = credentials
             if "metadata" not in resource:
                 resource["metadata"] = {}
-                resource["metadata"][self._MetadataKey.secret_hash] = calculate_secure_hash(
-                    credentials.dump(camel_case=True), shorten=True
-                )
+            resource["metadata"][self._MetadataKey.secret_hash] = calculate_secure_hash(
+                credentials.dump(camel_case=True), shorten=True
+            )
         return resources
 
     def load_resource(self, resource: dict[str, Any], is_dry_run: bool = False) -> WorkflowTriggerUpsert:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/workflow_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/workflow_loaders.py
@@ -50,7 +50,6 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ResourceCreationError,
     ToolkitRequiredValueError,
 )
-from cognite_toolkit._cdf_tk.feature_flags import Flags
 from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceLoader
 from cognite_toolkit._cdf_tk.tk_warnings import (
     LowSeverityWarning,
@@ -656,12 +655,11 @@ class WorkflowTriggerLoader(
             identifier = self.get_id(resource)
             credentials = read_auth(identifier, resource, self.client, "workflow trigger", self.console)
             self._authentication_by_id[identifier] = credentials
-            if Flags.CREDENTIALS_HASH.is_enabled():
-                if "metadata" not in resource:
-                    resource["metadata"] = {}
-                    resource["metadata"][self._MetadataKey.secret_hash] = calculate_secure_hash(
-                        credentials.dump(camel_case=True), shorten=True
-                    )
+            if "metadata" not in resource:
+                resource["metadata"] = {}
+                resource["metadata"][self._MetadataKey.secret_hash] = calculate_secure_hash(
+                    credentials.dump(camel_case=True), shorten=True
+                )
         return resources
 
     def load_resource(self, resource: dict[str, Any], is_dry_run: bool = False) -> WorkflowTriggerUpsert:

--- a/cognite_toolkit/_cdf_tk/utils/cdf.py
+++ b/cognite_toolkit/_cdf_tk/utils/cdf.py
@@ -18,7 +18,6 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitRequiredValueError,
     ToolkitTypeError,
 )
-from cognite_toolkit._cdf_tk.feature_flags import Flags
 from cognite_toolkit._cdf_tk.tk_warnings import (
     HighSeverityWarning,
     MediumSeverityWarning,
@@ -125,9 +124,7 @@ def read_auth(
 ) -> ClientCredentials:
     auth = resource.get("authentication")
     if auth is None:
-        if (client.config.is_strict_validation and Flags.STRICT_VALIDATION.is_enabled()) or not isinstance(
-            client.config.credentials, OAuthClientCredentials
-        ):
+        if client.config.is_strict_validation or not isinstance(client.config.credentials, OAuthClientCredentials):
             raise ToolkitRequiredValueError(f"Authentication is missing for {resource_name} {identifier!r}.")
         else:
             HighSeverityWarning(

--- a/tests/test_integration/test_commands/test_deploy.py
+++ b/tests/test_integration/test_commands/test_deploy.py
@@ -16,12 +16,15 @@ from cognite_toolkit._cdf_tk.data_classes import BuiltModuleList, ResourceDeploy
 from cognite_toolkit._cdf_tk.loaders import (
     RESOURCE_LOADER_LIST,
     FunctionLoader,
+    FunctionScheduleLoader,
     GraphQLLoader,
     HostedExtractorDestinationLoader,
     HostedExtractorSourceLoader,
     ResourceLoader,
     ResourceWorker,
     StreamlitLoader,
+    TransformationLoader,
+    WorkflowTriggerLoader,
 )
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 from cognite_toolkit._cdf_tk.utils.file import remove_trailing_newline
@@ -145,6 +148,8 @@ def get_changed_source_files(
             loader_cls in {HostedExtractorSourceLoader, HostedExtractorDestinationLoader}
             # External files that cannot (or not yet supported) be pulled
             or loader_cls in {GraphQLLoader, FunctionLoader, StreamlitLoader}
+            # Have authentication hashes that is different for each environment
+            or loader_cls in {TransformationLoader, FunctionScheduleLoader, WorkflowTriggerLoader}
         ):
             continue
         loader = loader_cls.create_loader(env_vars.get_client(), build_dir)

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_function_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_function_loader.py
@@ -155,9 +155,6 @@ class TestFunctionScheduleLoader:
         assert credentials.client_id == "toolkit-client-id"
         assert credentials.client_secret == "toolkit-client-secret"
 
-    @pytest.mark.skipif(
-        not Flags.CREDENTIALS_HASH.is_enabled(), reason="This test is only relevant when credentials hash is enabled"
-    )
     def test_credentials_unchanged_changed(self) -> None:
         local_content = """name: daily-8am-utc
 functionExternalId: fn_example_repeater

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_function_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_function_loader.py
@@ -9,7 +9,6 @@ from cognite.client.data_classes import Function, FunctionSchedule, FunctionWrit
 from cognite_toolkit._cdf_tk.client import ToolkitClientConfig
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.exceptions import ToolkitRequiredValueError
-from cognite_toolkit._cdf_tk.feature_flags import Flags
 from cognite_toolkit._cdf_tk.loaders import FunctionLoader, FunctionScheduleLoader, ResourceWorker
 from cognite_toolkit._cdf_tk.utils import calculate_directory_hash, calculate_secure_hash
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
@@ -123,9 +122,6 @@ secrets:
 
 
 class TestFunctionScheduleLoader:
-    @pytest.mark.skipif(
-        not Flags.STRICT_VALIDATION.is_enabled(), reason="This test is only relevant when strict validation is enabled"
-    )
     def test_credentials_missing_raise(self) -> None:
         schedule = dict(
             name="daily-8am-utc",

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_transformation_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_transformation_loader.py
@@ -11,7 +11,6 @@ from cognite.client.data_classes import data_modeling as dm
 from cognite_toolkit._cdf_tk.client.data_classes.raw import RawDatabase, RawTable
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.exceptions import ToolkitTypeError
-from cognite_toolkit._cdf_tk.feature_flags import Flags
 from cognite_toolkit._cdf_tk.loaders import (
     DataModelLoader,
     DataSetsLoader,
@@ -113,9 +112,6 @@ conflictMode: upsert
             raw_list = loader.load_resource_file(filepath, env_vars_with_client.dump())
             loader.load_resource(raw_list[0], is_dry_run=False)
 
-    @pytest.mark.skipif(
-        not Flags.CREDENTIALS_HASH.is_enabled(), reason="This test is only relevant when credentials hash is enabled"
-    )
     def test_auth_unchanged_changed(
         self,
         toolkit_client_approval: ApprovalToolkitClient,

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_workflow_loaders.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_workflow_loaders.py
@@ -49,9 +49,6 @@ workflowVersion: v1
         assert credentials.client_id == "toolkit-client-id"
         assert credentials.client_secret == "toolkit-client-secret"
 
-    @pytest.mark.skipif(
-        not Flags.CREDENTIALS_HASH.is_enabled(), reason="This test is only relevant when credentials hash is enabled"
-    )
     def test_credentials_unchanged_changed(self) -> None:
         local_content = """externalId: daily-8am-utc
 triggerRule:

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_workflow_loaders.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_workflow_loaders.py
@@ -9,15 +9,11 @@ from cognite.client.data_classes.workflows import WorkflowScheduledTriggerRule
 from cognite_toolkit._cdf_tk.client import ToolkitClientConfig
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.exceptions import ToolkitRequiredValueError
-from cognite_toolkit._cdf_tk.feature_flags import Flags
 from cognite_toolkit._cdf_tk.loaders import WorkflowTriggerLoader
 from cognite_toolkit._cdf_tk.utils import calculate_secure_hash
 
 
 class TestWorkflowTriggerLoader:
-    @pytest.mark.skipif(
-        not Flags.STRICT_VALIDATION.is_enabled(), reason="This test is only relevant when strict validation is enabled"
-    )
     def test_credentials_missing_raise(self) -> None:
         trigger_content = """externalId: daily-8am-utc
 triggerRule:

--- a/tests/test_unit/test_cdf_tk/test_utils/test_cdf.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_cdf.py
@@ -19,7 +19,13 @@ class TestTryFindError:
                 id="Missing environment variable",
             ),
             pytest.param(
-                OidcCredentials("my-client-id", "123", ["https://cognite.com"], "not-valid-uri", "my-project"),
+                OidcCredentials(
+                    client_id="my-client-id",
+                    client_secret="123",
+                    scopes=["https://cognite.com"],
+                    token_uri="not-valid-uri",
+                    cdf_project_name="my-project",
+                ),
                 "The tokenUri 'not-valid-uri' is not a valid URI.",
             ),
             pytest.param(None, None, id="empty"),

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_data_pipeline_3d_valhall.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_data_pipeline_3d_valhall.yaml
@@ -109,7 +109,7 @@ FunctionSchedule:
 - cronExpression: 15 * * * *
   data:
     ExtractionPipelineExtId: ep_ctx_3d_oid_fileshare_annotation
-  description: Run every 30 minute
+  description: 'Run every 30 minute cdf-auth: def5e2e0'
   functionExternalId: fn_context_3d_oid_fileshare_asset
   name: daily-every-60-min
 Group:

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_data_pipeline_asset_valhall.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_data_pipeline_asset_valhall.yaml
@@ -130,16 +130,16 @@ Transformation:
   ignoreNullFields: true
   isPublic: true
   name: asset:oid:workmate:asset_hierarchy
-  query: "--\n-- Create Asset Hierarchy using Transformation\n--\n-- Input data from\
-    \ RAW DB table (using example data)\n--\n-- Root node has parentExternal id =\
-    \ ''\n-- Transformation is connected to asset data set\n-- All metadata expect\
-    \ selected fileds are added to metadata\n--\nSELECT \n  externalId           \
-    \           as externalId,\n  if(parentExternalId is null, \n     '', \n     parentExternalId)\
-    \            as parentExternalId,\n  tag                             as name,\n\
-    \  sourceDb                        as source,\n  description,\n  dataset_id('ds_asset_oid')\
-    \     as dataSetId,\n  to_metadata_except(\n    array(\"sourceDb\", \"parentExternalId\"\
-    , \"description\"), *) \n                                  as metadata\nFROM \n\
-    \  `asset_oid_workmate`.`assets`\n"
+  query: "-- cdf-auth: f5da81f3\n--\n-- Create Asset Hierarchy using Transformation\n\
+    --\n-- Input data from RAW DB table (using example data)\n--\n-- Root node has\
+    \ parentExternal id = ''\n-- Transformation is connected to asset data set\n--\
+    \ All metadata expect selected fileds are added to metadata\n--\nSELECT \n  externalId\
+    \                      as externalId,\n  if(parentExternalId is null, \n     '',\
+    \ \n     parentExternalId)            as parentExternalId,\n  tag            \
+    \                 as name,\n  sourceDb                        as source,\n  description,\n\
+    \  dataset_id('ds_asset_oid')     as dataSetId,\n  to_metadata_except(\n    array(\"\
+    sourceDb\", \"parentExternalId\", \"description\"), *) \n                    \
+    \              as metadata\nFROM \n  `asset_oid_workmate`.`assets`\n"
   sourceOidcCredentials:
     audience: https://bluefield.cognitedata.com
     cdfProjectName: pytest-project

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_data_pipeline_files_valhall.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_data_pipeline_files_valhall.yaml
@@ -114,7 +114,7 @@ FunctionSchedule:
   data:
     WorkflowExtId: wf_oid_files_annotation
     WorkflowVersion: 1
-  description: Run every 30 minute
+  description: 'Run every 30 minute cdf-auth: def5e2e0'
   functionExternalId: fn_workflow_files_oid_fileshare_annotation
   name: every 30 min
 Group:
@@ -284,13 +284,13 @@ Transformation:
   ignoreNullFields: true
   isPublic: true
   name: files:oid:fileshare:file_metadata
-  query: "--\n-- Update file metdata using Transformation\n--\n-- Input data from\
-    \ RAW DB table (using example data) and uploaded files\n--\n\nWith \n  root_id\
-    \ AS (\n     Select id from _cdf.asset where externalId = 'WMT:VAL'\n  )\nSELECT\n\
-    \  file.id                          as id,\n  file.name                      \
-    \  as name,\n  file.externalId                  as externalId,\n  meta.source\
-    \                      as source,\n  meta.`mime_type`                 as mimeType,\n\
-    \  array(root_id.id)                as assetIds,\n  dataset_id('ds_files_oid')\
+  query: "-- cdf-auth: f5da81f3\n--\n-- Update file metdata using Transformation\n\
+    --\n-- Input data from RAW DB table (using example data) and uploaded files\n\
+    --\n\nWith \n  root_id AS (\n     Select id from _cdf.asset where externalId =\
+    \ 'WMT:VAL'\n  )\nSELECT\n  file.id                          as id,\n  file.name\
+    \                        as name,\n  file.externalId                  as externalId,\n\
+    \  meta.source                      as source,\n  meta.`mime_type`           \
+    \      as mimeType,\n  array(root_id.id)                as assetIds,\n  dataset_id('ds_files_oid')\
     \  as dataSetId,\n  map_concat(map(\"doc_type\", meta.doc_type),\n           \
     \ file.metadata)         as metadata\nFROM \n  `files_oid_fileshare`.`files_metadata`\
     \ meta,\n  _cdf.files                             file,\n  root_id\nWHERE \n \

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_data_pipeline_timeseries_valhall.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_data_pipeline_timeseries_valhall.yaml
@@ -165,7 +165,7 @@ FunctionSchedule:
 - cronExpression: 0,30 * * * *
   data:
     ExtractionPipelineExtId: ep_ctx_timeseries_oid_opcua_asset
-  description: Run every 30 minute
+  description: 'Run every 30 minute cdf-auth: def5e2e0'
   functionExternalId: fn_context_timeseries_oid_opcua_asset
   name: daily-every-30-min
 Group:

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_entity_matching.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_entity_matching.yaml
@@ -160,6 +160,8 @@ Workflow:
   externalId: entity_matching
 WorkflowTrigger:
 - externalId: entity_matching_trigger
+  metadata:
+    cognite-toolkit-auth-hash: f13a9e42
   triggerRule:
     cronExpression: 0 4 * * *
     triggerType: schedule

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_example_pump_asset_hierarchy.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_example_pump_asset_hierarchy.yaml
@@ -101,14 +101,14 @@ Transformation:
   ignoreNullFields: false
   isPublic: true
   name: pump_asset_hierarchy-load-collections_pump
-  query: "--- 1. asset root (defining all columns)\nSELECT\n    \"Lift Pump Stations\"\
-    \ AS name,\n    dataset_id(\"src:lift_pump_stations\") AS dataSetId,\n    \"lift_pump_stations:root\"\
-    \ AS externalId,\n    '' as parentExternalId,\n    \"An example pump dataset\"\
-    \ as description,\n    null as metadata\n\nUNION ALL\n--- 2. Lift Stations\nselect\n\
-    \    s.lift_station as name,\n    dataset_id(\"src:lift_pump_stations\") AS dataSetId,\n\
-    \    concat(\"lift_station:\", lower(replace(s.lift_station, ' ', '_'))) as externalId,\n\
-    \    'lift_pump_stations:root' as parentExternalId,\n    null as description,\n\
-    \    null as metadata\nFROM (\n    select\n        first_value(LiftStationID)\
+  query: "-- cdf-auth: f5da81f3\n--- 1. asset root (defining all columns)\nSELECT\n\
+    \    \"Lift Pump Stations\" AS name,\n    dataset_id(\"src:lift_pump_stations\"\
+    ) AS dataSetId,\n    \"lift_pump_stations:root\" AS externalId,\n    '' as parentExternalId,\n\
+    \    \"An example pump dataset\" as description,\n    null as metadata\n\nUNION\
+    \ ALL\n--- 2. Lift Stations\nselect\n    s.lift_station as name,\n    dataset_id(\"\
+    src:lift_pump_stations\") AS dataSetId,\n    concat(\"lift_station:\", lower(replace(s.lift_station,\
+    \ ' ', '_'))) as externalId,\n    'lift_pump_stations:root' as parentExternalId,\n\
+    \    null as description,\n    null as metadata\nFROM (\n    select\n        first_value(LiftStationID)\
     \ as lift_station\n    from pump_assets.`collections_pump`\n    group by LiftStationID\n\
     ) as s\n\nUNION ALL\n--- 3. Pumps\nSELECT\n    concat(\"Pump \", PumpModel) as\
     \ name,\n    dataset_id(\"src:lift_pump_stations\") AS dataSetId,\n    GlobalID\

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_infield_location.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_infield_location.yaml
@@ -410,21 +410,22 @@ Transformation:
   ignoreNullFields: true
   isPublic: true
   name: asset:oid:workmate:infield:sync_assets_from_hierarchy_to_apm
-  query: "--- Create All Assets without properties\n--- This is necessary so we can\
-    \ populate the direct relations\n--- in the next select statement\nselect\n  cast(asset.externalId\
-    \ as STRING) as externalId,\n  --- We skip the remaining properties,\n  --- but\
-    \ need to have these columns set so we can do a UNION ALL operation with the statement\
-    \ below.\n  null as parent,\n  null as source,\n  null as root,\n  null as description,\n\
-    \  null as title,\n  null as sourceId\nfrom\n  cdf_assetSubtree('WMT:VAL') as\
-    \ asset\n\nUNION ALL\n\n--- Create All Assets with properties including direct\
-    \ relations\nselect\n  cast(asset.externalId as STRING) as externalId,\n  (case\n\
-    \    when isnull(asset.parentExternalId) then null\n    else node_reference('sp_asset_oid_source',\
-    \ asset.parentExternalId)\n  end) as parent,\n  cast(\"Asset Hierarachy\" as STRING)\
-    \ as source,\n  node_reference('sp_asset_oid_source', cast(rootAsset.externalId\
-    \ as STRING)) as root,\n  cast(asset.description as STRING) as description,\n\
-    \  cast(asset.name as STRING) as title,\n  cast(asset.externalId as STRING) as\
-    \ sourceId\nfrom\n  cdf_assetSubtree('WMT:VAL') as asset\n  -- Get root asset\n\
-    \  inner join cdf_assetSubtree('WMT:VAL') as rootAsset on asset.rootId = rootAsset.id\n"
+  query: "-- cdf-auth: f5da81f3\n--- Create All Assets without properties\n--- This\
+    \ is necessary so we can populate the direct relations\n--- in the next select\
+    \ statement\nselect\n  cast(asset.externalId as STRING) as externalId,\n  ---\
+    \ We skip the remaining properties,\n  --- but need to have these columns set\
+    \ so we can do a UNION ALL operation with the statement below.\n  null as parent,\n\
+    \  null as source,\n  null as root,\n  null as description,\n  null as title,\n\
+    \  null as sourceId\nfrom\n  cdf_assetSubtree('WMT:VAL') as asset\n\nUNION ALL\n\
+    \n--- Create All Assets with properties including direct relations\nselect\n \
+    \ cast(asset.externalId as STRING) as externalId,\n  (case\n    when isnull(asset.parentExternalId)\
+    \ then null\n    else node_reference('sp_asset_oid_source', asset.parentExternalId)\n\
+    \  end) as parent,\n  cast(\"Asset Hierarachy\" as STRING) as source,\n  node_reference('sp_asset_oid_source',\
+    \ cast(rootAsset.externalId as STRING)) as root,\n  cast(asset.description as\
+    \ STRING) as description,\n  cast(asset.name as STRING) as title,\n  cast(asset.externalId\
+    \ as STRING) as sourceId\nfrom\n  cdf_assetSubtree('WMT:VAL') as asset\n  -- Get\
+    \ root asset\n  inner join cdf_assetSubtree('WMT:VAL') as rootAsset on asset.rootId\
+    \ = rootAsset.id\n"
   sourceOidcCredentials:
     audience: https://bluefield.cognitedata.com
     cdfProjectName: pytest-project
@@ -453,15 +454,15 @@ Transformation:
   ignoreNullFields: true
   isPublic: true
   name: workorder:oid:workmate:infield:sync_workorders_to_apm_activities
-  query: "  select\n    cast(`externalId` as STRING) as externalId,\n    cast(`description`\
-    \ as STRING) as description,\n    cast(`key` as STRING) as id,\n    cast(`status`\
-    \ as STRING) as status,\n    /* cast(`startTime` as TIMESTAMP) as startTime,\n\
-    \    cast(`endTime` as TIMESTAMP) as endTime,\n    NOTE!!! The below two datas\
-    \ just updates all workorders to be from now \n    and into the future. This is\
-    \ done for the sake of the demo data.\n    */\n    cast(current_date() as TIMESTAMP)\
-    \ as startTime,\n    cast(date_add(current_date(), 7) as TIMESTAMP) as endTime,\n\
-    \    cast(`title` as STRING) as title,\n    'WMT:VAL' as rootLocation,\n    'workmate'\
-    \ as source\n  from\n    `workorder_oid_workmate`.`workorders`;\n"
+  query: "-- cdf-auth: f5da81f3\n  select\n    cast(`externalId` as STRING) as externalId,\n\
+    \    cast(`description` as STRING) as description,\n    cast(`key` as STRING)\
+    \ as id,\n    cast(`status` as STRING) as status,\n    /* cast(`startTime` as\
+    \ TIMESTAMP) as startTime,\n    cast(`endTime` as TIMESTAMP) as endTime,\n   \
+    \ NOTE!!! The below two datas just updates all workorders to be from now \n  \
+    \  and into the future. This is done for the sake of the demo data.\n    */\n\
+    \    cast(current_date() as TIMESTAMP) as startTime,\n    cast(date_add(current_date(),\
+    \ 7) as TIMESTAMP) as endTime,\n    cast(`title` as STRING) as title,\n    'WMT:VAL'\
+    \ as rootLocation,\n    'workmate' as source\n  from\n    `workorder_oid_workmate`.`workorders`;\n"
   sourceOidcCredentials:
     audience: https://bluefield.cognitedata.com
     cdfProjectName: pytest-project

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_infield_second_location.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_infield_second_location.yaml
@@ -410,21 +410,22 @@ Transformation:
   ignoreNullFields: true
   isPublic: true
   name: asset:oid2:workmate:infield:sync_assets_from_hierarchy_to_apm
-  query: "--- Create All Assets without properties\n--- This is necessary so we can\
-    \ populate the direct relations\n--- in the next select statement\nselect\n  cast(asset.externalId\
-    \ as STRING) as externalId,\n  --- We skip the remaining properties,\n  --- but\
-    \ need to have these columns set so we can do a UNION ALL operation with the statement\
-    \ below.\n  null as parent,\n  null as source,\n  null as root,\n  null as description,\n\
-    \  null as title,\n  null as sourceId\nfrom\n  cdf_assetSubtree('WMT:VAL') as\
-    \ asset\n\nUNION ALL\n\n--- Create All Assets with properties including direct\
-    \ relations\nselect\n  cast(asset.externalId as STRING) as externalId,\n  (case\n\
-    \    when isnull(asset.parentExternalId) then null\n    else node_reference('sp_asset_oid2_source',\
-    \ asset.parentExternalId)\n  end) as parent,\n  cast(\"Asset Hierarachy\" as STRING)\
-    \ as source,\n  node_reference('sp_asset_oid2_source', cast(rootAsset.externalId\
-    \ as STRING)) as root,\n  cast(asset.description as STRING) as description,\n\
-    \  cast(asset.name as STRING) as title,\n  cast(asset.externalId as STRING) as\
-    \ sourceId\nfrom\n  cdf_assetSubtree('WMT:VAL') as asset\n  -- Get root asset\n\
-    \  inner join cdf_assetSubtree('WMT:VAL') as rootAsset on asset.rootId = rootAsset.id\n"
+  query: "-- cdf-auth: f5da81f3\n--- Create All Assets without properties\n--- This\
+    \ is necessary so we can populate the direct relations\n--- in the next select\
+    \ statement\nselect\n  cast(asset.externalId as STRING) as externalId,\n  ---\
+    \ We skip the remaining properties,\n  --- but need to have these columns set\
+    \ so we can do a UNION ALL operation with the statement below.\n  null as parent,\n\
+    \  null as source,\n  null as root,\n  null as description,\n  null as title,\n\
+    \  null as sourceId\nfrom\n  cdf_assetSubtree('WMT:VAL') as asset\n\nUNION ALL\n\
+    \n--- Create All Assets with properties including direct relations\nselect\n \
+    \ cast(asset.externalId as STRING) as externalId,\n  (case\n    when isnull(asset.parentExternalId)\
+    \ then null\n    else node_reference('sp_asset_oid2_source', asset.parentExternalId)\n\
+    \  end) as parent,\n  cast(\"Asset Hierarachy\" as STRING) as source,\n  node_reference('sp_asset_oid2_source',\
+    \ cast(rootAsset.externalId as STRING)) as root,\n  cast(asset.description as\
+    \ STRING) as description,\n  cast(asset.name as STRING) as title,\n  cast(asset.externalId\
+    \ as STRING) as sourceId\nfrom\n  cdf_assetSubtree('WMT:VAL') as asset\n  -- Get\
+    \ root asset\n  inner join cdf_assetSubtree('WMT:VAL') as rootAsset on asset.rootId\
+    \ = rootAsset.id\n"
   sourceOidcCredentials:
     audience: https://bluefield.cognitedata.com
     cdfProjectName: pytest-project
@@ -453,15 +454,15 @@ Transformation:
   ignoreNullFields: true
   isPublic: true
   name: workorder:oid2:workmate:infield:sync_workorders_to_apm_activities
-  query: "  select\n    cast(`externalId` as STRING) as externalId,\n    cast(`description`\
-    \ as STRING) as description,\n    cast(`key` as STRING) as id,\n    cast(`status`\
-    \ as STRING) as status,\n    /* cast(`startTime` as TIMESTAMP) as startTime,\n\
-    \    cast(`endTime` as TIMESTAMP) as endTime,\n    NOTE!!! The below two datas\
-    \ just updates all workorders to be from now \n    and into the future. This is\
-    \ done for the sake of the demo data.\n    */\n    cast(current_date() as TIMESTAMP)\
-    \ as startTime,\n    cast(date_add(current_date(), 7) as TIMESTAMP) as endTime,\n\
-    \    cast(`title` as STRING) as title,\n    'WMT:VAL' as rootLocation,\n    'workmate'\
-    \ as source\n  from\n    `workorder_oid_workmate`.`workorders`;\n"
+  query: "-- cdf-auth: f5da81f3\n  select\n    cast(`externalId` as STRING) as externalId,\n\
+    \    cast(`description` as STRING) as description,\n    cast(`key` as STRING)\
+    \ as id,\n    cast(`status` as STRING) as status,\n    /* cast(`startTime` as\
+    \ TIMESTAMP) as startTime,\n    cast(`endTime` as TIMESTAMP) as endTime,\n   \
+    \ NOTE!!! The below two datas just updates all workorders to be from now \n  \
+    \  and into the future. This is done for the sake of the demo data.\n    */\n\
+    \    cast(current_date() as TIMESTAMP) as startTime,\n    cast(date_add(current_date(),\
+    \ 7) as TIMESTAMP) as endTime,\n    cast(`title` as STRING) as title,\n    'WMT:VAL'\
+    \ as rootLocation,\n    'workmate' as source\n  from\n    `workorder_oid_workmate`.`workorders`;\n"
   sourceOidcCredentials:
     audience: https://bluefield.cognitedata.com
     cdfProjectName: pytest-project

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_ingestion.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_ingestion.yaml
@@ -241,6 +241,8 @@ Workflow:
   externalId: ingestion
 WorkflowTrigger:
 - externalId: ingestion
+  metadata:
+    cognite-toolkit-auth-hash: 003722e2
   triggerRule:
     cronExpression: 0 4 * * *
     triggerType: schedule

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_inrobot_common.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_inrobot_common.yaml
@@ -204,7 +204,8 @@ FunctionSchedule:
     read_multiple_dial_gauges_label: read_multiple_dial_gauges
     read_valve_label: read_valve
     spill_detection_label: unprocessed_spill_detection
-  description: Contextualizes the robot data and adds appropriate labels
+  description: 'Contextualizes the robot data and adds appropriate labels cdf-auth:
+    acb31846'
   functionExternalId: fn_contextualize_robot_data
   name: contextualize_robot_data
 - cronExpression: '* * * * *'
@@ -214,6 +215,7 @@ FunctionSchedule:
     input_label: read_ir
     output_label: ir_finished
     success_label: SUCCESS_IR
+  description: 'cdf-auth: acb31846'
   functionExternalId: fn_get_ir_data_from_ir_raw
   name: get_ir_data
 - cronExpression: '* * * * *'
@@ -223,7 +225,7 @@ FunctionSchedule:
     input_label: read_dial_gauge
     output_label: gauge_reading
     success_label: SUCCESS
-  description: Reads the dial gauge data from the robot
+  description: 'Reads the dial gauge data from the robot cdf-auth: acb31846'
   functionExternalId: fn_gauge_reading
   name: read_dial_gauge
 - cronExpression: '* * * * *'
@@ -233,6 +235,7 @@ FunctionSchedule:
     input_label: read_digital_gauge
     output_label: gauge_reading
     success_label: SUCCESS
+  description: 'cdf-auth: acb31846'
   functionExternalId: fn_gauge_reading
   name: read_digital_gauge
 - cronExpression: '* * * * *'
@@ -242,7 +245,7 @@ FunctionSchedule:
     input_label: read_level_gauge
     output_label: gauge_reading
     success_label: SUCCESS
-  description: Reads the level gauge data from the robot
+  description: 'Reads the level gauge data from the robot cdf-auth: acb31846'
   functionExternalId: fn_gauge_reading
   name: read_level_gauge
 - cronExpression: '* * * * *'
@@ -252,12 +255,13 @@ FunctionSchedule:
     input_label: read_valve
     output_label: gauge_reading
     success_label: SUCCESS
-  description: Reads the valve data from the robot
+  description: 'Reads the valve data from the robot cdf-auth: acb31846'
   functionExternalId: fn_gauge_reading
   name: read_valve
 - cronExpression: '* * * * *'
   data:
     data_set_external_id: ds_robot_1
+  description: 'cdf-auth: acb31846'
   functionExternalId: fn_threesixty
   name: threesixty
 Group:

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_oid_example_data.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_oid_example_data.yaml
@@ -789,10 +789,10 @@ Transformation:
   ignoreNullFields: true
   isPublic: true
   name: asset:oid:workmate:asset_hierarchy:example
-  query: "select\n  cast(`externalId` as STRING) as externalId,\n  cast(`tag` as STRING)\
-    \ as name,\n  cast(`description` as STRING) as description,\n  cast(`sourceDb`\
-    \ as STRING) as source,\n  cast(`parentExternalId` as STRING) as parentExternalId\n\
-    from\n  `asset_oid_workmate`.`assets`;\n"
+  query: "-- cdf-auth: f5da81f3\nselect\n  cast(`externalId` as STRING) as externalId,\n\
+    \  cast(`tag` as STRING) as name,\n  cast(`description` as STRING) as description,\n\
+    \  cast(`sourceDb` as STRING) as source,\n  cast(`parentExternalId` as STRING)\
+    \ as parentExternalId\nfrom\n  `asset_oid_workmate`.`assets`;\n"
   sourceOidcCredentials:
     audience: https://bluefield.cognitedata.com
     cdfProjectName: pytest-project
@@ -815,12 +815,12 @@ Transformation:
   ignoreNullFields: true
   isPublic: true
   name: event:oid:workmate:workitem:example
-  query: "with assetid (\nselect\n  first(wa.sourceExternalId) as workitemid,\n  collect_list(ai.id)\
-    \        as assetIds\nfrom\n  `workorder_oid_workmate`.`workitem2assets` wa,\n\
-    \  _cdf.assets                                ai\nwhere\n  ai.externalId = wa.targetExternalId\n\
-    GROUP BY sourceExternalId)\nselect\n  wo.externalId,\n  wo.itemInfo,\n  dataset_id('ds_transformations_oid')\
-    \  as dataSetId,\n  cast(from_unixtime(double(wo.`startTime`)/1000)\n        \
-    \                 as TIMESTAMP)  as startTime,\n  cast(from_unixtime(double(wo.`endTime`)/1000)\n\
+  query: "-- cdf-auth: f5da81f3\nwith assetid (\nselect\n  first(wa.sourceExternalId)\
+    \ as workitemid,\n  collect_list(ai.id)        as assetIds\nfrom\n  `workorder_oid_workmate`.`workitem2assets`\
+    \ wa,\n  _cdf.assets                                ai\nwhere\n  ai.externalId\
+    \ = wa.targetExternalId\nGROUP BY sourceExternalId)\nselect\n  wo.externalId,\n\
+    \  wo.itemInfo,\n  dataset_id('ds_transformations_oid')  as dataSetId,\n  cast(from_unixtime(double(wo.`startTime`)/1000)\n\
+    \                         as TIMESTAMP)  as startTime,\n  cast(from_unixtime(double(wo.`endTime`)/1000)\n\
     \                         as TIMESTAMP)  as endTime,\n  ai.assetIds          \
     \                 as assetIds,\n  \"workitem\"                            as type,\n\
     \  \"OID - workmate\"                      as source,\n  to_metadata_except(\n\
@@ -850,8 +850,8 @@ Transformation:
   ignoreNullFields: true
   isPublic: true
   name: event:oid:workmate:workorder:example
-  query: "with assetid (\nselect\n  first(wa.sourceExternalId) as workorderid,\n \
-    \ collect_list(ai.id)        as assetIds\nfrom\n  `workorder_oid_workmate`.`workorder2assets`\
+  query: "-- cdf-auth: f5da81f3\nwith assetid (\nselect\n  first(wa.sourceExternalId)\
+    \ as workorderid,\n  collect_list(ai.id)        as assetIds\nfrom\n  `workorder_oid_workmate`.`workorder2assets`\
     \ wa,\n  _cdf.assets                                 ai\nwhere\n  ai.externalId\
     \ = wa.targetExternalId\nGROUP BY sourceExternalId)\nselect\n  wo.externalId,\n\
     \  wo.description,\n  dataset_id('ds_transformations_oid')  as dataSetId,\n  cast(from_unixtime(double(wo.`startTime`)/1000)\n\

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org.yaml
@@ -371,7 +371,7 @@ FunctionSchedule:
     breakfast: 'today: peanut butter sandwich and coffee'
     dinner: 'today: steak and red wine'
     lunch: 'today: greek salad and water'
-  description: Run every day at 8am UTC
+  description: 'Run every day at 8am UTC cdf-auth: def5e2e0'
   functionExternalId: fn_first_function
   name: daily-8am-utc
 Group:
@@ -770,8 +770,8 @@ Transformation:
   ignoreNullFields: true
   isPublic: true
   name: example:first:transformation
-  query: "select\n  cast(`externalId` as STRING) as externalId\nfrom\n  `db_foo`.`table_foo`;\n\
-    -- this is a comment with an ← Unicode character"
+  query: "-- cdf-auth: f5da81f3\nselect\n  cast(`externalId` as STRING) as externalId\n\
+    from\n  `db_foo`.`table_foo`;\n-- this is a comment with an ← Unicode character"
   sourceOidcCredentials:
     audience: https://bluefield.cognitedata.com
     cdfProjectName: pytest-project
@@ -910,6 +910,8 @@ Workflow:
   externalId: baz
 WorkflowTrigger:
 - externalId: MyTrigger
+  metadata:
+    cognite-toolkit-auth-hash: def5e2e0
   triggerRule:
     cronExpression: 5 4 * * *
     triggerType: schedule


### PR DESCRIPTION
# Description

Release `0.5.0`. This is done by removing the alpha flags for the 4 features that are planned for v5.

## Changelog

- [ ] Patch
- [x] Minor
- [ ] Skip

## cdf

### Changed

- The `cdf dump datamodel` no longer includes data models that are global (in system space). You can get the original behavior by using the `--include-global` flag.
- Toolkit now stores a hash of the credentials of Workflow/Transformation/Function in the resources such that the resource is updated when the credentials change.
- For Workflow/Transformations/Function Toolkit no longer falls back to Toolkit credentials when validation-type != 'dev' in the `config.[env].yaml`. 

### Added
- Toolkit now support for `cdf dump workflow/transformation/group/node`.

## templates

No changes.
