### PR TITLE
Add a step to check for necessary permissions prior to deployment - GitHub Actions/Azure DevOps examples.

### DIFF
--- a/cognite_toolkit/_repo_files/AzureDevOps/.devops/deploy-pipeline.yml
+++ b/cognite_toolkit/_repo_files/AzureDevOps/.devops/deploy-pipeline.yml
@@ -3,7 +3,7 @@ trigger:
     include:
       - main
 
-variables: 
+variables:
   - group: 'dev-toolkit-credentials'
 
 
@@ -13,7 +13,7 @@ jobs:
     displayName: 'Deploy Dry Run'
     pool:
       vmImage: 'ubuntu-latest'
-    container: 
+    container:
       image: 'cognite/toolkit:0.0.0'
       env:
         CDF_CLUSTER: $(CDF_CLUSTER)
@@ -25,5 +25,7 @@ jobs:
       - checkout: self
       - script: cdf build
         displayName: 'Build the modules'
+      - script: cdf auth verify --no-prompt
+        displayName: 'Verify required permissions'
       - script: cdf deploy
         displayName: 'Deploy the modules'

--- a/cognite_toolkit/_repo_files/GitHub/.github/workflows/deploy.yaml
+++ b/cognite_toolkit/_repo_files/GitHub/.github/workflows/deploy.yaml
@@ -23,5 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build the modules
         run: cdf build
+      - name: Verify required permissions
+        run: cdf auth verify --no-prompt
       - name: Deploy the modules
         run: cdf deploy


### PR DESCRIPTION
# Description

Included a step to check for necessary permissions prior to deployment in GitHub Actions/Azure DevOps examples. As the toolkit integrates additional CDF resources, it may require extra permissions to be able to perform the deployment. This step ensures that all requisite permissions are granted to the toolkit principal group prior to the deployment process.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
