### PR TITLE
Temporarily skip test

### DIFF
--- a/tests/test_integration/test_commands/test_migrate_prepare.py
+++ b/tests/test_integration/test_commands/test_migrate_prepare.py
@@ -1,8 +1,13 @@
+import pytest
+
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.commands import MigrationPrepareCommand
 
 
 class TestMigrateTimeSeriesCommand:
+    @pytest.mark.skip(
+        reason="We are changing the migration model, so this test willbe out until the new model PR #1706 is merged."
+    )
     def test_migration_prepare_command(
         self,
         toolkit_client: ToolkitClient,


### PR DESCRIPTION
# Description

I am changing the migration model we are using. This causes the integration test that deploys it to fail as it is now in different versions depending on which branch you run the test from. Temporarily disabling it.

Ref: https://github.com/cognitedata/toolkit/pull/1706


## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
