### PR TITLE
[]  Avoid printing duplicated variables in warnings

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build.py
@@ -507,7 +507,7 @@ class BuildCommand(ToolkitCommand):
                     for w in replace_warnings
                     if isinstance(w, UnresolvedVariableWarning)
                 ]:
-                    variable_str = humanize_collection(unresolved_variables)
+                    variable_str = humanize_collection(set(unresolved_variables))
                     source_str = variables.source_path.as_posix() if variables.source_path else "config.[ENV].yaml"
                     suffix = "s" if len(unresolved_variables) > 1 else ""
                     message += f"\n{HINT_LEAD_TEXT}Add the following variable{suffix} to the {source_str!r} file: {variable_str!r}."


### PR DESCRIPTION
# Description

## User output
![image](https://github.com/user-attachments/assets/31da8ac9-d4ee-4c06-a1a8-f4d5409f78e6)


## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- When missing build variables your configuration files, Cognite Toolkit, no longer duplicates the output in the error message when running `cdf build`.

## templates

No changes.
