### PR TITLE
⛓Use YAML classes in the validation of assets, events, filemetadata, dataset, and labels

### DIFF
--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
@@ -37,6 +37,7 @@ from cognite_toolkit._cdf_tk.client.data_classes.sequences import (
     ToolkitSequenceRowsWriteList,
 )
 from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceLoader
+from cognite_toolkit._cdf_tk.resource_classes import AssetYAML, EventYAML
 from cognite_toolkit._cdf_tk.tk_warnings import LowSeverityWarning
 from cognite_toolkit._cdf_tk.utils import load_yaml_inject_variables
 from cognite_toolkit._cdf_tk.utils.diff_list import diff_list_hashable, diff_list_identifiable
@@ -54,6 +55,7 @@ class AssetLoader(ResourceLoader[str, AssetWrite, Asset, AssetWriteList, AssetLi
     resource_write_cls = AssetWrite
     list_cls = AssetList
     list_write_cls = AssetWriteList
+    yaml_cls = AssetYAML
     kind = "Asset"
     dependencies = frozenset({DataSetsLoader, LabelLoader})
     _doc_url = "Assets/operation/createAssets"
@@ -522,6 +524,7 @@ class EventLoader(ResourceLoader[str, EventWrite, Event, EventWriteList, EventLi
     resource_write_cls = EventWrite
     list_cls = EventList
     list_write_cls = EventWriteList
+    yaml_cls = EventYAML
     kind = "Event"
     dependencies = frozenset({DataSetsLoader, AssetLoader})
     _doc_url = "Events/operation/createEvents"

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/data_organization_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/data_organization_loaders.py
@@ -41,6 +41,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitRequiredValueError,
 )
 from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceLoader
+from cognite_toolkit._cdf_tk.resource_classes import DataSetYAML, LabelsYAML
 
 from .auth_loaders import GroupAllScopedLoader
 
@@ -53,6 +54,7 @@ class DataSetsLoader(ResourceLoader[str, DataSetWrite, DataSet, DataSetWriteList
     resource_write_cls = DataSetWrite
     list_cls = DataSetList
     list_write_cls = DataSetWriteList
+    yaml_cls = DataSetYAML
     kind = "DataSet"
     dependencies = frozenset({GroupAllScopedLoader})
     _doc_url = "Data-sets/operation/createDataSets"
@@ -181,6 +183,7 @@ class LabelLoader(
     resource_write_cls = LabelDefinitionWrite
     list_cls = LabelDefinitionList
     list_write_cls = LabelDefinitionWriteList
+    yaml_cls = LabelsYAML
     kind = "Label"
     dependencies = frozenset({DataSetsLoader, GroupAllScopedLoader})
     _doc_url = "Labels/operation/createLabelDefinitions"

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/file_loader.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/file_loader.py
@@ -46,6 +46,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitRequiredValueError,
 )
 from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceContainerLoader, ResourceLoader
+from cognite_toolkit._cdf_tk.resource_classes import FileMetadataYAML
 from cognite_toolkit._cdf_tk.utils import (
     in_dict,
 )
@@ -71,6 +72,7 @@ class FileMetadataLoader(
     resource_write_cls = FileMetadataWrite
     list_cls = FileMetadataList
     list_write_cls = FileMetadataWriteList
+    yaml_cls = FileMetadataYAML
     kind = "FileMetadata"
     dependencies = frozenset({DataSetsLoader, GroupAllScopedLoader, LabelLoader, AssetLoader})
 

--- a/cognite_toolkit/_cdf_tk/validation.py
+++ b/cognite_toolkit/_cdf_tk/validation.py
@@ -180,6 +180,16 @@ def _humanize_validation_error(error: ValidationError) -> list[str]:
             msg = f"The key {key!r} should be a valid string. Got {item['input']!r} of type {type(item['input']).__name__}. Hint: Use double quotes to force string."
         elif error_type == "string_type":
             msg = f"{item['msg']}. Got {item['input']!r} of type {type(item['input']).__name__}. Hint: Use double quotes to force string."
+        elif error_type in {
+            "int_type",
+            "bool_type",
+            "datetime_type",
+            "decimal_type",
+            "float_type",
+            "time_type",
+            "timedelta_type",
+        }:
+            msg = f"{item['msg']}. Got {item['input']!r} of type {type(item['input']).__name__}."
         else:
             # Default to the Pydantic error message
             msg = item["msg"]

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_asset.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_asset.py
@@ -1,7 +1,33 @@
+from collections.abc import Iterable
+from pathlib import Path
+
 import pytest
 
 from cognite_toolkit._cdf_tk.resource_classes import AssetYAML
+from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
+from cognite_toolkit._cdf_tk.validation import validate_resource_yaml_pydantic
 from tests.test_unit.utils import find_resources
+
+
+def invalid_asset_test_cases() -> Iterable:
+    yield pytest.param(
+        {"name": "Asset 1"}, {"Missing required field: 'externalId'"}, id="Missing required field: externalId"
+    )
+    yield pytest.param(
+        {"externalId": "asset_1", "name": "Asset 1", "parentId": 123},
+        {"Unused field: 'parentId'"},
+        id="Unused field: parentId",
+    )
+    yield pytest.param(
+        {"externalId": "asset_1", "name": "Asset 1", "metadata": {"groupNo": 123, "isGoverned": True}},
+        {
+            "In metadata the key 'groupNo' should be a valid string. Got 123 of type int. "
+            "Hint: Use double quotes to force string.",
+            "In metadata the key 'isGoverned' should be a valid string. Got True of type "
+            "bool. Hint: Use double quotes to force string.",
+        },
+        id="Invalid metadata types",
+    )
 
 
 class TestAssetYAML:
@@ -10,3 +36,12 @@ class TestAssetYAML:
         loaded = AssetYAML.model_validate(data)
 
         assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    @pytest.mark.parametrize("data, expected_errors", list(invalid_asset_test_cases()))
+    def test_invalid_asset_error_messages(self, data: dict | list, expected_errors: set[str]) -> None:
+        warning_list = validate_resource_yaml_pydantic(data, AssetYAML, Path("some_file.yaml"))
+        assert len(warning_list) == 1
+        format_warning = warning_list[0]
+        assert isinstance(format_warning, ResourceFormatWarning)
+
+        assert set(format_warning.errors) == expected_errors

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_dataset.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_dataset.py
@@ -1,7 +1,33 @@
+from collections.abc import Iterable
+from pathlib import Path
+
 import pytest
 
 from cognite_toolkit._cdf_tk.resource_classes import DataSetYAML
+from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
+from cognite_toolkit._cdf_tk.validation import validate_resource_yaml_pydantic
 from tests.test_unit.utils import find_resources
+
+
+def invalid_dataset_test_cases() -> Iterable:
+    yield pytest.param(
+        {"name": "MyDataSet"}, {"Missing required field: 'externalId'"}, id="Missing required field: externalId"
+    )
+    yield pytest.param(
+        {"externalId": "MyDataSet", "writeProtected": "yes"},
+        {"In field writeProtected input should be a valid boolean. Got 'yes' of type str."},
+        id="Invalid writeProtected type",
+    )
+    yield pytest.param(
+        {"externalId": "MyDataSet", "name": "TheDataSet", "metadata": {"groupNo": 123, "isGoverned": True}},
+        {
+            "In metadata the key 'groupNo' should be a valid string. Got 123 of type int. "
+            "Hint: Use double quotes to force string.",
+            "In metadata the key 'isGoverned' should be a valid string. Got True of type "
+            "bool. Hint: Use double quotes to force string.",
+        },
+        id="Invalid metadata types",
+    )
 
 
 class TestDataSetYAML:
@@ -10,3 +36,12 @@ class TestDataSetYAML:
         loaded = DataSetYAML.model_validate(data)
 
         assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    @pytest.mark.parametrize("data, expected_errors", list(invalid_dataset_test_cases()))
+    def test_invalid_asset_error_messages(self, data: dict | list, expected_errors: set[str]) -> None:
+        warning_list = validate_resource_yaml_pydantic(data, DataSetYAML, Path("some_file.yaml"))
+        assert len(warning_list) == 1
+        format_warning = warning_list[0]
+        assert isinstance(format_warning, ResourceFormatWarning)
+
+        assert set(format_warning.errors) == expected_errors

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_event.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_event.py
@@ -1,12 +1,53 @@
+from collections.abc import Iterable
+from pathlib import Path
+
 import pytest
 
 from cognite_toolkit._cdf_tk.resource_classes import EventYAML
+from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
+from cognite_toolkit._cdf_tk.validation import validate_resource_yaml_pydantic
 from tests.test_unit.utils import find_resources
 
 
-class TestAssetYAML:
+def invalid_event_test_cases() -> Iterable:
+    yield pytest.param(
+        {"type": "Workorder"}, {"Missing required field: 'externalId'"}, id="Missing required field: externalId"
+    )
+    yield pytest.param(
+        {"externalId": "1230098u-12907903", "assetExternalIds": [123, 456], "startTime": "2023-10-01T00:00:00Z"},
+        {
+            "In assetExternalIds input should be a valid string. Got 123 of type int. "
+            "Hint: Use double quotes to force string.",
+            "In assetExternalIds input should be a valid string. Got 456 of type int. "
+            "Hint: Use double quotes to force string.",
+            "In field startTime input should be a valid integer. Got '2023-10-01T00:00:00Z' of type str.",
+        },
+        id="Invalid data type in assetExternalIds",
+    )
+    yield pytest.param(
+        {"externalId": "123098u2-2370", "metadata": {"groupNo": 123, "isGoverned": True}},
+        {
+            "In metadata the key 'groupNo' should be a valid string. Got 123 of type int. "
+            "Hint: Use double quotes to force string.",
+            "In metadata the key 'isGoverned' should be a valid string. Got True of type "
+            "bool. Hint: Use double quotes to force string.",
+        },
+        id="Invalid metadata types",
+    )
+
+
+class TestEventYAML:
     @pytest.mark.parametrize("data", list(find_resources("Event")))
     def test_load_valid_asset(self, data: dict[str, object]) -> None:
         loaded = EventYAML.model_validate(data)
 
         assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    @pytest.mark.parametrize("data, expected_errors", list(invalid_event_test_cases()))
+    def test_invalid_asset_error_messages(self, data: dict | list, expected_errors: set[str]) -> None:
+        warning_list = validate_resource_yaml_pydantic(data, EventYAML, Path("some_file.yaml"))
+        assert len(warning_list) == 1
+        format_warning = warning_list[0]
+        assert isinstance(format_warning, ResourceFormatWarning)
+
+        assert set(format_warning.errors) == expected_errors

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_filemetadata.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_filemetadata.py
@@ -1,7 +1,36 @@
+from collections.abc import Iterable
+from pathlib import Path
+
 import pytest
 
 from cognite_toolkit._cdf_tk.resource_classes import FileMetadataYAML
+from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
+from cognite_toolkit._cdf_tk.validation import validate_resource_yaml_pydantic
 from tests.test_unit.utils import find_resources
+
+
+def invalid_filemetadata_test_cases() -> Iterable:
+    yield pytest.param(
+        {"name": "MyFile"}, {"Missing required field: 'externalId'"}, id="Missing required field: externalId"
+    )
+    yield pytest.param(
+        {"externalId": "my_file", "name": "TextFile", "mimeType": True},
+        {
+            "In field mimeType input should be a valid string. Got True of type bool. "
+            "Hint: Use double quotes to force string."
+        },
+        id="Invalid mimeType type",
+    )
+    yield pytest.param(
+        {"externalId": "MyFile", "name": "MyTextFile", "metadata": {"groupNo": 123, "isGoverned": True}},
+        {
+            "In metadata the key 'groupNo' should be a valid string. Got 123 of type int. "
+            "Hint: Use double quotes to force string.",
+            "In metadata the key 'isGoverned' should be a valid string. Got True of type "
+            "bool. Hint: Use double quotes to force string.",
+        },
+        id="Invalid metadata types",
+    )
 
 
 class TestFileMetadataYAML:
@@ -10,3 +39,12 @@ class TestFileMetadataYAML:
         loaded = FileMetadataYAML.model_validate(data)
 
         assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    @pytest.mark.parametrize("data, expected_errors", list(invalid_filemetadata_test_cases()))
+    def test_invalid_asset_error_messages(self, data: dict | list, expected_errors: set[str]) -> None:
+        warning_list = validate_resource_yaml_pydantic(data, FileMetadataYAML, Path("some_file.yaml"))
+        assert len(warning_list) == 1
+        format_warning = warning_list[0]
+        assert isinstance(format_warning, ResourceFormatWarning)
+
+        assert set(format_warning.errors) == expected_errors

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_labels.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_labels.py
@@ -1,7 +1,23 @@
+from collections.abc import Iterable
+from pathlib import Path
+
 import pytest
 
 from cognite_toolkit._cdf_tk.resource_classes.labels import LabelsYAML
+from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
+from cognite_toolkit._cdf_tk.validation import validate_resource_yaml_pydantic
 from tests.test_unit.utils import find_resources
+
+
+def invalid_label_test_cases() -> Iterable:
+    yield pytest.param(
+        {"name": "Pump"}, {"Missing required field: 'externalId'"}, id="Missing required field: externalId"
+    )
+    yield pytest.param(
+        {"externalId": "equipment:pump", "dataSetId": 123},
+        {"Unused field: 'dataSetId'", "Missing required field: 'name'"},
+        id="Unused field: dataSetId and missing name",
+    )
 
 
 class TestLabelsYAML:
@@ -10,3 +26,12 @@ class TestLabelsYAML:
         loaded = LabelsYAML.model_validate(data)
 
         assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    @pytest.mark.parametrize("data, expected_errors", list(invalid_label_test_cases()))
+    def test_invalid_asset_error_messages(self, data: dict | list, expected_errors: set[str]) -> None:
+        warning_list = validate_resource_yaml_pydantic(data, LabelsYAML, Path("some_file.yaml"))
+        assert len(warning_list) == 1
+        format_warning = warning_list[0]
+        assert isinstance(format_warning, ResourceFormatWarning)
+
+        assert set(format_warning.errors) == expected_errors

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_transformations.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_transformations.py
@@ -115,7 +115,7 @@ def invalid_transformation_test_cases() -> Iterable:
             "name": "Invalid ignore_null_fields",
             "ignoreNullFields": "yes",
         },
-        {"In field ignoreNullFields input should be a valid boolean"},
+        {"In field ignoreNullFields input should be a valid boolean. Got 'yes' of type str."},
         id="Invalid ignore_null_fields type",
     )
     yield pytest.param(


### PR DESCRIPTION
# Description

The YAML classes we use for validation are already made. This PR connects them to the loader class such that they will be used in the `cdf build` command. In addition, I made a set of tests cases for each as well as updated the function that humanize the pydantic errors. 

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Improved

- In the `cdf build` command, Toolkit now gives improved warning messages if the syntax in the configuration file is incorrect for `assets`, `events`, `filemetadata`, `dataset`, and `labels`.

## templates

No changes.
