### PR TITLE
Use pydantic for transformation validation

### DIFF
--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/transformation_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/transformation_loaders.py
@@ -79,6 +79,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitYAMLFormatError,
 )
 from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceLoader
+from cognite_toolkit._cdf_tk.resource_classes import TransformationYAML
 from cognite_toolkit._cdf_tk.utils import (
     calculate_secure_hash,
     humanize_collection,
@@ -111,6 +112,7 @@ class TransformationLoader(
     list_cls = TransformationList
     list_write_cls = TransformationWriteList
     kind = "Transformation"
+    yaml_cls = TransformationYAML
     dependencies = frozenset(
         {
             DataSetsLoader,

--- a/cognite_toolkit/_cdf_tk/resource_classes/transformations.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/transformations.py
@@ -55,6 +55,10 @@ class TransformationYAML(ToolkitResource):
         description="List of tags for the Transformation.",
         max_length=5,
     )
+    queryFile: str | None = Field(
+        default=None,
+        description="Used by Toolkit: Path to the SQL file containing the query for the transformation.",
+    )
 
     @model_serializer(mode="wrap")
     def serialize_transformation(self, handler: SerializerFunctionWrapHandler, info: SerializationInfo) -> dict:

--- a/cognite_toolkit/_cdf_tk/resource_classes/transformations.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/transformations.py
@@ -1,7 +1,7 @@
-from typing import Literal
+from typing import Any, Literal
 
 from cognite.client.data_classes import TransformationWrite
-from pydantic import Field, model_serializer
+from pydantic import Field, field_validator, model_serializer
 from pydantic_core.core_schema import SerializationInfo, SerializerFunctionWrapHandler
 
 from .base import BaseModelResource, ToolkitResource
@@ -66,3 +66,17 @@ class TransformationYAML(ToolkitResource):
         if self.destination:
             serialized_data["destination"] = self.destination.model_dump(**vars(info))
         return serialized_data
+
+    @field_validator("authentication", mode="before")
+    @classmethod
+    def validate_serialization(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+        if "read" in value or "write" in value:
+            return {
+                k: AuthenticationClientIdSecret.model_validate(v) if isinstance(v, dict) else v
+                for k, v in value.items()
+            }
+        if "scopes" in value or "tokenUri" in value or "cdfProjectName" in value or "audience" in value:
+            return OIDCCredential.model_validate(value)
+        return AuthenticationClientIdSecret.model_validate(value)

--- a/cognite_toolkit/_cdf_tk/validation.py
+++ b/cognite_toolkit/_cdf_tk/validation.py
@@ -138,7 +138,7 @@ def validate_resource_yaml_pydantic(
     warning_list: WarningList = WarningList()
     if isinstance(data, dict):
         try:
-            validation_cls.model_validate(data)
+            validation_cls.model_validate(data, strict=True)
         except ValidationError as e:
             warning_list.append(ResourceFormatWarning(source_file, tuple(_humanize_validation_error(e))))
     elif isinstance(data, list):
@@ -180,6 +180,8 @@ def _humanize_validation_error(error: ValidationError) -> list[str]:
             msg = item["msg"]
         if len(loc) > 1:
             msg = f"In {as_json_path(loc[:-1])} {msg[0].casefold()}{msg[1:]}"
+        elif len(loc) == 1 and isinstance(loc[0], str) and error_type not in {"extra_forbidden", "missing"}:
+            msg = f"In field {loc[0]} {msg[0].casefold()}{msg[1:]}"
         errors.append(msg)
     return errors
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
@@ -176,7 +176,7 @@ class TestCapabilities:
         [
             pytest.param(
                 {"datasetsAcl": {"actions": ["READ", "WRITE", "OWNER"], "scope": {"idscope": {"ids": ["my_dataset"]}}}},
-                ["invalid scope name 'idscope'. Expected all or idScope"],
+                ["In field scope invalid scope name 'idscope'. Expected all or idScope"],
                 id="Wrong case for datasetsAcl idScope",
             ),
             pytest.param(
@@ -187,7 +187,7 @@ class TestCapabilities:
                     }
                 },
                 [
-                    "invalid scope name 'idscope'. Expected all, datasetScope or idScope",
+                    "In field scope invalid scope name 'idscope'. Expected all, datasetScope or idScope",
                     "In actions input should be 'READ' or 'WRITE'. Got 'OWNER'.",
                 ],
                 id="Wrong case for extractionPipelinesAcl idScope",

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_transformations.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_transformations.py
@@ -1,8 +1,11 @@
 from collections.abc import Iterable
+from pathlib import Path
 
 import pytest
 
 from cognite_toolkit._cdf_tk.resource_classes import TransformationYAML
+from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
+from cognite_toolkit._cdf_tk.validation import validate_resource_yaml_pydantic
 from tests.test_unit.utils import find_resources
 
 
@@ -57,6 +60,84 @@ def transformation_destination_cases() -> Iterable:
     yield from (pytest.param(next(iter(des.values())), id=next(iter(des.keys()))) for des in transformation_destination)
 
 
+def invalid_transformation_test_cases() -> Iterable:
+    yield pytest.param(
+        {"name": "my_transformation", "ignoreNullFields": True},
+        {"Missing required field: 'externalId'"},
+        id="Missing externalId",
+    )
+    yield pytest.param(
+        {
+            "conflictMode": "upsert",
+            "dataSetExternalId": "ops:001:monitor",
+            "destination": {"type": "raw", "database": "ops:001:monitor:rawtable", "table": "rawtable"},
+            "authentication.write": {
+                "cdfProjectName": "my_project",
+                "clientId": "my_client_id",
+                "clientSecret": "my_client_secret",
+                "scopes": ["USER_MANAGEMENT", "DATASETS_WRITE"],
+                "tokenUri": "https://api.cognitedata.com/api/v1/oauth/token",
+            },
+            "externalId": "cdf_ops:raw:upsert:001:monitor",
+            "ignoreNullFields": True,
+            "isPublic": True,
+            "name": "cdf_ops:raw:upsert:001:monitor",
+            "authentication.read": {
+                "cdfProjectName": "my_project",
+                "clientId": "my_client_id",
+                "clientSecret": "my_client_secret",
+                "scopes": ["USER_MANAGEMENT", "DATASETS_READ"],
+                "tokenUri": "https://api.cognitedata.com/api/v1/oauth/token",
+            },
+        },
+        {"Unused field: 'authentication.read'", "Unused field: 'authentication.write'"},
+        id="Invalid authentication - base on real use case",
+    )
+    yield pytest.param(
+        {
+            "externalId": "tr_invalid_type",
+            "name": "Invalid ignore_null_fields",
+            "ignoreNullFields": "yes",
+        },
+        {"In field ignoreNullFields input should be a valid boolean"},
+        id="Invalid ignore_null_fields type",
+    )
+    yield pytest.param(
+        {
+            "externalId": "tr_too_many_tags",
+            "name": "Too many tags",
+            "ignoreNullFields": True,
+            "tags": ["a", "b", "c", "d", "e", "f"],
+        },
+        {"In field tags list should have at most 5 items after validation, not 6"},
+        id="Too many tags in transformation",
+    )
+    yield pytest.param(
+        {
+            "externalId": "tr_invalid_conflict",
+            "name": "Invalid conflict_mode",
+            "ignoreNullFields": True,
+            "conflictMode": "replace",
+        },
+        {"In field conflictMode input should be 'abort', 'delete', 'update' or 'upsert'. Got 'replace'."},
+        id="Invalid conflict_mode value",
+    )
+    yield pytest.param(
+        {
+            "externalId": "tr_invalid_auth",
+            "name": "Invalid authentication",
+            "ignoreNullFields": True,
+            "authentication": {"invalid_key": "value"},
+        },
+        {
+            "In authentication missing required field: 'clientId'",
+            "In authentication missing required field: 'clientSecret'",
+            "In authentication unused field: 'invalid_key'",
+        },
+        id="Invalid authentication type",
+    )
+
+
 class TestTransformationYAML:
     @pytest.mark.parametrize("data", list(find_resources("transformation")))
     def test_load_valid_transformation_file(self, data: dict[str, object]) -> None:
@@ -69,3 +150,13 @@ class TestTransformationYAML:
         loaded = TransformationYAML.model_validate(data)
 
         assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    @pytest.mark.parametrize("data, expected_errors", list(invalid_transformation_test_cases()))
+    def test_invalid_transformation_error_messages(self, data: dict | list, expected_errors: set[str]) -> None:
+        """Test the validate_resource_yaml function for GroupYAML."""
+        warning_list = validate_resource_yaml_pydantic(data, TransformationYAML, Path("some_file.yaml"))
+        assert len(warning_list) == 1
+        format_warning = warning_list[0]
+        assert isinstance(format_warning, ResourceFormatWarning)
+
+        assert set(format_warning.errors) == expected_errors


### PR DESCRIPTION
# Description

Start using the newly created `TransformationYAML` for validation in the `cdf build` command.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Improved

- In the `cdf build` command improved feedback if transformations configurations is not following the specifications.

## templates

No changes.
