### PR TITLE
[CDF-24577] Pydantic Validation for Labels

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_classes/labels.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/labels.py
@@ -1,0 +1,25 @@
+from pydantic import Field
+
+from .base import ToolkitResource
+
+
+class LabelsYAML(ToolkitResource):
+    external_id: str = Field(
+        description="The external ID provided by the client.",
+        max_length=255,
+    )
+    name: str = Field(
+        description="The name of the label.",
+        min_length=1,
+        max_length=140,
+    )
+    description: str | None = Field(
+        default=None,
+        description="The description of the label.",
+        min_length=1,
+        max_length=500,
+    )
+    data_set_external_id: str | None = Field(
+        default=None,
+        description="The id of the dataset this label belongs to.",
+    )

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_labels.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_labels.py
@@ -1,0 +1,12 @@
+import pytest
+
+from cognite_toolkit._cdf_tk.resource_classes.labels import LabelsYAML
+from tests.test_unit.utils import find_resources
+
+
+class TestLabelsYAML:
+    @pytest.mark.parametrize("data", list(find_resources("Label")))
+    def test_load_valid_label(self, data: dict[str, object]) -> None:
+        loaded = LabelsYAML.model_validate(data)
+
+        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data


### PR DESCRIPTION
# Description

This PR introduces pydantic model for Label Resource class that matches the YAML file format that toolkit expects.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
