### PR TITLE
[CDF-23856] 🚶 Pydantic Group

### DIFF
--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/auth_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/auth_loaders.py
@@ -48,6 +48,7 @@ from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.data_classes.raw import RawDatabase, RawTable
 from cognite_toolkit._cdf_tk.exceptions import ToolkitWrongResourceError
 from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceLoader
+from cognite_toolkit._cdf_tk.resource_classes import GroupYAML
 from cognite_toolkit._cdf_tk.tk_warnings import (
     HighSeverityWarning,
     MediumSeverityWarning,
@@ -74,6 +75,7 @@ class GroupLoader(ResourceLoader[str, GroupWrite, Group, GroupWriteList, GroupLi
     resource_write_cls = GroupWrite
     list_cls = GroupList
     list_write_cls = GroupWriteList
+    yaml_cls = GroupYAML
     resource_scopes = frozenset(
         {
             cap.IDScope,

--- a/cognite_toolkit/_cdf_tk/resource_classes/__init__.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/__init__.py
@@ -9,10 +9,12 @@ This is means that we have three set of resource classes we use in Toolkit:
 
 from .base import ToolkitResource
 from .dataset import DataSetYAML
+from .groups import GroupYAML
 from .timeseries import TimeSeriesYAML
 
 __all__ = [
     "DataSetYAML",
+    "GroupYAML",
     "TimeSeriesYAML",
     "ToolkitResource",
 ]

--- a/cognite_toolkit/_cdf_tk/resource_classes/capabilities.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/capabilities.py
@@ -1,0 +1,110 @@
+import sys
+from collections.abc import Sequence
+from types import MappingProxyType
+from typing import Any, ClassVar, Literal, cast
+
+from pydantic import BaseModel, ModelWrapValidatorHandler, field_validator, model_serializer, model_validator
+from pydantic_core.core_schema import SerializerFunctionWrapHandler
+
+from cognite_toolkit._cdf_tk.utils.collection import humanize_collection
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Self
+else:
+    from typing import Self
+
+from .base import BaseModelResource
+
+
+class Scope(BaseModelResource):
+    _scope_name: ClassVar[str]
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def find_scope_cls(cls, data: Any, handler: ModelWrapValidatorHandler[Self]) -> Self:
+        if isinstance(data, Scope):
+            return cast(Self, data)
+        if not isinstance(data, dict):
+            raise ValueError(f"Invalid scope data '{type(data)}' expected dict")
+
+        if cls is not Scope:
+            return handler(data)
+        name, content = next(iter(data.items()))
+        if name not in _SCOPE_CLASS_BY_NAME:
+            raise ValueError(
+                f"Invalid scope name '{name}'. Expected one of {humanize_collection(_SCOPE_CLASS_BY_NAME.keys(), bind_word='or')}"
+            )
+        cls_ = _SCOPE_CLASS_BY_NAME[name]
+        return cast(Self, cls_.model_validate(content))
+
+    @model_serializer(mode="wrap", when_used="always", return_type=dict)
+    def include_scope_name(self, handler: SerializerFunctionWrapHandler) -> dict:
+        if self._scope_name is None:
+            raise ValueError("Scope name is not set")
+        serialized_data = handler(self)
+        return {self._scope_name: serialized_data}
+
+
+class AllScope(Scope):
+    _scope_name = "all"
+
+
+class SpaceIDScope(Scope):
+    _scope_name = "spaceIdScope"
+    space_ids: Sequence[str]
+
+
+class Capability(BaseModel):
+    _capability_name: ClassVar[str]
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def find_capability_cls(cls, data: Any, handler: ModelWrapValidatorHandler[Self]) -> Self:
+        if cls is not Capability:
+            return handler(data)
+        if not isinstance(data, dict):
+            raise ValueError(f"Invalid capability data '{type(data)}' expected dict")
+        name, content = next(iter(data.items()))
+        if name not in _CAPABILITY_CLASS_BY_NAME:
+            raise ValueError(f"Invalid capability name '{name}'. Expected one of {_CAPABILITY_CLASS_BY_NAME.keys()}")
+        cls_ = _CAPABILITY_CLASS_BY_NAME[name]
+        return cast(Self, cls_.model_validate(content))
+
+    @model_serializer(mode="wrap", when_used="always", return_type=dict)
+    def include_capability_name(self, handler: SerializerFunctionWrapHandler) -> dict:
+        if self._capability_name is None:
+            raise ValueError("Capability name is not set")
+        serialized_data = handler(self)
+        return {self._capability_name: serialized_data}
+
+
+class DataModelInstancesAcl(Capability):
+    _capability_name = "dataModelInstancesAcl"
+    actions: list[Literal["READ", "WRITE", "WRITE_PROPERTIES"]]
+    scope: AllScope | SpaceIDScope
+
+    @field_validator("scope", mode="before")
+    @classmethod
+    def find_scope_cls(cls, data: Any) -> Scope:
+        return Scope.model_validate(data)
+
+
+class DataModelsAcl(Capability):
+    _capability_name = "dataModelsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | SpaceIDScope
+
+    @field_validator("scope", mode="before")
+    @classmethod
+    def find_scope_cls(cls, data: Any) -> Scope:
+        return Scope.model_validate(data)
+
+
+_CAPABILITY_CLASS_BY_NAME: MappingProxyType[str, type[Capability]] = MappingProxyType(
+    {c._capability_name: c for c in Capability.__subclasses__()}
+)
+ALL_CAPABILITIES = sorted(_CAPABILITY_CLASS_BY_NAME)
+
+_SCOPE_CLASS_BY_NAME: MappingProxyType[str, type[Scope]] = MappingProxyType(
+    {s._scope_name: s for s in Scope.__subclasses__()}
+)

--- a/cognite_toolkit/_cdf_tk/resource_classes/capabilities.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/capabilities.py
@@ -1,7 +1,6 @@
 import sys
-from collections.abc import Sequence
-from types import MappingProxyType
-from typing import Any, ClassVar, Literal, cast
+from types import MappingProxyType, UnionType
+from typing import Any, ClassVar, Literal, cast, get_args
 
 from pydantic import BaseModel, ModelWrapValidatorHandler, field_validator, model_serializer, model_validator
 from pydantic_core.core_schema import SerializerFunctionWrapHandler
@@ -32,7 +31,7 @@ class Scope(BaseModelResource):
         name, content = next(iter(data.items()))
         if name not in _SCOPE_CLASS_BY_NAME:
             raise ValueError(
-                f"Invalid scope name '{name}'. Expected one of {humanize_collection(_SCOPE_CLASS_BY_NAME.keys(), bind_word='or')}"
+                f"invalid scope name '{name}'. Expected one of {humanize_collection(_SCOPE_CLASS_BY_NAME.keys(), bind_word='or')}"
             )
         cls_ = _SCOPE_CLASS_BY_NAME[name]
         return cast(Self, cls_.model_validate(content))
@@ -49,13 +48,99 @@ class AllScope(Scope):
     _scope_name = "all"
 
 
+class CurrentUserScope(Scope):
+    _scope_name = "currentuserscope"
+
+
+class IDScope(Scope):
+    _scope_name = "idScope"
+    ids: list[str]
+
+
+class IDScopeLowerCase(Scope):
+    """Necessary due to lack of API standardisation on scope name: 'idScope' VS 'idscope'"""
+
+    _scope_name = "idscope"
+    ids: list[str]
+
+
+class InstancesScope(Scope):
+    _scope_name = "instancesScope"
+    instances: list[str]
+
+
+class ExtractionPipelineScope(Scope):
+    _scope_name = "extractionPipelineScope"
+    ids: list[str]
+
+
+class PostgresGatewayUsersScope(Scope):
+    _scope_name = "usersScope"
+    usernames: list[str]
+
+
+class DataSetScope(Scope):
+    _scope_name = "datasetScope"
+    ids: list[str]
+
+
+class TableScope(Scope):
+    _scope_name = "tableScope"
+    dbs_to_tables: dict[str, list[str] | dict[Literal["tables"], list[str]]]
+
+
+class AssetRootIDScope(Scope):
+    _scope_name = "assetRootIdScope"
+    root_ids: list[str]
+
+
+class ExperimentsScope(Scope):
+    _scope_name = "experimentscope"
+    experiments: list[str]
+
+
 class SpaceIDScope(Scope):
     _scope_name = "spaceIdScope"
-    space_ids: Sequence[str]
+    space_ids: list[str]
+
+
+class PartitionScope(Scope):
+    _scope_name = "partition"
+    partition_ids: list[int]
+
+
+class LegacySpaceScope(Scope):
+    _scope_name = "spaceScope"
+    external_ids: list[str]
+
+
+class LegacyDataModelScope(Scope):
+    _scope_name = "dataModelScope"
+    external_ids: list[str]
 
 
 class Capability(BaseModel):
     _capability_name: ClassVar[str]
+    scope: Scope
+
+    @field_validator("scope", mode="before")
+    @classmethod
+    def find_scope_cls(cls, data: Any) -> Scope:
+        annotation = cls.model_fields["scope"].annotation
+        if isinstance(annotation, UnionType):
+            valid_types = {s._scope_name for s in get_args(annotation)}
+        elif annotation is not None and issubclass(annotation, Scope):
+            valid_types = {annotation._scope_name}
+        else:
+            raise ValueError(f"Invalid scope annotation '{annotation}'")
+
+        name = next(iter(data.keys()))
+        if name not in valid_types:
+            raise ValueError(
+                f"invalid scope name '{name}'. Expected one of {humanize_collection(valid_types, bind_word='or')}"
+            )
+
+        return Scope.model_validate(data)
 
     @model_validator(mode="wrap")
     @classmethod
@@ -78,15 +163,232 @@ class Capability(BaseModel):
         return {self._capability_name: serialized_data}
 
 
+class AnalyticsAcl(Capability):
+    _capability_name = "analyticsAcl"
+    actions: list[Literal["READ", "EXECUTE", "LIST"]]
+    scope: AllScope
+
+
+class AnnotationsAcl(Capability):
+    _capability_name = "annotationsAcl"
+    actions: list[Literal["READ", "WRITE", "SUGGEST", "REVIEW"]]
+    scope: AllScope
+
+
+class AssetsAcl(Capability):
+    _capability_name = "assetsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | DataSetScope
+
+
+class DataSetsAcl(Capability):
+    _capability_name = "datasetsAcl"
+    actions: list[Literal["READ", "WRITE", "OWNER"]]
+    scope: AllScope | IDScope
+
+
+class DiagramParsingAcl(Capability):
+    _capability_name = "diagramParsingAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class DigitalTwinAcl(Capability):
+    _capability_name = "digitalTwinAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class EntityMatchingAcl(Capability):
+    _capability_name = "entitymatchingAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class EventsAcl(Capability):
+    _capability_name = "eventsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | DataSetScope
+
+
+class ExtractionPipelinesAcl(Capability):
+    _capability_name = "extractionPipelinesAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | IDScopeLowerCase | DataSetScope
+
+
+class ExtractionsRunAcl(Capability):
+    _capability_name = "extractionRunsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | DataSetScope | ExtractionPipelineScope
+
+
+class ExtractionConfigsAcl(Capability):
+    _capability_name = "extractionConfigsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | DataSetScope | ExtractionPipelineScope
+
+
+class FilesAcl(Capability):
+    _capability_name = "filesAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | DataSetScope
+
+
+class FunctionsAcl(Capability):
+    _capability_name = "functionsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class GeospatialAcl(Capability):
+    _capability_name = "geospatialAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class GeospatialCrsAcl(Capability):
+    _capability_name = "geospatialCrsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class GroupsAcl(Capability):
+    _capability_name = "groupsAcl"
+    actions: list[Literal["CREATE", "DELETE", "READ", "LIST", "UPDATE"]]
+    scope: AllScope | CurrentUserScope
+
+
+class LabelsAcl(Capability):
+    _capability_name = "labelsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | DataSetScope
+
+
+class LocationFiltersAcl(Capability):
+    _capability_name = "locationFiltersAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | IDScope
+
+
+class ProjectsAcl(Capability):
+    _capability_name = "projectsAcl"
+    actions: list[Literal["READ", "CREATE", "LIST", "UPDATE", "DELETE"]]
+    scope: AllScope
+
+
+class RawAcl(Capability):
+    _capability_name = "rawAcl"
+    actions: list[Literal["READ", "WRITE", "LIST"]]
+    scope: AllScope | TableScope
+
+
+class RelationshipsAcl(Capability):
+    _capability_name = "relationshipsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | DataSetScope
+
+
+class RoboticsAcl(Capability):
+    _capability_name = "roboticsAcl"
+    actions: list[Literal["READ", "CREATE", "UPDATE", "DELETE"]]
+    scope: AllScope | DataSetScope
+
+
+class SAPWritebackAcl(Capability):
+    _capability_name = "sapWritebackAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | InstancesScope
+
+
+class SAPWritebackRequestsAcl(Capability):
+    _capability_name = "sapWritebackRequestsAcl"
+    actions: list[Literal["WRITE", "LIST"]]
+    scope: AllScope | InstancesScope
+
+
+class SecurityCategoriesAcl(Capability):
+    _capability_name = "securityCategoriesAcl"
+    actions: list[Literal["MEMBEROF", "LIST", "CREATE", "UPDATE", "DELETE"]]
+    scope: AllScope | IDScopeLowerCase
+
+
+class SeismicAcl(Capability):
+    _capability_name = "seismicAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | PartitionScope
+
+
+class SequencesAcl(Capability):
+    _capability_name = "sequencesAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | DataSetScope
+
+
+class SessionsAcl(Capability):
+    _capability_name = "sessionsAcl"
+    actions: list[Literal["LIST", "CREATE", "DELETE"]]
+    scope: AllScope
+
+
+class ThreeDAcl(Capability):
+    _capability_name = "threedAcl"
+    actions: list[Literal["READ", "CREATE", "UPDATE", "DELETE"]]
+    scope: AllScope | DataSetScope
+
+
+class TimeSeriesAcl(Capability):
+    _capability_name = "timeSeriesAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | DataSetScope | IDScopeLowerCase | AssetRootIDScope
+
+
+class TimeSeriesSubscriptionsAcl(Capability):
+    _capability_name = "timeSeriesSubscriptionsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | DataSetScope
+
+
+class TransformationsAcl(Capability):
+    _capability_name = "transformationsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | DataSetScope
+
+
+class TypesAcl(Capability):
+    _capability_name = "typesAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class WellsAcl(Capability):
+    _capability_name = "wellsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class ExperimentsAcl(Capability):
+    _capability_name = "experimentAcl"
+    actions: list[Literal["USE"]]
+    scope: ExperimentsScope
+
+
+class TemplateGroupsAcl(Capability):
+    _capability_name = "templateGroupsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | DataSetScope
+
+
+class TemplateInstancesAcl(Capability):
+    _capability_name = "templateInstancesAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | DataSetScope
+
+
 class DataModelInstancesAcl(Capability):
     _capability_name = "dataModelInstancesAcl"
     actions: list[Literal["READ", "WRITE", "WRITE_PROPERTIES"]]
     scope: AllScope | SpaceIDScope
-
-    @field_validator("scope", mode="before")
-    @classmethod
-    def find_scope_cls(cls, data: Any) -> Scope:
-        return Scope.model_validate(data)
 
 
 class DataModelsAcl(Capability):
@@ -94,10 +396,101 @@ class DataModelsAcl(Capability):
     actions: list[Literal["READ", "WRITE"]]
     scope: AllScope | SpaceIDScope
 
-    @field_validator("scope", mode="before")
-    @classmethod
-    def find_scope_cls(cls, data: Any) -> Scope:
-        return Scope.model_validate(data)
+
+class PipelinesAcl(Capability):
+    _capability_name = "pipelinesAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class DocumentPipelinesAcl(Capability):
+    _capability_name = "documentPipelinesAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class FilePipelinesAcl(Capability):
+    _capability_name = "filePipelinesAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class NotificationsAcl(Capability):
+    _capability_name = "notificationsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class ScheduledCalculationsAcl(Capability):
+    _capability_name = "scheduledCalculationsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class MonitoringTasksAcl(Capability):
+    _capability_name = "monitoringTasksAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class HostedExtractorsAcl(Capability):
+    _capability_name = "hostedExtractorsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class VisionModelAcl(Capability):
+    _capability_name = "visionModelAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class DocumentFeedbackAcl(Capability):
+    _capability_name = "documentFeedbackAcl"
+    actions: list[Literal["CREATE", "READ", "DELETE"]]
+    scope: AllScope
+
+
+class WorkflowOrchestrationAcl(Capability):
+    _capability_name = "workflowOrchestrationAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | DataSetScope
+
+
+class PostgresGatewayAcl(Capability):
+    _capability_name = "postgresGatewayAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope | PostgresGatewayUsersScope
+
+
+class UserProfilesAcl(Capability):
+    _capability_name = "userProfilesAcl"
+    actions: list[Literal["READ"]]
+    scope: AllScope
+
+
+class AuditlogAcl(Capability):
+    _capability_name = "auditlogAcl"
+    actions: list[Literal["READ"]]
+    scope: AllScope
+
+
+class VideoStreamingAcl(Capability):
+    _capability_name = "videoStreamingAcl"
+    actions: list[Literal["READ", "WRITE", "SUBSCRIBE", "PUBLISH"]]
+    scope: AllScope | DataSetScope
+
+
+class LegacyModelHostingAcl(Capability):
+    _capability_name = "modelHostingAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
+
+
+class LegacyGenericsAcl(Capability):
+    _capability_name = "genericsAcl"
+    actions: list[Literal["READ", "WRITE"]]
+    scope: AllScope
 
 
 _CAPABILITY_CLASS_BY_NAME: MappingProxyType[str, type[Capability]] = MappingProxyType(
@@ -107,4 +500,8 @@ ALL_CAPABILITIES = sorted(_CAPABILITY_CLASS_BY_NAME)
 
 _SCOPE_CLASS_BY_NAME: MappingProxyType[str, type[Scope]] = MappingProxyType(
     {s._scope_name: s for s in Scope.__subclasses__()}
+)
+
+_SCOPE_BY_CLASS_NAME: MappingProxyType[str, str] = MappingProxyType(
+    {scope_cls.__name__: scope_name for scope_name, scope_cls in _SCOPE_CLASS_BY_NAME.items()}
 )

--- a/cognite_toolkit/_cdf_tk/resource_classes/capabilities.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/capabilities.py
@@ -94,7 +94,7 @@ class AssetRootIDScope(Scope):
     root_ids: list[str]
 
 
-class ExperimentsScope(Scope):
+class ExperimentScope(Scope):
     _scope_name = "experimentscope"
     experiments: list[str]
 
@@ -370,7 +370,7 @@ class WellsAcl(Capability):
 class ExperimentsAcl(Capability):
     _capability_name = "experimentAcl"
     actions: list[Literal["USE"]]
-    scope: ExperimentsScope
+    scope: ExperimentScope
 
 
 class TemplateGroupsAcl(Capability):

--- a/cognite_toolkit/_cdf_tk/resource_classes/groups.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/groups.py
@@ -1,0 +1,51 @@
+import sys
+from typing import Any, Literal, cast
+
+from cognite.client.data_classes import GroupWrite
+from pydantic import ModelWrapValidatorHandler, model_serializer, model_validator
+from pydantic_core.core_schema import SerializationInfo, SerializerFunctionWrapHandler
+
+from .base import ToolkitResource
+from .capabilities import Capability
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Self
+else:
+    from typing import Self
+
+
+class GroupYAML(ToolkitResource):
+    _cdf_resource = GroupWrite
+    name: str
+    capabilities: list[Capability] | None = None
+    metadata: dict[str, str] | None = None
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def select_group_type(cls, data: Any, handler: ModelWrapValidatorHandler[Self]) -> Self:
+        if cls is not GroupYAML:
+            return handler(data)
+        if "sourceId" in data:
+            return cast(Self, ExternalGroupYAML.model_validate(data))
+        elif "members" in data:
+            return cast(Self, CDFGroupYAML.model_validate(data))
+        raise ValueError("Missing required field: Either 'sourceId' or 'members'")
+
+    @model_serializer(mode="wrap")
+    def serialize_group(self, handler: SerializerFunctionWrapHandler, info: SerializationInfo) -> dict:
+        # Capabilities are serialized as empty dicts [{}, {}, ...]
+        # This issue arises because Pydantic's serialization mechanism doesn't automatically
+        # handle polymorphic serialization for subclasses of Capability.
+        # To address this, we include the below to explicitly calling model dump on the capabilities
+        serialized_data = handler(self)
+        if self.capabilities:
+            serialized_data["capabilities"] = [cap.model_dump(**vars(info)) for cap in self.capabilities]
+        return serialized_data
+
+
+class ExternalGroupYAML(GroupYAML):
+    source_id: str
+
+
+class CDFGroupYAML(GroupYAML):
+    members: list[str] | Literal["allUserAccounts"]

--- a/cognite_toolkit/_cdf_tk/validation.py
+++ b/cognite_toolkit/_cdf_tk/validation.py
@@ -171,6 +171,8 @@ def _humanize_validation_error(error: ValidationError) -> list[str]:
             msg = f"Missing required field: {loc[-1]!r}"
         elif error_type == "extra_forbidden":
             msg = f"Unused field: {loc[-1]!r}"
+        elif error_type == "value_error":
+            msg = str(item["ctx"]["error"])
         else:
             # Default to the Pydantic error message
             msg = item["msg"]

--- a/tests/test_unit/test_cdf_tk/test_commands/test_build.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_build.py
@@ -114,7 +114,7 @@ class TestBuildCommand:
         my_group = """name: gp_trigger_issue
 sourceId: '1234567890123456789'
 capabilities:
-- dataModelInstancesAcls:
+- dataModelInstancesAcl:
     actions:
     - READ
     scope:

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
@@ -1,0 +1,169 @@
+from collections.abc import Iterable
+
+import pytest
+
+from cognite_toolkit._cdf_tk.resource_classes.capabilities import Capability
+
+
+def all_acls() -> Iterable:
+    acl_list = [
+        {"annotationsAcl": {"actions": ["WRITE", "READ", "SUGGEST", "REVIEW"], "scope": {"all": {}}}},
+        {"assetsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"assetsAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": ["myDataSet"]}}}},
+        {"auditlogAcl": {"actions": ["READ"], "scope": {"all": {}}}},
+        {"dataModelInstancesAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"dataModelInstancesAcl": {"actions": ["READ"], "scope": {"spaceIdScope": {"spaceIds": ["maintain"]}}}},
+        {
+            "dataModelInstancesAcl": {
+                "actions": ["WRITE_PROPERTIES"],
+                "scope": {"spaceIdScope": {"spaceIds": ["tech-space"]}},
+            }
+        },
+        {"dataModelsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {
+            "dataModelsAcl": {
+                "actions": ["READ"],
+                "scope": {"spaceIdScope": {"spaceIds": ["maintain", "main-data"]}},
+            }
+        },
+        {"datasetsAcl": {"actions": ["READ", "WRITE", "OWNER"], "scope": {"all": {}}}},
+        {"datasetsAcl": {"actions": ["READ", "WRITE", "OWNER"], "scope": {"idscope": {"ids": ["my_dataset"]}}}},
+        {"diagramParsingAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"digitalTwinAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"documentFeedbackAcl": {"actions": ["CREATE", "READ", "DELETE"], "scope": {"all": {}}}},
+        {"documentPipelinesAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"entitymatchingAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"eventsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"eventsAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": ["myDataSet"]}}}},
+        {"eventsAcl": {"actions": ["READ"], "scope": {"datasetScope": {"ids": ["myDataSet", "myDataSet2"]}}}},
+        {"extractionConfigsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"extractionPipelinesAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {
+            "extractionPipelinesAcl": {
+                "actions": ["READ", "WRITE"],
+                "scope": {"idscope": {"ids": ["myPipeline", "myPipeline"]}},
+            }
+        },
+        {
+            "extractionPipelinesAcl": {
+                "actions": ["READ", "WRITE"],
+                "scope": {"datasetScope": {"ids": ["myDataSet", "myDataSet2"]}},
+            }
+        },
+        {"extractionRunsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"filePipelinesAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"filesAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"filesAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": ["myDataSet", "myDataSet2"]}}}},
+        {"functionsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"genericsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"groupsAcl": {"actions": ["LIST", "READ", "DELETE", "UPDATE", "CREATE"], "scope": {"all": {}}}},
+        {"groupsAcl": {"actions": ["READ", "CREATE", "UPDATE", "DELETE"], "scope": {"currentuserscope": {}}}},
+        {"hostedExtractorsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"labelsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"locationFiltersAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {
+            "locationFiltersAcl": {
+                "actions": ["READ", "WRITE"],
+                "scope": {"idScope": {"ids": ["dataset", "otherDataset"]}},
+            }
+        },
+        {"modelHostingAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"monitoringTasksAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"notificationsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"pipelinesAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {
+            "postgresGatewayAcl": {
+                "actions": ["READ", "WRITE"],
+                "scope": {"usersScope": {"usernames": ["test_1", "test_2"]}},
+            }
+        },
+        {"projectsAcl": {"actions": ["UPDATE", "LIST", "READ", "CREATE", "DELETE"], "scope": {"all": {}}}},
+        {"rawAcl": {"actions": ["READ", "WRITE", "LIST"], "scope": {"all": {}}}},
+        {
+            "rawAcl": {
+                "actions": ["READ", "WRITE", "LIST"],
+                "scope": {"tableScope": {"dbsToTables": {"no table in this": {}}}},
+            }
+        },
+        {
+            "rawAcl": {
+                "actions": ["READ", "WRITE", "LIST"],
+                "scope": {"tableScope": {"dbsToTables": {"test db 1": {"tables": ["empty tbl", "test tbl 1"]}}}},
+            }
+        },
+        {"relationshipsAcl": {"actions": ["READ"], "scope": {"all": {}}}},
+        {"relationshipsAcl": {"actions": ["READ"], "scope": {"datasetScope": {"ids": ["myDataSet", "myDataSet2"]}}}},
+        {"roboticsAcl": {"actions": ["READ", "CREATE", "UPDATE", "DELETE"], "scope": {"all": {}}}},
+        {"roboticsAcl": {"actions": ["READ"], "scope": {"datasetScope": {"ids": ["myDataSet"]}}}},
+        {"sapWritebackAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"sapWritebackAcl": {"actions": ["READ", "WRITE"], "scope": {"instancesScope": {"instances": ["123", "456"]}}}},
+        {"sapWritebackRequestsAcl": {"actions": ["WRITE", "LIST"], "scope": {"all": {}}}},
+        {
+            "sapWritebackRequestsAcl": {
+                "actions": ["WRITE", "LIST"],
+                "scope": {"instancesScope": {"instances": ["123", "456"]}},
+            }
+        },
+        {"scheduledCalculationsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {
+            "securityCategoriesAcl": {
+                "actions": ["DELETE", "MEMBEROF", "LIST", "CREATE", "UPDATE"],
+                "scope": {"all": {}},
+            }
+        },
+        {
+            "securityCategoriesAcl": {
+                "actions": ["MEMBEROF", "LIST", "CREATE", "UPDATE", "DELETE"],
+                "scope": {"idscope": {"ids": ["myCategory", "myOtherCategory"]}},
+            }
+        },
+        {"seismicAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"seismicAcl": {"actions": ["WRITE"], "scope": {"partition": {"partitionIds": [123, 456]}}}},
+        {"sequencesAcl": {"actions": ["READ"], "scope": {"all": {}}}},
+        {"sequencesAcl": {"actions": ["WRITE"], "scope": {"datasetScope": {"ids": ["myDataSet", "myDataSet2"]}}}},
+        {"sessionsAcl": {"actions": ["LIST", "CREATE", "DELETE"], "scope": {"all": {}}}},
+        {"templateGroupsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {
+            "templateGroupsAcl": {
+                "actions": ["READ", "WRITE"],
+                "scope": {"datasetScope": {"ids": ["myDataSet", "myDataSet2"]}},
+            }
+        },
+        {
+            "templateInstancesAcl": {
+                "actions": ["READ", "WRITE"],
+                "scope": {"datasetScope": {"ids": ["myDataSet", "myDataSet2"]}},
+            }
+        },
+        {"templateInstancesAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"threedAcl": {"actions": ["READ", "CREATE", "UPDATE", "DELETE"], "scope": {"all": {}}}},
+        {"timeSeriesAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {
+            "timeSeriesAcl": {
+                "actions": ["READ", "WRITE"],
+                "scope": {"datasetScope": {"ids": ["myDataSet", "myDataSet2"]}},
+            }
+        },
+        {"timeSeriesAcl": {"actions": ["READ"], "scope": {"idscope": {"ids": ["myTimeseries", "myOtherTimeseries"]}}}},
+        {"timeSeriesAcl": {"actions": ["WRITE", "READ"], "scope": {"assetRootIdScope": {"rootIds": ["myAsset"]}}}},
+        {"transformationsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"transformationsAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": ["myDataSet"]}}}},
+        {"visionModelAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"wellsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"workflowOrchestrationAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {
+            "workflowOrchestrationAcl": {
+                "actions": ["READ", "WRITE"],
+                "scope": {"datasetScope": {"ids": ["myDataSet", "myDataSet2"]}},
+            }
+        },
+    ]
+
+    yield from (pytest.param(acl, id=next(iter(acl.keys()))) for acl in acl_list)
+
+
+class TestCapabilities:
+    @pytest.mark.parametrize("acl", all_acls())
+    def test_load_dump_capability(self, acl: dict[str, object]) -> None:
+        capability = Capability.model_validate(acl)
+        assert capability.model_dump(by_alias=True, exclude_unset=True) == acl

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
@@ -12,7 +12,7 @@ def all_acls() -> Iterable:
         {"assetsAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": ["myDataSet"]}}}},
         {"auditlogAcl": {"actions": ["READ"], "scope": {"all": {}}}},
         {"dataModelInstancesAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
-        {"dataModelInstancesAcl": {"actions": ["READ"], "scope": {"spaceScope": {"externalIds": ["maintain"]}}}},
+        {"dataModelInstancesAcl": {"actions": ["READ"], "scope": {"spaceIdScope": {"spaceIds": ["maintain"]}}}},
         {
             "dataModelInstancesAcl": {
                 "actions": ["WRITE_PROPERTIES"],
@@ -23,7 +23,7 @@ def all_acls() -> Iterable:
         {
             "dataModelsAcl": {
                 "actions": ["READ"],
-                "scope": {"dataModelScope": {"externalIds": ["maintain", "main-data"]}},
+                "scope": {"spaceIdScope": {"spaceIds": ["maintain", "main-data"]}},
             }
         },
         {"datasetsAcl": {"actions": ["READ", "WRITE", "OWNER"], "scope": {"all": {}}}},

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
@@ -12,7 +12,7 @@ def all_acls() -> Iterable:
         {"assetsAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": ["myDataSet"]}}}},
         {"auditlogAcl": {"actions": ["READ"], "scope": {"all": {}}}},
         {"dataModelInstancesAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
-        {"dataModelInstancesAcl": {"actions": ["READ"], "scope": {"spaceIdScope": {"spaceIds": ["maintain"]}}}},
+        {"dataModelInstancesAcl": {"actions": ["READ"], "scope": {"spaceScope": {"externalIds": ["maintain"]}}}},
         {
             "dataModelInstancesAcl": {
                 "actions": ["WRITE_PROPERTIES"],
@@ -23,11 +23,11 @@ def all_acls() -> Iterable:
         {
             "dataModelsAcl": {
                 "actions": ["READ"],
-                "scope": {"spaceIdScope": {"spaceIds": ["maintain", "main-data"]}},
+                "scope": {"dataModelScope": {"externalIds": ["maintain", "main-data"]}},
             }
         },
         {"datasetsAcl": {"actions": ["READ", "WRITE", "OWNER"], "scope": {"all": {}}}},
-        {"datasetsAcl": {"actions": ["READ", "WRITE", "OWNER"], "scope": {"idscope": {"ids": ["my_dataset"]}}}},
+        {"datasetsAcl": {"actions": ["READ", "WRITE", "OWNER"], "scope": {"idScope": {"ids": ["my_dataset"]}}}},
         {"diagramParsingAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"digitalTwinAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"documentFeedbackAcl": {"actions": ["CREATE", "READ", "DELETE"], "scope": {"all": {}}}},

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_groups.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_groups.py
@@ -1,0 +1,12 @@
+import pytest
+
+from cognite_toolkit._cdf_tk.resource_classes import GroupYAML
+from tests.test_unit.utils import find_resources
+
+
+class TestTimeSeriesTK:
+    @pytest.mark.parametrize("data", list(find_resources("Group")))
+    def test_load_valid_timeseries(self, data: dict[str, object]) -> None:
+        loaded = GroupYAML.model_validate(data)
+
+        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data

--- a/tests/test_unit/test_cdf_tk/test_validation/test_validate_resource_pydantic.py
+++ b/tests/test_unit/test_cdf_tk/test_validation/test_validate_resource_pydantic.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from cognite_toolkit._cdf_tk.resource_classes import TimeSeriesYAML
+from cognite_toolkit._cdf_tk.resource_classes import GroupYAML, TimeSeriesYAML
 from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
 from cognite_toolkit._cdf_tk.validation import as_json_path, validate_resource_yaml_pydantic
 
@@ -49,6 +49,42 @@ def timeseries_yaml_test_cases() -> Iterable:
     )
 
 
+def group_yaml_test_cases() -> Iterable:
+    yield pytest.param(
+        {"sourceId": "123-345"},
+        {"Missing required field: 'name'"},
+        id="Missing name",
+    )
+    yield pytest.param(
+        {
+            "name": "invalid-group",
+            "capabilities": [{"dataModelInstancesAcl": {"actions": ["INVALID_ACTION"]}}],
+            "members": "allUserAccounts",
+        },
+        {
+            "In capabilities[0].actions input should be 'READ', 'WRITE' or 'WRITE_PROPERTIES'",
+            "In capabilities[0] missing required field: 'scope'",
+        },
+        id="Invalid action and missing scope",
+    )
+
+    yield pytest.param(
+        [
+            {
+                "name": "invalid-group",
+                "capabilities": [
+                    {"dataModelsAcl": {"actions": ["WRITE"], "scope": {"notExisting": {"spaceIds": {"my_space"}}}}}
+                ],
+                "members": "allUserAccounts",
+            }
+        ],
+        {
+            "In [0].capabilities[0] value error, Invalid scope name 'notExisting'. Expected one of all or spaceIdScope",
+        },
+        id="Invalid scope name",
+    )
+
+
 class TestValidateResourceYAML:
     @pytest.mark.parametrize("data, expected_errors", list(timeseries_yaml_test_cases()))
     def test_validate_timeseries_resource_yaml(self, data: dict | list, expected_errors: list[str]) -> None:
@@ -59,6 +95,16 @@ class TestValidateResourceYAML:
         assert isinstance(format_warning, ResourceFormatWarning)
 
         assert format_warning.errors == tuple(expected_errors)
+
+    @pytest.mark.parametrize("data, expected_errors", list(group_yaml_test_cases()))
+    def test_validate_group_resource_yaml(self, data: dict | list, expected_errors: set[str]) -> None:
+        """Test the validate_resource_yaml function for GroupYAML."""
+        warning_list = validate_resource_yaml_pydantic(data, GroupYAML, Path("some_file.yaml"))
+        assert len(warning_list) == 1
+        format_warning = warning_list[0]
+        assert isinstance(format_warning, ResourceFormatWarning)
+
+        assert set(format_warning.errors) == expected_errors
 
 
 class TestAsJsonPath:

--- a/tests/test_unit/test_cdf_tk/test_validation/test_validate_resource_pydantic.py
+++ b/tests/test_unit/test_cdf_tk/test_validation/test_validate_resource_pydantic.py
@@ -79,7 +79,7 @@ def group_yaml_test_cases() -> Iterable:
             }
         ],
         {
-            "In [0].capabilities[0] value error, Invalid scope name 'notExisting'. Expected one of all or spaceIdScope",
+            "In [0].capabilities[0] invalid scope name 'notExisting'. Expected one of all or spaceIdScope",
         },
         id="Invalid scope name",
     )


### PR DESCRIPTION
# Description
Toolkit: CLI for managing CDF configuration as code. The CDF resources are configured in YAML files that are typically checked into version control. 

Context: Up until now we have used the `cognite-sdk` data classes when loading these YAML files. This gives poor error messages when there are errors in the YAML files. In addition, Toolkit has a few deviation from the API spec, the most common Toolkit always uses external IDs instead of internal IDs. We have made the decision to implement `pydantic` to be able to give better error messages to the user when they mistype their `YAML` files.

Reason for size of this PR: Our Groups API has a lot of capabilities.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Improved

- Improved error message if group is not following the API specifications. 

## templates

No changes.
