### PR TITLE
[CDF-24874, CDF-24773] 🐞 Pull workflow trigger/transformation

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/pull.py
+++ b/cognite_toolkit/_cdf_tk/commands/pull.py
@@ -418,6 +418,7 @@ class PullCommand(ToolkitCommand):
         env_vars: EnvironmentVariables,
     ) -> None:
         client = env_vars.get_client()
+        client.config.is_strict_validation = False
         if not module_name_or_path:
             modules = ModuleDirectories.load(organization_dir, None)
             if not modules:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/transformation_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/transformation_loaders.py
@@ -80,6 +80,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
 )
 from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceLoader
 from cognite_toolkit._cdf_tk.resource_classes import TransformationYAML
+from cognite_toolkit._cdf_tk.tk_warnings import HighSeverityWarning
 from cognite_toolkit._cdf_tk.utils import (
     calculate_secure_hash,
     humanize_collection,
@@ -231,10 +232,10 @@ class TransformationLoader(
             if query_file is None and "query" not in item:
                 if filepath is None:
                     raise ValueError("filepath must be set if query is not set")
-                raise ToolkitYAMLFormatError(
-                    f"query property or is missing. It can be inline or a separate file named {filepath.stem}.sql or {external_id}.sql",
-                    filepath,
+                warning = HighSeverityWarning(
+                    f"query property or is missing in {filepath.as_posix()!r}. It can be inline or a separate file named {filepath.stem}.sql or {external_id}.sql",
                 )
+                warning.print_warning(console=self.console)
             elif query_file and not query_file.exists():
                 # We checked above that filepath is not None
                 raise ToolkitFileNotFoundError(f"Query file {query_file.as_posix()} not found", filepath)  # type: ignore[union-attr]


### PR DESCRIPTION
# Description

<del>Stacked on #1637</del>

Implementation of fix for pulling transformations and workflow triggers.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- The `cdf modules pull` command now only requires resources to be defined with their identifiers. For example, you can now define a transformation configuration with only `externalId` and then pull the rest of the definition from CDF.

## templates

No changes.
