### PR TITLE
Flattened location filter list on API call

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -183,6 +183,22 @@
       "justMyCode": false
     },
     {
+      "name": "cdf dump config location-filters",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "./cdf-tk-dev.py",
+      "args": [
+        "dump",
+        "config",
+        "location-filters",
+        "--verbose",
+        "-o",
+        "./cognite_toolkit/"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": false
+    },
+    {
       "name": "Python: init",
       "type": "debugpy",
       "request": "launch",

--- a/cognite_toolkit/_cdf_tk/client/api/location_filters.py
+++ b/cognite_toolkit/_cdf_tk/client/api/location_filters.py
@@ -92,5 +92,5 @@ class LocationFiltersAPI(APIClient):
         self._delete(url_path=f"{self._RESOURCE_PATH}/{id}")
 
     def list(self) -> LocationFilterList:
-        res = self._post(url_path=self._RESOURCE_PATH + "/list", json={"flat": False})
+        res = self._post(url_path=self._RESOURCE_PATH + "/list", json={"flat": True})
         return LocationFilterList._load(res.json()["items"], cognite_client=self._cognite_client)

--- a/cognite_toolkit/_cdf_tk/client/api/lookup.py
+++ b/cognite_toolkit/_cdf_tk/client/api/lookup.py
@@ -16,7 +16,6 @@ from cognite.client.exceptions import CogniteAPIError
 from cognite.client.utils.useful_types import SequenceNotStr
 
 from cognite_toolkit._cdf_tk.client.api_client import ToolkitAPI
-from cognite_toolkit._cdf_tk.client.data_classes.location_filters import LocationFilterList
 from cognite_toolkit._cdf_tk.constants import DRY_RUN_ID
 from cognite_toolkit._cdf_tk.exceptions import ResourceRetrievalError
 from cognite_toolkit._cdf_tk.tk_warnings import MediumSeverityWarning
@@ -277,16 +276,10 @@ class SecurityCategoriesLookUpAPI(AllLookUpAPI):
 
 class LocationFiltersLookUpAPI(AllLookUpAPI):
     def _lookup(self) -> None:
-        def _recursive_lookup(locs: LocationFilterList) -> None:
-            for loc in locs:
-                if loc.external_id and loc.id:
-                    self._cache[loc.external_id] = loc.id
-                    self._reverse_cache[loc.id] = loc.external_id
-                if loc.locations:
-                    _recursive_lookup(loc.locations)
-
-        location_filters = self._toolkit_client.location_filters.list()
-        _recursive_lookup(location_filters)
+        for location in self._toolkit_client.location_filters.list():
+            if location.external_id and location.id:
+                self._cache[location.external_id] = location.id
+                self._reverse_cache[location.id] = location.external_id
 
     def _read_acl(self) -> Capability:
         return LocationFiltersAcl(


### PR DESCRIPTION
# Description

Letting the Location Filter API do the flattening 

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip

## cdf

### Improved

- Set the LocationFilter API flag flat=True, making the recursive lookup in the code redundant

## templates

No changes.
