### PR TITLE
[CDF-24340] 😵‍💫 Report label update correctly

### DIFF
--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/data_organization_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/data_organization_loaders.py
@@ -28,7 +28,6 @@ from cognite.client.data_classes import (
     LabelDefinitionWrite,
     capabilities,
 )
-from cognite.client.data_classes._base import T_CogniteResourceList
 from cognite.client.data_classes.capabilities import (
     Capability,
     DataSetsAcl,
@@ -185,6 +184,7 @@ class LabelLoader(
     kind = "Label"
     dependencies = frozenset({DataSetsLoader, GroupAllScopedLoader})
     _doc_url = "Labels/operation/createLabelDefinitions"
+    support_update = False
 
     @property
     def display_name(self) -> str:
@@ -231,12 +231,6 @@ class LabelLoader(
 
     def retrieve(self, ids: SequenceNotStr[str]) -> LabelDefinitionList:
         return self.client.labels.retrieve(ids, ignore_unknown_ids=True)
-
-    def update(self, items: T_CogniteResourceList) -> LabelDefinitionList:
-        existing = self.client.labels.retrieve([item.external_id for item in items])
-        if existing:
-            self.delete([item.external_id for item in items])
-        return self.client.labels.create(items)
 
     def delete(self, ids: SequenceNotStr[str]) -> int:
         try:

--- a/tests/test_integration/test_loaders/test_resource_loaders.py
+++ b/tests/test_integration/test_loaders/test_resource_loaders.py
@@ -211,27 +211,18 @@ class TestLabelLoader:
         delete_count = loader.delete(["non_existing"])
         assert delete_count == 0
 
-    def test_create_update_delete_label(self, cognite_client: CogniteClient) -> None:
-        initial = LabelDefinitionWrite(
+    def test_create_delete_label(self, toolkit_client: ToolkitClient) -> None:
+        label = LabelDefinitionWrite(
             external_id=f"tmp_test_create_update_delete_label_{RUN_UNIQUE_ID}",
             name="Initial name",
         )
-        update = LabelDefinitionWrite(
-            external_id=f"tmp_test_create_update_delete_label_{RUN_UNIQUE_ID}",
-            name="Updated name",
-        )
-
-        loader = LabelLoader(cognite_client, None)
+        loader = LabelLoader(toolkit_client, None)
 
         try:
-            created = loader.create(LabelDefinitionWriteList([initial]))
+            created = loader.create(LabelDefinitionWriteList([label]))
             assert len(created) == 1
-
-            updated = loader.update(LabelDefinitionWriteList([update]))
-            assert len(updated) == 1
-            assert updated[0].name == "Updated name"
         finally:
-            loader.delete([initial.external_id])
+            loader.delete([label.external_id])
 
 
 class TestAssetLoader:


### PR DESCRIPTION
# Description

## Before
![image](https://github.com/user-attachments/assets/8ca741fa-9d26-473c-9d04-14a7fcfc1cff)

## After
![image](https://github.com/user-attachments/assets/375b8d46-1a64-4f9e-ba23-a46d901c789b)

Note there is also a soft delete issue for labels, but suggest we do not address it.
![image](https://github.com/user-attachments/assets/98cb9d91-dd70-4a70-97bb-4414a6189725)


## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- When running `cdf deploy` on label resources, changes are no longer incorrectly reported as update, but instead delete + create.

## templates

No changes.
