### PR TITLE
🧑‍🔧Fix failing test

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/run.py
+++ b/cognite_toolkit/_cdf_tk/commands/run.py
@@ -400,6 +400,7 @@ if __name__ == "__main__":
         external_id: str | None = None,
         data_source: str | WorkflowVersionId | None = None,
         rebuild_env: bool = False,
+        virtual_env_folder_name: str = virtual_env_folder,
     ) -> None:
         try:
             from ._virtual_env import FunctionVirtualEnvironment
@@ -417,7 +418,7 @@ if __name__ == "__main__":
 
         function_external_id = function_build.identifier
 
-        virtual_envs_dir = organization_dir / self.virtual_env_folder
+        virtual_envs_dir = organization_dir / virtual_env_folder_name
         virtual_envs_dir.mkdir(exist_ok=True)
         readme_overview = virtual_envs_dir / "README.md"
         if not readme_overview.exists():

--- a/tests/test_unit/test_cdf_tk/test_commands/test_run.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_run.py
@@ -86,6 +86,7 @@ class TestRunFunction:
             external_id="fn_test3",
             data_source="daily-8pm-utc",
             rebuild_env=False,
+            virtual_env_folder_name="function_local_venvs_test_run_local_function",
         )
 
     @patch.dict(
@@ -105,6 +106,7 @@ class TestRunFunction:
             external_id="fn_test3",
             data_source="workflow",
             rebuild_env=False,
+            virtual_env_folder_name="function_local_venvs_test_run_local_function_workflow",
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

We have a functionality `cdf run function local` which creates a Python virtual environment to execute a CogniteFunction locally. This is causing issues as we are running the test suite in with 8 workers and have two tests for this functionality. This leads them to compete for the same virtual environment which on Windows ends with `Permission` error and on Linux/Max `OSError: [Errno 26] Text file busy`. 

This PR solves the issue by letting the location of the virtual environment folder be an argument and set it differently for the two tests, such that they create one virtual environment each.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
