### PR TITLE
[prep CDF-24982] 😏 Canvas retrieve with subcomponents

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/api/canvas.py
+++ b/cognite_toolkit/_cdf_tk/client/api/canvas.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Sequence
-from typing import Any, overload
+from typing import Any, Literal, overload
 
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.data_modeling import InstanceSort, NodeApplyResultList, NodeId, NodeList
@@ -25,12 +25,32 @@ class CanvasAPI:
         return [item.external_id for item in result.nodes]
 
     @overload
-    def retrieve(self, external_id: str | None = None) -> Canvas | None: ...
+    def retrieve(
+        self, external_id: str | None = None, retrieve_connections: Literal["skip", "full"] = "skip"
+    ) -> Canvas | None: ...
 
     @overload
-    def retrieve(self, external_id: SequenceNotStr[str]) -> NodeList[Canvas]: ...
+    def retrieve(
+        self, external_id: SequenceNotStr[str], retrieve_connections: Literal["skip", "full"] = "skip"
+    ) -> NodeList[Canvas]: ...
 
-    def retrieve(self, external_id: str | SequenceNotStr[str] | None = None) -> Canvas | NodeList[Canvas] | None:
+    def retrieve(
+        self,
+        external_id: str | SequenceNotStr[str] | None = None,
+        retrieve_connections: Literal["skip", "full"] = "skip",
+    ) -> Canvas | NodeList[Canvas] | None:
+        """Retrieve a canvas or a list of canvases by their external IDs.
+
+        If the retrieve connections parameter is set to 'full', it will retrieve all connections associated with the canvases.
+
+        Args:
+            external_id (str | SequenceNotStr[str] | None): The external ID of the canvas or a sequence of external IDs.
+            retrieve_connections (Literal["skip", "full"]): Whether to skip or retrieve full connections. Defaults to 'skip'.
+
+        Returns:
+            Canvas | NodeList[Canvas] | None: A single Canvas object if a single external ID is provided, a NodeList of Canvas objects if multiple external IDs are provided, or None if no external ID is provided.
+
+        """
         if isinstance(external_id, str):
             return self._instance_api.retrieve_nodes(NodeId(self.instance_space, external_id), node_cls=Canvas)
         elif isinstance(external_id, Iterable):

--- a/cognite_toolkit/_cdf_tk/client/api/canvas.py
+++ b/cognite_toolkit/_cdf_tk/client/api/canvas.py
@@ -1,12 +1,16 @@
-from collections.abc import Iterable, Sequence
-from typing import Any, Literal, overload
+from collections.abc import Sequence
+from typing import Any, Literal
 
 from cognite.client._constants import DEFAULT_LIMIT_READ
 from cognite.client.data_classes.data_modeling import InstanceSort, NodeApplyResultList, NodeId, NodeList
 from cognite.client.data_classes.filters import Filter
 from cognite.client.utils.useful_types import SequenceNotStr
 
-from cognite_toolkit._cdf_tk.client.data_classes.canvas import CANVAS_INSTANCE_SPACE, Canvas, CanvasApply
+from cognite_toolkit._cdf_tk.client.data_classes.canvas import (
+    CANVAS_INSTANCE_SPACE,
+    Canvas,
+    CanvasApply,
+)
 
 from .extended_data_modeling import ExtendedInstancesAPI
 
@@ -24,41 +28,43 @@ class CanvasAPI:
         result = self._instance_api.delete([NodeId(self.instance_space, item) for item in external_ids])
         return [item.external_id for item in result.nodes]
 
