### PR TITLE
[CDF-24982] 🧑‍🎨➡ Canvas migration

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
+++ b/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
@@ -13,6 +13,7 @@ from .api.extended_raw import ExtendedRawAPI
 from .api.extended_timeseries import ExtendedTimeSeriesAPI
 from .api.location_filters import LocationFiltersAPI
 from .api.lookup import LookUpGroup
+from .api.migration import MigrationAPI
 from .api.robotics import RoboticsAPI
 from .api.verify import VerifyAPI
 
@@ -87,6 +88,7 @@ class ToolkitClient(CogniteClient):
             self.time_series: ExtendedTimeSeriesAPI = ExtendedTimeSeriesAPI(self._config, self._API_VERSION, self)
         self.raw: ExtendedRawAPI = ExtendedRawAPI(self._config, self._API_VERSION, self)
         self.canvas = CanvasAPI(self.data_modeling.instances)
+        self.migration = MigrationAPI(self.data_modeling.instances)
 
     @property
     def config(self) -> ToolkitClientConfig:

--- a/cognite_toolkit/_cdf_tk/client/api/migration.py
+++ b/cognite_toolkit/_cdf_tk/client/api/migration.py
@@ -1,0 +1,57 @@
+from collections.abc import Sequence
+from itertools import groupby
+
+from cognite.client.data_classes.data_modeling import NodeList, filters, query
+
+from cognite_toolkit._cdf_tk.client.data_classes.migration import AssetCentricId, Mapping
+from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
+
+from .extended_data_modeling import ExtendedInstancesAPI
+
+
+class MappingAPI:
+    def __init__(self, instance_api: ExtendedInstancesAPI) -> None:
+        self._instance_api = instance_api
+        self._RETRIEVE_LIMIT = 1000
+        self._view_id = Mapping.get_source()
+
+    def retrieve(self, ids: Sequence[AssetCentricId]) -> NodeList[Mapping]:
+        """Retrieve a list of mappings by their IDs.
+
+        Args:
+            ids (Sequence[AssetCentricId]): A sequence of AssetCentricId objects representing the IDs of the mappings to retrieve.
+        """
+        results: NodeList[Mapping] = NodeList[Mapping]([])
+        for chunk in chunker_sequence(ids, self._RETRIEVE_LIMIT):
+            retrieve_query = query.Query(
+                with_={
+                    "mappings": query.NodeResultSetExpression(
+                        filter=filters.And(filters.HasData(views=[self._view_id]), self._create_dms_filter(ids)),
+                        limit=len(chunk),
+                    ),
+                },
+                select={"mappings": query.Select([query.SourceSelector(self._view_id, ["*"])])},
+            )
+            chunk_response = self._instance_api.query(retrieve_query)
+            results.extend([Mapping._load(item.dump()) for item in chunk_response.get("mappings", [])])
+        return results
+
+    @staticmethod
+    def _create_dms_filter(ids: Sequence[AssetCentricId]) -> filters.Filter:
+        """Create a filter that matches all the AssetCentricIds in the list."""
+        if not ids:
+            raise ValueError("Cannot create a filter from an empty AssetCentricIdList.")
+        to_or_filters: list[filters.Filter] = []
+        mapping_view = Mapping.get_source()
+        for resource_type, resource_ids in groupby(
+            sorted(ids, key=lambda x: x.resource_type), key=lambda x: x.resource_type
+        ):
+            is_resource = filters.Equals(mapping_view.as_property_ref("resourceType"), resource_type)
+            is_id = filters.In(mapping_view.as_property_ref("id"), [resource_id.id_ for resource_id in resource_ids])
+            to_or_filters.append(filters.And(is_resource, is_id))
+        return filters.Or(*to_or_filters)
+
+
+class MigrationAPI:
+    def __init__(self, instance_api: ExtendedInstancesAPI) -> None:
+        self.mapping = MappingAPI(instance_api)

--- a/cognite_toolkit/_cdf_tk/client/data_classes/canvas.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/canvas.py
@@ -485,6 +485,16 @@ class ContainerReferenceApply(_ContainerReferenceProperties, TypedNodeApply):
         self.max_width = max_width
         self.max_height = max_height
 
