### PR TITLE
[CDF-24575] Pydantic Validation for 3D models

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_classes/threedmodels.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/threedmodels.py
@@ -1,0 +1,19 @@
+from pydantic import Field
+
+from .base import ToolkitResource
+
+
+class ThreeDModelYAML(ToolkitResource):
+    data_set_external_id: str | None = Field(
+        default=None, description="The id of the dataset this 3D model belongs to."
+    )
+    name: str = Field(
+        description="The name of the model.",
+        min_length=1,
+        max_length=255,
+    )
+    metadata: dict[str, str] | None = Field(
+        default=None,
+        description="Custom, application-specific metadata.",
+        max_length=16,
+    )

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_threedmodels.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_threedmodels.py
@@ -1,0 +1,12 @@
+import pytest
+
+from cognite_toolkit._cdf_tk.resource_classes.threedmodels import ThreeDModelYAML
+from tests.test_unit.utils import find_resources
+
+
+class TestDataSetYAML:
+    @pytest.mark.parametrize("data", list(find_resources("3DModel")))
+    def test_load_valid_dataset(self, data: dict[str, object]) -> None:
+        loaded = ThreeDModelYAML.model_validate(data)
+
+        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data


### PR DESCRIPTION
# Description

This PR introduces pydantic model for 3D Model Resource class that matches the YAML file format that toolkit expects.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
