### PR TITLE
[CDF-24461] 🧁 Support Infield Configuration Part 2

### DIFF
--- a/cdf.toml
+++ b/cdf.toml
@@ -8,6 +8,7 @@ import-cmd = true
 module-repeat = true
 populate = true
 agents = false
+infield = true
 
 [plugins]
 run = true

--- a/cognite_toolkit/_cdf_tk/client/data_classes/apm_config_v1.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/apm_config_v1.py
@@ -17,6 +17,7 @@ from cognite.client.data_classes._base import (
     CogniteObject,
     CogniteResourceList,
     WriteableCogniteResource,
+    WriteableCogniteResourceList,
 )
 from cognite.client.data_classes.data_modeling import Node, NodeApply, NodeOrEdgeData, ViewId
 from cognite.client.utils._text import to_camel_case
@@ -331,3 +332,10 @@ class APMConfig(APMConfigCore):
 
 class APMConfigWriteList(CogniteResourceList[APMConfigWrite]):
     _RESOURCE = APMConfigWrite
+
+
+class APMConfigList(WriteableCogniteResourceList[APMConfigWrite, APMConfig]):
+    _RESOURCE = APMConfig
+
+    def as_write(self) -> APMConfigWriteList:
+        return APMConfigWriteList([item.as_write() for item in self], self._cognite_client)