+    def as_asset_centric_id(self) -> AssetCentricId:
+        if self.container_reference_type not in {"asset", "event", "file", "sequence", "timeseries"}:
+            raise ValueError(
+                f"Cannot convert ContainerReference of type {self.container_reference_type} to AssetCentricId."
+            )
+        return AssetCentricId(
+            resource_type=self.container_reference_type,
+            id_=self.resource_id,
+        )
+
 
 class ContainerReference(_ContainerReferenceProperties, TypedNode):
     """This represents the reading format of container reference.

--- a/cognite_toolkit/_cdf_tk/client/data_classes/canvas.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/canvas.py
@@ -17,6 +17,8 @@ from cognite.client.data_classes.data_modeling.instances import (
 )
 from cognite.client.data_classes.data_modeling.query import QueryResult
 
+from .migration import AssetCentricId
+
 CANVAS_INSTANCE_SPACE = "IndustrialCanvasInstanceSpace"
 SOLUTION_TAG_SPACE = "SolutionTagsInstanceSpace"
 CANVAS_SCHEMA_SPACE = "cdf_industrial_canvas"
@@ -574,6 +576,16 @@ class ContainerReference(_ContainerReferenceProperties, TypedNode):
             max_height=self.max_height,
             existing_version=self.version,
             type=self.type,
+        )
+
+    def as_asset_centric_id(self) -> AssetCentricId:
+        if self.container_reference_type not in {"asset", "event", "file", "sequence", "timeseries"}:
+            raise ValueError(
+                f"Cannot convert ContainerReference of type {self.container_reference_type} to AssetCentricId."
+            )
+        return AssetCentricId(
+            resource_type=self.container_reference_type,
+            id_=self.resource_id,
         )
 
 

--- a/cognite_toolkit/_cdf_tk/client/data_classes/migration.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/migration.py
@@ -18,17 +18,6 @@ class AssetCentricId(CogniteObject):
     resource_type: Literal["asset", "event", "file", "sequence", "timeseries"]
     id_: int
 
-    @property
-    def core_view_external_id(self) -> str:
-        if self.resource_type == "sequence":
-            raise ValueError("Sequences do not have a core view external ID.")
-        return {
-            "asset": "CogniteAsset",
-            "event": "CogniteActivity",
-            "file": "CogniteFile",
-            "timeseries": "CogniteTimeSeries",
-        }[self.resource_type]
-
     @classmethod
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> AssetCentricId:
         """Load an AssetCentricId from a dictionary."""
@@ -108,3 +97,14 @@ class Mapping(_MappingProperties, TypedNode):
             resource_type=self.resource_type,
             id_=self.id_,
         )
+
+    @property
+    def default_core_view_external_id(self) -> str:
+        if self.resource_type == "sequence":
+            raise ValueError("Sequences do not have a core view external ID.")
+        return {
+            "asset": "CogniteAsset",
+            "event": "CogniteActivity",
+            "file": "CogniteFile",
+            "timeseries": "CogniteTimeSeries",
+        }[self.resource_type]

--- a/cognite_toolkit/_cdf_tk/client/data_classes/migration.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/migration.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from cognite.client import CogniteClient
+from cognite.client.data_classes._base import CogniteObject
+from cognite.client.data_classes.data_modeling import DirectRelationReference
+from cognite.client.data_classes.data_modeling.ids import ViewId
+from cognite.client.data_classes.data_modeling.instances import (
+    PropertyOptions,
+    TypedNode,
+)
+
+
+@dataclass(frozen=True)
+class AssetCentricId(CogniteObject):
+    resource_type: Literal["asset", "event", "file", "sequence", "timeseries"]
+    id_: int
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> AssetCentricId:
+        """Load an AssetCentricId from a dictionary."""
+        return cls(
+            resource_type=resource["resourceType"],
+            id_=resource["id"],
+        )
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump the AssetCentricId to a dictionary."""
+        return {
+            "resourceType" if camel_case else "resource_type": self.resource_type,
+            "id" if camel_case else "id_": self.id_,
+        }
+
+
+class _MappingProperties:
+    resource_type = PropertyOptions("resourceType")
+    id_ = PropertyOptions("id")
+    data_set_id = PropertyOptions("dataSetId")
+    classic_external_id = PropertyOptions("classicExternalId")
+
+    @classmethod
+    def get_source(cls) -> ViewId:
+        return ViewId("cognite_migration", "Mapping", "v1")
+
+
+class Mapping(_MappingProperties, TypedNode):
+    """This represents the reading format of mapping.
+
+    It is used to when data is read from CDF.
+
+    The mapping between asset-centric and data modeling resources
+
+    Args:
+        space: The space where the node is located.
+        external_id: The external id of the mapping.
+        version (int): DMS version.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970,
+            Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970,
+            Coordinated Universal Time (UTC), minus leap seconds.
+        resource_type: The resource type field.
+        id_: The id field.
+        data_set_id: The data set id field.
+        classic_external_id: The classic external id field.
+        type: Direct relation pointing to the type node.
+        deleted_time: The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time
+            (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances
+            are filtered out of query results, but present in sync results
+    """
+
+    def __init__(
+        self,
+        space: str,
+        external_id: str,
+        version: int,
+        last_updated_time: int,
+        created_time: int,
+        *,
+        resource_type: Literal["asset", "event", "file", "sequence", "timeseries"],
+        id_: int,
+        data_set_id: int | None = None,
+        classic_external_id: str | None = None,
+        type: DirectRelationReference | None = None,
+        deleted_time: int | None = None,
+    ) -> None:
+        TypedNode.__init__(self, space, external_id, version, last_updated_time, created_time, deleted_time, type)
+        self.resource_type = resource_type
+        self.id_ = id_
+        self.data_set_id = data_set_id
+        self.classic_external_id = classic_external_id
+
+    def as_asset_centric_id(self) -> AssetCentricId:
+        """Return the AssetCentricId representation of the mapping."""
+        return AssetCentricId(
+            resource_type=self.resource_type,
+            id_=self.id_,
+        )

