### PR TITLE
[CDF-24416] 🔩 Dump global data model no longer skips views, containers, and spaces

### DIFF
--- a/tests/test_integration/test_commands/test_dump_data_model.py
+++ b/tests/test_integration/test_commands/test_dump_data_model.py
@@ -1,8 +1,12 @@
 from pathlib import Path
 
+from cognite.client.data_classes.data_modeling import DataModelId
+
 from cognite_toolkit._cdf_tk.apps import DumpApp
 from cognite_toolkit._cdf_tk.client import ToolkitClient
-from cognite_toolkit._cdf_tk.loaders import DataModelLoader
+from cognite_toolkit._cdf_tk.commands import DumpResourceCommand
+from cognite_toolkit._cdf_tk.commands.dump_resource import DataModelFinder
+from cognite_toolkit._cdf_tk.loaders import ContainerLoader, DataModelLoader, SpaceLoader, ViewLoader
 
 
 class TestDumpResource:
@@ -16,3 +20,20 @@ class TestDumpResource:
         data_model_folder = tmp_path / DataModelLoader.folder_name
         assert data_model_folder.exists()
         assert sum(1 for _ in data_model_folder.glob(f"*{DataModelLoader.kind}.yaml")) == 1
+
+    def test_dump_global_model(self, toolkit_client: ToolkitClient, tmp_path: Path) -> None:
+        output_dir = tmp_path / "output"
+        cmd = DumpResourceCommand(silent=True)
+        cmd.dump_to_yamls(
+            DataModelFinder(toolkit_client, DataModelId("cdf_cdm", "CogniteCore", "v1")),
+            output_dir=output_dir,
+            clean=False,
+            verbose=False,
+        )
+
+        data_model_folder = output_dir / DataModelLoader.folder_name
+        assert data_model_folder.exists()
+        assert sum(1 for _ in data_model_folder.glob(f"*{DataModelLoader.kind}.yaml")) == 1
+        assert sum(1 for _ in data_model_folder.glob(f"**/*{ViewLoader.kind}.yaml")) == 33
+        assert sum(1 for _ in data_model_folder.glob(f"**/*{ContainerLoader.kind}.yaml")) == 29
+        assert sum(1 for _ in data_model_folder.glob(f"**/*{SpaceLoader.kind}.yaml")) == 2


### PR DESCRIPTION
# Description

See changelog below.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- The command `cdf dump datamodel` no longer skips views, containers, and spaces, when you select a global model. For example, `cdf dump datamodel cdf_cdm CogniteCore v1`, now dumps all views, containers and spaces.

## templates

No changes.
