### PR TITLE
💣Fix fragile tests

### DIFF
--- a/tests/test_integration/test_commands/test_migrate_timeseries.py
+++ b/tests/test_integration/test_commands/test_migrate_timeseries.py
@@ -1,3 +1,4 @@
+import random
 import time
 from datetime import datetime
 from pathlib import Path
@@ -21,7 +22,7 @@ def three_timeseries_with_datapoints(
     timeseries = TimeSeriesWriteList([])
     for i in range(3):
         ts = TimeSeriesWrite(
-            external_id=f"toolkit_test_migration_{i}",
+            external_id=f"toolkit_test_migration_{i}_{random.randint(0, 10_000)!s}",
             name=f"toolkit_test_migration_{i}",
             is_string=False,
             is_step=False,


### PR DESCRIPTION
# Description

The `test_migrate_timeseries_command` fails to run in parallel as it creates and deletes the same timeseries. This ensures that the timeseries used for testing migrations are unique for each run.

![image](https://github.com/user-attachments/assets/3b174aaa-a468-46c7-967f-fa510f3ca467)


## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