--- a/cognite_toolkit/_cdf_tk/client/data_classes/migration.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/migration.py
@@ -18,6 +18,17 @@ class AssetCentricId(CogniteObject):
     resource_type: Literal["asset", "event", "file", "sequence", "timeseries"]
     id_: int
 
+    @property
+    def core_view_external_id(self) -> str:
+        if self.resource_type == "sequence":
+            raise ValueError("Sequences do not have a core view external ID.")
+        return {
+            "asset": "CogniteAsset",
+            "event": "CogniteActivity",
+            "file": "CogniteFile",
+            "timeseries": "CogniteTimeSeries",
+        }[self.resource_type]
+
     @classmethod
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> AssetCentricId:
         """Load an AssetCentricId from a dictionary."""

--- a/cognite_toolkit/_cdf_tk/client/testing.py
+++ b/cognite_toolkit/_cdf_tk/client/testing.py
@@ -19,6 +19,7 @@ from .api.lookup import (
     SecurityCategoriesLookUpAPI,
     TimeSeriesLookUpAPI,
 )
+from .api.migration import MappingAPI, MigrationAPI
 from .api.robotics import RoboticsAPI
 from .api.robotics.capabilities import CapabilitiesAPI
 from .api.robotics.data_postprocessing import DataPostProcessingAPI
@@ -56,6 +57,8 @@ class ToolkitClientMock(CogniteClientMock):
         self.lookup.security_categories = MagicMock(spec_set=SecurityCategoriesLookUpAPI)
         self.lookup.location_filters = MagicMock(spec_set=LocationFiltersLookUpAPI)
         self.lookup.extraction_pipelines = MagicMock(spec_set=ExtractionPipelineLookUpAPI)
+        self.migration = MagicMock(spec=MigrationAPI)
+        self.migration.mapping = MagicMock(spec_set=MappingAPI)
 
         self.robotics = MagicMock()
         self.robotics.robots = MagicMock(spec=RoboticsAPI)

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/canvas.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/canvas.py
@@ -1,3 +1,4 @@
+from cognite.client.data_classes import filters
 from cognite.client.data_classes.capabilities import Capability, DataModelInstancesAcl, DataModelsAcl, SpaceIDScope
 from rich import print
 
@@ -24,8 +25,13 @@ class MigrationCanvasCommand(ToolkitCommand):
         self._validate_authorization(client)
         self._validate_migration_mappings_exists(client)
         external_ids = external_ids or InteractiveCanvasSelect(client).select_external_ids()
-
-        print(f"Would migrate {len(external_ids)} canvases: {humanize_collection(external_ids)}")
+        if external_ids is None or not external_ids:
+            print("No canvases selected for migration.")
+            return
+        action = "Would migrate" if dry_run else "Migrating"
+        print(f"{action} {len(external_ids)} canvases.")
+        for external_id in external_ids:
+            self._migrate_canvas(client, external_id, dry_run=dry_run, verbose=verbose)
 
     @classmethod
     def _validate_authorization(cls, client: ToolkitClient) -> None:
@@ -54,3 +60,28 @@ class MigrationCanvasCommand(ToolkitCommand):
                 f"The migration mapping view {MAPPING_VIEW_ID} does not exist. "
                 f"Please run the `cdf migrate prepare` command to deploy the migration data model."
             )
