### PR TITLE
[CDF-24460] 😅 CI run tests on 3.11 and 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,8 +75,9 @@ jobs:
       matrix:
         python-version:
           - "3.10"
-          # Skipping  3.11 as we assume it is covered by 3.10 and 3.12
+          - "3.11"
           - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
# Description

Guarantee that we support `3.11` and `3.13`.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
