### PR TITLE
[CDF-25070] ⛓️‍💥 Unlink timeseries

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/api/extended_timeseries.py
+++ b/cognite_toolkit/_cdf_tk/client/api/extended_timeseries.py
@@ -125,7 +125,7 @@ class ExtendedTimeSeriesAPI(TimeSeriesAPI):
         if id is None and external_id is None:
             return None
         if isinstance(id, int) and isinstance(external_id, str):
-            raise ValueError("Either id or external_id must be provided, or both as a sequence.")
+            raise ValueError("Cannot specify both id and external_id as single values. Use one or the other.")
         is_single = isinstance(id, int) or isinstance(external_id, str)
         identifiers = IdentifierSequence.load(id, external_id)
 

--- a/tests/auth_utils.py
+++ b/tests/auth_utils.py
@@ -16,7 +16,7 @@ _LOGIN_FLOW: TypeAlias = Literal["infer", "client_credentials", "interactive", "
 _VALID_LOGIN_FLOWS = get_args(_LOGIN_FLOW)
 
 
-def get_toolkit_client(env_file_name: str) -> ToolkitClient:
+def get_toolkit_client(env_file_name: str, enable_set_pending_ids: bool = False) -> ToolkitClient:
     """Instantiate a ToolkitClient using environment variables. If the environment variables are not set, the user will
     be prompted to enter them.
 
@@ -24,6 +24,7 @@ def get_toolkit_client(env_file_name: str) -> ToolkitClient:
         env_file_name: The name of the .env file to look for in the repository root / current working directory. If
         the file is found, the variables will be loaded from the file. If the file is not found, the user will
         be prompted to enter the variables and the file will be created.
+        enable_set_pending_ids: Whether to enable the set_pending_ids method on the client.
 
     Returns:
         ToolkitClient: A ToolkitClient instance.
@@ -37,13 +38,13 @@ def get_toolkit_client(env_file_name: str) -> ToolkitClient:
     if repo_root:
         with suppress(KeyError, FileNotFoundError, TypeError):
             variables = _from_dotenv(repo_root / env_file_name)
-            client = variables.get_client()
+            client = variables.get_client(enable_set_pending_ids)
             print(f"Found {env_file_name} file in repository root. Loaded variables from {env_file_name} file.")
             return client
     elif (Path.cwd() / env_file_name).exists():
         with suppress(KeyError, FileNotFoundError, TypeError):
             variables = _from_dotenv(Path.cwd() / env_file_name)
-            client = variables.get_client()
+            client = variables.get_client(enable_set_pending_ids)
             print(
                 f"Found {env_file_name} file in current working directory. Loaded variables from {env_file_name} file."
             )
@@ -52,7 +53,7 @@ def get_toolkit_client(env_file_name: str) -> ToolkitClient:
     with suppress(KeyError):
         variables = EnvironmentVariables.create_from_environ()
         print("Loaded variables from environment variables.")
-        return variables.get_client()
+        return variables.get_client(enable_set_pending_ids)
     # If not found, prompt the user
     variables = _prompt_user()
     if repo_root and _env_in_gitignore(repo_root, env_file_name):
@@ -62,7 +63,7 @@ def get_toolkit_client(env_file_name: str) -> ToolkitClient:
         # We do not offer to create the file in the repository root if it is in .gitignore
         # as an inexperienced user might accidentally commit it.
         print("Cannot create .env file in repository root as there is no .env entry in the .gitignore.")
-        return variables.get_client()
+        return variables.get_client(enable_set_pending_ids)
     else:
         env_file = Path.cwd() / env_file_name
         location = "current working directory"
@@ -77,7 +78,7 @@ def get_toolkit_client(env_file_name: str) -> ToolkitClient:
         env_file.write_text(variables.create_env_file())
         print(f"Created {env_file_name} file in {location}.")
 
-    return variables.get_client()
+    return variables.get_client(enable_set_pending_ids)
 
 
 @dataclass
@@ -226,7 +227,7 @@ class EnvironmentVariables:
             raise KeyError("TOKEN must be set in the environment", "TOKEN")
         return Token(self.TOKEN)
 
-    def get_client(self) -> ToolkitClient:
+    def get_client(self, enable_set_pending_ids: bool = False) -> ToolkitClient:
         config = ToolkitClientConfig(
             client_name=CLIENT_NAME,
             project=self.CDF_PROJECT,
@@ -235,7 +236,7 @@ class EnvironmentVariables:
             max_workers=self.CDF_MAX_WORKERS,
             timeout=self.CDF_TIMEOUT,
         )
-        return ToolkitClient(config)
+        return ToolkitClient(config, enable_set_pending_ids)
 
     def create_env_file(self) -> str:
         lines: list[str] = []

--- a/tests/test_unit/test_cdf_tk/test_client/conftest.py
+++ b/tests/test_unit/test_cdf_tk/test_client/conftest.py
@@ -1,0 +1,36 @@
+import pytest
+from cognite.client import global_config
+from cognite.client.credentials import Token
+
+from cognite_toolkit._cdf_tk.client import ToolkitClientConfig
+
+BASE_URL = "http://blabla.cognitedata.com"
+TOKEN_URL = "https://test.com/token"
+
+
+@pytest.fixture
+def toolkit_config():
+    return ToolkitClientConfig(
+        client_name="test-client",
+        project="test-project",
+        base_url=BASE_URL,
+        max_workers=1,
+        timeout=10,
+        credentials=Token("abc"),
+    )
+
+
+@pytest.fixture
+def disable_gzip():
+    old = global_config.disable_gzip
+    global_config.disable_gzip = True
+    yield
+    global_config.disable_gzip = old
+
+
+@pytest.fixture
+def max_retries_2():
+    old = global_config.max_retries
+    global_config.max_retries = 2
+    yield
+    global_config.max_retries = old

--- a/tests/test_unit/test_cdf_tk/test_client/test_extended_timeseries.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_extended_timeseries.py
@@ -1,0 +1,53 @@
+from collections.abc import Sequence
+
+import pytest
+import responses
+from cognite.client.utils.useful_types import SequenceNotStr
+
+from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
+from cognite_toolkit._cdf_tk.client.data_classes.extended_timeseries import ExtendedTimeSeriesList
+
+
+class TestExtendedTimeSeriesAPI:
+    @pytest.mark.parametrize(
+        "id, external_id, expected_list",
+        [
+            pytest.param(None, "my_timeseries", False, id="External ID only"),
+            pytest.param(123, None, False, id="ID only"),
+            pytest.param([123, 456], None, True, id="List of IDs"),
+            pytest.param(None, ["my_timeseries", "my_other_timeseries"], True, id="List of External IDs"),
+            pytest.param([123, 456], ["my_timeseries", "my_other_timeseries"], True, id="List of IDs and External IDs"),
+        ],
+    )
+    def test_unlink_instance_ids_valid(
+        self,
+        id: int | Sequence[int] | None,
+        external_id: str | SequenceNotStr[str] | None,
+        expected_list: bool,
+        toolkit_config: ToolkitClientConfig,
+    ) -> None:
+        client = ToolkitClient(config=toolkit_config, enable_set_pending_ids=True)
+        url = f"{toolkit_config.base_url}/api/v1/projects/test-project/timeseries/unlink-instance-ids"
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                url,
+                status=200,
+                json={"items": [{"externalId": "does-not-matter", "id": 123, "createdTime": 0, "lastUpdatedTime": 0}]},
+            )
+            result = client.time_series.unlink_instance_ids(id=id, external_id=external_id)
+
+        is_list = isinstance(result, ExtendedTimeSeriesList)
+        assert is_list == expected_list, f"Expected result to be a list: {expected_list}, got {is_list}"
+
+    def test_unlink_instance_ids_none_return_none(self, toolkit_config: ToolkitClientConfig) -> None:
+        client = ToolkitClient(config=toolkit_config, enable_set_pending_ids=True)
+        result = client.time_series.unlink_instance_ids(id=None, external_id=None)
+        assert result is None
+
+    def test_unlink_instance_ids_invalid(self, toolkit_config: ToolkitClientConfig) -> None:
+        client = ToolkitClient(config=toolkit_config, enable_set_pending_ids=True)
+        with pytest.raises(
+            ValueError, match="Cannot specify both id and external_id as single values. Use one or the other."
+        ):
+            client.time_series.unlink_instance_ids(id=123, external_id="123")

--- a/tests/test_unit/test_cdf_tk/test_client/test_instances.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_instances.py
@@ -3,44 +3,11 @@ import socket
 
 import pytest
 import responses
-from cognite.client import global_config
-from cognite.client.credentials import Token
 from cognite.client.data_classes.data_modeling import NodeApply, NodeOrEdgeData, ViewId
 from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteTimeSeriesApply
 from cognite.client.exceptions import CogniteAPIError, CogniteConnectionError, CogniteReadTimeout
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
-
-BASE_URL = "http://blabla.cognitedata.com"
-TOKEN_URL = "https://test.com/token"
-
-
-@pytest.fixture
-def toolkit_config():
-    return ToolkitClientConfig(
-        client_name="test-client",
-        project="test-project",
-        base_url=BASE_URL,
-        max_workers=1,
-        timeout=10,
-        credentials=Token("abc"),
-    )
-
-
-@pytest.fixture
-def disable_gzip():
-    old = global_config.disable_gzip
-    global_config.disable_gzip = True
-    yield
-    global_config.disable_gzip = old
-
-
-@pytest.fixture
-def max_retries_2():
-    old = global_config.max_retries
-    global_config.max_retries = 2
-    yield
-    global_config.max_retries = old
 
 
 @pytest.fixture()


### PR DESCRIPTION
# Description

This implements the unlink endpoint for timeseries. Currently, this is only deployed in a dev cluster. The unlink endpoint enables you to unlink CogniteTimeSeries from an asset centric timeseries. This is useful in the case when you want to delete the CogniteTimeSeries nodes, but not lose the datapoints stored. 

The expected way this will be used

1. Unlink asset-centric timeseries from CogniteTimeSeries.
2. Delete CogniteTimeSeries.
3. Set pending instance ID on the asset-centric timeseries.
4. Create new CogniteTimeSeries.

This is necessary if you want the asset-centric timeseries to be linked to a different node than what is currently linked to.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