+
+    def _migrate_canvas(
+        self,
+        client: ToolkitClient,
+        external_id: str,
+        dry_run: bool = False,
+        verbose: bool = False,
+    ) -> None:
+        # 1. Fetch canvas with all its connections, including implicit.
+        # 2a. Try to download mappings for the resources reference in the canvas.
+        # 2b. If not found, Warning and skip.
+        # 3. If dry_run, log all good and go to next.
+        # 4. If not dry_run, create a new canvas version with updated mappings and connections.
+        # 5. Deploy new version of the canvas. (Include rollback if something goes wrong?)
+
+        canvas = client.canvas.retrieve(external_id=external_id)
+        if not canvas:
+            # Todo Warning
+            print(f"Canvas with external ID '{external_id}' not found.")
+            return
+        if verbose:
+            print(f"Found canvas: {canvas.name}")
+        node_id = canvas.as_id()
+        is_canvas = filters.Equals(["edge", "startNode"], node_id.dump(include_instance_type=False))
+        edges = client.data_modeling.instances.list(instance_type="edge", space=CANVAS_INSTANCE_SPACE, filter=is_canvas)

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/canvas.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/canvas.py
@@ -1,12 +1,19 @@
+from cognite.client.data_classes.capabilities import Capability, DataModelInstancesAcl, DataModelsAcl, SpaceIDScope
 from rich import print
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
+from cognite_toolkit._cdf_tk.client.data_classes.canvas import CANVAS_INSTANCE_SPACE, Canvas
 from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
+from cognite_toolkit._cdf_tk.exceptions import AuthenticationError, ToolkitMigrationError
 from cognite_toolkit._cdf_tk.utils import humanize_collection
 from cognite_toolkit._cdf_tk.utils.interactive_select import InteractiveCanvasSelect
 
+from .data_model import MAPPING_VIEW_ID
+
 
 class MigrationCanvasCommand(ToolkitCommand):
+    canvas_schema_space = Canvas.get_source().space
+
     def migrate_canvas(
         self,
         client: ToolkitClient,
@@ -14,5 +21,36 @@ class MigrationCanvasCommand(ToolkitCommand):
         dry_run: bool = False,
         verbose: bool = False,
     ) -> None:
+        self._validate_authorization(client)
+        self._validate_migration_mappings_exists(client)
         external_ids = external_ids or InteractiveCanvasSelect(client).select_external_ids()
+
         print(f"Would migrate {len(external_ids)} canvases: {humanize_collection(external_ids)}")
+
+    @classmethod
+    def _validate_authorization(cls, client: ToolkitClient) -> None:
+        required_capabilities: list[Capability] = [
+            DataModelsAcl(
+                actions=[DataModelsAcl.Action.Read],
+                scope=SpaceIDScope([cls.canvas_schema_space, MAPPING_VIEW_ID.space]),
+            ),
+            DataModelInstancesAcl(
+                actions=[
+                    DataModelInstancesAcl.Action.Read,
+                    DataModelInstancesAcl.Action.Write,
+                    DataModelInstancesAcl.Action.Write_Properties,
+                ],
+                scope=SpaceIDScope([CANVAS_INSTANCE_SPACE]),
+            ),
+        ]
+        if missing := client.iam.verify_capabilities(required_capabilities):
+            raise AuthenticationError(f"Missing required capabilities: {humanize_collection(missing)}.")
+
+    @classmethod
+    def _validate_migration_mappings_exists(cls, client: ToolkitClient) -> None:
+        view = client.data_modeling.views.retrieve(MAPPING_VIEW_ID)
+        if not view:
+            raise ToolkitMigrationError(
+                f"The migration mapping view {MAPPING_VIEW_ID} does not exist. "
+                f"Please run the `cdf migrate prepare` command to deploy the migration data model."
+            )

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/canvas.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/canvas.py
@@ -117,11 +117,7 @@ class MigrationCanvasCommand(ToolkitCommand):
             self._migrate_container_reference(ref, mapping_by_reference_id) for ref in new_canvas.container_references
         ]
         new_canvas.container_references = []
-        try:
-            _ = client.canvas.industrial.new_version(new_canvas, canvas)
-        except CogniteAPIError as e:
-            client.canvas.industrial.delete(new_canvas)
-            self.warn(HighSeverityWarning(f"Failed to create new version of canvas '{canvas.canvas.name}': {e}"))
+        _ = client.canvas.industrial.new_version(new_canvas, canvas)
         self.console(
             f'Canvas "{canvas.canvas.name}" migrated successfully with {len(new_canvas.fdm_instance_container_references)} references to data model instances.'
         )

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/canvas.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/canvas.py
@@ -8,7 +8,7 @@ from cognite_toolkit._cdf_tk.client.data_classes.canvas import (
     ContainerReferenceApply,
     FdmInstanceContainerReferenceApply,
 )
