### PR TITLE
[prep CDF-24984] 👷 Refactor migration command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -310,3 +310,4 @@ my_*/
 !cognite_toolkit/_builtin_modules/custom/my_module/
 function_local_venvs*/
 qa_pending_id/
+tests/**/cdf.toml

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/__init__.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/__init__.py
@@ -1,0 +1,3 @@
+from .timeseries import MigrateTimeseriesCommand
+
+__all__ = ["MigrateTimeseriesCommand"]

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_classes.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_classes.py
@@ -1,10 +1,22 @@
+import csv
+import sys
 from collections.abc import Collection, Iterator, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import SupportsIndex, overload
 
 from cognite.client.data_classes.data_modeling import NodeId
 
 from cognite_toolkit._cdf_tk.client.data_classes.pending_instances_ids import PendingInstanceId
+from cognite_toolkit._cdf_tk.exceptions import (
+    ToolkitFileNotFoundError,
+    ToolkitValueError,
+)
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 @dataclass
@@ -77,3 +89,74 @@ class MigrationMappingList(list, Sequence[MigrationMapping]):
             for mapping in self
             if isinstance(mapping, IdMigrationMapping | ExternalIdMigrationMapping) and mapping.data_set_id is not None
         }
+
+    @classmethod
+    def read_mapping_file(cls, mapping_file: Path) -> Self:
+        if not mapping_file.exists():
+            raise ToolkitFileNotFoundError(f"Mapping file {mapping_file} does not exist.")
+        if mapping_file.suffix != ".csv":
+            raise ToolkitValueError(f"Mapping file {mapping_file} must be a CSV file.")
+        with mapping_file.open(mode="r") as f:
+            csv_file = csv.reader(f)
+            header = next(csv_file, None)
+            header = cls._validate_csv_header(header)
+            if header[0] == "id":
+                return cls._read_id_mapping(csv_file)
+            else:  # header[0] == "externalId":
+                return cls._read_external_id_mapping(csv_file)
+
+    @classmethod
+    def _validate_csv_header(cls, header: list[str] | None) -> list[str]:
+        if header is None:
+            raise ToolkitValueError("Mapping file is empty")
+        errors: list[str] = []
+        if len(header) < 3:
+            errors.append("Mapping file must have at least 3 columns: id/externalId, space, externalId.")
+        if len(header) >= 5:
+            errors.append("Mapping file must have at most 4 columns: id/externalId, dataSetId, space, externalId.")
+        if header[0] not in {"id", "externalId"}:
+            errors.append("First column must be 'id' or 'externalId'.")
+        if len(header) == 4 and header[1] != "dataSetId":
+            errors.append("If there are 4 columns, the second column must be 'dataSetId'.")
+        if header[-2:] != ["space", "externalId"]:
+            errors.append("Last two columns must be 'space' and 'externalId'.")
+        if errors:
+            error_str = "\n - ".join(errors)
+            raise ToolkitValueError(f"Invalid mapping file header:\n - {error_str}")
+        return header
+
+    @classmethod
+    def _read_id_mapping(cls, csv_file: Iterator[list[str]]) -> Self:
+        """Read a CSV file with ID mappings."""
+        mappings = cls()
+        for no, row in enumerate(csv_file, 1):
+            try:
+                id_ = int(row[0])
+                data_set_id = int(row[1]) if len(row) == 4 and row[1] else None
+            except ValueError as e:
+                raise ToolkitValueError(
+                    f"Invalid ID or dataSetId in row {no}: {row}. ID and dataSetId must be integers."
+                ) from e
+            instance_id = NodeId(*row[-2:])
+            mappings.append(
+                IdMigrationMapping(resource_type="timeseries", id=id_, instance_id=instance_id, data_set_id=data_set_id)
+            )
+        return mappings
+
+    @classmethod
+    def _read_external_id_mapping(cls, csv_file: Iterator[list[str]]) -> Self:
+        """Read a CSV file with external ID mappings."""
+        mappings = cls()
+        for row in csv_file:
+            external_id = row[0]
+            data_set_id = int(row[1]) if len(row) == 4 and row[1] else None
+            instance_id = NodeId(*row[-2:])
+            mappings.append(
+                ExternalIdMigrationMapping(
+                    resource_type="timeseries",
+                    external_id=external_id,
+                    instance_id=instance_id,
+                    data_set_id=data_set_id,
+                )
+            )
+        return mappings

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_classes.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_classes.py
@@ -1,0 +1,79 @@
+from collections.abc import Collection, Iterator, Sequence
+from dataclasses import dataclass
+from typing import SupportsIndex, overload
+
+from cognite.client.data_classes.data_modeling import NodeId
+
+from cognite_toolkit._cdf_tk.client.data_classes.pending_instances_ids import PendingInstanceId
+
+
+@dataclass
+class MigrationMapping:
+    resource_type: str
+    instance_id: NodeId
+
+
+@dataclass
+class IdMigrationMapping(MigrationMapping):
+    id: int
+    data_set_id: int | None = None
+
+
+@dataclass
+class ExternalIdMigrationMapping(MigrationMapping):
+    external_id: str
+    data_set_id: int | None = None
+
+
+class MigrationMappingList(list, Sequence[MigrationMapping]):
+    # Implemented to get correct type hints
+    def __init__(self, collection: Collection[MigrationMapping] | None = None) -> None:
+        super().__init__(collection or [])
+
+    def __iter__(self) -> Iterator[MigrationMapping]:
+        return super().__iter__()
+
+    @overload
+    def __getitem__(self, index: SupportsIndex) -> MigrationMapping: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> "MigrationMappingList": ...
+
+    def __getitem__(self, index: SupportsIndex | slice, /) -> "MigrationMapping | MigrationMappingList":
+        if isinstance(index, slice):
+            return MigrationMappingList(super().__getitem__(index))
+        return super().__getitem__(index)
+
+    def get_ids(self) -> list[int]:
+        """Return a list of IDs from the migration mappings."""
+        return [mapping.id for mapping in self if isinstance(mapping, IdMigrationMapping)]
+
+    def get_external_ids(self) -> list[str]:
+        """Return a list of external IDs from the migration mappings."""
+        return [mapping.external_id for mapping in self if isinstance(mapping, ExternalIdMigrationMapping)]
+
+    def as_node_ids(self) -> list[NodeId]:
+        """Return a list of NodeIds from the migration mappings."""
+        return [mapping.instance_id for mapping in self]
+
+    def spaces(self) -> set[str]:
+        """Return a set of spaces from the migration mappings."""
+        return {mapping.instance_id.space for mapping in self}
+
+    def as_pending_ids(self) -> list[PendingInstanceId]:
+        return [
+            PendingInstanceId(
+                pending_instance_id=mapping.instance_id,
+                id=mapping.id if isinstance(mapping, IdMigrationMapping) else None,
+                external_id=mapping.external_id if isinstance(mapping, ExternalIdMigrationMapping) else None,
+            )
+            for mapping in self
+        ]
+
+    def get_data_set_ids(self) -> set[int]:
+        """Return a list of data set IDs from the migration mappings."""
+        return {
+            mapping.data_set_id
+            for mapping in self
+            if isinstance(mapping, IdMigrationMapping | ExternalIdMigrationMapping) and mapping.data_set_id is not None
+        }

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/timeseries.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/timeseries.py
@@ -1,5 +1,3 @@
-import csv
-from collections.abc import Iterator
 from pathlib import Path
 
 import questionary
