### PR TITLE
[CDF-24918] ⏱ Toolkit client set-pending-instance-id

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
+++ b/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
@@ -7,6 +7,7 @@ from cognite.client.credentials import CredentialProvider
 
 from .api.agents.agents import AgentsAPI
 from .api.dml import DMLAPI
+from .api.extended_timeseries import ExtendedTimeSeriesAPI
 from .api.location_filters import LocationFiltersAPI
 from .api.lookup import LookUpGroup
 from .api.robotics import RoboticsAPI
@@ -70,7 +71,7 @@ class ToolkitClientConfig(ClientConfig):
 
 
 class ToolkitClient(CogniteClient):
-    def __init__(self, config: ToolkitClientConfig | None = None) -> None:
+    def __init__(self, config: ToolkitClientConfig | None = None, enable_set_pending_ids: bool = False) -> None:
         super().__init__(config=config)
         self.location_filters = LocationFiltersAPI(self._config, self._API_VERSION, self)
         self.robotics = RoboticsAPI(self._config, self._API_VERSION, self)
@@ -78,6 +79,8 @@ class ToolkitClient(CogniteClient):
         self.verify = VerifyAPI(self._config, self._API_VERSION, self)
         self.lookup = LookUpGroup(self._config, self._API_VERSION, self)
         self.agents = AgentsAPI(self._config, self._API_VERSION, self)
+        if enable_set_pending_ids:
+            self.time_series = ExtendedTimeSeriesAPI(self._config, self._API_VERSION, self)
 
     @property
     def config(self) -> ToolkitClientConfig:

