### PR TITLE
[CDF-24411] 	🐛 Fix skip workflow trigger

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -234,7 +234,9 @@ class WorkflowFinder(ResourceFinder[WorkflowVersionId]):
         else:
             yield [self.identifier], None, WorkflowVersionLoader.create_loader(self.client), None
         trigger_loader = WorkflowTriggerLoader.create_loader(self.client)
-        trigger_list = WorkflowTriggerList(trigger_loader.iterate(parent_ids=[self.identifier.workflow_external_id]))
+        trigger_list = WorkflowTriggerList(
+            list(trigger_loader.iterate(parent_ids=[self.identifier.workflow_external_id]))
+        )
         yield [], trigger_list, trigger_loader, None
 
 

--- a/tests/test_unit/approval_client/config.py
+++ b/tests/test_unit/approval_client/config.py
@@ -493,6 +493,7 @@ API_RESOURCES = [
             # "delete": [Method(api_class_method="delete", mock_name="delete")],
             "retrieve": [
                 Method(api_class_method="retrieve", mock_class_method="return_value"),
+                Method(api_class_method="list", mock_class_method="return_values"),
             ],
         },
     ),


### PR DESCRIPTION
# Description

The base class `CogniteResourceList` in the PySDK takes an iterable, but it exhausted the iterable in a checking, thus it practice it has to take a sequence.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- When running `cdf dump workflow` the Toolkit now includes triggers if the selected workflow has triggers.
## templates

No changes.
