### PR TITLE
[CDF-24164] 🤓 fix: allow help on version mismatch

### DIFF
--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -55,7 +55,11 @@ class ModulesConfig:
     def load(cls, raw: dict[str, Any]) -> ModulesConfig:
         version = raw["version"]
         packages = raw.get("packages", {})
-        if version != _version.__version__ and (len(sys.argv) > 2 and sys.argv[1:3] != ["modules", "upgrade"]):
+        if (
+            version != _version.__version__
+            and (len(sys.argv) > 2 and sys.argv[1:3] != ["modules", "upgrade"])
+            and "--help" not in sys.argv
+        ):
             raise ToolkitVersionError(
                 f"The version of the modules ({version}) does not match the version of the installed CLI "
                 f"({_version.__version__}). Please either run `cdf-tk modules upgrade` to upgrade the modules OR "


### PR DESCRIPTION
# Description

## Error message
![image](https://github.com/user-attachments/assets/b3e41956-bac3-4cd5-ab9f-ab245c953241)


## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- Allow `--help` flag on `cdf.toml` and CLI version mismatch

## templates

No changes.
