### PR TITLE
[CDF-24576] Pydantic Validation for Security Categories

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_classes/securitycategories.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/securitycategories.py
@@ -1,0 +1,7 @@
+from pydantic import Field
+
+from .base import ToolkitResource
+
+
+class SecuritytCategoriesYAML(ToolkitResource):
+    name: str = Field(description="The name of the data set.")

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_securitycategories.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_securitycategories.py
@@ -1,0 +1,12 @@
+import pytest
+
+from cognite_toolkit._cdf_tk.resource_classes.securitycategories import SecuritytCategoriesYAML
+from tests.test_unit.utils import find_resources
+
+
+class TestSecuritytCategoriesYAML:
+    @pytest.mark.parametrize("data", list(find_resources("SecurityCategory")))
+    def test_load_valid_security_categories(self, data: dict[str, object]) -> None:
+        loaded = SecuritytCategoriesYAML.model_validate(data)
+
+        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data


### PR DESCRIPTION
# Description

This PR introduces pydantic model for Security Category Resource class that matches the YAML file format that toolkit expects.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