-from cognite_toolkit._cdf_tk.client.data_classes.migration import Mapping
+from cognite_toolkit._cdf_tk.client.data_classes.migration import Mapping, AssetCentricId
 from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
 from cognite_toolkit._cdf_tk.exceptions import AuthenticationError, ToolkitMigrationError
 from cognite_toolkit._cdf_tk.tk_warnings import HighSeverityWarning, MediumSeverityWarning
@@ -127,7 +127,7 @@ class MigrationCanvasCommand(ToolkitCommand):
         )
 
     def _migrate_container_reference(
-        self, reference: ContainerReferenceApply, mapping_by_reference_id: dict[str, Mapping]
+        self, reference: ContainerReferenceApply, mapping_by_reference_id: dict[AssetCentricId, Mapping]
     ) -> FdmInstanceContainerReferenceApply:
         """Migrate a single container reference by replacing the asset-centric ID with the data model instance ID."""
         raise NotImplementedError()

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_model.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_model.py
@@ -66,6 +66,10 @@ MAPPING_VIEW = dm.ViewApply(
     },
 )
 
+
+MAPPING_VIEW_ID = MAPPING_VIEW.as_id()
+
+
 COGNITE_MIGRATION_MODEL = dm.DataModelApply(
     space=SPACE.space,
     external_id="CogniteMigration",

--- a/tests/auth_utils.py
+++ b/tests/auth_utils.py
@@ -222,9 +222,9 @@ class EnvironmentVariables:
         )
 
     def get_token(self) -> Token:
-        if not self.TOKEN:
+        if not self.CDF_TOKEN:
             raise KeyError("TOKEN must be set in the environment", "TOKEN")
-        return Token(self.TOKEN)
+        return Token(self.CDF_TOKEN)
 
     def get_client(self) -> ToolkitClient:
         config = ToolkitClientConfig(
@@ -289,7 +289,7 @@ def _prompt_user() -> EnvironmentVariables:
     variables.LOGIN_FLOW = login_flow  # type: ignore[assignment]
     if login_flow == "token":
         token = Prompt.ask("Enter token")
-        variables.TOKEN = token
+        variables.CDF_TOKEN = token
         return variables
 
     variables.IDP_CLIENT_ID = Prompt.ask("Enter IDP Client ID")

--- a/tests/test_integration/test_toolkit_client/test_migration.py
+++ b/tests/test_integration/test_toolkit_client/test_migration.py
@@ -1,0 +1,42 @@
+import pytest
+from cognite.client.data_classes.data_modeling import NodeApply, NodeApplyList, NodeList, NodeOrEdgeData, Space
+
+from cognite_toolkit._cdf_tk.client import ToolkitClient
+from cognite_toolkit._cdf_tk.client.data_classes.migration import Mapping
+
+
+@pytest.fixture(scope="session")
+def three_mappings(toolkit_client: ToolkitClient, toolkit_space: Space) -> NodeList[Mapping]:
+    nodes = NodeApplyList(
+        [
+            NodeApply(
+                space=toolkit_space.space,
+                external_id=f"toolkit_test_migration_{i}",
+                sources=[
+                    NodeOrEdgeData(
+                        Mapping.get_source(),
+                        {
+                            "resourceType": "asset",
+                            "id": i,
+                        },
+                    )
+                ],
+            )
+            for i in range(3)
+        ]
+    )
+
+    _ = toolkit_client.data_modeling.instances.apply(nodes)
+
+    created = toolkit_client.data_modeling.instances.retrieve_nodes(nodes.as_ids(), node_cls=Mapping)
+    assert len(created) == 3, "Expected 3 mappings to be created"
+    return created
+
+
+class TestMappingAPI:
+    def test_retrieve_mappings(self, toolkit_client: ToolkitClient, three_mappings: NodeList[Mapping]) -> None:
+        ids = [mapping.as_asset_centric_id() for mapping in three_mappings]
+
+        retrieved = toolkit_client.migration.mapping.retrieve(ids)
+
+        assert retrieved.dump() == three_mappings.dump(), "Failed to retrieve mappings using asset-centric IDs"


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Added

- [alpha] New command `cdf migrate canvas` that enables migration of Canvas from asset-centric to data modeling.

## templates

No changes.
