### PR TITLE
[CDF-23633] 🪲 Failed lookup not deployed asset

### DIFF
--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
@@ -300,7 +300,7 @@ class SequenceLoader(ResourceLoader[str, SequenceWrite, Sequence, SequenceWriteL
         if ds_external_id := resource.pop("dataSetExternalId", None):
             resource["dataSetId"] = self.client.lookup.data_sets.id(ds_external_id, is_dry_run)
         if asset_external_id := resource.pop("assetExternalId", None):
-            resource["assetId"] = self.client.lookup.assets.id(asset_external_id)
+            resource["assetId"] = self.client.lookup.assets.id(asset_external_id, is_dry_run)
         return SequenceWrite._load(resource)
 
     def dump_resource(self, resource: Sequence, local: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/timeseries_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/timeseries_loaders.py
@@ -106,7 +106,7 @@ class TimeSeriesLoader(ResourceContainerLoader[str, TimeSeriesWrite, TimeSeries,
                 security_categories_names, is_dry_run
             )
         if asset_external_id := resource.pop("assetExternalId", None):
-            resource["assetId"] = self.client.lookup.assets.id(asset_external_id)
+            resource["assetId"] = self.client.lookup.assets.id(asset_external_id, is_dry_run)
         return TimeSeriesWrite._load(resource)
 
     def dump_resource(self, resource: TimeSeries, local: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_classic_loaders.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_classic_loaders.py
@@ -1,0 +1,40 @@
+from cognite.client.data_classes import SequenceWrite
+from cognite.client.utils.useful_types import SequenceNotStr
+
+from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
+from cognite_toolkit._cdf_tk.loaders import SequenceLoader
+
+
+class TestSequenceLoader:
+    def test_load_timeseries_ref_not_yet_deployed(self) -> None:
+        actual_is_dry_run: list[bool] = []
+
+        def mock_id_lookup(
+            external_id: str | SequenceNotStr[str], is_dry_run: bool = False, allow_empty: bool = False
+        ) -> int | list[int]:
+            actual_is_dry_run.append(is_dry_run)
+            return -1 if isinstance(external_id, str) else [-1] * len(external_id)
+
+        with monkeypatch_toolkit_client() as client:
+            client.lookup.data_sets.id.side_effect = mock_id_lookup
+            client.lookup.assets.id.side_effect = mock_id_lookup
+            client.lookup.security_categories.id.side_effect = mock_id_lookup
+            loader = SequenceLoader.create_loader(client)
+
+        resource = {
+            "externalId": "mySequence",
+            "columns": [
+                {"externalId": "myColumn1"},
+                {"externalId": "myColumn2"},
+            ],
+            "assetExternalId": "my_asset",
+            "dataSetExternalId": "my_dataset",
+        }
+
+        seq = loader.load_resource(resource.copy(), is_dry_run=True)
+        _ = loader.load_resource(resource.copy(), is_dry_run=False)
+
+        assert isinstance(seq, SequenceWrite)
+        assert seq.asset_id == -1
+        assert seq.data_set_id == -1
+        assert actual_is_dry_run == [True] * 2 + [False] * 2

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_time_series_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_time_series_loader.py
@@ -1,5 +1,8 @@
 import yaml
+from cognite.client.data_classes import TimeSeriesWrite
+from cognite.client.utils.useful_types import SequenceNotStr
 
+from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.loaders import TimeSeriesLoader
 from tests.test_unit.approval_client import ApprovalToolkitClient
 from tests.test_unit.approval_client.client import LookUpAPIMock
@@ -46,3 +49,34 @@ description: PH 1stStgSuctCool Gas Out
         loaded = loader.load_resource(ts_dict, is_dry_run=False)
 
         assert loaded.data_set_id == -1
+
+    def test_load_timeseries_ref_not_yet_deployed(self) -> None:
+        actual_is_dry_run: list[bool] = []
+
+        def mock_id_lookup(
+            external_id: str | SequenceNotStr[str], is_dry_run: bool = False, allow_empty: bool = False
+        ) -> int | list[int]:
+            actual_is_dry_run.append(is_dry_run)
+            return -1 if isinstance(external_id, str) else [-1] * len(external_id)
+
+        with monkeypatch_toolkit_client() as client:
+            client.lookup.data_sets.id.side_effect = mock_id_lookup
+            client.lookup.assets.id.side_effect = mock_id_lookup
+            client.lookup.security_categories.id.side_effect = mock_id_lookup
+            loader = TimeSeriesLoader.create_loader(client)
+
+        resource = {
+            "externalId": "MyTimeseries",
+            "assetExternalId": "my_asset",
+            "dataSetExternalId": "my_dataset",
+            "securityCategoryNames": ["my_security_category"],
+        }
+
+        ts = loader.load_resource(resource.copy(), is_dry_run=True)
+        _ = loader.load_resource(resource.copy(), is_dry_run=False)
+
+        assert isinstance(ts, TimeSeriesWrite)
+        assert ts.asset_id == -1
+        assert ts.data_set_id == -1
+        assert ts.security_categories == [-1]
+        assert actual_is_dry_run == [True] * 3 + [False] * 3


### PR DESCRIPTION
# Description

User error message:
![image](https://github.com/user-attachments/assets/1b9e01ed-e1e4-4d80-b0fa-d0c3bc07adaf)

In addition, to the two places the `....id(some_external_id, is_dry_run)` argument was missing, I have checked that everywhere else this is called is correctly passing the `is_dry_run` argument

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- When deploying a TimeSeries or Sequence referencing an asset with the `--dry-run` flag, Toolkit no longer fails with `ResourceRetrievalError`.

## templates

No changes.
