### PR TITLE
[CDF-24932] 📊 Added statistics API

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
+++ b/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
@@ -7,10 +7,10 @@ from cognite.client.credentials import CredentialProvider
 
 from .api.agents.agents import AgentsAPI
 from .api.dml import DMLAPI
+from .api.extended_data_modeling import ExtendedDataModelingAPI
 from .api.location_filters import LocationFiltersAPI
 from .api.lookup import LookUpGroup
 from .api.robotics import RoboticsAPI
-from .api.statistics import StatisticsAPI
 from .api.verify import VerifyAPI
 
 
@@ -79,7 +79,7 @@ class ToolkitClient(CogniteClient):
         self.verify = VerifyAPI(self._config, self._API_VERSION, self)
         self.lookup = LookUpGroup(self._config, self._API_VERSION, self)
         self.agents = AgentsAPI(self._config, self._API_VERSION, self)
-        self.data_modeling_statistics = StatisticsAPI(self._config, self._API_VERSION, self)
+        self.data_modeling = ExtendedDataModelingAPI(self._config, self._API_VERSION, self)
 
     @property
     def config(self) -> ToolkitClientConfig:

--- a/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
+++ b/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
@@ -79,7 +79,7 @@ class ToolkitClient(CogniteClient):
         self.verify = VerifyAPI(self._config, self._API_VERSION, self)
         self.lookup = LookUpGroup(self._config, self._API_VERSION, self)
         self.agents = AgentsAPI(self._config, self._API_VERSION, self)
-        self.statistics = StatisticsAPI(self._config, self._API_VERSION, self)
+        self.data_modeling_statistics = StatisticsAPI(self._config, self._API_VERSION, self)
 
     @property
     def config(self) -> ToolkitClientConfig:

--- a/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
+++ b/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
@@ -10,6 +10,7 @@ from .api.dml import DMLAPI
 from .api.location_filters import LocationFiltersAPI
 from .api.lookup import LookUpGroup
 from .api.robotics import RoboticsAPI
+from .api.statistics import StatisticsAPI
 from .api.verify import VerifyAPI
 
 
@@ -78,6 +79,7 @@ class ToolkitClient(CogniteClient):
         self.verify = VerifyAPI(self._config, self._API_VERSION, self)
         self.lookup = LookUpGroup(self._config, self._API_VERSION, self)
         self.agents = AgentsAPI(self._config, self._API_VERSION, self)
+        self.statistics = StatisticsAPI(self._config, self._API_VERSION, self)
 
     @property
     def config(self) -> ToolkitClientConfig:

--- a/cognite_toolkit/_cdf_tk/client/api/extended_data_modeling.py
+++ b/cognite_toolkit/_cdf_tk/client/api/extended_data_modeling.py
@@ -1,0 +1,10 @@
+from cognite.client._api.data_modeling import DataModelingAPI
+from cognite.client._cognite_client import ClientConfig, CogniteClient
+
+from .statistics import StatisticsAPI
+
+
+class ExtendedDataModelingAPI(DataModelingAPI):
+    def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
+        super().__init__(config, api_version, cognite_client)
+        self.statistics = StatisticsAPI(config, api_version, cognite_client)

--- a/cognite_toolkit/_cdf_tk/client/api/statistics.py
+++ b/cognite_toolkit/_cdf_tk/client/api/statistics.py
@@ -1,0 +1,72 @@
+import itertools
+from typing import overload
+
+from cognite.client._api_client import APIClient
+from cognite.client._cognite_client import CogniteClient
+from cognite.client.config import ClientConfig
+from cognite.client.data_classes.data_modeling.ids import _load_space_identifier
+from cognite.client.utils.useful_types import SequenceNotStr
+
+from cognite_toolkit._cdf_tk.client.data_classes.statistics import (
+    ProjectStatsAndLimits,
+    SpaceInstanceCounts,
+    SpaceInstanceCountsList,
+)
+
+
+class StatisticsAPI(APIClient):
+    _RESOURCE_PATH = "/models/statistics"
+
+    def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
+        # This is an alpha API, which requires a specific version.
+        super().__init__(config, "v1", cognite_client)
+        self._RETRIEVE_LIMIT = 100
+
+    def project(self) -> ProjectStatsAndLimits:
+        """`Retrieve project-wide usage data and limits
+
+        Returns the usage data and limits for a project's data modelling usage, including data model schemas
+        and graph instances
+
+        Returns:
+            ProjectStatsAndLimits: The requested statistics and limits
+
+        """
+        response_data = self._get(self._RESOURCE_PATH).json()
+        if "project" not in response_data:
+            response_data["project"] = self._cognite_client._config.project
+        return ProjectStatsAndLimits._load(response_data)
+
+    @overload
+    def list(self, space: str) -> SpaceInstanceCounts: ...
+
+    @overload
+    def list(self, space: SequenceNotStr[str] | None = None) -> SpaceInstanceCountsList: ...
+
+    def list(self, space: str | SequenceNotStr[str] | None = None) -> SpaceInstanceCounts | SpaceInstanceCountsList:
+        """`Retrieve usage data and limits per space
+
+        Args:
+            space (str | SequenceNotStr[str] | None): The space or spaces to retrieve statistics for.
+                If None, all spaces will be retrieved.
+
+        Returns:
+            SpaceInstanceCounts | SpaceInstanceCountsList: InstanceStatsPerSpace if a single space is given, else
+                InstanceStatsList (which is a list of InstanceStatsPerSpace)
+
+        """
+        if space is None:
+            return SpaceInstanceCountsList._load(self._get(self._RESOURCE_PATH + "/spaces").json()["items"])
+
+        is_single = isinstance(space, str)
+
+        ids = _load_space_identifier(space)
+        result = SpaceInstanceCountsList._load(
+            itertools.chain.from_iterable(
+                self._post(self._RESOURCE_PATH + "/spaces/byids", json={"items": chunk.as_dicts()}).json()["items"]
+                for chunk in ids.chunked(self._RETRIEVE_LIMIT)
+            )
+        )
+        if is_single:
+            return result[0]
+        return result