--- a/cognite_toolkit/_cdf_tk/client/api/extended_timeseries.py
+++ b/cognite_toolkit/_cdf_tk/client/api/extended_timeseries.py
@@ -1,0 +1,307 @@
+from collections.abc import Sequence
+from typing import Any, overload
+
+from cognite.client._api.time_series import SortSpec, TimeSeriesAPI
+from cognite.client._constants import DEFAULT_LIMIT_READ
+from cognite.client.data_classes.data_modeling import NodeId
+from cognite.client.data_classes.filters import Filter
+from cognite.client.data_classes.time_series import TimeSeriesFilter, TimeSeriesSort
+from cognite.client.utils._auxiliary import exactly_one_is_not_none
+from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client.utils._validation import prepare_filter_sort, process_asset_subtree_ids, process_data_set_ids
+from cognite.client.utils.useful_types import SequenceNotStr
+
+from cognite_toolkit._cdf_tk.client.data_classes.extended_timeseries import ExtendedTimeSeries, ExtendedTimeSeriesList
+from cognite_toolkit._cdf_tk.client.data_classes.pending_instances_ids import PendingInstanceId
+
+
+class ExtendedTimeSeriesAPI(TimeSeriesAPI):
+    """Extended TimeSeriesAPI to include pending ID methods."""
+
+    @overload
+    def set_pending_ids(
+        self, instance_id: NodeId | tuple[str, str], id: int | None = None, external_id: str | None = None
+    ) -> ExtendedTimeSeries: ...
+
+    @overload
+    def set_pending_ids(self, instance_id: Sequence[PendingInstanceId]) -> ExtendedTimeSeriesList: ...
+
+    def set_pending_ids(
+        self,
+        instance_id: NodeId | tuple[str, str] | Sequence[PendingInstanceId],
+        id: int | None = None,
+        external_id: str | None = None,
+    ) -> ExtendedTimeSeries | ExtendedTimeSeriesList:
+        """Set a pending identifier for a time series.
+
+        Args:
+            instance_id: The pending instance ID to set.
+            id: The ID of the time series.
+            external_id: The external ID of the time series.
+
+        Returns:
+            ExtendedTimeSeries: If a single instance ID is provided, returns the updated ExtendedTimeSeries object.
+        """
+        if isinstance(instance_id, NodeId) or (
+            isinstance(instance_id, tuple)
+            and len(instance_id) == 2
+            and isinstance(instance_id[0], str)
+            and isinstance(instance_id[1], str)
+        ):
+            return self._set_single_pending_id(instance_id, id, external_id)
+        elif isinstance(instance_id, Sequence) and all(isinstance(item, PendingInstanceId) for item in instance_id):
+            return self._set_multiple_pending_ids(instance_id)  # type: ignore[arg-type]
+        else:
+            raise TypeError(
+                "instance_id must be a NodeId, a tuple of (str, str), or a sequence of PendingIdentifier objects."
+            )
+
+    def _set_single_pending_id(
+        self, instance_id: NodeId | tuple[str, str], id: int | None = None, external_id: str | None = None
+    ) -> ExtendedTimeSeries:
+        if not exactly_one_is_not_none(id, external_id):
+            raise ValueError("Exactly one of 'id' or 'external_id' must be provided.")
+        body: dict[str, Any] = {
+            "pendingInstanceId": NodeId.load(instance_id).dump(include_instance_type=False),
+        }
+        if id is not None:
+            body["id"] = id
+        if external_id is not None:
+            body["externalId"] = external_id
+
+        response = self._post(
+            url_path=f"{self._RESOURCE_PATH}/set-pending-instance-ids",
+            json={"items": [body]},
+            headers={"cdf-version": "alpha"},
+        )
+        data = response.json()
+        if "items" not in data or not data["items"]:
+            raise ValueError("No items returned from the API. Check if the request was successful.")
+
+        return ExtendedTimeSeries._load(data["items"][0], cognite_client=self._cognite_client)
+
+    def _set_multiple_pending_ids(self, identifiers: Sequence[PendingInstanceId]) -> ExtendedTimeSeriesList:
+        """Set multiple pending identifiers for time series.
+
+        Args:
+            identifiers: A sequence of PendingIdentifier objects containing the pending instance IDs and optional IDs or external IDs.
+
+        Returns:
+            ExtendedTimeSeriesList: A list of ExtendedTimeSeries objects with the updated pending identifiers.
+        """
+        body = [identifier.dump(camel_case=True) for identifier in identifiers]
+        response = self._post(
+            url_path=f"{self._RESOURCE_PATH}/set-pending-instance-ids", json={"items": body}, api_subversion="alpha"
+        )
+        data = response.json()
+        return ExtendedTimeSeriesList._load(data["items"], cognite_client=self._cognite_client)
+
+    def retrieve(
+        self, id: int | None = None, external_id: str | None = None, instance_id: NodeId | None = None
+    ) -> ExtendedTimeSeries | None:
+        """`Retrieve a single time series by id. <https://developer.cognite.com/api#tag/Time-series/operation/getTimeSeriesByIds>`_
+
+        Args:
+            id (int | None): ID
+            external_id (str | None): External ID
+            instance_id (NodeId | None): Instance ID
+
+        Returns:
+            TimeSeries | None: Requested time series or None if it does not exist.
+
+        Examples:
+
+            Get time series by id:
+
+                >>> from cognite.client import CogniteClient
+                >>> client = CogniteClient()
+                >>> res = client.time_series.retrieve(id=1)
+
+            Get time series by external id:
+
+                >>> res = client.time_series.retrieve(external_id="1")
+        """
+        identifiers = IdentifierSequence.load(ids=id, external_ids=external_id, instance_ids=instance_id).as_singleton()
+        return self._retrieve_multiple(
+            list_cls=ExtendedTimeSeriesList,
+            resource_cls=ExtendedTimeSeries,
+            identifiers=identifiers,
+            api_subversion="alpha",
+        )
+
+    def retrieve_multiple(
+        self,
+        ids: Sequence[int] | None = None,
+        external_ids: SequenceNotStr[str] | None = None,
+        instance_ids: Sequence[NodeId] | None = None,
+        ignore_unknown_ids: bool = False,
+    ) -> ExtendedTimeSeriesList:
+        """`Retrieve multiple time series by id. <https://developer.cognite.com/api#tag/Time-series/operation/getTimeSeriesByIds>`_
+
+        Args:
+            ids (Sequence[int] | None): IDs
+            external_ids (SequenceNotStr[str] | None): External IDs
+            instance_ids (Sequence[NodeId] | None): Instance IDs
+            ignore_unknown_ids (bool): Ignore IDs and external IDs that are not found rather than throw an exception.
+
+        Returns:
+            TimeSeriesList: The requested time series.
+
+        Examples:
+
+            Get time series by id:
+
+                >>> from cognite.client import CogniteClient
+                >>> client = CogniteClient()
+                >>> res = client.time_series.retrieve_multiple(ids=[1, 2, 3])
+
+            Get time series by external id:
+
+                >>> res = client.time_series.retrieve_multiple(external_ids=["abc", "def"])
+        """
+        identifiers = IdentifierSequence.load(ids=ids, external_ids=external_ids, instance_ids=instance_ids)
+        return self._retrieve_multiple(
+            list_cls=ExtendedTimeSeriesList,
+            resource_cls=ExtendedTimeSeries,
+            identifiers=identifiers,
+            ignore_unknown_ids=ignore_unknown_ids,
+            api_subversion="alpha",
+        )
+
+    def list(
+        self,
+        name: str | None = None,
+        unit: str | None = None,
+        unit_external_id: str | None = None,
+        unit_quantity: str | None = None,
+        is_string: bool | None = None,
+        is_step: bool | None = None,
+        asset_ids: Sequence[int] | None = None,
+        asset_external_ids: SequenceNotStr[str] | None = None,
+        asset_subtree_ids: int | Sequence[int] | None = None,
+        asset_subtree_external_ids: str | SequenceNotStr[str] | None = None,
+        data_set_ids: int | Sequence[int] | None = None,
+        data_set_external_ids: str | SequenceNotStr[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        external_id_prefix: str | None = None,
+        created_time: dict[str, Any] | None = None,
+        last_updated_time: dict[str, Any] | None = None,
+        partitions: int | None = None,
+        limit: int | None = DEFAULT_LIMIT_READ,
+        advanced_filter: Filter | dict[str, Any] | None = None,
+        sort: SortSpec | list[SortSpec] | None = None,
+    ) -> ExtendedTimeSeriesList:
+        """`List time series <https://developer.cognite.com/api#tag/Time-series/operation/listTimeSeries>`_
+
+        Args:
+            name (str | None): Name of the time series. Often referred to as tag.
+            unit (str | None): Unit of the time series.
+            unit_external_id (str | None): Filter on unit external ID.
+            unit_quantity (str | None): Filter on unit quantity.
+            is_string (bool | None): Whether the time series is a string time series.
+            is_step (bool | None): Whether the time series is a step (piecewise constant) time series.
+            asset_ids (Sequence[int] | None): List time series related to these assets.
+            asset_external_ids (SequenceNotStr[str] | None): List time series related to these assets.
+            asset_subtree_ids (int | Sequence[int] | None): Only include time series that are related to an asset in a subtree rooted at any of these assetIds. If the total size of the given subtrees exceeds 100,000 assets, an error will be returned.
+            asset_subtree_external_ids (str | SequenceNotStr[str] | None): Only include time series that are related to an asset in a subtree rooted at any of these assetExternalIds. If the total size of the given subtrees exceeds 100,000 assets, an error will be returned.
+            data_set_ids (int | Sequence[int] | None): Return only time series in the specified data set(s) with this id / these ids.
+            data_set_external_ids (str | SequenceNotStr[str] | None): Return only time series in the specified data set(s) with this external id / these external ids.
+            metadata (dict[str, Any] | None): Custom, application specific metadata. String key -> String value
+            external_id_prefix (str | None): Filter by this (case-sensitive) prefix for the external ID.
+            created_time (dict[str, Any] | None):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.
+            last_updated_time (dict[str, Any] | None):  Range between two timestamps. Possible keys are `min` and `max`, with values given as time stamps in ms.
+            partitions (int | None): Retrieve resources in parallel using this number of workers (values up to 10 allowed), limit must be set to `None` (or `-1`).
+            limit (int | None): Maximum number of time series to return.  Defaults to 25. Set to -1, float("inf") or None to return all items.
+            advanced_filter (Filter | dict[str, Any] | None): Advanced filter query using the filter DSL (Domain Specific Language). It allows defining complex filtering expressions that combine simple operations, such as equals, prefix, exists, etc., using boolean operators and, or, and not. See examples below for usage.
+            sort (SortSpec | list[SortSpec] | None): The criteria to sort by. Defaults to desc for `_score_` and asc for all other properties. Sort is not allowed if `partitions` is used.
+
+        Returns:
+            TimeSeriesList: The requested time series.
+
+        .. note::
+            When using `partitions`, there are few considerations to keep in mind:
+                * `limit` has to be set to `None` (or `-1`).
+                * API may reject requests if you specify more than 10 partitions. When Cognite enforces this behavior, the requests result in a 400 Bad Request status.
+                * Partitions are done independently of sorting: there's no guarantee of the sort order between elements from different partitions. For this reason providing a `sort` parameter when using `partitions` is not allowed.
+
+        Examples:
+
+            List time series:
+
+                >>> from cognite.client import CogniteClient
+                >>> client = CogniteClient()
+                >>> res = client.time_series.list(limit=5)
+
+            Iterate over time series:
+
+                >>> for ts in client.time_series:
+                ...     ts # do something with the time series
+
+            Iterate over chunks of time series to reduce memory load:
+
+                >>> for ts_list in client.time_series(chunk_size=2500):
+                ...     ts_list # do something with the time series
+
+            Using advanced filter, find all time series that have a metadata key 'timezone' starting with 'Europe',
+            and sort by external id ascending:
+
+                >>> from cognite.client.data_classes import filters
+                >>> in_timezone = filters.Prefix(["metadata", "timezone"], "Europe")
+                >>> res = client.time_series.list(advanced_filter=in_timezone, sort=("external_id", "asc"))
+
+            Note that you can check the API documentation above to see which properties you can filter on
+            with which filters.
+
+            To make it easier to avoid spelling mistakes and easier to look up available properties
+            for filtering and sorting, you can also use the `TimeSeriesProperty` and `SortableTimeSeriesProperty` Enums.
+
+                >>> from cognite.client.data_classes import filters
+                >>> from cognite.client.data_classes.time_series import TimeSeriesProperty, SortableTimeSeriesProperty
+                >>> in_timezone = filters.Prefix(TimeSeriesProperty.metadata_key("timezone"), "Europe")
+                >>> res = client.time_series.list(
+                ...     advanced_filter=in_timezone,
+                ...     sort=(SortableTimeSeriesProperty.external_id, "asc"))
+
+            Combine filter and advanced filter:
+
+                >>> from cognite.client.data_classes import filters
+                >>> not_instrument_lvl5 = filters.And(
+                ...    filters.ContainsAny("labels", ["Level5"]),
+                ...    filters.Not(filters.ContainsAny("labels", ["Instrument"]))
+                ... )
+                >>> res = client.time_series.list(asset_subtree_ids=[123456], advanced_filter=not_instrument_lvl5)
+        """
+        asset_subtree_ids_processed = process_asset_subtree_ids(asset_subtree_ids, asset_subtree_external_ids)
+        data_set_ids_processed = process_data_set_ids(data_set_ids, data_set_external_ids)
+
+        filter = TimeSeriesFilter(
+            name=name,
+            unit=unit,
+            unit_external_id=unit_external_id,
+            unit_quantity=unit_quantity,
+            is_step=is_step,
+            is_string=is_string,
+            asset_ids=asset_ids,
+            asset_external_ids=asset_external_ids,
+            asset_subtree_ids=asset_subtree_ids_processed,
+            metadata=metadata,
+            data_set_ids=data_set_ids_processed,
+            created_time=created_time,
+            last_updated_time=last_updated_time,
+            external_id_prefix=external_id_prefix,
+        ).dump(camel_case=True)
+
+        prep_sort = prepare_filter_sort(sort, TimeSeriesSort)
+        self._validate_filter(advanced_filter)
+
+        return self._list(
+            list_cls=ExtendedTimeSeriesList,
+            resource_cls=ExtendedTimeSeries,
+            method="POST",
+            filter=filter,
+            advanced_filter=advanced_filter,
+            sort=prep_sort,
+            limit=limit,
+            partitions=partitions,
+            api_subversion="alpha",
+        )

--- a/cognite_toolkit/_cdf_tk/client/data_classes/extended_timeseries.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/extended_timeseries.py
@@ -1,0 +1,97 @@
+from collections.abc import Sequence
+from typing import Any, Self, cast
+
+from cognite.client import CogniteClient
+from cognite.client.data_classes.data_modeling import NodeId
+from cognite.client.data_classes.time_series import TimeSeries, TimeSeriesList
+
+
+class ExtendedTimeSeries(TimeSeries):
+    """Extended TimeSeries with pending instance ID support.
+
+    Args:
+        id (int | None): A server-generated ID for the object.
+        external_id (str | None): The externally supplied ID for the time series.
+        instance_id (NodeId | None): The Instance ID for the time series. (Only applicable for time series created in DMS)
+        name (str | None): The display short name of the time series.
+        is_string (bool | None): Whether the time series is string valued or not.
+        metadata (dict[str, str] | None): Custom, application-specific metadata. String key -> String value. Limits: Maximum length of key is 32 bytes, value 512 bytes, up to 16 key-value pairs.
+        unit (str | None): The physical unit of the time series.
+        unit_external_id (str | None): The physical unit of the time series (reference to unit catalog). Only available for numeric time series.
+        asset_id (int | None): Asset ID of equipment linked to this time series.
+        is_step (bool | None): Whether the time series is a step series or not.
+        description (str | None): Description of the time series.
+        security_categories (Sequence[int] | None): The required security categories to access this time series.
+        data_set_id (int | None): The dataSet ID for the item.
+        created_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        last_updated_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        legacy_name (str | None): This field is not used by the API and will be removed October 2024.
+        cognite_client (CogniteClient | None): The client to associate with this object.
+    """
+
+    def __init__(
+        self,
+        id: int | None = None,
+        external_id: str | None = None,
+        instance_id: NodeId | None = None,
+        name: str | None = None,
+        is_string: bool | None = None,
+        metadata: dict[str, str] | None = None,
+        unit: str | None = None,
+        unit_external_id: str | None = None,
+        asset_id: int | None = None,
+        is_step: bool | None = None,
+        description: str | None = None,
+        security_categories: Sequence[int] | None = None,
+        data_set_id: int | None = None,
+        created_time: int | None = None,
+        last_updated_time: int | None = None,
+        pending_instance_id: NodeId | None = None,
+        legacy_name: str | None = None,
+        cognite_client: CogniteClient | None = None,
+    ) -> None:
+        super().__init__(
+            external_id=external_id,
+            instance_id=instance_id,
+            name=name,
+            is_string=is_string,
+            metadata=metadata,
+            unit=unit,
+            unit_external_id=unit_external_id,
+            asset_id=asset_id,
+            is_step=is_step,
+            description=description,
+            security_categories=security_categories,
+            data_set_id=data_set_id,
+            legacy_name=legacy_name,
+        )
+        # id/created_time/last_updated_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
+        self.created_time: int = created_time  # type: ignore
+        self.last_updated_time: int = last_updated_time  # type: ignore
+        self._cognite_client = cast("CogniteClient", cognite_client)
+        self.pending_instance_id = pending_instance_id
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        instance = super()._load(resource, cognite_client)
+        if isinstance(instance.pending_instance_id, dict):
+            instance.pending_instance_id = NodeId.load(instance.pending_instance_id)
+        return instance
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump the object to a dictionary"""
+        output = super().dump(camel_case=camel_case)
+        if self.pending_instance_id is not None:
+            output["pendingInstanceId" if camel_case else "pending_instance_id"] = self.pending_instance_id.dump(
+                camel_case=camel_case, include_instance_type=False
+            )
+        return output
+
+
+class ExtendedTimeSeriesList(TimeSeriesList):
+    _RESOURCE = ExtendedTimeSeries  # type: ignore[assignment]

--- a/cognite_toolkit/_cdf_tk/client/data_classes/extended_timeseries.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/extended_timeseries.py
@@ -1,9 +1,15 @@
+import sys
 from collections.abc import Sequence
-from typing import Any, Self, cast
+from typing import Any, cast
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes.data_modeling import NodeId
 from cognite.client.data_classes.time_series import TimeSeries, TimeSeriesList
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class ExtendedTimeSeries(TimeSeries):

--- a/cognite_toolkit/_cdf_tk/client/data_classes/extended_timeseries.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/extended_timeseries.py
@@ -31,6 +31,8 @@ class ExtendedTimeSeries(TimeSeries):
         data_set_id (int | None): The dataSet ID for the item.
         created_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         last_updated_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        pending_instance_id (NodeId | None): The pending instance ID for the time series. This is used in the migration of times series to CogniteTimeSeries
+            to specify which instance this time series should be linked with by the TimeSeries syncer service.
         legacy_name (str | None): This field is not used by the API and will be removed October 2024.
         cognite_client (CogniteClient | None): The client to associate with this object.
     """

--- a/cognite_toolkit/_cdf_tk/client/data_classes/pending_instances_ids.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/pending_instances_ids.py
@@ -1,0 +1,49 @@
+import sys
+from dataclasses import dataclass
+
+from cognite.client import CogniteClient
+from cognite.client.data_classes._base import CogniteObject
+from cognite.client.data_classes.data_modeling import NodeId
+from cognite.client.utils._auxiliary import exactly_one_is_not_none
+
+if sys.version_info >= (3, 11):
+    from typing import Any, Self
+else:
+    from typing_extensions import Self
+
+
+@dataclass(frozen=True)
+class PendingInstanceId(CogniteObject):
+    """A pending instance ID is a NodeId that is set on a TimeSeries or FileMetadata that tells
+    the respective syncer that when that Node is created, it should be linked to the
+    TimeSeries or FileMetadata.
+    """
+
+    instance_id: NodeId
+    id: int | None = None
+    external_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not exactly_one_is_not_none(self.id, self.external_id):
+            raise ValueError("Either id or external_id must be set for PendingInstanceId.")
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        """Load a PendingInstanceId from a dictionary."""
+        return cls(
+            instance_id=NodeId.load(resource["instanceId"]),
+            id=resource.get("id"),
+            external_id=resource.get("externalId"),
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump the PendingInstanceId to a dictionary."""
+        output: dict[str, Any] = {
+            "instanceId" if camel_case else "instance_id": self.instance_id.dump(camel_case=camel_case),
+        }
+        if self.id is not None:
+            output["id"] = self.id
+        if self.external_id is not None:
+            output["externalId"] = self.external_id
+
+        return output

--- a/cognite_toolkit/_cdf_tk/client/data_classes/pending_instances_ids.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/pending_instances_ids.py
@@ -20,7 +20,7 @@ class PendingInstanceId(CogniteObject):
     TimeSeries or FileMetadata.
     """
 
-    instance_id: NodeId
+    pending_instance_id: NodeId
     id: int | None = None
     external_id: str | None = None
 
@@ -32,7 +32,7 @@ class PendingInstanceId(CogniteObject):
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         """Load a PendingInstanceId from a dictionary."""
         return cls(
-            instance_id=NodeId.load(resource["instanceId"]),
+            pending_instance_id=NodeId.load(resource["pendingInstanceId"]),
             id=resource.get("id"),
             external_id=resource.get("externalId"),
         )
@@ -40,7 +40,9 @@ class PendingInstanceId(CogniteObject):
     def dump(self, camel_case: bool = True) -> dict[str, Any]:
         """Dump the PendingInstanceId to a dictionary."""
         output: dict[str, Any] = {
-            "instanceId" if camel_case else "instance_id": self.instance_id.dump(camel_case=camel_case),
+            "pendingInstanceId" if camel_case else "pending_instance_id": self.pending_instance_id.dump(
+                camel_case=camel_case, include_instance_type=False
+            ),
         }
         if self.id is not None:
             output["id"] = self.id

--- a/cognite_toolkit/_cdf_tk/client/data_classes/pending_instances_ids.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/pending_instances_ids.py
@@ -1,5 +1,6 @@
 import sys
 from dataclasses import dataclass
+from typing import Any
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes._base import CogniteObject
@@ -7,7 +8,7 @@ from cognite.client.data_classes.data_modeling import NodeId
 from cognite.client.utils._auxiliary import exactly_one_is_not_none
 
 if sys.version_info >= (3, 11):
-    from typing import Any, Self
+    from typing import Self
 else:
     from typing_extensions import Self
 

--- a/tests/test_integration/test_toolkit_client/test_extended_timeseries.py
+++ b/tests/test_integration/test_toolkit_client/test_extended_timeseries.py
@@ -1,0 +1,78 @@
+from datetime import datetime
+
+from cognite.client.data_classes import TimeSeries, TimeSeriesWrite
+from cognite.client.data_classes.data_modeling import NodeApplyResultList, SpaceApply
+from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteTimeSeriesApply
+from cognite.client.utils._time import datetime_to_ms
+
+from cognite_toolkit._cdf_tk.client import ToolkitClient
+
+
+class TestExtendedTimeSeriesAPI:
+    def test_set_pending_instance_id(self, dev_cluster_client: ToolkitClient) -> None:
+        """Happy path for setting a pending instance ID on a time series.
+
+        1. Create asset-centric time series.
+        2. Insert data points.
+        3. Set pending instance ID.
+        4. Create a CogniteTimeSeries
+        5. Retrieve data points using the Node ID.
+        6. Insert more data points using the Node ID.
+        7. Retrieve data points again using the external ID of the original asset-centric time series.
+        """
+        client = dev_cluster_client
+        space = "toolkit_test_space"
+        ts = TimeSeriesWrite(
+            external_id="ts_toolkit_integration_test_happy_path",
+            name="Toolkit Integration Test Happy Path",
+            is_step=False,
+            is_string=False,
+        )
+        cognite_ts = CogniteTimeSeriesApply(
+            space=space,
+            external_id=ts.external_id,
+            is_step=False,
+            time_series_type="numeric",
+            name="Toolkit Integration Test Happy Path",
+        )
+        datapoints = [
+            {"timestamp": datetime_to_ms(datetime(2020, 1, 1, 0, 0, 0)), "value": 1.0},
+            {"timestamp": datetime_to_ms(datetime(2020, 1, 2, 0, 0, 0)), "value": 2.0},
+            {"timestamp": datetime_to_ms(datetime(2020, 1, 3, 0, 0, 0)), "value": 3.0},
+        ]
+        more_datapoints = [
+            {"timestamp": datetime_to_ms(datetime(2020, 1, 4, 0, 0, 0)), "value": 4.0},
+            {"timestamp": datetime_to_ms(datetime(2020, 1, 5, 0, 0, 0)), "value": 5.0},
+        ]
+        created: TimeSeries | None = None
+        created_dm: NodeApplyResultList | None = None
+        try:
+            client.data_modeling.spaces.apply(SpaceApply(space))
+
+            created = client.time_series.create(ts)
+            client.time_series.data.insert(datapoints, external_id=ts.external_id)
+            updated = client.time_series.set_pending_ids(cognite_ts.as_id(), external_id=ts.external_id)
+            assert updated.pending_instance_id == cognite_ts.as_id()
+
+            created_dm = client.data_modeling.instances.apply(cognite_ts).nodes
+
+            retrieve_datapoints = client.time_series.data.retrieve(instance_id=cognite_ts.as_id())
+            assert len(retrieve_datapoints) == len(datapoints)
+            assert retrieve_datapoints.dump()["datapoints"] == datapoints
+            client.time_series.data.insert(more_datapoints, instance_id=cognite_ts.as_id())
+
+            retrieve_datapoints2 = client.time_series.data.retrieve(external_id=ts.external_id)
+            assert len(retrieve_datapoints2) == len(datapoints) + len(more_datapoints)
+            assert retrieve_datapoints2.dump()["datapoints"] == datapoints + more_datapoints
+
+            retrieved_ts = client.time_series.retrieve(external_id=ts.external_id)
+            assert retrieved_ts.instance_id == cognite_ts.as_id()
+            listed = client.time_series.list(external_id_prefix=ts.external_id)
+            assert len(listed) == 1
+            assert listed[0].external_id == ts.external_id
+        finally:
+            if created is not None and created_dm is None:
+                client.time_series.delete(external_id=ts.external_id)
+            if created_dm is not None:
+                # This will delete the CogniteTimeSeries and the asset-centric time series
+                client.data_modeling.instances.delete(cognite_ts.as_id())


### PR DESCRIPTION
# Description

**REVIEWER**: The core part of this PR is ~90 lines, the `.set_instance_ids()` method in the `ExtendedTimeSeriesAPI`. The rest is copy-paste from the CogniteSDK with addding `pending_instance_ids` to the `ExtendedTimeSeries` and same for the `.retrieve`, `.retrieve_multiple` and `.list` methods with setting `alpha` flag and returning `ExtendedTimeSeries`.

In the upgrade from `TimeSeries` to `CogniteTimeSeries`, we need to link the newly created `CogniteTimeSeries` nodes to existing asset-centric timeseries to avoid reingesting all datapoints. This is the first PR in building this tooling that can do that linking. The tooling will depend on an alpha feature in the `timeseries` endpoint which accepts setting a property `pendingInstanceId` that is used as follows.

1. Set `pendindInstanceId` on existing asset-centric timeseries
2. Create the `CogniteTimeSeries` with the node ID set in step 1.
3. The timeseries syncer will then link the newly created `CogniteTimeSeries` node to the existing asset-centri timeseries from step 1, instead of creating a new one.

This PR adds support for this endpoint into the internal `ToolkitClient` which is not exposed to the end-user. This will be used as a basis for a future `cdf migrate timeseries` command.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip

