### PR TITLE
[prep CDF-24554]  Prep dump events

### DIFF
--- a/cdf.toml
+++ b/cdf.toml
@@ -10,6 +10,7 @@ module-repeat = true
 populate = true
 agents = false
 infield = true
+dump-data = true
 
 [plugins]
 run = true

--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -19,6 +19,7 @@ from cognite_toolkit._cdf_tk.commands.dump_resource import (
     WorkflowFinder,
 )
 from cognite_toolkit._cdf_tk.exceptions import ToolkitRequiredValueError
+from cognite_toolkit._cdf_tk.feature_flags import Flags
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 
 
@@ -26,21 +27,44 @@ class DumpApp(typer.Typer):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.callback(invoke_without_command=True)(self.dump_main)
-        self.command("datamodel")(self.dump_datamodel_cmd)
+        if Flags.DUMP_DATA.is_enabled():
+            self.add_typer(DumpDataApp(*args, **kwargs), name="data")
+            self.add_typer(DumpConfigApp(*args, **kwargs), name="config")
+        else:
+            self.command("datamodel")(DumpConfigApp.dump_datamodel_cmd)
 
-        self.command("asset")(self.dump_asset_cmd)
-        self.command("timeseries")(self.dump_timeseries_cmd)
+            self.command("asset")(DumpDataApp.dump_asset_cmd)
+            self.command("timeseries")(DumpDataApp.dump_timeseries_cmd)
 
-        self.command("workflow")(self.dump_workflow)
-        self.command("transformation")(self.dump_transformation)
-        self.command("group")(self.dump_group)
-        self.command("node")(self.dump_node)
+            self.command("workflow")(DumpConfigApp.dump_workflow)
+            self.command("transformation")(DumpConfigApp.dump_transformation)
+            self.command("group")(DumpConfigApp.dump_group)
+            self.command("node")(DumpConfigApp.dump_node)
 
     @staticmethod
     def dump_main(ctx: typer.Context) -> None:
         """Commands to dump resource configurations from CDF into a temporary directory."""
         if ctx.invoked_subcommand is None:
             print("Use [bold yellow]cdf dump --help[/] for more information.")
+        return None
+
+
+class DumpConfigApp(typer.Typer):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.callback(invoke_without_command=True)(self.dump_config_main)
+
+        self.command("datamodel")(self.dump_datamodel_cmd)
+        self.command("workflow")(self.dump_workflow)
+        self.command("transformation")(self.dump_transformation)
+        self.command("group")(self.dump_group)
+        self.command("node")(self.dump_node)
+
+    @staticmethod
+    def dump_config_main(ctx: typer.Context) -> None:
+        """Commands to dump resource configurations from CDF into a temporary directory."""
+        if ctx.invoked_subcommand is None:
+            print("Use [bold yellow]cdf dump config --help[/] for more information.")
         return None
 
     @staticmethod
@@ -321,6 +345,21 @@ class DumpApp(typer.Typer):
                 verbose=verbose,
             )
         )
+
+
+class DumpDataApp(typer.Typer):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.callback(invoke_without_command=True)(self.dump_data_main)
+        self.command("asset")(self.dump_asset_cmd)
+        self.command("timeseries")(self.dump_timeseries_cmd)
+
+    @staticmethod
+    def dump_data_main(ctx: typer.Context) -> None:
+        """Commands to dump data from CDF into a temporary directory."""
+        if ctx.invoked_subcommand is None:
+            print("Use [bold yellow]cdf dump data --help[/] for more information.")
+        return None
 
     @staticmethod
     def dump_asset_cmd(

--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -36,7 +36,8 @@ class DumpApp(typer.Typer):
         self.command("group")(self.dump_group)
         self.command("node")(self.dump_node)
 
-    def dump_main(self, ctx: typer.Context) -> None:
+    @staticmethod
+    def dump_main(ctx: typer.Context) -> None:
         """Commands to dump resource configurations from CDF into a temporary directory."""
         if ctx.invoked_subcommand is None:
             print("Use [bold yellow]cdf dump --help[/] for more information.")
@@ -321,8 +322,8 @@ class DumpApp(typer.Typer):
             )
         )
 
+    @staticmethod
     def dump_asset_cmd(
-        self,
         ctx: typer.Context,
         hierarchy: Annotated[
             Optional[list[str]],
@@ -399,8 +400,8 @@ class DumpApp(typer.Typer):
             )
         )
 