@@ -11,7 +9,7 @@ from cognite.client.data_classes.capabilities import (
     SpaceIDScope,
     TimeSeriesAcl,
 )
-from cognite.client.data_classes.data_modeling import DirectRelationReference, NodeId, ViewId
+from cognite.client.data_classes.data_modeling import DirectRelationReference, ViewId
 from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteTimeSeriesApply
 from cognite.client.exceptions import CogniteAPIError
 from rich import print
@@ -24,14 +22,13 @@ from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
 from cognite_toolkit._cdf_tk.constants import DMS_INSTANCE_LIMIT_MARGIN
 from cognite_toolkit._cdf_tk.exceptions import (
     AuthenticationError,
-    ToolkitFileNotFoundError,
     ToolkitValueError,
 )
 from cognite_toolkit._cdf_tk.tk_warnings import HighSeverityWarning
 from cognite_toolkit._cdf_tk.utils import humanize_collection
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 
-from .data_classes import ExternalIdMigrationMapping, IdMigrationMapping, MigrationMappingList
+from .data_classes import MigrationMappingList
 
 
 class MigrateTimeseriesCommand(ToolkitCommand):
@@ -50,7 +47,7 @@ class MigrateTimeseriesCommand(ToolkitCommand):
         auto_yes: bool = False,
     ) -> None:
         """Migrate resources from Asset-Centric to data modeling in CDF."""
-        mappings = self.read_mapping_file(mapping_file)
+        mappings = MigrationMappingList.read_mapping_file(mapping_file)
 
         self._validate_access(client, mappings)
         self._validate_timeseries_existence(client, mappings)
@@ -190,77 +187,6 @@ class MigrateTimeseriesCommand(ToolkitCommand):
                 print(f"Created {len(created):,} CogniteTimeSeries.")
             total_migrated += len(created)
         print(f"Successfully migrated {total_migrated:,} TimeSeries to CogniteTimeSeries.")
