### PR TITLE
[CDF-24991] 🌍 Asset profiler

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_profile_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_profile_app.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any
+from typing import Annotated, Any, Optional
 
 import typer
 from rich import print
@@ -13,6 +13,7 @@ class ProfileApp(typer.Typer):
         super().__init__(*args, **kwargs)
         self.callback(invoke_without_command=True)(self.main)
         self.command("asset-centric")(self.asset_centric)
+        self.command("assets")(self.assets)
         self.command("raw")(self.raw)
         self.command("transformations")(self.transformations)
 
@@ -37,6 +38,28 @@ class ProfileApp(typer.Typer):
                 verbose,
             )
         )
+
+    @staticmethod
+    def assets(
+        ctx: typer.Context,
+        hierarchy: Annotated[
+            Optional[str],
+            typer.Option(
+                "--hierarchy",
+                "-h",
+                help="The asset hierarchy to profile. This should be the externalId of the root asset. If not provided,"
+                " ",
+            ),
+        ] = None,
+        verbose: bool = False,
+    ) -> None:
+        """This command gives an overview over the assets in the given hierarchy.
+
+        It works by listing all assets, events, files, timeseries, and sequences related to the given hierarchy.
+        In addition, it lists the data sets that is used for each of the resources, the transformations that writes to
+        these data sets, and the RAW tables that is used in these transformations..
+        """
+        raise NotImplementedError()
 
     @staticmethod
     def raw(

--- a/cognite_toolkit/_cdf_tk/apps/_profile_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_profile_app.py
@@ -3,7 +3,7 @@ from typing import Annotated, Any, Optional
 import typer
 from rich import print
 
-from cognite_toolkit._cdf_tk.commands import ProfileCommand, ProfileRawCommand
+from cognite_toolkit._cdf_tk.commands import ProfileAssetCommand, ProfileCommand, ProfileRawCommand
 from cognite_toolkit._cdf_tk.commands._profile import ProfileTransformationCommand
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 
@@ -59,7 +59,15 @@ class ProfileApp(typer.Typer):
         In addition, it lists the data sets that is used for each of the resources, the transformations that writes to
         these data sets, and the RAW tables that is used in these transformations..
         """
-        raise NotImplementedError()
+        client = EnvironmentVariables.create_from_environment().get_client()
+        cmd = ProfileAssetCommand()
+        cmd.run(
+            lambda: cmd.assets(
+                client,
+                hierarchy,
+                verbose,
+            )
+        )
 
     @staticmethod
     def raw(

--- a/cognite_toolkit/_cdf_tk/client/data_classes/raw.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/raw.py
@@ -54,6 +54,10 @@ class RawTable(WriteableCogniteResource):
     def as_write(self) -> RawTable:
         return self
 
+    def __str__(self) -> str:
+        """Return the table name in the format 'db_name.table_name'."""
+        return f"{self.db_name}.{self.table_name}"
+
 
 class RawDatabaseList(WriteableCogniteResourceList[RawDatabase, RawDatabase]):
     _RESOURCE = RawDatabase

--- a/cognite_toolkit/_cdf_tk/commands/__init__.py
+++ b/cognite_toolkit/_cdf_tk/commands/__init__.py
@@ -1,5 +1,5 @@
 from ._populate import PopulateCommand
-from ._profile import ProfileCommand, ProfileRawCommand
+from ._profile import ProfileAssetCommand, ProfileCommand, ProfileRawCommand
 from ._purge import PurgeCommand
 from .auth import AuthCommand
 from .build_cmd import BuildCommand
@@ -27,6 +27,7 @@ __all__ = [
     "InitCommand",
     "ModulesCommand",
     "PopulateCommand",
+    "ProfileAssetCommand",
     "ProfileCommand",
     "ProfileRawCommand",
     "PullCommand",

--- a/cognite_toolkit/_cdf_tk/commands/_profile.py
+++ b/cognite_toolkit/_cdf_tk/commands/_profile.py
@@ -671,7 +671,7 @@ class ProfileAssetCommand(ToolkitCommand):
                 current = table_content.pop(ResourceLineageID(resource=agg_id, dataset=dataset))
                 for transformation in result:
                     copy_ = current.copy()
-                    copy_.transformation = transformation.external_id or "<unknown>"
+                    copy_.transformation = f"{transformation.name} ({transformation.external_id})"
                     sources = get_transformation_sources(transformation.query or "")
                     if not sources:
                         table_content[ResourceLineageID(resource=agg_id, dataset=dataset)] = copy_

--- a/cognite_toolkit/_cdf_tk/commands/_profile.py
+++ b/cognite_toolkit/_cdf_tk/commands/_profile.py
@@ -671,7 +671,7 @@ class ProfileAssetCommand(ToolkitCommand):
                 current = table_content.pop(ResourceLineageID(resource=agg_id, dataset=dataset))
                 for transformation in result:
                     copy_ = current.copy()
-                    copy_.transformation = transformation.name or transformation.external_id or "<unknown>"
+                    copy_.transformation = transformation.external_id or "<unknown>"
                     sources = get_transformation_sources(transformation.query or "")
                     if not sources:
                         table_content[ResourceLineageID(resource=agg_id, dataset=dataset)] = copy_

--- a/cognite_toolkit/_cdf_tk/utils/cdf.py
+++ b/cognite_toolkit/_cdf_tk/utils/cdf.py
@@ -1,5 +1,4 @@
 import sys
-import importlib.util
 from collections.abc import Hashable, Iterator
 from dataclasses import dataclass
 from typing import Any, Literal, overload
@@ -19,7 +18,6 @@ from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
 from cognite_toolkit._cdf_tk.client.data_classes.raw import RawTable
 from cognite_toolkit._cdf_tk.constants import ENV_VAR_PATTERN
 from cognite_toolkit._cdf_tk.exceptions import (
-    ToolkitMissingDependencyError,
     ToolkitRequiredValueError,
     ToolkitTypeError,
 )

--- a/cognite_toolkit/_cdf_tk/utils/cdf.py
+++ b/cognite_toolkit/_cdf_tk/utils/cdf.py
@@ -1,6 +1,7 @@
 import sys
 from collections.abc import Hashable, Iterator
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any, Literal, overload
 from urllib.parse import urlparse
 
@@ -175,6 +176,7 @@ def read_auth(
         return ClientCredentials(authentication["clientId"], authentication["clientSecret"])
 
 
+@lru_cache
 def get_transformation_sources(query: str) -> list[RawTable | str]:
     """Search the SQL query for source tables."""
     parser = SQLParser(query, operation="Lookup transformation source")

--- a/cognite_toolkit/_cdf_tk/utils/hashing.py
+++ b/cognite_toolkit/_cdf_tk/utils/hashing.py
@@ -46,10 +46,10 @@ def calculate_secure_hash(item: dict[str, Any], shorten: bool = False) -> str:
 
 def calculate_str_or_file_hash(content: str | Path, shorten: bool = False) -> str:
     if isinstance(content, str):
-        byte_content = content.encode("utf-8")
-    else:
-        byte_content = content.read_bytes()
-    return calculate_bytes_or_file_hash(byte_content, shorten)
+        return calculate_bytes_or_file_hash(content.encode("utf-8"), shorten)
+    elif isinstance(content, Path):
+        return calculate_bytes_or_file_hash(content, shorten)
+    raise TypeError("Content must be a string or a Path object.")
 
 
 def calculate_bytes_or_file_hash(content: bytes | Path, shorten: bool = False) -> str:

--- a/cognite_toolkit/_cdf_tk/utils/sql_parser.py
+++ b/cognite_toolkit/_cdf_tk/utils/sql_parser.py
@@ -49,6 +49,19 @@ class SQLParser:
             self.parse()
         return self._destination_columns
 
+    def is_using_data_set(
+        self, data_set_ids: list[int] | None = None, data_set_external_ids: list[str] | None = None
+    ) -> bool:
+        for data_set_id in data_set_ids or []:
+            if str(data_set_id) in self.query:
+                return True
+        for data_set_external_id in data_set_external_ids or []:
+            if f'dataset_id("{data_set_external_id}")' in self.query:
+                return True
+            elif f"dataset_external_id('{data_set_external_id}')" in self.query:
+                return True
+        return False
+
     def parse(self) -> None:
         """Parse the SQL query and extract table names."""
         import sqlparse

--- a/tests/test_unit/test_cdf_tk/test_utils/test_hashing.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_hashing.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from cognite_toolkit._cdf_tk.utils.hashing import calculate_bytes_or_file_hash, calculate_str_or_file_hash
+
+
+def test_hash_filepath_equals_windows_line_endings(tmp_path: Path) -> None:
+    # This test ensures that the hash of a file with Windows line endings is the same as the hash of the same file
+    # with Unix line endings.
+    my_file = tmp_path / "test_file.txt"
+    my_file.write_text("Hello, World!\r\n", encoding="utf-8", newline="\r\n")
+
+    bytes_method = calculate_bytes_or_file_hash(my_file, shorten=True)
+    str_method = calculate_str_or_file_hash(my_file, shorten=True)
+    assert bytes_method == str_method, "Hash mismatch between bytes and str methods for file with Windows line endings"


### PR DESCRIPTION
# Description

The goal of this profiler is to get an overview over the linage of an Asset Hierarchy.
It works by selecting an hierarchy, the profiler will then for each resource (assets, events, timeseries, files, sequences) do the following
* Count the resources
* Find the used data sets.
* Count resources in each dataset
* Find the transformations writing to the datasets.
* Find the RAW tables used as the source.
* Find the size of the raw tables.

![image](https://github.com/user-attachments/assets/9d5df254-d100-4cf5-851b-95d8d5bd4049)


## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Added

- [alpha] New command `cdf profile assets` which enable profiling asset hierarchy, along with resources, datasets, transformations, and RAW tables, i.e., showing the linage of the asset hierarchy.

## templates

No changes.
