### PR TITLE
Making .env override default True

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_core_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_core_app.py
@@ -51,7 +51,7 @@ class CoreApp(typer.Typer):
             typer.Option(
                 help="Load the .env file in this or the parent directory, but also override currently set environment variables",
             ),
-        ] = False,
+        ] = True,
         env_path: Annotated[
             Optional[str],
             typer.Option(
@@ -62,7 +62,7 @@ class CoreApp(typer.Typer):
             bool,
             typer.Option(
                 "--version",
-                help="See which version of the tooklit and the templates are installed.",
+                help="See which version of the Toolkit is installed.",
                 callback=_version_callback,
             ),
         ] = False,


### PR DESCRIPTION
# Description

### If the user has a .env file, its content takes precendence by default.  

There have been multiple cases where the default behaviour of load_dotenv() has confused users and caused problems because ordinary environment variables take precedence over the .env file, for example `CDF_PROJECT`:

What the user expects the Toolkit to use: 
```.env
CDF_PROJECT=my_dev_project 
CDF_CLUSTER=westeurope-1
...
```

What the Toolkit uses (default load_dotenv())
```
echo $CDF_PROJECT
my_prod_project  
```

The `override_env` flag is designed to avoid that, but most users are unaware of it. We think it is unlikely that users want to mix and match.


## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Changed

- If the user uses a .env file, it takes precedence over local environment variables

## templates

No changes.