-
-    @classmethod
-    def read_mapping_file(cls, mapping_file: Path) -> MigrationMappingList:
-        if not mapping_file.exists():
-            raise ToolkitFileNotFoundError(f"Mapping file {mapping_file} does not exist.")
-        if mapping_file.suffix != ".csv":
-            raise ToolkitValueError(f"Mapping file {mapping_file} must be a CSV file.")
-        with mapping_file.open(mode="r") as f:
-            csv_file = csv.reader(f)
-            header = next(csv_file, None)
-            header = cls._validate_csv_header(header)
-            if header[0] == "id":
-                return cls._read_id_mapping(csv_file)
-            else:  # header[0] == "externalId":
-                return cls._read_external_id_mapping(csv_file)
-
-    @classmethod
-    def _validate_csv_header(cls, header: list[str] | None) -> list[str]:
-        if header is None:
-            raise ToolkitValueError("Mapping file is empty")
-        errors: list[str] = []
-        if len(header) < 3:
-            errors.append("Mapping file must have at least 3 columns: id/externalId, space, externalId.")
-        if len(header) >= 5:
-            errors.append("Mapping file must have at most 4 columns: id/externalId, dataSetId, space, externalId.")
-        if header[0] not in {"id", "externalId"}:
-            errors.append("First column must be 'id' or 'externalId'.")
-        if len(header) == 4 and header[1] != "dataSetId":
-            errors.append("If there are 4 columns, the second column must be 'dataSetId'.")
-        if header[-2:] != ["space", "externalId"]:
-            errors.append("Last two columns must be 'space' and 'externalId'.")
-        if errors:
-            error_str = "\n - ".join(errors)
-            raise ToolkitValueError(f"Invalid mapping file header:\n - {error_str}")
-        return header
-
-    @classmethod
-    def _read_id_mapping(cls, csv_file: Iterator[list[str]]) -> MigrationMappingList:
-        """Read a CSV file with ID mappings."""
-        mappings = MigrationMappingList()
-        for no, row in enumerate(csv_file, 1):
-            try:
-                id_ = int(row[0])
-                data_set_id = int(row[1]) if len(row) == 4 and row[1] else None
-            except ValueError as e:
-                raise ToolkitValueError(
-                    f"Invalid ID or dataSetId in row {no}: {row}. ID and dataSetId must be integers."
-                ) from e
-            instance_id = NodeId(*row[-2:])
-            mappings.append(
-                IdMigrationMapping(resource_type="timeseries", id=id_, instance_id=instance_id, data_set_id=data_set_id)
-            )
-        return mappings
-
-    @classmethod
-    def _read_external_id_mapping(cls, csv_file: Iterator[list[str]]) -> MigrationMappingList:
-        """Read a CSV file with external ID mappings."""
-        mappings = MigrationMappingList()
-        for row in csv_file:
-            external_id = row[0]
-            data_set_id = int(row[1]) if len(row) == 4 and row[1] else None
-            instance_id = NodeId(*row[-2:])
-            mappings.append(
-                ExternalIdMigrationMapping(
-                    resource_type="timeseries",
-                    external_id=external_id,
-                    instance_id=instance_id,
-                    data_set_id=data_set_id,
-                )
-            )
-        return mappings
 
     @classmethod
     def as_cognite_timeseries(cls, ts: ExtendedTimeSeries) -> CogniteTimeSeriesApply:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_timeseries_migration.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_timeseries_migration.py
@@ -6,7 +6,7 @@ from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteTimeSeriesAp
 
 from cognite_toolkit._cdf_tk.client.data_classes.extended_timeseries import ExtendedTimeSeries
 from cognite_toolkit._cdf_tk.commands import MigrateTimeseriesCommand
