### PR TITLE
[CDF-24651] 👷 Fix template

### DIFF
--- a/cognite_toolkit/_builtin_modules/contextualization/cdf_p_and_id_parser/functions/contextualization_p_and_id_annotater/handler.py
+++ b/cognite_toolkit/_builtin_modules/contextualization/cdf_p_and_id_parser/functions/contextualization_p_and_id_annotater/handler.py
@@ -224,7 +224,8 @@ def trigger_diagram_detection_jobs(
         is_file_type = dm.filters.In(
             file_view.as_property_ref("mimeType"), ["application/pdf", "image/jpeg", "image/png", "image/tiff"]
         )
-        is_selected = dm.filters.And(is_view, is_uploaded, is_file_type)
+        is_instance_space = dm.filters.SpaceFilter(config.data.instance_spaces, instance_type="node")
+        is_selected = dm.filters.And(is_view, is_uploaded, is_file_type, is_instance_space)
 
         entities = get_entities(client, job_config, instance_spaces, logger)
         if not entities:

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_p_and_id_parser.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_p_and_id_parser.yaml
@@ -44,7 +44,7 @@ Function:
   fileId: -1
   functionPath: handler.py
   metadata:
-    cognite-toolkit-hash: /=24448fa1;handler.py=4c9f5a26;requirements.txt=1d4815ec
+    cognite-toolkit-hash: /=e024a566;handler.py=8c89b5ab;requirements.txt=1d4815ec
   name: P&ID Annotator
   owner: Anonymous
 Node:


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

No changes.

## templates

### Fixed

- The module `cdf_p_and_id_parser` had a bug in the example function, were it did not filter correctly on the instance ID set in the configuration This is now fixed.
