### PR TITLE
[prep CDF-24982] 🎪Duplicate canvas

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/data_classes/canvas.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/canvas.py
@@ -826,10 +826,9 @@ class IndustrialCanvasApply:
         instances = self.as_instances()
         ids: list[NodeId | EdgeId] = []
         for instance in instances:
-            if isinstance(instance, NodeApply) and (
-                include_solution_tags or not isinstance(instance, CogniteSolutionTagApply)
-            ):
-                ids.append(NodeId(instance.space, instance.external_id))
+            if isinstance(instance, NodeApply):
+                if include_solution_tags or not isinstance(instance, CogniteSolutionTagApply):
+                    ids.append(NodeId(instance.space, instance.external_id))
             elif isinstance(instance, EdgeApply):
                 ids.append(EdgeId(instance.space, instance.external_id))
             else:

--- a/tests/test_unit/test_cdf_tk/test_client/test_canvas.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_canvas.py
@@ -52,10 +52,16 @@ class TestLoadDump:
 
         duplicated = instance.duplicate()
 
-        original_ids = set(instance.as_instance_ids())
-        duplicated_ids = set(duplicated.as_instance_ids())
+        original_ids = set(instance.as_instance_ids(include_solution_tags=False))
+        duplicated_ids = set(duplicated.as_instance_ids(include_solution_tags=False))
         overlapping_ids = original_ids.intersection(duplicated_ids)
         assert not overlapping_ids
+
+        original_ids = set(instance.as_instance_ids(include_solution_tags=True))
+        duplicated_ids = set(duplicated.as_instance_ids(include_solution_tags=True))
+        overlapping_ids = original_ids.intersection(duplicated_ids)
+        solution_tags_ids = {tag.as_id() for tag in instance.solution_tags}
+        assert solution_tags_ids == overlapping_ids, "Expected original IDs to match solution tags IDs"
 
 
 @pytest.fixture()

--- a/tests/test_unit/test_cdf_tk/test_client/test_canvas.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_canvas.py
@@ -19,6 +19,7 @@ from cognite_toolkit._cdf_tk.client.data_classes.canvas import (
     ContainerReferenceApply,
     FdmInstanceContainerReference,
     FdmInstanceContainerReferenceApply,
+    IndustrialCanvasApply,
 )
 from tests.test_unit.utils import FakeCogniteResourceGenerator
 
@@ -45,6 +46,16 @@ class TestLoadDump:
         reloaded = node_cls.load(dumped)
 
         assert reloaded == instance, f"Expected: {instance}, but got: {reloaded}"
+
+    def test_duplicate_industrial(self) -> None:
+        instance = FakeCogniteResourceGenerator().create_instance(IndustrialCanvasApply)
+
+        duplicated = instance.duplicate()
+
+        original_ids = set(instance.as_instance_ids())
+        duplicated_ids = set(duplicated.as_instance_ids())
+        overlapping_ids = original_ids.intersection(duplicated_ids)
+        assert not overlapping_ids
 
 
 @pytest.fixture()


### PR DESCRIPTION
# Description

This is part of a multiple PRs for adding support migration of Canvas from asset-centric to data modeling.

This adds a helper method for duplicated canvases.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