-from cognite_toolkit._cdf_tk.commands._migrate import (
+from cognite_toolkit._cdf_tk.commands._migrate.data_classes import (
     ExternalIdMigrationMapping,
     IdMigrationMapping,
     MigrationMappingList,

--- a/tests/test_unit/test_cdf_tk/test_commands/test_timeseries_migration.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_timeseries_migration.py
@@ -15,6 +15,55 @@ from cognite_toolkit._cdf_tk.commands._migrate.data_classes import (
 
 class TestMigrateTimeSeriesCommand:
     @pytest.mark.parametrize(
+        "ts, expected",
+        [
+            (
+                ExtendedTimeSeries(
+                    external_id="full_ts",
+                    data_set_id=123,
+                    description="Test description",
+                    name="Test Time Series",
+                    is_step=True,
+                    is_string=False,
+                    unit="m/s",
+                    unit_external_id="velocity:m-per-sec",
+                    pending_instance_id=NodeId("sp_full_ts", "full_ts_id"),
+                ),
+                CogniteTimeSeriesApply(
+                    space="sp_full_ts",
+                    external_id="full_ts_id",
+                    is_step=True,
+                    time_series_type="numeric",
+                    name="Test Time Series",
+                    description="Test description",
+                    source_unit="m/s",
+                    unit=DirectRelationReference("cdf_cdm_units", "velocity:m-per-sec"),
+                ),
+            ),
+            (
+                ExtendedTimeSeries(
+                    external_id="minimum_ts",
+                    is_step=False,
+                    is_string=True,
+                    pending_instance_id=NodeId("sp_step_ts", "step_ts_id"),
+                ),
+                CogniteTimeSeriesApply(
+                    space="sp_step_ts",
+                    external_id="step_ts_id",
+                    is_step=False,
+                    time_series_type="string",
+                ),
+            ),
+        ],
+    )
+    def test_as_cognite_timeseries(self, ts: ExtendedTimeSeries, expected: CogniteTimeSeriesApply) -> None:
+        actual = MigrateTimeseriesCommand.as_cognite_timeseries(ts)
+
+        assert actual.dump() == expected.dump()
+
+
+class TestMigrationMappingList:
+    @pytest.mark.parametrize(
         "content, expected",
         [
             (
@@ -94,8 +143,7 @@ class TestMigrateTimeSeriesCommand:
     def test_read_mapping_file(self, content: str, expected: MigrationMappingList, tmp_path: Path) -> None:
         input_file = tmp_path / "mapping_file.csv"
         input_file.write_text(content, encoding="utf-8")
-        cmd = MigrateTimeseriesCommand()
-        actual = cmd.read_mapping_file(input_file)
+        actual = MigrationMappingList.read_mapping_file(input_file)
         assert actual == expected
 
     @pytest.mark.parametrize(
@@ -151,54 +199,6 @@ class TestMigrateTimeSeriesCommand:
         input_file = tmp_path / "mapping_file.csv"
         input_file.write_text(content, encoding="utf-8")
 
-        cmd = MigrateTimeseriesCommand()
         with pytest.raises(ValueError) as exc_info:
-            cmd.read_mapping_file(input_file)
+            MigrationMappingList.read_mapping_file(input_file)
         assert str(exc_info.value) == expected_msg
-
-    @pytest.mark.parametrize(
-        "ts, expected",
-        [
-            (
-                ExtendedTimeSeries(
-                    external_id="full_ts",
-                    data_set_id=123,
-                    description="Test description",
-                    name="Test Time Series",
-                    is_step=True,
-                    is_string=False,
-                    unit="m/s",
-                    unit_external_id="velocity:m-per-sec",
-                    pending_instance_id=NodeId("sp_full_ts", "full_ts_id"),
-                ),
-                CogniteTimeSeriesApply(
-                    space="sp_full_ts",
-                    external_id="full_ts_id",
-                    is_step=True,
-                    time_series_type="numeric",
-                    name="Test Time Series",
-                    description="Test description",
-                    source_unit="m/s",
-                    unit=DirectRelationReference("cdf_cdm_units", "velocity:m-per-sec"),
-                ),
-            ),
-            (
-                ExtendedTimeSeries(
-                    external_id="minimum_ts",
-                    is_step=False,
-                    is_string=True,
-                    pending_instance_id=NodeId("sp_step_ts", "step_ts_id"),
-                ),
-                CogniteTimeSeriesApply(
-                    space="sp_step_ts",
-                    external_id="step_ts_id",
-                    is_step=False,
-                    time_series_type="string",
-                ),
-            ),
-        ],
-    )
-    def test_as_cognite_timeseries(self, ts: ExtendedTimeSeries, expected: CogniteTimeSeriesApply) -> None:
-        actual = MigrateTimeseriesCommand.as_cognite_timeseries(ts)
-
-        assert actual.dump() == expected.dump()

--- a/tests/test_unit/test_cdf_tk/test_utils/test_collection.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_collection.py
@@ -1,6 +1,6 @@
 from cognite.client.data_classes.data_modeling import NodeId
 
-from cognite_toolkit._cdf_tk.commands._migrate import IdMigrationMapping, MigrationMappingList
+from cognite_toolkit._cdf_tk.commands._migrate.data_classes import IdMigrationMapping, MigrationMappingList
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 
 


### PR DESCRIPTION
# Description

This is a pure refactoring. 

1. First making the `_migrate.py` module into a package. Motivation is to separate out the data classes from the command.
2. Move the reading csv logic out from the `MigrateTimeseriesCommand` to the `MigrationMappingList` class. This will make it easier to reuse across multiple migration commands.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip

