### PR TITLE
Expose new yaml classe in module

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_classes/__init__.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/__init__.py
@@ -7,15 +7,37 @@ This is means that we have three set of resource classes we use in Toolkit:
 3. Read resource classes (from cognite-sdk): Represent the read/response format the Cognite resources.
 """
 
+from .asset import AssetYAML
 from .base import BaseModelResource, ToolkitResource
 from .dataset import DataSetYAML
+from .event import EventYAML
+from .filemetadata import FileMetadataYAML
+from .function_schedule import FunctionScheduleYAML
+from .functions import FunctionsYAML
 from .groups import GroupYAML
+from .labels import LabelsYAML
+from .location import LocationYAML
+from .raw_database_table import DatabaseYAML, TableYAML
+from .securitycategories import SecurityCategoriesYAML
+from .space import SpaceYAML
 from .timeseries import TimeSeriesYAML
 
 __all__ = [
+    "AssetYAML",
     "BaseModelResource",
     "DataSetYAML",
+    "DatabaseYAML",
+    "EventYAML",
+    "FileMetadataYAML",
+    "FunctionScheduleYAML",
+    "FunctionsYAML",
     "GroupYAML",
+    "LabelsYAML",
+    "LocationYAML",
+    "SecurityCategoriesYAML",
+    "SpaceYAML",
+    "TableYAML",
     "TimeSeriesYAML",
+    "ToolkitResource",
     "ToolkitResource",
 ]

--- a/cognite_toolkit/_cdf_tk/resource_classes/securitycategories.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/securitycategories.py
@@ -3,5 +3,5 @@ from pydantic import Field
 from .base import ToolkitResource
 
 
-class SecuritytCategoriesYAML(ToolkitResource):
+class SecurityCategoriesYAML(ToolkitResource):
     name: str = Field(description="The name of the data set.")

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_securitycategories.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_securitycategories.py
@@ -1,12 +1,12 @@
 import pytest
 
-from cognite_toolkit._cdf_tk.resource_classes.securitycategories import SecuritytCategoriesYAML
+from cognite_toolkit._cdf_tk.resource_classes.securitycategories import SecurityCategoriesYAML
 from tests.test_unit.utils import find_resources
 
 
 class TestSecuritytCategoriesYAML:
     @pytest.mark.parametrize("data", list(find_resources("SecurityCategory")))
     def test_load_valid_security_categories(self, data: dict[str, object]) -> None:
-        loaded = SecuritytCategoriesYAML.model_validate(data)
+        loaded = SecurityCategoriesYAML.model_validate(data)
 
         assert loaded.model_dump(exclude_unset=True, by_alias=True) == data


### PR DESCRIPTION
# Description

We have added several `pydantic` classes which will be used for validation. To avoid merge conflicts these have not yet been included in the `__init__` file of the module. This PR does that work for the latest pydantic classes that @Aashutosh-cognite has added.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