--- a/cognite_toolkit/_cdf_tk/client/data_classes/apm_config_v1.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/apm_config_v1.py
@@ -40,7 +40,7 @@ class APMConfigObject(CogniteObject):
     in the property featureConfiguration in the view (APM_Config, APM_Config, 1) is changed in the future.
     """
 
-    _extra: dict[str, Any] = field(default_factory=dict)
+    _extra: dict[str, Any] = field(default_factory=dict, init=False)
 
     @classmethod
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
@@ -89,7 +89,7 @@ class ThreeDConfiguration(APMConfigObject):
         output = super().dump(camel_case=camel_case)
         for snake, camel in [("full_weight_models", "fullWeightModels"), ("light_weight_models", "lightWeightModels")]:
             if hasattr(self, snake):
-                output[camel if camel_case else snake] = [value.dump() for value in getattr(self, snake)]
+                output[camel if camel_case else snake] = [value.dump() for value in getattr(self, snake) or []]
         return output
 
 
@@ -121,7 +121,8 @@ class RootLocationDataFilters(APMConfigObject):
         output = super().dump(camel_case=camel_case)
         for key in ["general", "assets", "files", "timeseries"]:
             if hasattr(self, key):
-                output[key] = getattr(self, key).dump(camel_case=camel_case)
+                if value := getattr(self, key):
+                    output[key] = value.dump(camel_case=camel_case)
         return output
 
 
@@ -224,7 +225,8 @@ class ObservationsConfig(APMConfigObject):
         output = super().dump(camel_case=camel_case)
         for key in ["files", "description", "asset", "troubleshooting", "type", "priority"]:
             if hasattr(self, key):
-                output[key] = getattr(self, key).dump(camel_case=camel_case)
+                if value := getattr(self, key):
+                    output[key] = value.dump(camel_case=camel_case)
         return output
 
 

--- a/cognite_toolkit/_cdf_tk/client/data_classes/apm_config_v1.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/apm_config_v1.py
@@ -8,6 +8,7 @@ data sets, spaces, and groups.
 
 import sys
 from abc import ABC
+from collections.abc import Sequence
 from dataclasses import dataclass, field, fields
 from functools import lru_cache
 from typing import Any
@@ -19,7 +20,7 @@ from cognite.client.data_classes._base import (
     WriteableCogniteResource,
     WriteableCogniteResourceList,
 )
-from cognite.client.data_classes.data_modeling import Node, NodeApply, NodeOrEdgeData, ViewId
+from cognite.client.data_classes.data_modeling import Node, NodeApply, NodeApplyList, NodeOrEdgeData, ViewId
 from cognite.client.utils._text import to_camel_case
 
 if sys.version_info >= (3, 11):
@@ -473,9 +474,16 @@ class APMConfig(APMConfigCore):
 class APMConfigWriteList(CogniteResourceList[APMConfigWrite]):
     _RESOURCE = APMConfigWrite
 
+    def as_nodes(self) -> NodeApplyList:
+        return NodeApplyList([item.as_node() for item in self])
+
 
 class APMConfigList(WriteableCogniteResourceList[APMConfigWrite, APMConfig]):
     _RESOURCE = APMConfig
 
     def as_write(self) -> APMConfigWriteList:
-        return APMConfigWriteList([item.as_write() for item in self], self._cognite_client)
+        return APMConfigWriteList([item.as_write() for item in self])
+
+    @classmethod
+    def from_nodes(cls, node: Sequence[Node]) -> Self:
+        return cls([cls._RESOURCE.from_node(item) for item in node], cognite_client=None)

--- a/cognite_toolkit/_cdf_tk/feature_flags.py
+++ b/cognite_toolkit/_cdf_tk/feature_flags.py
@@ -28,6 +28,10 @@ class Flags(Enum):
         "visible": True,
         "description": "Enables support for Atlas Agents and Agent Tools",
     }
+    INFIELD: ClassVar[dict[str, Any]] = {  # type: ignore[misc]
+        "visible": True,
+        "description": "Enables support for Infield configs",
+    }
 
     def is_enabled(self) -> bool:
         return FeatureFlag.is_enabled(self)

--- a/cognite_toolkit/_cdf_tk/loaders/__init__.py
+++ b/cognite_toolkit/_cdf_tk/loaders/__init__.py
@@ -42,6 +42,7 @@ from ._resource_loaders import (
     HostedExtractorJobLoader,
     HostedExtractorMappingLoader,
     HostedExtractorSourceLoader,
+    InfieldV1Loader,
     LabelLoader,
     LocationFilterLoader,
     NodeLoader,
@@ -80,7 +81,8 @@ if not FeatureFlag.is_enabled(Flags.GRAPHQL):
     _EXCLUDED_LOADERS.add(GraphQLLoader)
 if not FeatureFlag.is_enabled(Flags.AGENTS):
     _EXCLUDED_LOADERS.add(AgentLoader)
-
+if not FeatureFlag.is_enabled(Flags.INFIELD):
+    _EXCLUDED_LOADERS.add(InfieldV1Loader)
 
 LOADER_BY_FOLDER_NAME: dict[str, list[type[Loader]]] = {}
 for _loader in itertools.chain(
@@ -113,6 +115,7 @@ ResourceTypes: TypeAlias = Literal[  # type: ignore[no-redef, misc]
     "3dmodels",
     "agents",
     "auth",
+    "cdf_applications",
     "classic",
     "data_models",
     "data_sets",

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/__init__.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/__init__.py
@@ -12,6 +12,7 @@ from .datamodel_loaders import (
     ViewLoader,
 )
 from .extraction_pipeline_loaders import ExtractionPipelineConfigLoader, ExtractionPipelineLoader
+from .fieldops_loaders import InfieldV1Loader
 from .file_loader import CogniteFileLoader, FileMetadataLoader
 from .function_loaders import FunctionLoader, FunctionScheduleLoader
 from .group_scoped_loader import GroupResourceScopedLoader
@@ -60,6 +61,7 @@ __all__ = [
     "HostedExtractorJobLoader",
     "HostedExtractorMappingLoader",
     "HostedExtractorSourceLoader",
+    "InfieldV1Loader",
     "LabelLoader",
     "LocationFilterLoader",
     "NodeLoader",

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/fieldops_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/fieldops_loaders.py
@@ -144,6 +144,10 @@ class InfieldV1Loader(ResourceLoader[str, APMConfigWrite, APMConfig, APMConfigWr
 
     @classmethod
     def get_dependent_items(cls, item: dict) -> Iterable[tuple[type[ResourceLoader], Hashable]]:
+        if isinstance(app_data_space_id := item.get("appDataSpaceId"), str):
+            yield SpaceLoader, app_data_space_id
+        if isinstance(customer_data_space_id := item.get("customerDataSpaceId"), str):
+            yield SpaceLoader, customer_data_space_id
         for config in cls._get_root_location_configurations(item) or []:
             if isinstance(asset_external_id := config.get("assetExternalId"), str):
                 yield AssetLoader, asset_external_id
@@ -170,9 +174,9 @@ class InfieldV1Loader(ResourceLoader[str, APMConfigWrite, APMConfig, APMConfigWr
                 for asset_external_id in filter_.get("assetSubtreeExternalIds", []):
                     if isinstance(asset_external_id, str):
                         yield AssetLoader, asset_external_id
-                for space in filter_.get("appDataInstanceSpaces", []):
-                    if isinstance(space, str):
-                        yield SpaceLoader, space
+                if app_data_instance_space := filter_.get("appDataInstanceSpace"):
+                    if isinstance(app_data_instance_space, str):
+                        yield SpaceLoader, app_data_instance_space
 
     def load_resource(self, resource: dict[str, Any], is_dry_run: bool = False) -> APMConfigWrite:
         root_location_configurations = self._get_root_location_configurations(resource)

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/fieldops_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/fieldops_loaders.py
@@ -1,0 +1,111 @@
+import collections.abc
+from collections.abc import Hashable, Iterable
+from functools import lru_cache
+from typing import Any, final
+
+from cognite.client.data_classes.capabilities import Capability
+from cognite.client.utils.useful_types import SequenceNotStr
+
+from cognite_toolkit._cdf_tk._parameters import ParameterSpec, ParameterSpecSet
+from cognite_toolkit._cdf_tk.client.data_classes.apm_config_v1 import (
+    APMConfig,
+    APMConfigList,
+    APMConfigWrite,
+    APMConfigWriteList,
+)
+from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceLoader
+
+from .auth_loaders import GroupAllScopedLoader
+from .classic_loaders import AssetLoader
+from .data_organization_loaders import DataSetsLoader
+from .datamodel_loaders import SpaceLoader
+from .group_scoped_loader import GroupResourceScopedLoader
+
+
+@final
+class InfieldV1Loader(ResourceLoader[str, APMConfigWrite, APMConfig, APMConfigWriteList, APMConfigList]):
+    folder_name = "cdf_applications"
+    filename_pattern = r"^.*\.InfieldV1$"  # Matches all yaml files whose stem ends with '.InfieldV1'.
+    filetypes = frozenset({"yaml", "yml"})
+    resource_cls = APMConfig
+    resource_write_cls = APMConfigWrite
+    list_cls = APMConfigList
+    list_write_cls = APMConfigWriteList
+    kind = "InfieldV1"
+    dependencies = frozenset(
+        {DataSetsLoader, AssetLoader, SpaceLoader, GroupAllScopedLoader, GroupResourceScopedLoader}
+    )
+    _doc_url = "Instances/operation/applyNodeAndEdges"
+
+    @property
+    def display_name(self) -> str:
+        return "infield configs"
+
+    @classmethod
+    def get_id(cls, item: APMConfig | APMConfigWrite | dict) -> str:
+        if isinstance(item, dict):
+            return item["externalId"]
+        if not item.external_id:
+            raise KeyError("APMConfig must have external_id")
+        return item.external_id
+
+    @classmethod
+    def dump_id(cls, id: str) -> dict[str, Any]:
+        return {"externalId": id}
+
+    @classmethod
+    def get_required_capability(
+        cls, items: collections.abc.Sequence[APMConfigWrite] | None, read_only: bool
+    ) -> Capability | list[Capability]:
+        raise NotImplementedError
+
+    def create(self, items: APMConfigWriteList) -> APMConfigList:
+        raise NotImplementedError
+
+    def retrieve(self, ids: SequenceNotStr[str]) -> APMConfigList:
+        raise NotImplementedError
+
+    def update(self, items: APMConfigWriteList) -> APMConfigList:
+        raise NotImplementedError
+
+    def delete(self, ids: SequenceNotStr[str | int]) -> int:
+        raise NotImplementedError
+
+    def _iterate(
+        self,
+        data_set_external_id: str | None = None,
+        space: str | None = None,
+        parent_ids: list[Hashable] | None = None,
+    ) -> Iterable[APMConfig]:
+        raise NotImplementedError
+
+    @classmethod
+    @lru_cache(maxsize=1)
+    def get_write_cls_parameter_spec(cls) -> ParameterSpecSet:
+        spec = super().get_write_cls_parameter_spec()
+        # Added by toolkit
+        spec.add(
+            ParameterSpec(
+                ("featureConfiguration", "rootLocationConfiguration", "dataSetExternalId"),
+                frozenset({"str"}),
+                is_required=False,
+                _is_nullable=False,
+            )
+        )
+        spec.discard(
+            ParameterSpec(
+                (
+                    "featureConfiguration",
+                    "rootLocationConfiguration",
+                    "dataSetId",
+                ),
+                frozenset({"int"}),
+                is_required=False,
+                _is_nullable=False,
+            )
+        )
+        return spec
+
+    @classmethod
+    def get_dependent_items(cls, item: dict) -> Iterable[tuple[type[ResourceLoader], Hashable]]:
+        raise NotImplementedError

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/fieldops_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/fieldops_loaders.py
@@ -211,7 +211,7 @@ class InfieldV1Loader(ResourceLoader[str, APMConfigWrite, APMConfig, APMConfigWr
                 if not isinstance(filter_, dict):
                     continue
                 if data_set_ids := filter_.pop("dataSetIds", None):
-                    filter_["dataSetIds"] = self.client.lookup.data_sets.external_id(data_set_ids)
+                    filter_["dataSetExternalIds"] = self.client.lookup.data_sets.external_id(data_set_ids)
         return dumped
 
     @staticmethod

--- a/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InfieldV1.yaml
+++ b/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InfieldV1.yaml
@@ -1,0 +1,14 @@
+- externalId: default_infield_config_minimal
+  featureConfiguration:
+    rootLocationConfigurations:
+    - assetExternalId: WMT:VAL
+      appDataInstanceSpace: sp_infield_oid_app_data
+      sourceDataInstanceSpace: sp_asset_oid_source
+      templateAdmins:
+      - gp_infield_oid_template_admins
+      checklistAdmins:
+      - gp_infield_oid_checklist_admins
+      dataSetExternalId: ds_complete_org
+  customerDataSpaceId: APM_SourceData
+  customerDataSpaceVersion: '1'
+  name: Infield APM App Config

--- a/tests/test_unit/test_cdf_tk/test_client/test_apm_config_v1.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_apm_config_v1.py
@@ -1,6 +1,7 @@
+import pytest
 from cognite.client.data_classes.data_modeling import Node
 
-from cognite_toolkit._cdf_tk.client.data_classes.apm_config_v1 import APMConfig, APMConfigWrite
+from cognite_toolkit._cdf_tk.client.data_classes.apm_config_v1 import APMConfig, APMConfigCore, APMConfigWrite
 from tests.test_unit.utils import FakeCogniteResourceGenerator
 
 
@@ -82,3 +83,13 @@ class TestAPMConfigV1Class:
         node_apply = write_config.as_node()
 
         assert node_apply.dump() == node.as_write().dump()
+
+    @pytest.mark.parametrize("config_cls", [APMConfig, APMConfigWrite])
+    def test_apm_config_write_dump_load_yaml(self, config_cls: type[APMConfigCore]) -> None:
+        instance = FakeCogniteResourceGenerator(seed=1338).create_instance(config_cls)
+
+        yaml_str = instance.dump_yaml()
+
+        loaded_instance = config_cls.load(yaml_str)
+
+        assert loaded_instance.dump() == instance.dump()

--- a/tests/test_unit/test_cdf_tk/test_client/test_apm_config_v1.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_apm_config_v1.py
@@ -1,0 +1,43 @@
+from cognite_toolkit._cdf_tk.client.data_classes.apm_config_v1 import APMConfig, APMConfigWrite
+from tests.test_unit.utils import FakeCogniteResourceGenerator
+
+
+class TestAPMConfigV1Class:
+    def test_apm_config_data_class_dump_load(self):
+        config = FakeCogniteResourceGenerator(seed=1337).create_instance(APMConfig)
+
+        dumped = config.dump()
+        assert config == APMConfig._load(dumped)
+
+    def test_apm_config_write_data_class_dump_load(self):
+        config = FakeCogniteResourceGenerator(seed=1333).create_instance(APMConfigWrite)
+
+        dumped = config.dump()
+        assert config == APMConfigWrite._load(dumped)
+
+    def test_load_unknown_field_in_feature_configuration(self):
+        config = FakeCogniteResourceGenerator(seed=1337).create_instance(APMConfig)
+        dumped = config.dump()
+        unknown_object = {
+            "with_unknown_field": True,
+            "unknown_field": "unknown_value",
+        }
+        dumped["featureConfiguration"]["unknown_field"] = unknown_object
+
+        loaded = APMConfig._load(dumped)
+        redumped = loaded.dump()
+        assert redumped["featureConfiguration"]["unknown_field"] == unknown_object
+
+    def test_load_unknown_nested_field_in_feature_configuration(self):
+        config = FakeCogniteResourceGenerator(seed=1337).create_instance(APMConfig)
+        dumped = config.dump()
+        unknown_object = {
+            "with_unknown_field": True,
+            "unknown_field": "unknown_value",
+        }
+        assert isinstance(dumped["featureConfiguration"]["rootLocationConfigurations"], list)
+        dumped["featureConfiguration"]["rootLocationConfigurations"].append(unknown_object)
+
+        loaded = APMConfig._load(dumped)
+        redumped = loaded.dump()
+        assert redumped["featureConfiguration"]["rootLocationConfigurations"][-1] == unknown_object

--- a/tests/test_unit/test_cdf_tk/test_client/test_apm_config_v1.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_apm_config_v1.py
@@ -1,21 +1,23 @@
+from cognite.client.data_classes.data_modeling import Node
+
 from cognite_toolkit._cdf_tk.client.data_classes.apm_config_v1 import APMConfig, APMConfigWrite
 from tests.test_unit.utils import FakeCogniteResourceGenerator
 
 
 class TestAPMConfigV1Class:
-    def test_apm_config_data_class_dump_load(self):
+    def test_apm_config_data_class_dump_load(self) -> None:
         config = FakeCogniteResourceGenerator(seed=1337).create_instance(APMConfig)
 
         dumped = config.dump()
         assert config == APMConfig._load(dumped)
 
-    def test_apm_config_write_data_class_dump_load(self):
+    def test_apm_config_write_data_class_dump_load(self) -> None:
         config = FakeCogniteResourceGenerator(seed=1333).create_instance(APMConfigWrite)
 
         dumped = config.dump()
         assert config == APMConfigWrite._load(dumped)
 
-    def test_load_unknown_field_in_feature_configuration(self):
+    def test_load_unknown_field_in_feature_configuration(self) -> None:
         config = FakeCogniteResourceGenerator(seed=1337).create_instance(APMConfig)
         dumped = config.dump()
         unknown_object = {
@@ -28,7 +30,7 @@ class TestAPMConfigV1Class:
         redumped = loaded.dump()
         assert redumped["featureConfiguration"]["unknown_field"] == unknown_object
 
-    def test_load_unknown_nested_field_in_feature_configuration(self):
+    def test_load_unknown_nested_field_in_feature_configuration(self) -> None:
         config = FakeCogniteResourceGenerator(seed=1337).create_instance(APMConfig)
         dumped = config.dump()
         unknown_object = {
@@ -41,3 +43,42 @@ class TestAPMConfigV1Class:
         loaded = APMConfig._load(dumped)
         redumped = loaded.dump()
         assert redumped["featureConfiguration"]["rootLocationConfigurations"][-1] == unknown_object
+
+    def test_from_node_as_write_to_node(self) -> None:
+        node = Node._load(
+            {
+                "space": "APM_Config",
+                "externalId": "my_config",
+                "version": 1,
+                "lastUpdatedTime": 1,
+                "createdTime": 1,
+                "properties": {
+                    "APM_Config": {
+                        "APM_Config/1": {
+                            "customerDataSpaceId": "APM_SourceData",
+                            "customerDataSpaceVersion": "1",
+                            "name": "Infield APM App Config",
+                            "featureConfiguration": {
+                                "rootLocationConfigurations": [
+                                    {
+                                        "assetExternalId": "MyAsset",
+                                        "appDataInstanceSpace": "my_instance_space",
+                                        "sourceDataInstanceSpace": "my_source_space",
+                                        "templateAdmins": ["admin1", "admin2"],
+                                        "checklistAdmins": ["admin3"],
+                                    },
+                                ],
+                            },
+                        }
+                    }
+                },
+            }
+        )
+
+        read_config = APMConfig.from_node(node)
+
+        write_config = read_config.as_write()
+
+        node_apply = write_config.as_node()
+
+        assert node_apply.dump() == node.as_write().dump()

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_base_loaders.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_base_loaders.py
@@ -226,6 +226,8 @@ def test_resource_types_is_up_to_date() -> None:
 
     if not FeatureFlag.is_enabled(Flags.AGENTS):
         extra.discard("agents")
+    if not FeatureFlag.is_enabled(Flags.INFIELD):
+        extra.discard("cdf_applications")
 
     assert not missing, f"Missing {missing=}"
     assert not extra, f"Extra {extra=}"

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_fieldops_loaders.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_fieldops_loaders.py
@@ -1,0 +1,61 @@
+from cognite_toolkit._cdf_tk.client.data_classes.apm_config_v1 import (
+    APMConfigWrite,
+    FeatureConfiguration,
+    ResourceFilters,
+    RootLocationConfiguration,
+    RootLocationDataFilters,
+)
+from cognite_toolkit._cdf_tk.loaders import (
+    AssetLoader,
+    DataSetsLoader,
+    GroupResourceScopedLoader,
+    InfieldV1Loader,
+    SpaceLoader,
+)
+
+
+class TestInfieldV1Loader:
+    def test_dependent_items(self) -> None:
+        item = APMConfigWrite(
+            external_id="my_config",
+            app_data_space_id="my_app_data_space",
+            customer_data_space_id="my_customer_data_space",
+            feature_configuration=FeatureConfiguration(
+                root_location_configurations=[
+                    RootLocationConfiguration(
+                        asset_external_id="my_root_asset",
+                        template_admins=["my_admin_group1", "my_admin_group2"],
+                        checklist_admins=["my_admin_group3"],
+                        source_data_instance_space="my_source_data_space",
+                        data_filters=RootLocationDataFilters(
+                            assets=ResourceFilters(
+                                asset_subtree_external_ids=["my_asset_subtree"],
+                            ),
+                        ),
+                    )
+                ]
+            ),
+        )
+        dumped = item.dump()
+        dumped["featureConfiguration"]["rootLocationConfigurations"][0]["dataSetExternalId"] = "my_dataset"
+        dumped["featureConfiguration"]["rootLocationConfigurations"][0]["dataFilters"]["assets"][
+            "dataSetExternalIds"
+        ] = ["my_other_dataset"]
+
+        actual = {
+            (loader_cls.__name__, identifier) for loader_cls, identifier in InfieldV1Loader.get_dependent_items(dumped)
+        }
+
+        assert actual == {
+            (AssetLoader.__name__, "my_root_asset"),
+            (DataSetsLoader.__name__, "my_dataset"),
+            (SpaceLoader.__name__, "my_app_data_space"),
+            (SpaceLoader.__name__, "my_customer_data_space"),
+            (SpaceLoader.__name__, "my_source_data_space"),
+            (GroupResourceScopedLoader.__name__, "my_admin_group1"),
+            (GroupResourceScopedLoader.__name__, "my_admin_group2"),
+            (GroupResourceScopedLoader.__name__, "my_admin_group3"),
+            (DataSetsLoader.__name__, "my_other_dataset"),
+            (AssetLoader.__name__, "my_asset_subtree"),
+            (SpaceLoader.__name__, "my_source_data_space"),
+        }

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_fieldops_loaders.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_fieldops_loaders.py
@@ -1,3 +1,5 @@
+import pytest
+
 from cognite_toolkit._cdf_tk.client.data_classes.apm_config_v1 import (
     APMConfigWrite,
     FeatureConfiguration,
@@ -5,6 +7,7 @@ from cognite_toolkit._cdf_tk.client.data_classes.apm_config_v1 import (
     RootLocationConfiguration,
     RootLocationDataFilters,
 )
+from cognite_toolkit._cdf_tk.feature_flags import Flags
 from cognite_toolkit._cdf_tk.loaders import (
     AssetLoader,
     DataSetsLoader,
@@ -15,6 +18,7 @@ from cognite_toolkit._cdf_tk.loaders import (
 
 
 class TestInfieldV1Loader:
+    @pytest.mark.skipif(not Flags.INFIELD.is_enabled(), reason="Alpha feature is not enabled")
     def test_dependent_items(self) -> None:
         item = APMConfigWrite(
             external_id="my_config",

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags.yaml
@@ -92,6 +92,29 @@ Node:
       type: view
       version: v1
   space: sp_nodes
+- externalId: default_infield_config_minimal
+  instanceType: node
+  sources:
+  - properties:
+      customerDataSpaceId: APM_SourceData
+      customerDataSpaceVersion: '1'
+      featureConfiguration:
+        rootLocationConfigurations:
+        - appDataInstanceSpace: sp_infield_oid_app_data
+          assetExternalId: WMT:VAL
+          checklistAdmins:
+          - gp_infield_oid_checklist_admins
+          dataSetId: 7982613576047462211
+          sourceDataInstanceSpace: sp_asset_oid_source
+          templateAdmins:
+          - gp_infield_oid_template_admins
+      name: Infield APM App Config
+    source:
+      externalId: APM_Config
+      space: APM_Config
+      type: view
+      version: '1'
+  space: APM_Config
 Space:
 - space: sp_instance
 - space: sp_schema

--- a/tests/test_unit/utils.py
+++ b/tests/test_unit/utils.py
@@ -208,6 +208,8 @@ class FakeCogniteResourceGenerator:
             elif name == "args" or name == "kwargs":
                 # Skipping generic arguments.
                 continue
+            elif name.startswith("_"):
+                continue
             elif parameter.annotation is inspect.Parameter.empty:
                 raise ValueError(f"Parameter {name} of {resource_cls.__name__} is missing annotation")
             elif skip_defaulted_args and parameter.default is not inspect.Parameter.empty:


### PR DESCRIPTION
# Description

Part 2 of #1531. 

Today Toolkit implicitly supports Infield configurations through supporting Nodes. This is causing complexity on the user side as the Infield configuration contains for example dataSetId which the user is then responsible for looking up across CDF projects. This PR adds explicit support for the Infield Configuration.

This PR uses the data class from the last PR and creates an Infield Loader.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Added

- (alpha) Support for Infield resource.

## templates

No changes.
