### PR TITLE
[CDF-24410] 🙃 Key error streamlit

### DIFF
--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/file_loader.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/file_loader.py
@@ -143,7 +143,7 @@ class FileMetadataLoader(
 
     def dump_resource(self, resource: FileMetadata, local: dict[str, Any] | None = None) -> dict[str, Any]:
         dumped = resource.as_write().dump()
-        if ds_id := dumped.pop("dataSetId"):
+        if ds_id := dumped.pop("dataSetId", None):
             dumped["dataSetExternalId"] = self.client.lookup.data_sets.external_id(ds_id)
         if security_categories := dumped.pop("securityCategories", []):
             dumped["securityCategoryNames"] = self.client.lookup.security_categories.external_id(security_categories)

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_file_metadata_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_file_metadata_loader.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 from _pytest.mark import ParameterSet
 from _pytest.monkeypatch import MonkeyPatch
-from cognite.client.data_classes import FileMetadataWrite, FileMetadataWriteList
+from cognite.client.data_classes import FileMetadata, FileMetadataWrite, FileMetadataWriteList
 
 from cognite_toolkit._cdf_tk.loaders import FileMetadataLoader
 from tests.test_unit.approval_client import ApprovalToolkitClient
@@ -87,3 +87,17 @@ class TestLoadResources:
         path = MagicMock(spec=Path)
         path.exists.return_value = True
         return path
+
+    def test_dump_file_metadata_without_dataset(
+        self, monkeypatch: MonkeyPatch, toolkit_client_approval: ApprovalToolkitClient
+    ) -> None:
+        metadata = FileMetadata("my_file", name="my_file.txt", mime_type="text/plain")
+        loader = FileMetadataLoader.create_loader(toolkit_client_approval.mock_client)
+
+        dumped = loader.dump_resource(metadata)
+
+        assert dumped == {
+            "externalId": "my_file",
+            "name": "my_file.txt",
+            "mimeType": "text/plain",
+        }


### PR DESCRIPTION
# Description

User error:
![image](https://github.com/user-attachments/assets/1b7b34a7-5824-4123-8ad4-1f31cbd62527)


## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- Updating a FileMetadata or Streamlit app without a dataSetId no longer raiser a `KeyError` when using the `cdf deploy` command.

## templates

No changes.
