### PR TITLE
[prep CDF-24984] 👷Refactor deploy command part2

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_core_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_core_app.py
@@ -301,7 +301,7 @@ class CoreApp(typer.Typer):
         cmd = DeployCommand(print_warning=True)
         env_vars = EnvironmentVariables.create_from_environment()
         cmd.run(
-            lambda: cmd.execute(
+            lambda: cmd.deploy_build_directory(
                 env_vars=env_vars,
                 build_dir=build_dir,
                 build_env_name=build_env_name,

--- a/cognite_toolkit/_cdf_tk/commands/clean.py
+++ b/cognite_toolkit/_cdf_tk/commands/clean.py
@@ -88,13 +88,12 @@ class CleanCommand(ToolkitCommand):
         if not files:
             return None
         # Since we do a clean, we do not want to verify that everything exists wrt data sets, spaces etc.
-        existing_resources, duplicated = worker.load_resources(
+        local_resources = worker.load_resources(
             filepaths=files,
-            return_existing=True,
             environment_variables=env_vars.dump(include_os=True),
             is_dry_run=True,
-            verbose=verbose,
         )
+        existing_resources = loader.retrieve(list(local_resources.keys()))
         nr_of_existing = len(existing_resources)
 
         if drop:
@@ -105,7 +104,7 @@ class CleanCommand(ToolkitCommand):
             with_data = ""
         print(f"[bold]{prefix} {nr_of_existing} {loader.display_name} {with_data}from CDF...[/]")
         if not isinstance(loader, RawDatabaseLoader):
-            for duplicate in duplicated:
+            for duplicate in worker.duplicates:
                 self.warn(LowSeverityWarning(f"Duplicate {loader.display_name} {duplicate}."))
 
         # Deleting resources.

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -38,7 +38,6 @@ from cognite_toolkit._cdf_tk.exceptions import (
 )
 from cognite_toolkit._cdf_tk.loaders import (
     DataLoader,
-    GroupLoader,
     Loader,
     RawDatabaseLoader,
     ResourceContainerLoader,
@@ -47,7 +46,7 @@ from cognite_toolkit._cdf_tk.loaders import (
 )
 from cognite_toolkit._cdf_tk.loaders._base_loaders import T_WritableCogniteResourceList
 from cognite_toolkit._cdf_tk.tk_warnings import EnvironmentVariableMissingWarning
-from cognite_toolkit._cdf_tk.tk_warnings.base import catch_warnings
+from cognite_toolkit._cdf_tk.tk_warnings.base import WarningList, catch_warnings
 from cognite_toolkit._cdf_tk.tk_warnings.other import (
     LowSeverityWarning,
     ToolkitDependenciesIncludedWarning,
@@ -259,7 +258,7 @@ class DeployCommand(ToolkitCommand):
         if not files:
             return None
 
-        with catch_warnings(EnvironmentVariableMissingWarning) as warning_list:
+        with catch_warnings(EnvironmentVariableMissingWarning) as env_var_warnings:
             to_create, to_update, to_delete, unchanged = worker.prepare_resources(
                 files,
                 environment_variables=env_vars.dump(include_os=True),
@@ -267,9 +266,9 @@ class DeployCommand(ToolkitCommand):
                 force_update=force_update,
                 verbose=verbose,
             )
-        if warning_list:
-            print(str(warning_list))
-            self.warning_list.extend(warning_list)
+        if env_var_warnings:
+            print(str(env_var_warnings))
+            self.warning_list.extend(env_var_warnings)
 
         # We are not counting to_delete as these are captured by to_create.
         # (to_delete is used for resources that does not support update and instead needs to be deleted and recreated)
@@ -279,83 +278,105 @@ class DeployCommand(ToolkitCommand):
 
         prefix = "Would deploy" if dry_run else "Deploying"
         print(f"[bold]{prefix} {nr_of_items} {loader.display_name} to CDF...[/]")
+
         # Moved here to avoid printing before the above message.
         if not isinstance(loader, RawDatabaseLoader):
             for duplicate in worker.duplicates:
                 self.warn(LowSeverityWarning(f"Skipping duplicate {loader.display_name} {duplicate}."))
 
-        nr_of_created = nr_of_changed = nr_of_unchanged = nr_of_deleted = 0
-
         if dry_run:
-            if (
-                loader.support_drop
-                and has_done_drop
-                and (not isinstance(loader, ResourceContainerLoader) or has_dropped_data)
-            ):
-                # Means the resources will be deleted and not left unchanged or changed
-                for item in unchanged:
-                    # We cannot use extents as LoadableNodes cannot be extended.
-                    to_create.append(item)
-                for item in to_update:
-                    to_create.append(item)
-                unchanged.clear()
-                to_update.clear()
-
-            nr_of_unchanged += len(unchanged)
-            nr_of_created += len(to_create)
-            nr_of_deleted += len(to_delete)
-            if isinstance(loader, GroupLoader):
-                nr_of_deleted += len(to_update)
-                nr_of_created += len(to_update)
-            else:
-                nr_of_changed += len(to_update)
+            result = self.dry_run_deploy(
+                to_create,
+                to_update,
+                to_delete,
+                unchanged,
+                loader,
+                has_done_drop,
+                has_dropped_data,
+            )
         else:
-            environment_variable_warning_by_id = {
-                identifier: warning
-                for warning in warning_list
-                if isinstance(warning, EnvironmentVariableMissingWarning)
-                for identifier in warning.identifiers or []
-            }
-            nr_of_unchanged += len(unchanged)
-
-            if to_delete:
-                deleted = loader.delete(to_delete)
-                nr_of_deleted += deleted
-
-            if to_create:
-                created = self._create_resources(to_create, loader, environment_variable_warning_by_id)
-                nr_of_created += created
-
-            if to_update:
-                updated = self._update_resources(to_update, loader, environment_variable_warning_by_id)
-                if isinstance(loader, GroupLoader):
-                    nr_of_deleted += updated
-                    nr_of_created += updated
-                else:
-                    nr_of_changed += updated
+            result = self.actual_deploy(to_create, to_update, to_delete, unchanged, loader, env_var_warnings)
 
         if verbose:
             self._verbose_print(to_create, to_update, unchanged, loader, dry_run)
 
         if isinstance(loader, ResourceContainerLoader):
-            return ResourceContainerDeployResult(
-                name=loader.display_name,
-                created=nr_of_created,
-                changed=nr_of_changed,
-                deleted=nr_of_deleted,
-                unchanged=nr_of_unchanged,
-                total=nr_of_items,
+            return ResourceContainerDeployResult.from_resource_deploy_result(
+                result,
                 item_name=loader.item_name,
             )
-        else:
-            return ResourceDeployResult(
-                name=loader.display_name,
-                created=nr_of_created,
-                changed=nr_of_changed,
-                deleted=nr_of_deleted,
-                unchanged=nr_of_unchanged,
-                total=nr_of_items,
-            )
+        return result
+
+    def actual_deploy(
+        self,
+        to_create: T_CogniteResourceList,
+        to_update: T_CogniteResourceList,
+        to_delete: list[T_ID],
+        unchanged: T_CogniteResourceList,
+        loader: ResourceLoader[
+            T_ID, T_WriteClass, T_WritableCogniteResource, T_CogniteResourceList, T_WritableCogniteResourceList
+        ],
+        env_var_warnings: WarningList,
+    ) -> ResourceDeployResult:
+        environment_variable_warning_by_id = {
+            identifier: warning
+            for warning in env_var_warnings
+            if isinstance(warning, EnvironmentVariableMissingWarning)
+            for identifier in warning.identifiers or []
+        }
+        nr_of_unchanged = len(unchanged)
+        nr_of_deleted, nr_of_created, nr_of_changed = 0, 0, 0
+        if to_delete:
+            deleted = loader.delete(to_delete)
+            nr_of_deleted += deleted
+        if to_create:
+            created = self._create_resources(to_create, loader, environment_variable_warning_by_id)
+            nr_of_created += created
+        if to_update:
+            updated = self._update_resources(to_update, loader, environment_variable_warning_by_id)
+            nr_of_changed += updated
+        return ResourceDeployResult(
+            name=loader.display_name,
+            created=nr_of_created,
+            deleted=nr_of_deleted,
+            changed=nr_of_changed,
+            unchanged=nr_of_unchanged,
+            total=nr_of_created + nr_of_deleted + nr_of_changed + nr_of_unchanged,
+        )
+
+    @staticmethod
+    def dry_run_deploy(
+        to_create: T_CogniteResourceList,
+        to_update: T_CogniteResourceList,
+        to_delete: list[T_ID],
+        unchanged: T_CogniteResourceList,
+        loader: ResourceLoader[
+            T_ID, T_WriteClass, T_WritableCogniteResource, T_CogniteResourceList, T_WritableCogniteResourceList
+        ],
+        has_done_drop: bool,
+        has_dropped_data: bool,
+    ) -> ResourceDeployResult:
+        if (
+            loader.support_drop
+            and has_done_drop
+            and (not isinstance(loader, ResourceContainerLoader) or has_dropped_data)
+        ):
+            # Means the resources will be deleted and not left unchanged or changed
+            for item in unchanged:
+                # We cannot use extents as LoadableNodes cannot be extended.
+                to_create.append(item)
+            for item in to_update:
+                to_create.append(item)
+            unchanged.clear()
+            to_update.clear()
+        return ResourceDeployResult(
+            name=loader.display_name,
+            created=len(to_create),
+            deleted=len(to_delete),
+            changed=len(to_update),
+            unchanged=len(unchanged),
+            total=len(to_create) + len(to_delete) + len(to_update) + len(unchanged),
+        )
 
     @staticmethod
     def _verbose_print(

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -260,7 +260,7 @@ class DeployCommand(ToolkitCommand):
             return None
 
         with catch_warnings(EnvironmentVariableMissingWarning) as warning_list:
-            to_create, to_update, to_delete, unchanged, duplicated = worker.load_resources(
+            to_create, to_update, to_delete, unchanged = worker.prepare_resources(
                 files,
                 environment_variables=env_vars.dump(include_os=True),
                 is_dry_run=dry_run,
@@ -281,7 +281,7 @@ class DeployCommand(ToolkitCommand):
         print(f"[bold]{prefix} {nr_of_items} {loader.display_name} to CDF...[/]")
         # Moved here to avoid printing before the above message.
         if not isinstance(loader, RawDatabaseLoader):
-            for duplicate in duplicated:
+            for duplicate in worker.duplicates:
                 self.warn(LowSeverityWarning(f"Skipping duplicate {loader.display_name} {duplicate}."))
 
         nr_of_created = nr_of_changed = nr_of_unchanged = nr_of_deleted = 0

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -11,7 +11,6 @@ from rich import print
 from rich.markup import escape
 from rich.panel import Panel
 
-from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
 from cognite_toolkit._cdf_tk.commands.clean import CleanCommand
 from cognite_toolkit._cdf_tk.constants import (
@@ -75,62 +74,49 @@ class DeployCommand(ToolkitCommand):
         include: list[str] | None,
         verbose: bool,
     ) -> None:
-        include = self._clean_command.validate_include(include)
-
-        build = self._load_build(build_dir, build_env_name)
-        client = env_vars.get_client(build.is_strict_validation)
-        selected_loaders = self._clean_command.get_selected_loaders(build_dir, build.read_resource_folders, include)
-        ordered_loaders = self._order_loaders(selected_loaders, build_dir)
-        self._start_message(build_dir, dry_run, env_vars)
-        results = DeployResults([], "deploy", dry_run=dry_run)
-        if drop or drop_data:
-            self._clean(client, results, build, build_dir, drop, drop_data, dry_run, env_vars, ordered_loaders, verbose)
-
-        self._deploy(
-            client,
-            results,
-            build,
-            build_dir,
-            drop,
-            drop_data,
-            dry_run,
-            env_vars,
-            force_update,
-            ordered_loaders,
-            verbose,
-        )
-
-        if results.has_counts:
-            print(results.counts_table())
-        if results.has_uploads:
-            print(results.uploads_table())
-
-    def _load_build(self, build_dir: Path, build_env_name: str | None) -> BuildEnvironment:
         if not build_dir.is_dir():
             raise ToolkitNotADirectoryError(
                 "The build directory does not exists. Did you forget to run `cdf build` first?"
             )
+        include = self._clean_command._process_include(include)
         build_environment_file_path = build_dir / BUILD_ENVIRONMENT_FILE
         if not build_environment_file_path.is_file():
             raise ToolkitFileNotFoundError(
                 f"Could not find build environment file '{BUILD_ENVIRONMENT_FILE}' in '{build_dir}'. "
                 "Did you forget to run `cdf build` first?"
             )
-        build = BuildEnvironment.load(read_yaml_file(build_environment_file_path), build_env_name, "deploy")
-        build.set_environment_variables()
-        errors = build.check_source_files_changed()
+
+        deploy_state = BuildEnvironment.load(read_yaml_file(build_environment_file_path), build_env_name, "deploy")
+
+        deploy_state.set_environment_variables()
+
+        errors = deploy_state.check_source_files_changed()
         for error in errors:
             self.warn(error)
         if errors:
             raise ToolkitDeployResourceError(
                 "One or more source files have been modified since the last build. Please rebuild the project."
             )
-        return build
+        client = env_vars.get_client(deploy_state.is_strict_validation)
+        environment_vars = ""
+        if not _RUNNING_IN_BROWSER:
+            environment_vars = f"\n\nConnected to {env_vars.as_string()}"
 
-    def _order_loaders(
-        self, selected_loaders: dict[type[Loader], frozenset[type[Loader]]], build_dir: Path
-    ) -> list[type[Loader]]:
-        """The loaders must be topological sorted to ensure that dependencies are deployed in the correct order."""
+        verb = "Checking" if dry_run else "Deploying"
+
+        print(
+            Panel(
+                f"[bold]{verb}[/]resource files from {build_dir} directory.{environment_vars}",
+                expand=False,
+            )
+        )
+
+        selected_loaders = self._clean_command.get_selected_loaders(
+            build_dir, deploy_state.read_resource_folders, include
+        )
+
+        results = DeployResults([], "deploy", dry_run=dry_run)
+
         ordered_loaders: list[type[Loader]] = []
         should_include: list[type[Loader]] = []
         # The topological sort can include loaders that are not selected, so we need to check for that.
@@ -143,103 +129,65 @@ class DeployCommand(ToolkitCommand):
             # There should be a warning in the build step if it is missing.
         if should_include:
             self.warn(ToolkitDependenciesIncludedWarning(list({item.folder_name for item in should_include})))
-        return ordered_loaders
 
-    @staticmethod
-    def _start_message(build_dir: Path, dry_run: bool, env_vars: EnvironmentVariables) -> None:
-        environment_vars = ""
-        if not _RUNNING_IN_BROWSER:
-            environment_vars = f"\n\nConnected to {env_vars.as_string()}"
-        verb = "Checking" if dry_run else "Deploying"
-        print(
-            Panel(
-                f"[bold]{verb}[/]resource files from {build_dir} directory.{environment_vars}",
-                expand=False,
-            )
-        )
+        result: DeployResult | None
+        if drop or drop_data:
+            # Drop has to be done in the reverse order of deploy.
+            if drop and drop_data:
+                print(Panel("[bold] Cleaning resources as --drop and --drop-data are passed[/]"))
+            elif drop:
+                print(Panel("[bold] Cleaning resources as --drop is passed[/]"))
+            elif drop_data:
+                print(Panel("[bold] Cleaning resources as --drop-data is passed[/]"))
 
-    def _clean(
-        self,
-        client: ToolkitClient,
-        results: DeployResults,
-        build: BuildEnvironment,
-        build_dir: Path,
-        drop: bool,
-        drop_data: bool,
-        dry_run: bool,
-        env_vars: EnvironmentVariables,
-        ordered_loaders: list[type[Loader]],
-        verbose: bool,
-    ) -> None:
-        # Drop has to be done in the reverse order of deploy.
-        if drop and drop_data:
-            print(Panel("[bold] Cleaning resources as --drop and --drop-data are passed[/]"))
-        elif drop:
-            print(Panel("[bold] Cleaning resources as --drop is passed[/]"))
-        elif drop_data:
-            print(Panel("[bold] Cleaning resources as --drop-data is passed[/]"))
-        else:
-            return None
+            for loader_cls in reversed(ordered_loaders):
+                if not issubclass(loader_cls, ResourceLoader):
+                    continue
+                loader: ResourceLoader = loader_cls.create_loader(client, build_dir)
+                result = self._clean_command.clean_resources(
+                    loader,
+                    env_vars=env_vars,
+                    read_modules=deploy_state.read_modules,
+                    drop=drop,
+                    dry_run=dry_run,
+                    drop_data=drop_data,
+                    verbose=verbose,
+                )
+                if result:
+                    results[result.name] = result
+            print("[bold]...cleaning complete![/]")
 
-        for loader_cls in reversed(ordered_loaders):
-            if not issubclass(loader_cls, ResourceLoader):
-                continue
-            loader: ResourceLoader = loader_cls.create_loader(client, build_dir)
-            result = self._clean_command.clean_resources(
-                loader,
-                env_vars=env_vars,
-                read_modules=build.read_modules,
-                drop=drop,
-                dry_run=dry_run,
-                drop_data=drop_data,
-                verbose=verbose,
-            )
-            if result:
-                results[result.name] = result
-        print("[bold]...cleaning complete![/]")
-        return None
-
-    def _deploy(
-        self,
-        client: ToolkitClient,
-        results: DeployResults,
-        build: BuildEnvironment,
-        build_dir: Path,
-        drop: bool,
-        drop_data: bool,
-        dry_run: bool,
-        env_vars: EnvironmentVariables,
-        force_update: bool,
-        ordered_loaders: list[type[Loader]],
-        verbose: bool,
-    ) -> None:
-        if verbose:
+        if drop or drop_data:
             print(Panel("[bold]DEPLOYING resources...[/]"))
 
         for loader_cls in ordered_loaders:
-            loader = loader_cls.create_loader(client, build_dir)
-            resource_result: DeployResult | None
-            if isinstance(loader, ResourceLoader):
-                resource_result = self.deploy_resources(
-                    loader,
+            loader_instance = loader_cls.create_loader(client, build_dir)
+            cdf_result: DeployResult | None
+            if isinstance(loader_instance, ResourceLoader):
+                cdf_result = self.deploy_resources(
+                    loader_instance,
                     env_vars,
-                    build.read_modules,
+                    deploy_state.read_modules,
                     dry_run,
                     drop,
                     drop_data,
                     force_update,
                     verbose,
                 )
-            elif isinstance(loader, DataLoader):
-                resource_result = self.upload_data(loader, build, dry_run, verbose)
+            elif isinstance(loader_instance, DataLoader):
+                cdf_result = self.upload_data(loader_instance, deploy_state, dry_run, verbose)
             else:
                 raise ValueError(f"Unsupported loader type {type(loader)}.")
 
-            if resource_result:
-                results[resource_result.name] = resource_result
+            if cdf_result:
+                results[cdf_result.name] = cdf_result
             if verbose:
                 print("")  # Extra newline
-        return None
+
+        if results.has_counts:
+            print(results.counts_table())
+        if results.has_uploads:
+            print(results.uploads_table())
 
     def deploy_resources(
         self,
@@ -357,8 +305,8 @@ class DeployCommand(ToolkitCommand):
                 total=nr_of_items,
             )
 
-    @staticmethod
     def _verbose_print(
+        self,
         to_create: T_CogniteResourceList,
         to_update: T_CogniteResourceList,
         unchanged: T_CogniteResourceList,
@@ -439,8 +387,8 @@ class DeployCommand(ToolkitCommand):
             return f"\n  {HINT_LEAD_TEXT}This is likely due to missing environment variable{suffix}: {variables_str}"
         return ""
 
-    @staticmethod
     def upload_data(
+        self,
         loader: DataLoader,
         state: BuildEnvironment,
         dry_run: bool = False,

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -62,7 +62,7 @@ class DeployCommand(ToolkitCommand):
         super().__init__(print_warning, skip_tracking, silent)
         self._clean_command = CleanCommand(print_warning, skip_tracking=True)
 
-    def execute(
+    def deploy_build_directory(
         self,
         env_vars: EnvironmentVariables,
         build_dir: Path,
@@ -83,9 +83,11 @@ class DeployCommand(ToolkitCommand):
         self._start_message(build_dir, dry_run, env_vars)
         results = DeployResults([], "deploy", dry_run=dry_run)
         if drop or drop_data:
-            self._clean(client, results, build, build_dir, drop, drop_data, dry_run, env_vars, ordered_loaders, verbose)
+            self.clean_all_resources(
+                client, results, build, build_dir, drop, drop_data, dry_run, env_vars, ordered_loaders, verbose
+            )
 
-        self._deploy(
+        self.deploy_all_resources(
             client,
             results,
             build,
@@ -157,7 +159,7 @@ class DeployCommand(ToolkitCommand):
             )
         )
 
-    def _clean(
+    def clean_all_resources(
         self,
         client: ToolkitClient,
         results: DeployResults,
@@ -198,7 +200,7 @@ class DeployCommand(ToolkitCommand):
         print("[bold]...cleaning complete![/]")
         return None
 
-    def _deploy(
+    def deploy_all_resources(
         self,
         client: ToolkitClient,
         results: DeployResults,
@@ -219,7 +221,7 @@ class DeployCommand(ToolkitCommand):
             loader = loader_cls.create_loader(client, build_dir)
             resource_result: DeployResult | None
             if isinstance(loader, ResourceLoader):
-                resource_result = self.deploy_resources(
+                resource_result = self.deploy_resource_type(
                     loader,
                     env_vars,
                     build.read_modules,
@@ -240,7 +242,7 @@ class DeployCommand(ToolkitCommand):
                 print("")  # Extra newline
         return None
 
-    def deploy_resources(
+    def deploy_resource_type(
         self,
         loader: ResourceLoader[
             T_ID, T_WriteClass, T_WritableCogniteResource, T_CogniteResourceList, T_WritableCogniteResourceList

--- a/cognite_toolkit/_cdf_tk/data_classes/_deploy_results.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_deploy_results.py
@@ -77,6 +77,21 @@ class ResourceContainerDeployResult(ResourceDeployResult):
             self.dropped_datapoints += other.dropped_datapoints
         return self
 
+    @classmethod
+    def from_resource_deploy_result(
+        cls, result: ResourceDeployResult, item_name: str = "", dropped_datapoints: int = 0
+    ) -> ResourceContainerDeployResult:
+        return cls(
+            name=result.name,
+            created=result.created,
+            deleted=result.deleted,
+            changed=result.changed,
+            unchanged=result.unchanged,
+            total=result.total,
+            item_name=item_name,
+            dropped_datapoints=dropped_datapoints,
+        )
+
 
 @dataclass
 class UploadDeployResult(DeployResult):

--- a/cognite_toolkit/_cdf_tk/loaders/_worker.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_worker.py
@@ -94,7 +94,10 @@ class ResourceWorker(
 
         self.validate_access(local_by_id, is_dry_run)
 
-        return self.categorize_resources(local_by_id, force_update, verbose)
+        # Lookup the existing resources in CDF
+        cdf_resources: T_WritableCogniteResourceList
+        cdf_resources = self.loader.retrieve(list(local_by_id.keys()))
+        return self.categorize_resources(local_by_id, cdf_resources, force_update, verbose)
 
     def load_resources(
         self, filepaths: list[Path], environment_variables: dict[str, str | None] | None, is_dry_run: bool
@@ -143,12 +146,12 @@ class ResourceWorker(
             raise self.loader.client.verify.create_error(missing, action=f"clean {self.loader.display_name}")
 
     def categorize_resources(
-        self, local_by_id: dict[T_ID, tuple[dict[str, Any], T_WriteClass]], force_update: bool, verbose: bool
+        self,
+        local_by_id: dict[T_ID, tuple[dict[str, Any], T_WriteClass]],
+        cdf_resources: T_WritableCogniteResourceList,
+        force_update: bool,
+        verbose: bool,
     ) -> tuple[T_CogniteResourceList, T_CogniteResourceList, list[T_ID], T_CogniteResourceList]:
-        # Lookup the existing resources in CDF
-        cdf_resources: T_WritableCogniteResourceList
-        cdf_resources = self.loader.retrieve(list(local_by_id.keys()))
-
         to_create: T_CogniteResourceList
         to_update: T_CogniteResourceList
         to_delete: list[T_ID] = []

--- a/cognite_toolkit/_cdf_tk/loaders/_worker.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_worker.py
@@ -5,7 +5,7 @@ import warnings
 from collections.abc import Hashable
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generic, Literal, overload
+from typing import TYPE_CHECKING, Any, Generic
 
 from cognite.client.data_classes._base import (
     T_CogniteResourceList,
@@ -37,6 +37,7 @@ class ResourceWorker(
         ],
     ):
         self.loader = loader
+        self.duplicates: list[T_ID] = []
 
     def load_files(
         self, sort: bool = True, directory: Path | None = None, read_modules: list[ReadModule] | None = None
@@ -64,45 +65,43 @@ class ResourceWorker(
         # sort.
         return sorted(filepaths, key=sort_key)
 
-    @overload
-    def load_resources(
+    def prepare_resources(
         self,
         filepaths: list[Path],
-        return_existing: Literal[True],
         environment_variables: dict[str, str | None] | None = None,
         is_dry_run: bool = False,
         force_update: bool = False,
         verbose: bool = False,
-    ) -> tuple[T_WritableCogniteResourceList, list[T_ID]]: ...
+    ) -> tuple[T_CogniteResourceList, T_CogniteResourceList, list[T_ID], T_CogniteResourceList]:
+        """Prepare resources for deployment by loading them from files, validating access, and categorizing them into create, update, delete, and unchanged lists.
 
-    @overload
-    def load_resources(
-        self,
-        filepaths: list[Path],
-        return_existing: Literal[False] = False,
-        environment_variables: dict[str, str | None] | None = None,
-        is_dry_run: bool = False,
-        force_update: bool = False,
-        verbose: bool = False,
-    ) -> tuple[T_CogniteResourceList, T_CogniteResourceList, list[T_ID], T_CogniteResourceList, list[T_ID]]: ...
+        Args:
+            filepaths: The list of file paths to load resources from.
+            environment_variables: Environment variables to use for variable replacement in the resource files.
+            is_dry_run: Whether to perform a dry run (no actual changes made).
+            force_update: Whether to force update existing resources even if they are unchanged.
+            verbose: Whether to print detailed information about the resources being processed.
+
+        Returns:
+            A tuple containing:
+                - to_create: List of resources to create.
+                - to_update: List of resources to update.
+                - to_delete: List of resource IDs to delete.
+                - unchanged: List of resources that are unchanged.
+
+        """
+        local_by_id = self.load_resources(filepaths, environment_variables, is_dry_run)
+
+        self.validate_access(local_by_id, is_dry_run)
+
+        return self.categorize_resources(local_by_id, force_update, verbose)
 
     def load_resources(
-        self,
-        filepaths: list[Path],
-        return_existing: bool = False,
-        environment_variables: dict[str, str | None] | None = None,
-        is_dry_run: bool = False,
-        force_update: bool = False,
-        verbose: bool = False,
-    ) -> (
-        tuple[T_CogniteResourceList, T_CogniteResourceList, list[T_ID], T_CogniteResourceList, list[T_ID]]
-        | tuple[T_WritableCogniteResourceList, list[T_ID]]
-    ):
-        duplicates: list[T_ID] = []
+        self, filepaths: list[Path], environment_variables: dict[str, str | None] | None, is_dry_run: bool
+    ) -> dict[T_ID, tuple[dict[str, Any], T_WriteClass]]:
         local_by_id: dict[T_ID, tuple[dict[str, Any], T_WriteClass]] = {}  # type: ignore[assignment]
         # Load all resources from files, get ids, and remove duplicates.
         environment_variables = environment_variables or {}
-
         for filepath in filepaths:
             with catch_warnings(EnvironmentVariableMissingWarning) as warning_list:
                 try:
@@ -122,7 +121,7 @@ class ResourceWorker(
                     # should be handled by the other loader.
                     continue
                 if identifier in local_by_id:
-                    duplicates.append(identifier)
+                    self.duplicates.append(identifier)
                 else:
                     local_by_id[identifier] = resource_dict, loaded
 
@@ -134,18 +133,21 @@ class ResourceWorker(
                     warnings.warn(warning, stacklevel=2)
                 else:
                     warning.print_warning()
+        return local_by_id
 
+    def validate_access(self, local_by_id: dict[T_ID, tuple[dict[str, Any], T_WriteClass]], is_dry_run: bool) -> None:
         capabilities = self.loader.get_required_capability(
             [item for _, item in local_by_id.values()], read_only=is_dry_run
         )
         if capabilities and (missing := self.loader.client.verify.authorization(capabilities)):
             raise self.loader.client.verify.create_error(missing, action=f"clean {self.loader.display_name}")
 
+    def categorize_resources(
+        self, local_by_id: dict[T_ID, tuple[dict[str, Any], T_WriteClass]], force_update: bool, verbose: bool
+    ) -> tuple[T_CogniteResourceList, T_CogniteResourceList, list[T_ID], T_CogniteResourceList]:
         # Lookup the existing resources in CDF
         cdf_resources: T_WritableCogniteResourceList
         cdf_resources = self.loader.retrieve(list(local_by_id.keys()))
-        if return_existing:
-            return cdf_resources, duplicates
 
         to_create: T_CogniteResourceList
         to_update: T_CogniteResourceList
@@ -182,4 +184,4 @@ class ResourceWorker(
                         expand=False,
                     )
                 )
-        return to_create, to_update, to_delete, unchanged, duplicates
+        return to_create, to_update, to_delete, unchanged

--- a/cognite_toolkit/demo/_base.py
+++ b/cognite_toolkit/demo/_base.py
@@ -157,7 +157,7 @@ class CogniteToolkitDemo:
             raise AuthenticationError("Environment variables not set.")
 
         deploy.run(
-            lambda: deploy.execute(
+            lambda: deploy.deploy_build_directory(
                 # MyPy fails to see th check above.
                 env_vars=self._env_vars,  # type: ignore[arg-type]
                 build_dir=self._build_dir,

--- a/module_upgrade/run_check.py
+++ b/module_upgrade/run_check.py
@@ -249,7 +249,7 @@ def run_modules_upgrade(
         build.execute(False, project_path, build_path, selected=None, build_env_name="dev", no_clean=False)
 
         deploy = DeployCommand(print_warning=False)
-        deploy.execute(
+        deploy.deploy_build_directory(
             env_vars,
             build_path,
             build_env_name="dev",

--- a/tests/test_integration/test_commands/test_deploy.py
+++ b/tests/test_integration/test_commands/test_deploy.py
@@ -55,7 +55,7 @@ def test_deploy_complete_org(env_vars: EnvironmentVariables, build_dir: Path) ->
         os.environ,
         {"EVENTHUB_CLIENT_ID": client_id, "EVENTHUB_CLIENT_SECRET": client_secret},
     ):
-        deploy_command.execute(
+        deploy_command.deploy_build_directory(
             env_vars=env_vars,
             build_dir=build_dir,
             build_env_name="dev",
@@ -97,7 +97,7 @@ def test_deploy_complete_org_alpha(env_vars: EnvironmentVariables, build_dir: Pa
         os.environ,
         {"EVENTHUB_CLIENT_ID": client_id, "EVENTHUB_CLIENT_SECRET": client_secret},
     ):
-        deploy_command.execute(
+        deploy_command.deploy_build_directory(
             env_vars,
             build_dir=build_dir,
             build_env_name="dev",

--- a/tests/test_integration/test_commands/test_deploy.py
+++ b/tests/test_integration/test_commands/test_deploy.py
@@ -126,7 +126,7 @@ def get_changed_resources(env_vars: EnvironmentVariables, build_dir: Path) -> di
         loader = loader_cls.create_loader(client, build_dir)
         worker = ResourceWorker(loader)
         files = worker.load_files()
-        _, to_update, *__ = worker.load_resources(files, environment_variables=env_vars.dump())
+        _, to_update, *__ = worker.prepare_resources(files, environment_variables=env_vars.dump())
         if changed := (set(loader.get_ids(to_update)) - {NodeId("sp_nodes", "MyExtendedFile")}):
             # We do not have a way to get CogniteFile extensions. This is a workaround to avoid the test failing.
             changed_resources[loader.display_name] = changed

--- a/tests/test_integration/test_loaders/test_resource_loaders.py
+++ b/tests/test_integration/test_loaders/test_resource_loaders.py
@@ -834,7 +834,7 @@ properties:
             _ = loader.create(ViewApplyList([resource]))
 
         worker = ResourceWorker(loader)
-        to_create, to_change, to_delete, unchanged, _ = worker.load_resources([filepath])
+        to_create, to_change, to_delete, unchanged = worker.prepare_resources([filepath])
 
         assert {
             "create": len(to_create),

--- a/tests/test_integration/test_loaders/test_resource_loaders.py
+++ b/tests/test_integration/test_loaders/test_resource_loaders.py
@@ -716,7 +716,7 @@ workflowDefinition:
             _ = loader.create(WorkflowVersionUpsertList([resource]))
 
         worker = ResourceWorker(loader)
-        to_create, to_change, to_delete, unchanged, _ = worker.load_resources([filepath])
+        to_create, to_change, to_delete, unchanged = worker.prepare_resources([filepath])
 
         assert {
             "create": len(to_create),

--- a/tests/test_unit/test_cdf_tk/test_commands/test_deploy.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_deploy.py
@@ -15,7 +15,7 @@ class TestDeployCommand:
         worker = ResourceWorker(ViewLoader.create_loader(env_vars_with_client.get_client()))
 
         with pytest.raises(TypeError) as e:
-            worker.load_resources([path], environment_variables={}, is_dry_run=True, verbose=False)
+            worker.prepare_resources([path], environment_variables={}, is_dry_run=True, verbose=False)
 
         assert e.value
 

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_base_loaders.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_base_loaders.py
@@ -77,7 +77,7 @@ def test_loader_class(
 ):
     cmd = DeployCommand(print_warning=False)
     loader = loader_cls.create_loader(env_vars_with_client.get_client(), LOAD_DATA)
-    cmd.deploy_resources(loader, env_vars_with_client, [], dry_run=False)
+    cmd.deploy_resource_type(loader, env_vars_with_client, [], dry_run=False)
 
     dump = toolkit_client_approval.dump()
     data_regression.check(dump, fullpath=SNAPSHOTS_DIR / f"{loader.folder_name}.yaml")
@@ -98,7 +98,7 @@ class TestDeployResources:
         expected_order = ["MyView", "MyOtherView"]
 
         cmd = DeployCommand(print_warning=False)
-        cmd.deploy_resources(
+        cmd.deploy_resource_type(
             ViewLoader.create_loader(env_vars_with_client.get_client(), BUILD_DIR),
             env_vars_with_client,
             [],

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_container_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_container_loader.py
@@ -76,7 +76,7 @@ indexes: {}
         toolkit_client_approval.append(Container, [cdf_container])
 
         worker = ResourceWorker(loader)
-        to_create, to_change, to_delete, unchanged, _ = worker.load_resources([file])
+        to_create, to_change, to_delete, unchanged = worker.prepare_resources([file])
         assert {
             "create": len(to_create),
             "change": len(to_change),

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_data_model_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_data_model_loader.py
@@ -55,7 +55,7 @@ class TestDataModelLoader:
             env_vars_with_client.get_client(),
         )
         worker = ResourceWorker(loader)
-        to_create, to_change, to_delete, unchanged, _ = worker.load_resources([filepath])
+        to_create, to_change, to_delete, unchanged = worker.prepare_resources([filepath])
 
         assert {
             "create": len(to_create),

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_data_set_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_data_set_loader.py
@@ -25,7 +25,7 @@ class TestDataSetsLoader:
         toolkit_client_approval.append(DataSet, first)
 
         worker = ResourceWorker(loader)
-        to_create, to_change, to_delete, unchanged, _ = worker.load_resources(
+        to_create, to_change, to_delete, unchanged = worker.prepare_resources(
             [LOAD_DATA / "data_sets" / "1.my_datasets.yaml"]
         )
 

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_extraction_pipeline_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_extraction_pipeline_loader.py
@@ -51,7 +51,7 @@ class TestExtractionPipelineDependencies:
 
         loader = ExtractionPipelineConfigLoader.create_loader(toolkit_client_approval.mock_client)
         worker = ResourceWorker(loader)
-        to_create, changed, to_delete, unchanged, _ = worker.load_resources([local_file])
+        to_create, changed, to_delete, unchanged = worker.prepare_resources([local_file])
         assert {
             "create": len(to_create),
             "changed": len(changed),

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_function_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_function_loader.py
@@ -72,7 +72,7 @@ secrets:
         filepath.parent.name = FunctionLoader.folder_name
 
         worker = ResourceWorker(FunctionLoader.create_loader(env_vars_with_client.get_client(), tmp_path))
-        to_create, to_update, to_delete, unchanged, _ = worker.load_resources([filepath])
+        to_create, to_update, to_delete, unchanged = worker.prepare_resources([filepath])
 
         assert {
             "create": len(to_create),
@@ -89,7 +89,7 @@ secrets:
             }
         )
         toolkit_client_approval.append(Function, cdf_function)
-        to_create, to_update, to_delete, unchanged, _ = worker.load_resources([filepath])
+        to_create, to_update, to_delete, unchanged = worker.prepare_resources([filepath])
 
         assert {
             "create": len(to_create),

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_group_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_group_loader.py
@@ -112,7 +112,7 @@ class TestGroupLoader:
             name="new_group", source_id="123", capabilities=loaded.capabilities
         ).dump_yaml()
         worker = ResourceWorker(loader)
-        to_create, to_change, to_delete, unchanged, _ = worker.load_resources(
+        to_create, to_change, to_delete, unchanged = worker.prepare_resources(
             [
                 LOAD_DATA / "auth" / "1.my_group_scoped.yaml",
                 new_file,
@@ -153,7 +153,7 @@ class TestGroupLoader:
 
         # group exists, no changes
         worker = ResourceWorker(loader)
-        to_create, to_change, to_delete, unchanged, _ = worker.load_resources(
+        to_create, to_change, to_delete, unchanged = worker.prepare_resources(
             [LOAD_DATA / "auth" / "1.my_group_scoped.yaml"]
         )
 
@@ -258,7 +258,7 @@ deletedTime: -1
         filepath.read_text.return_value = local_group
 
         worker = ResourceWorker(loader)
-        to_create, to_change, to_delete, unchanged, _ = worker.load_resources([filepath])
+        to_create, to_change, to_delete, unchanged = worker.prepare_resources([filepath])
         assert {
             "create": len(to_create),
             "change": len(to_change),
@@ -312,7 +312,7 @@ deletedTime: -1
         filepath.read_text.return_value = local_group
 
         worker = ResourceWorker(loader)
-        to_create, to_change, to_delete, unchanged, _ = worker.load_resources([filepath])
+        to_create, to_change, to_delete, unchanged = worker.prepare_resources([filepath])
         assert {
             "create": len(to_create),
             "change": len(to_change),

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_view_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_view_loader.py
@@ -86,7 +86,7 @@ class TestViewLoader:
         toolkit_client_approval.append(dm.View, [cdf_view])
 
         worker = ResourceWorker(loader)
-        to_create, to_change, to_delete, unchanged, _ = worker.load_resources([file])
+        to_create, to_change, to_delete, unchanged = worker.prepare_resources([file])
         assert {
             "create": len(to_create),
             "change": len(to_change),

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_worker.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_worker.py
@@ -39,9 +39,7 @@ authentication:
 """
         output_capture = io.StringIO()
         with contextlib.redirect_stdout(output_capture):
-            _ = worker.load_resources(
-                [local_file], return_existing=False, environment_variables={}, is_dry_run=False, verbose=True
-            )
+            _ = worker.prepare_resources([local_file], environment_variables={}, is_dry_run=False, verbose=True)
 
         terminal_output = output_capture.getvalue()
         assert "my_super_secret_42" not in terminal_output

--- a/tests/test_unit/test_cli/test_behavior.py
+++ b/tests/test_unit/test_cli/test_behavior.py
@@ -72,7 +72,7 @@ def test_inject_custom_environmental_variables(
         on_error="raise",
         verbose=False,
     )
-    DeployCommand(silent=True).execute(
+    DeployCommand(silent=True).deploy_build_directory(
         env_vars=env_vars_with_client,
         build_dir=build_tmp_path,
         build_env_name="dev",
@@ -551,7 +551,7 @@ def test_deploy_group_with_unknown_acl(
     toolkit_client_approval: ApprovalToolkitClient,
     env_vars_with_client: EnvironmentVariables,
 ) -> None:
-    DeployCommand(silent=True).execute(
+    DeployCommand(silent=True).deploy_build_directory(
         env_vars=env_vars_with_client,
         build_dir=BUILD_GROUP_WITH_UNKNOWN_ACL,
         build_env_name="dev",
@@ -651,7 +651,7 @@ def test_build_deploy_location_filter_with_same_filename_in_different_modules(
         "raise",
     )
 
-    DeployCommand(silent=True).execute(
+    DeployCommand(silent=True).deploy_build_directory(
         env_vars_with_client,
         build_tmp_path,
         None,
@@ -688,7 +688,7 @@ def test_build_deploy_keep_special_characters(
         False, NAUGHTY_PROJECT, build_dir, ["encoding_issue"], None, False, env_vars_with_client.get_client(), "raise"
     )
 
-    DeployCommand(silent=True).execute(
+    DeployCommand(silent=True).deploy_build_directory(
         env_vars_with_client,
         build_dir,
         None,

--- a/tests/test_unit/test_cli/test_command_sequences.py
+++ b/tests/test_unit/test_cli/test_command_sequences.py
@@ -78,7 +78,7 @@ def test_build_deploy_module(
         on_error="raise",
     )
 
-    DeployCommand(skip_tracking=True, silent=True).execute(
+    DeployCommand(skip_tracking=True, silent=True).deploy_build_directory(
         env_vars=env_vars_with_client,
         build_dir=build_tmp_path,
         build_env_name="dev",
@@ -127,7 +127,7 @@ def test_build_deploy_with_dry_run(
         on_error="raise",
         verbose=False,
     )
-    DeployCommand(skip_tracking=True, silent=True).execute(
+    DeployCommand(skip_tracking=True, silent=True).deploy_build_directory(
         env_vars=env_vars_with_client,
         build_dir=build_tmp_path,
         build_env_name="dev",
@@ -209,7 +209,7 @@ def test_build_deploy_complete_org(
         client=env_vars_with_client.get_client(),
         on_error="raise",
     )
-    DeployCommand(silent=True, skip_tracking=True).execute(
+    DeployCommand(silent=True, skip_tracking=True).deploy_build_directory(
         env_vars=env_vars_with_client,
         build_dir=build_tmp_path,
         build_env_name="dev",


### PR DESCRIPTION
# Description

<del>Stacked on #1644 </del>

**Context** I want to reuse the logic from the deploy command in the upcoming `cdf migrate prepare` command to deploy a migration model. This is currently not possible as the deploy command expects resources to be in a file and not already in memory. This PR is part 1 of refactoring of the deploy command, such that it becomes easier to read and reuse. 

In this PR I have:
1. Split the now renamed method `prepare_resources` into three smaller methods in the `Resource Worker`. 
2. Split the now named `deploy_resource_type` method into smaller methods. This is increased readability and ease of reuse.
3. Renaming of all the deploy methods in the DeployCommand to reflect the abstraction level.


Note there is zero change to logic, thus not touching any tests.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip

