### PR TITLE
[CDF-24555] 📂 Support dump files

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -9,6 +9,7 @@ from rich import print
 from cognite_toolkit._cdf_tk.commands import DumpDataCommand, DumpResourceCommand
 from cognite_toolkit._cdf_tk.commands.dump_data import (
     AssetFinder,
+    FileMetadataFinder,
     TimeSeriesFinder,
 )
 from cognite_toolkit._cdf_tk.commands.dump_resource import (
@@ -21,7 +22,11 @@ from cognite_toolkit._cdf_tk.commands.dump_resource import (
 from cognite_toolkit._cdf_tk.exceptions import ToolkitRequiredValueError
 from cognite_toolkit._cdf_tk.feature_flags import Flags
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
-from cognite_toolkit._cdf_tk.utils.interactive_select import AssetInteractiveSelect, TimeSeriesInteractiveSelect
+from cognite_toolkit._cdf_tk.utils.interactive_select import (
+    AssetInteractiveSelect,
+    FileMetadataInteractiveSelect,
+    TimeSeriesInteractiveSelect,
+)
 
 
 class DumpApp(typer.Typer):
@@ -433,6 +438,84 @@ class DumpDataApp(typer.Typer):
         cmd.run(
             lambda: cmd.dump_table(
                 AssetFinder(client, hierarchy or [], data_set or []),
+                output_dir,
+                clean,
+                limit,
+                format_,  # type: ignore [arg-type]
+                verbose,
+            )
+        )
+
+    @staticmethod
+    def dump_files_cmd(
+        ctx: typer.Context,
+        hierarchy: Annotated[
+            Optional[list[str]],
+            typer.Option(
+                "--hierarchy",
+                "-h",
+                help="Asset hierarchy (sub-trees) to dump filemetadata from.",
+            ),
+        ] = None,
+        data_set: Annotated[
+            Optional[list[str]],
+            typer.Option(
+                "--data-set",
+                "-d",
+                help="Data set to dump. If neither hierarchy nor data set is provided, the user will be prompted.",
+            ),
+        ] = None,
+        format_: Annotated[
+            str,
+            typer.Option(
+                "--format",
+                "-f",
+                help="Format to dump the filemetadata in. Supported formats: csv, and parquet.",
+            ),
+        ] = "csv",
+        limit: Annotated[
+            Optional[int],
+            typer.Option(
+                "--limit",
+                "-l",
+                help="Limit the number of filemetadata to dump.",
+            ),
+        ] = None,
+        output_dir: Annotated[
+            Path,
+            typer.Option(
+                "--output-dir",
+                "-o",
+                help="Where to dump the filemetadata files.",
+                allow_dash=True,
+            ),
+        ] = Path("tmp"),
+        clean: Annotated[
+            bool,
+            typer.Option(
+                "--clean",
+                "-c",
+                help="Delete the output directory before dumping the filemetadata.",
+            ),
+        ] = False,
+        verbose: Annotated[
+            bool,
+            typer.Option(
+                "--verbose",
+                "-v",
+                help="Turn on to get more verbose output when running the command",
+            ),
+        ] = False,
+    ) -> None:
+        """This command will dump the selected events to the selected format in the folder specified, defaults to /tmp."""
+        cmd = DumpDataCommand()
+        cmd.validate_directory(output_dir, clean)
+        client = EnvironmentVariables.create_from_environment().get_client()
+        if hierarchy is None and data_set is None:
+            hierarchy, data_set = FileMetadataInteractiveSelect(client).interactive_select_hierarchy_datasets()
+        cmd.run(
+            lambda: cmd.dump_table(
+                FileMetadataFinder(client, hierarchy or [], data_set or []),
                 output_dir,
                 clean,
                 limit,

--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -358,6 +358,7 @@ class DumpDataApp(typer.Typer):
         super().__init__(*args, **kwargs)
         self.callback(invoke_without_command=True)(self.dump_data_main)
         self.command("asset")(self.dump_asset_cmd)
+        self.command("files-metadata")(self.dump_files_cmd)
         self.command("timeseries")(self.dump_timeseries_cmd)
 
     @staticmethod

--- a/cognite_toolkit/_cdf_tk/commands/dump_data.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_data.py
@@ -10,6 +10,8 @@ from cognite.client.data_classes import (
     Asset,
     AssetFilter,
     DataSetList,
+    FileMetadata,
+    FileMetadataFilter,
     LabelDefinitionList,
     TimeSeries,
     TimeSeriesFilter,
@@ -25,7 +27,14 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitIsADirectoryError,
     ToolkitValueError,
 )
-from cognite_toolkit._cdf_tk.loaders import AssetLoader, DataSetsLoader, LabelLoader, ResourceLoader, TimeSeriesLoader
+from cognite_toolkit._cdf_tk.loaders import (
+    AssetLoader,
+    DataSetsLoader,
+    FileMetadataLoader,
+    LabelLoader,
+    ResourceLoader,
+    TimeSeriesLoader,
+)
 from cognite_toolkit._cdf_tk.utils.cdf import metadata_key_counts
 from cognite_toolkit._cdf_tk.utils.file import safe_rmtree
 from cognite_toolkit._cdf_tk.utils.producer_worker import ProducerWorkerExecutor
@@ -244,6 +253,55 @@ class AssetFinder(AssetCentricFinder[Asset]):
         sorted_keys = sorted([key for key, count in metadata_keys if count > 0])
         columns.extend([SchemaColumn(name=f"metadata.{key}", type="string") for key in sorted_keys])
         return columns
+
+
+class FileMetadataFinder(AssetCentricFinder[FileMetadata]):
+    supported_formats = frozenset({"csv", "parquet"})
+
+    def _create_loader(self, client: ToolkitClient) -> ResourceLoader:
+        return FileMetadataLoader.create_loader(client)
+
+    def _aggregate_count(self, hierarchies: list[str], data_sets: list[str]) -> int:
+        result = self.client.files.aggregate(
+            filter=FileMetadataFilter(
+                data_set_ids=[{"externalId": item} for item in data_sets] or None,
+                asset_subtree_ids=[{"externalId": item} for item in hierarchies] or None,
+            )
+        )
+        return result[0].count if result else 0
+
+    def _get_resource_columns(self) -> list[SchemaColumn]:
+        columns = [
+            SchemaColumn(name="externalId", type="string"),
+            SchemaColumn(name="name", type="string"),
+            SchemaColumn(name="directory", type="string"),
+            SchemaColumn(name="source", type="string"),
+            SchemaColumn(name="mimeType", type="string"),
+            SchemaColumn(name="assetExternalIds", type="string", is_array=True),
+            SchemaColumn(name="dataSetExternalId", type="string"),
+            SchemaColumn(name="sourceCreatedTime", type="integer"),
+            SchemaColumn(name="sourceModifiedTime", type="integer"),
+            SchemaColumn(name="securityCategories", type="string", is_array=True),
+            SchemaColumn(name="labels", type="string", is_array=True),
+            SchemaColumn(name="geoLocation", type="json"),
+        ]
+        data_set_ids = self.client.lookup.data_sets.id(self.data_sets) if self.data_sets else []
+        root_ids = self.client.lookup.assets.id(self.hierarchies) if self.hierarchies else []
+        metadata_keys = metadata_key_counts(self.client, "files", data_set_ids or None, root_ids or None)
+        sorted_keys = sorted([key for key, count in metadata_keys if count > 0])
+        columns.extend([SchemaColumn(name=f"metadata.{key}", type="string") for key in sorted_keys])
+        return columns
+
+    def create_resource_iterator(self, limit: int | None) -> Iterable:
+        return self.client.files(
+            chunk_size=1000,
+            asset_subtree_external_ids=self.hierarchies or None,
+            data_set_external_ids=self.data_sets or None,
+            limit=limit,
+        )
+
+    def _resource_processor(self, items: Iterable[FileMetadata]) -> list[tuple[str, list[dict[str, Any]]]]:
+        return [("", self._to_write(items))]
 
 
 class TimeSeriesFinder(AssetCentricFinder[TimeSeries]):

--- a/cognite_toolkit/_cdf_tk/commands/dump_data.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_data.py
@@ -294,7 +294,7 @@ class FileMetadataFinder(AssetCentricFinder[FileMetadata]):
 
     def create_resource_iterator(self, limit: int | None) -> Iterable:
         return self.client.files(
-            chunk_size=1000,
+            chunk_size=self.chunk_size,
             asset_subtree_external_ids=self.hierarchies or None,
             data_set_external_ids=self.data_sets or None,
             limit=limit,

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -2,7 +2,15 @@ from abc import abstractmethod
 from functools import lru_cache
 
 import questionary
-from cognite.client.data_classes import Asset, AssetFilter, AssetList, DataSet, DataSetList, TimeSeriesFilter
+from cognite.client.data_classes import (
+    Asset,
+    AssetFilter,
+    AssetList,
+    DataSet,
+    DataSetList,
+    FileMetadataFilter,
+    TimeSeriesFilter,
+)
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 
@@ -113,6 +121,17 @@ class AssetInteractiveSelect(AssetCentricInteractiveSelect):
                 asset_subtree_ids=[{"externalId": item} for item in hierarchies] or None,
             )
         )
+
+
+class FileMetadataInteractiveSelect(AssetCentricInteractiveSelect):
+    def _aggregate_count(self, hierarchies: list[str], data_sets: list[str]) -> int:
+        result = self.client.files.aggregate(
+            filter=FileMetadataFilter(
+                data_set_ids=[{"externalId": item} for item in data_sets] or None,
+                asset_subtree_ids=[{"externalId": item} for item in hierarchies] or None,
+            )
+        )
+        return result[0].count if result else 0
 
 
 class TimeSeriesInteractiveSelect(AssetCentricInteractiveSelect):

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_data.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_data.py
@@ -118,11 +118,15 @@ class TestDumpData:
                 properties={},
             ),
         )
+        my_other_file = FileMetadata(
+            "my_other_file_タシ",
+            name="My Other File",
+        )
         cmd = DumpDataCommand(skip_tracking=False, print_warning=False)
         output_dir = tmp_path / "file_dump"
         with monkeypatch_toolkit_client() as client:
-            client.files.return_value = [FileMetadataList([my_file])]
-            client.files.aggregate.return_value = [CountAggregate(count=1)]
+            client.files.return_value = [FileMetadataList([my_file, my_other_file])]
+            client.files.aggregate.return_value = [CountAggregate(count=2)]
             client.labels.retrieve.return_value = LabelDefinitionList([my_label])
             client.data_sets.retrieve_multiple.return_value = [dataset]
             client.lookup.assets.external_id.return_value = "rootAsset"
@@ -143,13 +147,14 @@ class TestDumpData:
         output_csvs = list(output_dir.rglob("*.csv"))
         assert len(output_csvs) == 1
         output_csv = output_csvs[0]
-        assert output_csv.read_text().splitlines() == [
+        assert output_csv.read_text(encoding="utf-8").splitlines() == [
             "externalId,name,directory,source,mimeType,assetExternalIds,dataSetExternalId,sourceCreatedTime,"
             "sourceModifiedTime,securityCategories,labels,geoLocation,metadata.key",
             "my_file,My File,my_directory,MySource,application/octet-stream,rootAsset,my_dataset,,,,['label1'],"
             "\"{'type': 'Feature', 'geometry': {'type': 'LineString', 'coordinates': [[1.0, 1.0], [2.0, 2.0], "
             "[3.0, 3.0]]}, 'properties': {}}\""
             ",value",
+            "my_other_file_タシ,My Other File,,,,,,,,,,,",
         ]
 
         dataset_yamls = list(output_dir.rglob("*DataSet.yaml"))

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_data.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_data.py
@@ -3,9 +3,13 @@ from pathlib import Path
 from cognite.client.data_classes import (
     Asset,
     AssetList,
+    CountAggregate,
     DataSet,
+    FileMetadata,
+    FileMetadataList,
     GeoLocation,
     Geometry,
+    Label,
     LabelDefinition,
     LabelDefinitionList,
     TimeSeries,
@@ -15,7 +19,7 @@ from cognite.client.data_classes import (
 
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.commands import DumpDataCommand
-from cognite_toolkit._cdf_tk.commands.dump_data import AssetFinder, TimeSeriesFinder
+from cognite_toolkit._cdf_tk.commands.dump_data import AssetFinder, FileMetadataFinder, TimeSeriesFinder
 from cognite_toolkit._cdf_tk.utils.file import read_yaml_file
 
 
@@ -94,6 +98,69 @@ class TestDumpData:
 
         parquet_files = list(parquet_dir.rglob("*.parquet"))
         assert len(parquet_files) == 1
+
+    def test_dump_filemetadata(self, tmp_path: Path) -> None:
+        my_label = LabelDefinition(external_id="label1", name="Label 1")
+        dataset = DataSet(external_id="my_dataset", name="My Dataset", id=123)
+        my_file = FileMetadata(
+            external_id="my_file",
+            name="My File",
+            data_set_id=dataset.id,
+            metadata={"key": "value"},
+            source="MySource",
+            labels=[Label(external_id=my_label.external_id)],
+            asset_ids=[1],
+            mime_type="application/octet-stream",
+            directory="my_directory",
+            geo_location=GeoLocation(
+                type="Feature",
+                geometry=Geometry(type="LineString", coordinates=[[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]]),
+                properties={},
+            ),
+        )
+        cmd = DumpDataCommand(skip_tracking=False, print_warning=False)
+        output_dir = tmp_path / "file_dump"
+        with monkeypatch_toolkit_client() as client:
+            client.files.return_value = [FileMetadataList([my_file])]
+            client.files.aggregate.return_value = [CountAggregate(count=1)]
+            client.labels.retrieve.return_value = LabelDefinitionList([my_label])
+            client.data_sets.retrieve_multiple.return_value = [dataset]
+            client.lookup.assets.external_id.return_value = "rootAsset"
+            client.lookup.data_sets.external_id.return_value = dataset.external_id
+            client.transformations.preview.return_value = TransformationPreviewResult(
+                None, [{"key": "key", "key_count": 1}]
+            )
+
+            cmd.dump_table(
+                FileMetadataFinder(client, ["rootAsset"], []),
+                output_dir,
+                clean=True,
+                limit=None,
+                format_="csv",
+                verbose=False,
+            )
+
+        output_csvs = list(output_dir.rglob("*.csv"))
+        assert len(output_csvs) == 1
+        output_csv = output_csvs[0]
+        assert output_csv.read_text().splitlines() == [
+            "externalId,name,directory,source,mimeType,assetExternalIds,dataSetExternalId,sourceCreatedTime,"
+            "sourceModifiedTime,securityCategories,labels,geoLocation,metadata.key",
+            "my_file,My File,my_directory,MySource,application/octet-stream,rootAsset,my_dataset,,,,['label1'],"
+            "\"{'type': 'Feature', 'geometry': {'type': 'LineString', 'coordinates': [[1.0, 1.0], [2.0, 2.0], "
+            "[3.0, 3.0]]}, 'properties': {}}\""
+            ",value",
+        ]
+
+        dataset_yamls = list(output_dir.rglob("*DataSet.yaml"))
+        assert len(dataset_yamls) == 1
+        dataset_yaml = dataset_yamls[0]
+        assert read_yaml_file(dataset_yaml) == [dataset.as_write().dump()]
+
+        label_yamls = list(output_dir.rglob("*Label.yaml"))
+        assert len(label_yamls) == 1
+        label_yaml = label_yamls[0]
+        assert read_yaml_file(label_yaml) == [my_label.as_write().dump()]
 
     def test_dump_timeseries(self, tmp_path: Path) -> None:
         dataset = DataSet(external_id="my_dataset", name="My Dataset", id=123)

--- a/tests/test_unit/test_cdf_tk/test_utils/test_interactive_select.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_interactive_select.py
@@ -1,12 +1,13 @@
 from cognite.client.data_classes import (
     Asset,
+    CountAggregate,
     DataSet,
 )
 from questionary import Choice
 
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.utils.interactive_select import (
-    AssetInteractiveSelect,
+    FileMetadataInteractiveSelect,
     TimeSeriesInteractiveSelect,
 )
 from tests.test_unit.utils import MockQuestionary
@@ -25,17 +26,47 @@ class TestInteractiveSelect:
         answers = ["Hierarchy", select_hierarchy, "Data Set", select_data_set, "Done"]
         with (
             monkeypatch_toolkit_client() as client,
-            MockQuestionary(AssetInteractiveSelect.__module__, monkeypatch, answers),
+            MockQuestionary(FileMetadataInteractiveSelect.__module__, monkeypatch, answers),
         ):
             client.assets.list.return_value = [Asset(id=1, external_id="Root1"), Asset(id=2, external_id="Root2")]
-            client.assets.aggregate_count.return_value = 100
+            client.files.aggregate.return_value = [CountAggregate(count=100)]
             client.data_sets.list.return_value = [
                 DataSet(id=1, external_id="dataset1"),
                 DataSet(id=2, external_id="dataset2"),
                 DataSet(id=3, external_id="dataset3"),
             ]
 
-            selector = AssetInteractiveSelect(client)
+            selector = FileMetadataInteractiveSelect(client)
+            selected_hierarchy, selected_dataset = selector.interactive_select_hierarchy_datasets()
+
+        assert selected_hierarchy == ["Root2"]
+        assert selected_dataset == ["dataset3"]
+
+    def test_interactive_select_filemetadata(self, monkeypatch) -> None:
+        def select_data_set(choices: list[Choice]) -> list[str]:
+            assert len(choices) == 3
+            return [choices[2].value]
+
+        def select_hierarchy(choices: list[Choice]) -> list[str]:
+            assert len(choices) == 2
+            return [choices[1].value]
+
+        answers = ["Data Set", select_data_set, "Hierarchy", select_hierarchy, "Done"]
+        with (
+            monkeypatch_toolkit_client() as client,
+            MockQuestionary(TimeSeriesInteractiveSelect.__module__, monkeypatch, answers),
+        ):
+            client.data_sets.list.return_value = [
+                DataSet(id=1, external_id="dataset1", name="Dataset 1"),
+                DataSet(id=2, external_id="dataset2", name="Dataset 2"),
+                DataSet(id=3, external_id="dataset3", name="Dataset 3"),
+            ]
+            client.assets.list.return_value = [
+                Asset(id=1, external_id="Root1", name="Root 1"),
+                Asset(id=2, external_id="Root2", name="Root 2"),
+            ]
+            client.time_series.aggregate_count.return_value = 100
+            selector = TimeSeriesInteractiveSelect(client)
             selected_hierarchy, selected_dataset = selector.interactive_select_hierarchy_datasets()
 
         assert selected_hierarchy == ["Root2"]

--- a/tests/test_unit/test_cdf_tk/test_utils/test_interactive_select.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_interactive_select.py
@@ -7,6 +7,7 @@ from questionary import Choice
 
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.utils.interactive_select import (
+    AssetInteractiveSelect,
     FileMetadataInteractiveSelect,
     TimeSeriesInteractiveSelect,
 )
@@ -26,17 +27,17 @@ class TestInteractiveSelect:
         answers = ["Hierarchy", select_hierarchy, "Data Set", select_data_set, "Done"]
         with (
             monkeypatch_toolkit_client() as client,
-            MockQuestionary(FileMetadataInteractiveSelect.__module__, monkeypatch, answers),
+            MockQuestionary(AssetInteractiveSelect.__module__, monkeypatch, answers),
         ):
             client.assets.list.return_value = [Asset(id=1, external_id="Root1"), Asset(id=2, external_id="Root2")]
-            client.files.aggregate.return_value = [CountAggregate(count=100)]
+            client.assets.aggregate_count.return_value = 100
             client.data_sets.list.return_value = [
                 DataSet(id=1, external_id="dataset1"),
                 DataSet(id=2, external_id="dataset2"),
                 DataSet(id=3, external_id="dataset3"),
             ]
 
-            selector = FileMetadataInteractiveSelect(client)
+            selector = AssetInteractiveSelect(client)
             selected_hierarchy, selected_dataset = selector.interactive_select_hierarchy_datasets()
 
         assert selected_hierarchy == ["Root2"]
@@ -54,7 +55,7 @@ class TestInteractiveSelect:
         answers = ["Data Set", select_data_set, "Hierarchy", select_hierarchy, "Done"]
         with (
             monkeypatch_toolkit_client() as client,
-            MockQuestionary(TimeSeriesInteractiveSelect.__module__, monkeypatch, answers),
+            MockQuestionary(FileMetadataInteractiveSelect.__module__, monkeypatch, answers),
         ):
             client.data_sets.list.return_value = [
                 DataSet(id=1, external_id="dataset1", name="Dataset 1"),
@@ -65,12 +66,35 @@ class TestInteractiveSelect:
                 Asset(id=1, external_id="Root1", name="Root 1"),
                 Asset(id=2, external_id="Root2", name="Root 2"),
             ]
-            client.time_series.aggregate_count.return_value = 100
-            selector = TimeSeriesInteractiveSelect(client)
+            client.files.aggregate.return_value = [CountAggregate(100)]
+            selector = FileMetadataInteractiveSelect(client)
             selected_hierarchy, selected_dataset = selector.interactive_select_hierarchy_datasets()
 
         assert selected_hierarchy == ["Root2"]
         assert selected_dataset == ["dataset3"]
+
+    def test_interactive_select_filemetadata_empty_cdf(self, monkeypatch) -> None:
+        def select_data_set(choices: list[Choice]) -> list[str]:
+            assert len(choices) == 0
+            return []
+
+        def select_hierarchy(choices: list[Choice]) -> list[str]:
+            assert len(choices) == 0
+            return []
+
+        answers = ["Data Set", select_data_set, "Hierarchy", select_hierarchy, "Done"]
+        with (
+            monkeypatch_toolkit_client() as client,
+            MockQuestionary(FileMetadataInteractiveSelect.__module__, monkeypatch, answers),
+        ):
+            client.data_sets.list.return_value = []
+            client.assets.list.return_value = []
+            client.files.aggregate.return_value = [CountAggregate(100)]
+            selector = FileMetadataInteractiveSelect(client)
+            selected_hierarchy, selected_dataset = selector.interactive_select_hierarchy_datasets()
+
+        assert selected_hierarchy == []
+        assert selected_dataset == []
 
     def test_interactive_select_timeseries(self, monkeypatch) -> None:
         def select_data_set(choices: list[Choice]) -> list[str]:


### PR DESCRIPTION
# Description

Adds support for dumping file metadata to csv/parquet.

![image](https://github.com/user-attachments/assets/792487db-988d-414e-878d-0edde9911490)


## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Added

- [alpha] Support for dumping files medata, `cdf dump data filesmetadata`. To enable this set the flag `dump_data = true`.

## templates

No changes.
