### PR TITLE
😐 Fix git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -309,3 +309,4 @@ tmp.py
 tmp*.py
 my_*/
 !cognite_toolkit/_builtin_modules/custom/my_module/
+function_local_venvs*/


### PR DESCRIPTION
# Description

The fix in #1546 introduced a fix to the virtual environment. This means all folders starting with `function_local_venvs` must ignored.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