--- a/cognite_toolkit/_cdf_tk/client/data_classes/statistics.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/statistics.py
@@ -1,0 +1,130 @@
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+from cognite.client import CogniteClient
+from cognite.client.data_classes._base import CogniteObject, CogniteResource, CogniteResourceList
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+
+@dataclass
+class InstanceCounts(CogniteResource):
+    nodes: int
+    edges: int
+    soft_deleted_nodes: int
+    soft_deleted_edges: int
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            nodes=resource["nodes"],
+            edges=resource["edges"],
+            soft_deleted_nodes=resource["softDeletedNodes"],
+            soft_deleted_edges=resource["softDeletedEdges"],
+        )
+
+
+@dataclass
+class SpaceInstanceCounts(InstanceCounts):
+    space: str
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            space=resource["space"],
+            nodes=resource["nodes"],
+            edges=resource["edges"],
+            soft_deleted_nodes=resource["softDeletedNodes"],
+            soft_deleted_edges=resource["softDeletedEdges"],
+        )
+
+
+class SpaceInstanceCountsList(CogniteResourceList):
+    _RESOURCE = SpaceInstanceCounts
+
+
+@dataclass
+class CountLimitPair(CogniteObject):
+    count: int
+    limit: int
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            count=resource["count"],
+            limit=resource["limit"],
+        )
+
+
+@dataclass
+class InstanceCountsLimits(InstanceCounts):
+    instances_limit: int
+    soft_deleted_instances_limit: int
+
+    @property
+    def instances(self) -> int:
+        return self.nodes + self.edges
+
+    @property
+    def soft_deleted_instances(self) -> int:
+        return self.soft_deleted_nodes + self.soft_deleted_edges
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            nodes=resource["nodes"],
+            edges=resource["edges"],
+            soft_deleted_nodes=resource["softDeletedNodes"],
+            soft_deleted_edges=resource["softDeletedEdges"],
+            instances_limit=resource["instancesLimit"],
+            soft_deleted_instances_limit=resource["softDeletedInstancesLimit"],
+        )
+
+
+@dataclass
+class ProjectStatsAndLimits(CogniteResource):
+    project: str
+    spaces: CountLimitPair
+    containers: CountLimitPair
+    views: CountLimitPair
+    data_models: CountLimitPair
+    container_properties: CountLimitPair
+    instances: InstanceCountsLimits
+    concurrent_read_limit: int
+    concurrent_write_limit: int
+    concurrent_delete_limit: int
+
+    @classmethod
+    def _load(cls, data: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        return cls(
+            project=data["project"],
+            spaces=CountLimitPair._load(data["spaces"]),
+            containers=CountLimitPair._load(data["containers"]),
+            views=CountLimitPair._load(data["views"]),
+            data_models=CountLimitPair._load(data["dataModels"]),
+            container_properties=CountLimitPair._load(data["containerProperties"]),
+            instances=InstanceCountsLimits._load(data["instances"]),
+            concurrent_read_limit=data["concurrentReadLimit"],
+            concurrent_write_limit=data["concurrentWriteLimit"],
+            concurrent_delete_limit=data["concurrentDeleteLimit"],
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        return {
+            "project": self.project,
+            "spaces": self.spaces.dump(camel_case=camel_case),
+            "containers": self.containers.dump(camel_case=camel_case),
+            "views": self.views.dump(camel_case=camel_case),
+            "dataModels" if camel_case else "data_models": self.data_models.dump(camel_case=camel_case),
+            "containerProperties" if camel_case else "container_properties": self.container_properties.dump(
+                camel_case=camel_case
+            ),
+            "instances": self.instances.dump(camel_case=camel_case),
+            "concurrentReadLimit" if camel_case else "concurrent_read_limit": self.concurrent_read_limit,
+            "concurrentWriteLimit" if camel_case else "concurrent_write_limit": self.concurrent_write_limit,
+            "concurrentDeleteLimit" if camel_case else "concurrent_delete_limit": self.concurrent_delete_limit,
+        }

--- a/cognite_toolkit/_cdf_tk/client/testing.py
+++ b/cognite_toolkit/_cdf_tk/client/testing.py
@@ -64,7 +64,7 @@ class ToolkitClientMock(CogniteClientMock):
         self.robotics.maps = MagicMock(spec_set=MapsAPI)
         self.robotics.capabilities = MagicMock(spec_set=CapabilitiesAPI)
 
-        self.data_modeling_statistics = MagicMock(spec_set=StatisticsAPI)
+        self.data_modeling.statistics = MagicMock(spec_set=StatisticsAPI)
 
         self.verify = MagicMock(spec_set=VerifyAPI)
 

--- a/cognite_toolkit/_cdf_tk/client/testing.py
+++ b/cognite_toolkit/_cdf_tk/client/testing.py
@@ -24,6 +24,7 @@ from .api.robotics.data_postprocessing import DataPostProcessingAPI
 from .api.robotics.frames import FramesAPI
 from .api.robotics.locations import LocationsAPI as RoboticsLocationsAPI
 from .api.robotics.maps import MapsAPI
+from .api.statistics import StatisticsAPI
 from .api.verify import VerifyAPI
 
 
@@ -62,6 +63,8 @@ class ToolkitClientMock(CogniteClientMock):
         self.robotics.frames = MagicMock(spec_set=FramesAPI)
         self.robotics.maps = MagicMock(spec_set=MapsAPI)
         self.robotics.capabilities = MagicMock(spec_set=CapabilitiesAPI)
+
+        self.statistics = MagicMock(spec_set=StatisticsAPI)
 
         self.verify = MagicMock(spec_set=VerifyAPI)
 

--- a/cognite_toolkit/_cdf_tk/client/testing.py
+++ b/cognite_toolkit/_cdf_tk/client/testing.py
@@ -64,7 +64,7 @@ class ToolkitClientMock(CogniteClientMock):
         self.robotics.maps = MagicMock(spec_set=MapsAPI)
         self.robotics.capabilities = MagicMock(spec_set=CapabilitiesAPI)
 
-        self.statistics = MagicMock(spec_set=StatisticsAPI)
+        self.data_modeling_statistics = MagicMock(spec_set=StatisticsAPI)
 
         self.verify = MagicMock(spec_set=VerifyAPI)
 

--- a/tests/test_integration/test_toolkit_client/test_data_modeling_statistics.py
+++ b/tests/test_integration/test_toolkit_client/test_data_modeling_statistics.py
@@ -1,0 +1,32 @@
+import pytest
+
+from cognite_toolkit._cdf_tk.client import ToolkitClient
+from cognite_toolkit._cdf_tk.client.data_classes.statistics import ProjectStatsAndLimits
+
+
+@pytest.fixture(scope="session")
+def project_usage(toolkit_client: ToolkitClient) -> ProjectStatsAndLimits:
+    """Fixture to retrieve project usage statistics."""
+    return toolkit_client.data_modeling.statistics.project()
+
+
+class TestStatisticsAPI:
+    def test_list_project_instance_usage(self, project_usage: ProjectStatsAndLimits) -> None:
+        assert project_usage.instances.instances < project_usage.instances.instances_limit
+
+    def test_list_space_instance_usage(self, toolkit_client: ToolkitClient) -> None:
+        spaces = toolkit_client.data_modeling.spaces.list(limit=1)
+        assert len(spaces) > 0
+        selected_space = spaces[0].space
+
+        space_usage = toolkit_client.data_modeling.statistics.list(space=selected_space)
+
+        assert space_usage.space == selected_space
+
+    def test_list_all_spaces(self, toolkit_client: ToolkitClient, project_usage: ProjectStatsAndLimits) -> None:
+        space_usages = toolkit_client.data_modeling.statistics.list()
+
+        assert len(space_usages) > 0
+        total = sum(space_usage.nodes + space_usage.edges for space_usage in space_usages)
+
+        assert total == project_usage.instances.instances


### PR DESCRIPTION
# Description

This adds the `statistics` endpoint to the internal `ToolkitClient`, i.e., not exposed to end-users.

This is a copy of this PR that has already been through risk-review: https://github.com/cognitedata/neat/pull/1163

**Context**: Toolkit will be used in migration of timeseries/files/canvas. All these requires writing nodes/edges to CDF in large amounts. We need the statistics endpoint (even though it is not yet even in alpha) to ensure that Toolkit cannot be used to fill up a CDF projects with nodes and edges, as that can cause data loss from applications such as Infield, Canvas, or other third-party applications. This has already happen in the past with Neat.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
