### PR TITLE
🐛Unwrap bug

### DIFF
--- a/tests/test_unit/test_cdf_tk/test_client/test_instances.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_instances.py
@@ -4,7 +4,11 @@ import socket
 import pytest
 import responses
 from cognite.client.data_classes.data_modeling import NodeApply, NodeOrEdgeData, ViewId
-from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteAssetApply, CogniteTimeSeriesApply
+from cognite.client.data_classes.data_modeling.cdm.v1 import (
+    CogniteAnnotationApply,
+    CogniteAssetApply,
+    CogniteTimeSeriesApply,
+)
 from cognite.client.exceptions import CogniteAPIError, CogniteConnectionError, CogniteReadTimeout
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
@@ -22,7 +26,7 @@ def some_timeseries() -> CogniteTimeSeriesApply:
 
 class TestInstances:
     def test_apply_fast_failed_multiple_types(self, toolkit_config) -> None:
-        two_node_types = [
+        different_instance_types = [
             CogniteTimeSeriesApply(
                 space="some_space",
                 external_id="test_time_series",
@@ -33,6 +37,14 @@ class TestInstances:
                 space="some_space",
                 external_id="test_asset",
                 name="Test Asset",
+            ),
+            CogniteAnnotationApply(
+                space="some_space",
+                external_id="test_annotation",
+                type=("some_space", "entity.match"),
+                start_node=("some_space", "test_asset"),
+                end_node=("some_space", "test_asset"),
+                name="Test Annotation",
             ),
         ]
         url = f"{toolkit_config.base_url}/api/v1/projects/test-project/models/instances"
@@ -45,7 +57,7 @@ class TestInstances:
             )
             client = ToolkitClient(config=toolkit_config)
             with pytest.raises(CogniteAPIError) as exc_info:
-                _ = client.data_modeling.instances.apply_fast(two_node_types)
+                _ = client.data_modeling.instances.apply_fast(different_instance_types)
 
         error = exc_info.value
         assert isinstance(error, CogniteAPIError)

--- a/tests/test_unit/test_cdf_tk/test_client/test_instances.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_instances.py
@@ -62,7 +62,8 @@ class TestInstances:
         error = exc_info.value
         assert isinstance(error, CogniteAPIError)
         assert error.code == 400
-        assert error.message == "the message"
+        assert error.message == "Invalid request"
+        assert error.failed == [instance.as_id() for instance in different_instance_types]
 
     @pytest.mark.usefixtures("disable_gzip")
     def test_apply_fast_429_status_split(self, toolkit_config: ToolkitClientConfig) -> None:


### PR DESCRIPTION
# Description

This helper function is used in the error message if the request fails. The current implementation assumes that all instances are of the same type, which is incorrect, while the fix just use the identifier.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
