### PR TITLE
[CDF-24483] Added 'usedFor' variable to make sure 3d data model is correct

### DIFF
--- a/cognite_toolkit/_builtin_modules/models/cdf_scene/data_models/containers/scene_Cdf3dRevisionProperties.Container.yaml
+++ b/cognite_toolkit/_builtin_modules/models/cdf_scene/data_models/containers/scene_Cdf3dRevisionProperties.Container.yaml
@@ -1,6 +1,7 @@
 space: {{ schemaSpace }}
 externalId: Cdf3dRevisionProperties
 name: Cdf3dRevisionProperties
+usedFor: edge
 properties:
   revisionId:
     type:

--- a/cognite_toolkit/_builtin_modules/models/cdf_scene/data_models/containers/scene_Image360CollectionProperties.Container.yaml
+++ b/cognite_toolkit/_builtin_modules/models/cdf_scene/data_models/containers/scene_Image360CollectionProperties.Container.yaml
@@ -1,6 +1,7 @@
 space: {{ schemaSpace }}
 externalId: Image360CollectionProperties
 name: Image360CollectionProperties
+usedFor: edge
 properties:
   image360CollectionExternalId:
     type:

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_scene.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_scene.yaml
@@ -13,6 +13,7 @@ Container:
         list: false
         type: int64
   space: scene
+  usedFor: edge
 - constraints: {}
   externalId: EnvironmentMap
   indexes: {}
@@ -51,6 +52,7 @@ Container:
         list: false
         type: text
   space: scene
+  usedFor: edge
 - constraints: {}
   externalId: Image360CollectionScene
   indexes: {}


### PR DESCRIPTION
# Description

Users of the built-in 3d configuration module got in trouble because two containers lacked `usedFor` and defaulted to `node`, where in reality they are meant for edges.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- Added missing usedFor: edge variables in 3d containers 

## templates

No changes.