+    @staticmethod
     def dump_timeseries_cmd(
-        self,
         ctx: typer.Context,
         hierarchy: Annotated[
             Optional[list[str]],

--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -386,11 +386,7 @@ class DumpDataApp(typer.Typer):
             typer.Option(
                 "--format",
                 "-f",
-                help=(
-                    "Format to dump the assets in. Supported formats: yaml, csv, and parquet."
-                    if Flags.DUMP_DATA.is_enabled()
-                    else "Format to dump the timeseries in. Supported formats: Csv, and parquet."
-                ),
+                help="Format to dump the assets in. Supported formats: csv, and parquet.",
             ),
         ] = "csv",
         limit: Annotated[
@@ -467,11 +463,7 @@ class DumpDataApp(typer.Typer):
             typer.Option(
                 "--format",
                 "-f",
-                help=(
-                    "Format to dump the timeseries in. Supported formats: yaml, csv, and parquet."
-                    if Flags.DUMP_DATA.is_enabled()
-                    else "Format to dump the timeseries in. Supported formats: Csv, and parquet."
-                ),
+                help="Format to dump the timeseries in. Supported formats: csv, and parquet.",
             ),
         ] = "csv",
         limit: Annotated[

--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -386,7 +386,11 @@ class DumpDataApp(typer.Typer):
             typer.Option(
                 "--format",
                 "-f",
-                help="Format to dump the assets in. Supported formats: yaml, csv, and parquet.",
+                help=(
+                    "Format to dump the assets in. Supported formats: yaml, csv, and parquet."
+                    if Flags.DUMP_DATA.is_enabled()
+                    else "Format to dump the timeseries in. Supported formats: Csv, and parquet."
+                ),
             ),
         ] = "csv",
         limit: Annotated[
@@ -463,7 +467,11 @@ class DumpDataApp(typer.Typer):
             typer.Option(
                 "--format",
                 "-f",
-                help="Format to dump the timeseries in. Supported formats: yaml, csv, and parquet.",
+                help=(
+                    "Format to dump the timeseries in. Supported formats: yaml, csv, and parquet."
+                    if Flags.DUMP_DATA.is_enabled()
+                    else "Format to dump the timeseries in. Supported formats: Csv, and parquet."
+                ),
             ),
         ] = "csv",
         limit: Annotated[

--- a/cognite_toolkit/_cdf_tk/feature_flags.py
+++ b/cognite_toolkit/_cdf_tk/feature_flags.py
@@ -32,6 +32,10 @@ class Flags(Enum):
         "visible": True,
         "description": "Enables support for Infield configs",
     }
+    DUMP_DATA: ClassVar[dict[str, Any]] = {  # type: ignore[misc]
+        "visible": True,
+        "description": "Enables support for the dump data command",
+    }
 
     def is_enabled(self) -> bool:
         return FeatureFlag.is_enabled(self)

--- a/cognite_toolkit/_cdf_tk/feature_flags.py
+++ b/cognite_toolkit/_cdf_tk/feature_flags.py
@@ -34,7 +34,7 @@ class Flags(Enum):
     }
     DUMP_DATA: ClassVar[dict[str, Any]] = {  # type: ignore[misc]
         "visible": True,
-        "description": "Enables support for the dump data command",
+        "description": "Splits the dump command in dump data and dump config",
     }
 
     def is_enabled(self) -> bool:

--- a/tests/test_integration/test_commands/test_dump_data_model.py
+++ b/tests/test_integration/test_commands/test_dump_data_model.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from cognite.client.data_classes.data_modeling import DataModelId
 
-from cognite_toolkit._cdf_tk.apps import DumpApp
+from cognite_toolkit._cdf_tk.apps._dump_app import DumpConfigApp
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.commands import DumpResourceCommand
 from cognite_toolkit._cdf_tk.commands.dump_resource import DataModelFinder
@@ -11,7 +11,7 @@ from cognite_toolkit._cdf_tk.loaders import ContainerLoader, DataModelLoader, Sp
 
 class TestDumpResource:
     def test_dump_model_without_version(self, toolkit_client: ToolkitClient, tmp_path: Path) -> None:
-        DumpApp().dump_datamodel_cmd(
+        DumpConfigApp().dump_datamodel_cmd(
             None,
             ["cdf_cdm", "CogniteCore"],
             tmp_path,


### PR DESCRIPTION
# Description

Dumping assets and timeseries goes to csv/parquet format, while data models, nodes, groups, transformations, and workflows goes to YAML thus configuration format. Suggest we split these before the introduction of dump events/files/location filters to make it clear what you are dumping to disk.

### Before
![image](https://github.com/user-attachments/assets/e3f9d586-b153-4dad-a97b-40f38532a077)

## After
![image](https://github.com/user-attachments/assets/22956cdd-d343-4a10-952c-09c7cd5e48e2)


## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Improved

- [alpha] Introduces new `alpha` flag `dump-data` that splits the `cdf dump` plugin command into `cdf dump data` and `cdf dump config`. This is to make it clearer what is data and what is configurations.

## templates

No changes.
