### PR TITLE
repo: accommodate different letter casings in --host= option

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/repo.py
+++ b/cognite_toolkit/_cdf_tk/commands/repo.py
@@ -54,7 +54,11 @@ class RepoCommand(ToolkitCommand):
         if host is None:
             repo_host = questionary.select("Where do are you hosting the repository?", REPOSITORY_HOSTING).ask()
         else:
-            repo_host = host
+            repo_host = next((provider
+                              for provider
+                              in REPOSITORY_HOSTING
+                              if provider.casefold() == host.casefold()),
+                             "Other")
         if repo_host == "GitHub":
             self.console("The repository will be hosted on GitHub.")
         elif repo_host == "Azure DevOps":


### PR DESCRIPTION
# Description

I was surprised to see no `.github/workflows/deploy.yaml` file after calling `cdf-tk repo init --host=Github`. The file is only created when the option matches "GitHub" with a capital H.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Changed

- Currently the `--host=` option value is ignored if it does not case-sensitively match a value in the `REPOSITORY_HOSTING` array. This change makes the matching case-insensitive and falls back to the "Other" repository hosting option if no match is found.

## templates

No changes.
