### PR TITLE
fix configuration value for workflows, fix bug with datapoints extractor

### DIFF
--- a/cognite_toolkit/_builtin_modules/bootcamp/ice_cream_api/default.config.yaml
+++ b/cognite_toolkit/_builtin_modules/bootcamp/ice_cream_api/default.config.yaml
@@ -3,7 +3,7 @@ icapi_extractors_source_id: <OBJECT ID FOR ICAPI EXTRACTORS ENTRA GROUP>
 tokenUri: ${IDP_TOKEN_URL}
 cdfProjectName: ${CDF_PROJECT}
 scopes: ${IDP_SCOPES}
-icapi_trigger_client_id: ${IDP_CLIENT_ID}
-icapi_trigger_client_secret: ${IDP_CLIENT_SECRET}
+icapi_trigger_client_id: ${ICAPI_EXTRACTORS_CLIENT_ID}
+icapi_trigger_client_secret: ${ICAPI_EXTRACTORS_CLIENT_SECRET}
 icapi_extractors_client_id: ${ICAPI_EXTRACTORS_CLIENT_ID}
 icapi_extractors_client_secret: ${ICAPI_EXTRACTORS_CLIENT_SECRET}

--- a/cognite_toolkit/_builtin_modules/bootcamp/ice_cream_api/functions/icapi_datapoints_extractor/handler.py
+++ b/cognite_toolkit/_builtin_modules/bootcamp/ice_cream_api/functions/icapi_datapoints_extractor/handler.py
@@ -157,11 +157,11 @@ def handle(client: CogniteClient = None, data=None):
                     client.time_series.data.insert_multiple(datapoints=to_insert)
                     to_insert = []
 
-        if to_insert:
-            client.time_series.data.insert_multiple(datapoints=to_insert)
-            print(f"  {hours}h of Datapoints took {default_timer() - big_start:.2f} seconds")
-        else:
-            print(f"  No TimeSeries, for {hours}h of Datapoints took {default_timer() - big_start:.2f} seconds")
+            if to_insert:
+                client.time_series.data.insert_multiple(datapoints=to_insert)
+                print(f"  {hours}h of Datapoints took {default_timer() - big_start:.2f} seconds")
+            else:
+                print(f"  No TimeSeries, for {hours}h of Datapoints took {default_timer() - big_start:.2f} seconds")
 
         report_ext_pipe(client, "success")
     except Exception as e:


### PR DESCRIPTION
# Description

Fixed Bootcamp workflows using incorrect credentials, fixed bug introduced in last change for datapoints extractor.

## Changelog

- [ ] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- Bootcamp config.test.yaml had incorrect credentials for workflow variables
- fixed bug that would miss list of datapoints when list was < 50

## templates

No changes.