-    @overload
     def retrieve(
         self, external_id: str | None = None, retrieve_connections: Literal["skip", "full"] = "skip"
-    ) -> Canvas | None: ...
+    ) -> Canvas | None:
+        """Retrieve a canvas with a given external ID.
 
-    @overload
-    def retrieve(
-        self, external_id: SequenceNotStr[str], retrieve_connections: Literal["skip", "full"] = "skip"
-    ) -> NodeList[Canvas]: ...
-
-    def retrieve(
-        self,
-        external_id: str | SequenceNotStr[str] | None = None,
-        retrieve_connections: Literal["skip", "full"] = "skip",
-    ) -> Canvas | NodeList[Canvas] | None:
-        """Retrieve a canvas or a list of canvases by their external IDs.
-
-        If the retrieve connections parameter is set to 'full', it will retrieve all connections associated with the canvases.
+        If the retrieve connections parameter is set to 'full', it will retrieve all connections associated with the Canvas will
+        be returned.
 
         Args:
             external_id (str | SequenceNotStr[str] | None): The external ID of the canvas or a sequence of external IDs.
             retrieve_connections (Literal["skip", "full"]): Whether to skip or retrieve full connections. Defaults to 'skip'.
 
         Returns:
-            Canvas | NodeList[Canvas] | None: A single Canvas object if a single external ID is provided, a NodeList of Canvas objects if multiple external IDs are provided, or None if no external ID is provided.
+            Canvas | NodeList[Canvas] | None: A single Canvas object if a single external ID is provided.
 
         """
-        if isinstance(external_id, str):
+        if retrieve_connections == "skip":
             return self._instance_api.retrieve_nodes(NodeId(self.instance_space, external_id), node_cls=Canvas)
-        elif isinstance(external_id, Iterable):
-            return self._instance_api.retrieve_nodes(
-                [NodeId(self.instance_space, item) for item in external_id], node_cls=Canvas
-            )
         else:
-            raise TypeError(f"Expected str or SequenceNotStr[str], got {type(external_id)}")
+            canvas_query = self._canvas_with_connections_query(external_id)
+            result = self._instance_api.query(canvas_query)
+            return Canvas._load_query(result)
+
+    def retrieve_multiple(self, external_ids: SequenceNotStr[str]) -> NodeList[Canvas]:
+        """Retrieve a list of canvases by their external IDs.
+
+
+        Args:
+            external_ids (SequenceNotStr[str]): The external IDs of the Canvases to retrieve.
+
+        Returns:
+            NodeList[Canvas]: A list of Canvas objects corresponding to the provided external IDs.
+
+        """
+        return self._instance_api.retrieve_nodes(
+            [NodeId(self.instance_space, external_id) for external_id in external_ids], node_cls=Canvas
+        )
 
     def list(
         self,

--- a/cognite_toolkit/_cdf_tk/client/data_classes/canvas.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/canvas.py
@@ -1,12 +1,14 @@
+from collections.abc import Sequence
 from datetime import datetime
 
-from cognite.client.data_classes.data_modeling import DirectRelationReference
+from cognite.client.data_classes.data_modeling import DirectRelationReference, filters, query
 from cognite.client.data_classes.data_modeling.ids import ViewId
 from cognite.client.data_classes.data_modeling.instances import (
     PropertyOptions,
     TypedNode,
     TypedNodeApply,
 )
+from cognite.client.data_classes.data_modeling.query import QueryResult
 
 CANVAS_INSTANCE_SPACE = "IndustrialCanvasInstanceSpace"
 SOLUTION_TAG_SPACE = "SolutionTagsInstanceSpace"
@@ -749,3 +751,111 @@ class Canvas(_CanvasProperties, TypedNode):
             existing_version=self.version,
             type=self.type,
         )
+
+
+class IndustrialCanvas:
+    """This class represents one instances of the Canvas with all connected data."""
+
+    def __init__(
+        self,
+        canvas: Canvas,
+        annotations: list[CanvasAnnotation] | None = None,
+        container_references: list[ContainerReference] | None = None,
+        fdm_instance_container_references: list[FdmInstanceContainerReference] | None = None,
+        solution_tags: list[CogniteSolutionTag] | None = None,
+    ) -> None:
+        self.canvas = canvas
+        self.annotations = annotations or []
+        self.container_references = container_references or []
+        self.fdm_instance_container_references = fdm_instance_container_references or []
+        self.solution_tags = solution_tags or []
+
+    @classmethod
+    def load(cls, result: QueryResult) -> "IndustrialCanvas":
+        """Load an IndustrialCanvas instance from a QueryResult."""
+        raise NotImplementedError()
+
+    @classmethod
+    def create_query(cls, external_id: str) -> query.Query:
+        schema_space = Canvas.get_source().space
+        return query.Query(
+            with_={
+                "canvas": query.NodeResultSetExpression(
+                    filter=filters.InstanceReferences([(CANVAS_INSTANCE_SPACE, external_id)]),
+                    limit=1,
+                ),
+                "solutionTags": query.NodeResultSetExpression(
+                    from_="canvas",
+                    through=Canvas.get_source().as_property_ref("solutionTags"),
+                ),
+                "annotationEdges": query.EdgeResultSetExpression(
+                    from_="canvas",
+                    filter=filters.Equals(
+                        ["edge", "type"], {"space": schema_space, "externalId": "referencesCanvasAnnotation"}
+                    ),
+                    node_filter=filters.HasData(views=[CanvasAnnotation.get_source()]),
+                    direction="outwards",
+                ),
+                "containerReferenceEdges": query.EdgeResultSetExpression(
+                    from_="canvas",
+                    filter=filters.Equals(
+                        ["edge", "type"], {"space": schema_space, "externalId": "referencesContainerReference"}
+                    ),
+                    node_filter=filters.HasData(views=[ContainerReference.get_source()]),
+                    direction="outwards",
+                ),
+                "fdmInstanceContainerReferenceEdges": query.EdgeResultSetExpression(
+                    from_="canvas",
+                    filter=filters.Equals(
+                        ["edge", "type"],
+                        {"space": schema_space, "externalId": "referencesFdmInstanceContainerReference"},
+                    ),
+                    node_filter=filters.HasData(views=[FdmInstanceContainerReference.get_source()]),
+                    direction="outwards",
+                ),
+                "annotations": query.NodeResultSetExpression(from_="annotationEdges"),
+                "containerReferences": query.NodeResultSetExpression(from_="containerReferenceEdges"),
+                "fdmInstanceContainerReferences": query.NodeResultSetExpression(
+                    from_="fdmInstanceContainerReferenceEdges"
+                ),
+            },
+            select={
+                "canvas": query.Select([query.SourceSelector(Canvas.get_source(), properties=["*"])]),
+                "solutionTags": query.Select([query.SourceSelector(CogniteSolutionTag.get_source(), properties=["*"])]),
+                "annotations": query.Select([query.SourceSelector(CanvasAnnotation.get_source(), properties=["*"])]),
+                "containerReferences": query.Select(
+                    [query.SourceSelector(ContainerReference.get_source(), properties=["*"])]
+                ),
+                "fdmInstanceContainerReferences": query.Select(
+                    [query.SourceSelector(FdmInstanceContainerReference.get_source(), properties=["*"])]
+                ),
+            },
+        )
+
+
+class IndustrialCanvasApply:
+    """This class represents the writing format of IndustrialCanvas.
+
+    It is used to when data is written to CDF.
+
+    Args:
+        canvas: The Canvas object.
+        annotations: A list of CanvasAnnotation objects.
+        container_references: A list of ContainerReference objects.
+        fdm_instance_container_references: A list of FdmInstanceContainerReference objects.
+        solution_tags: A list of CogniteSolutionTag objects.
+    """
+
+    def __init__(
+        self,
+        canvas: CanvasApply,
+        annotations: Sequence[CanvasAnnotation] | None = None,
+        container_references: Sequence[ContainerReferenceApply] | None = None,
+        fdm_instance_container_references: Sequence[FdmInstanceContainerReferenceApply] | None = None,
+        solution_tags: Sequence[CogniteSolutionTagApply] | None = None,
+    ) -> None:
+        self.canvas = canvas
+        self.annotations = annotations or []
+        self.container_references = container_references or []
+        self.fdm_instance_container_references = fdm_instance_container_references or []
+        self.solution_tags = solution_tags or []


### PR DESCRIPTION
# Description

This  for adding them support migration of Canvas from asset-centric to data modeling.

This PR extends the CanvasAPI with `retrieve_connections` paramter on the `.retrieve` method. This is such that the canvas can be retrieved with all the extra subcomponents. 

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip

