### PR TITLE
[prep CDF-24984] 👷Refactor deploy command Part 1

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/clean.py
+++ b/cognite_toolkit/_cdf_tk/commands/clean.py
@@ -322,7 +322,7 @@ class CleanCommand(ToolkitCommand):
         return selected_loaders
 
     @staticmethod
-    def _process_include(include: list[str] | None) -> list[str]:
+    def validate_include(include: list[str] | None) -> list[str]:
         if include and (invalid_types := set(include).difference(AVAILABLE_DATA_TYPES)):
             raise ToolkitValidationError(
                 f"Invalid resource types specified: {invalid_types}, available types: {AVAILABLE_DATA_TYPES}"

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_base_loaders.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_base_loaders.py
@@ -29,7 +29,6 @@ from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.commands import BuildCommand, DeployCommand, ModulesCommand
 from cognite_toolkit._cdf_tk.data_classes import (
     BuildConfigYAML,
-    BuildEnvironment,
 )
 from cognite_toolkit._cdf_tk.feature_flags import FeatureFlag, Flags
 from cognite_toolkit._cdf_tk.loaders import (
@@ -78,7 +77,7 @@ def test_loader_class(
 ):
     cmd = DeployCommand(print_warning=False)
     loader = loader_cls.create_loader(env_vars_with_client.get_client(), LOAD_DATA)
-    cmd.deploy_resources(loader, env_vars_with_client, BuildEnvironment(), dry_run=False)
+    cmd.deploy_resources(loader, env_vars_with_client, [], dry_run=False)
 
     dump = toolkit_client_approval.dump()
     data_regression.check(dump, fullpath=SNAPSHOTS_DIR / f"{loader.folder_name}.yaml")
@@ -102,7 +101,7 @@ class TestDeployResources:
         cmd.deploy_resources(
             ViewLoader.create_loader(env_vars_with_client.get_client(), BUILD_DIR),
             env_vars_with_client,
-            BuildEnvironment(),
+            [],
             dry_run=False,
         )
 


### PR DESCRIPTION
# Description

**Context** I want to reuse the logic from the deploy command in the upcoming `cdf migrate prepare` command to deploy a migration model. This is currently not possible as the deploy command expects resources to be in a file and not already in memory. This PR is part 1 of refactoring of the deploy command, such that it becomes easier to read and reuse. 

The refactoring I have done in this PR is to split the `.execute()` method into smaller function for increased readability. 
The current version is 106 lines long, while the new one introduce in this PR is 14. 

Note there is zero change to logic, thus not touching any tests.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
