### PR TITLE
[prep CDF-25018] 📋 Support set-pending-ids for files

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
+++ b/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
@@ -9,6 +9,7 @@ from .api.agents.agents import AgentsAPI
 from .api.canvas import CanvasAPI
 from .api.dml import DMLAPI
 from .api.extended_data_modeling import ExtendedDataModelingAPI
+from .api.extended_files import ExtendedFileMetadataAPI
 from .api.extended_raw import ExtendedRawAPI
 from .api.extended_timeseries import ExtendedTimeSeriesAPI
 from .api.location_filters import LocationFiltersAPI
@@ -88,6 +89,7 @@ class ToolkitClient(CogniteClient):
         self.data_modeling: ExtendedDataModelingAPI = ExtendedDataModelingAPI(self._config, self._API_VERSION, self)
         if enable_set_pending_ids:
             self.time_series: ExtendedTimeSeriesAPI = ExtendedTimeSeriesAPI(self._config, self._API_VERSION, self)
+            self.files: ExtendedFileMetadataAPI = ExtendedFileMetadataAPI(self._config, self._API_VERSION, self)
         self.raw: ExtendedRawAPI = ExtendedRawAPI(self._config, self._API_VERSION, self)
         self.canvas = CanvasAPI(self.data_modeling.instances)
         self.migration = MigrationAPI(self.data_modeling.instances)

--- a/cognite_toolkit/_cdf_tk/client/api/extended_files.py
+++ b/cognite_toolkit/_cdf_tk/client/api/extended_files.py
@@ -1,0 +1,159 @@
+from collections.abc import Sequence
+from typing import overload
+
+from cognite.client import ClientConfig, CogniteClient
+from cognite.client._api.files import FilesAPI
+from cognite.client.data_classes.data_modeling import NodeId
+from cognite.client.utils._auxiliary import split_into_chunks, unpack_items_in_payload
+from cognite.client.utils._concurrency import execute_tasks
+from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client.utils.useful_types import SequenceNotStr
+
+from cognite_toolkit._cdf_tk.client.data_classes.extended_filemetdata import (
+    ExtendedFileMetadata,
+    ExtendedFileMetadataList,
+)
+from cognite_toolkit._cdf_tk.client.data_classes.pending_instances_ids import PendingInstanceId
+
+
+class ExtendedFileMetadataAPI(FilesAPI):
+    """Extended FileMetadata to include pending ID methods."""
+
+    def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
+        super().__init__(config, api_version, cognite_client)
+        self._PENDING_IDS_LIMIT = 1000
+
+    @overload
+    def set_pending_ids(
+        self, instance_id: NodeId | tuple[str, str], id: int | None = None, external_id: str | None = None
+    ) -> ExtendedFileMetadata: ...
+
+    @overload
+    def set_pending_ids(self, instance_id: Sequence[PendingInstanceId]) -> ExtendedFileMetadataList: ...
+
+    def set_pending_ids(
+        self,
+        instance_id: NodeId | tuple[str, str] | Sequence[PendingInstanceId],
+        id: int | None = None,
+        external_id: str | None = None,
+    ) -> ExtendedFileMetadata | ExtendedFileMetadataList:
+        """Set a pending identifier for one or more filemetadata..
+
+        Args:
+            instance_id: The pending instance ID to set.
+            id: The ID of the time series.
+            external_id: The external ID of the time series.
+
+        Returns:
+            ExtendedFileMetadata: If a single instance ID is provided, returns the updated ExtendedTimeSeries object.
+        """
+        if isinstance(instance_id, NodeId) or (
+            isinstance(instance_id, tuple)
+            and len(instance_id) == 2
+            and isinstance(instance_id[0], str)
+            and isinstance(instance_id[1], str)
+        ):
+            return self._set_pending_ids([PendingInstanceId(instance_id, id=id, external_id=external_id)])[0]  # type: ignore[return-value, arg-type]
+        elif isinstance(instance_id, Sequence) and all(isinstance(item, PendingInstanceId) for item in instance_id):
+            return self._set_pending_ids(instance_id)  # type: ignore[arg-type]
+        else:
+            raise TypeError(
+                "instance_id must be a NodeId, a tuple of (str, str), or a sequence of PendingIdentifier objects."
+            )
+
+    def _set_pending_ids(self, identifiers: Sequence[PendingInstanceId]) -> ExtendedFileMetadataList:
+        tasks = [
+            {
+                "url_path": f"{self._RESOURCE_PATH}/set-pending-instance-ids",
+                "json": {
+                    "items": [identifier.dump(camel_case=True) for identifier in id_chunk],
+                },
+                "api_subversion": "alpha",
+            }
+            for id_chunk in split_into_chunks(list(identifiers), self._PENDING_IDS_LIMIT)
+        ]
+        tasks_summary = execute_tasks(
+            self._post,
+            tasks,
+            max_workers=self._config.max_workers,
+            fail_fast=True,
+        )
+        tasks_summary.raise_compound_exception_if_failed_tasks(
+            task_unwrap_fn=unpack_items_in_payload,
+        )
+
+        retrieved_items = tasks_summary.joined_results(lambda res: res.json()["items"])
+
+        return ExtendedFileMetadataList._load(retrieved_items, cognite_client=self._cognite_client)
+
+    def retrieve(
+        self, id: int | None = None, external_id: str | None = None, instance_id: NodeId | None = None
+    ) -> ExtendedFileMetadata | None:
+        """`Retrieve a single file metadata by id. <https://developer.cognite.com/api#tag/Files/operation/getFileByInternalId>`_
+
+        Args:
+            id (int | None): ID
+            external_id (str | None): External ID
+            instance_id (NodeId | None): Instance ID
+
+        Returns:
+            FileMetadata | None: Requested file metadata or None if it does not exist.
+
+        Examples:
+
+            Get file metadata by id:
+
+                >>> from cognite.client import CogniteClient
+                >>> client = CogniteClient()
+                >>> res = client.files.retrieve(id=1)
+
+            Get file metadata by external id:
+
+                >>> res = client.files.retrieve(external_id="1")
+        """
+        identifiers = IdentifierSequence.load(ids=id, external_ids=external_id, instance_ids=instance_id).as_singleton()
+        return self._retrieve_multiple(
+            list_cls=ExtendedFileMetadataList,
+            resource_cls=ExtendedFileMetadata,
+            identifiers=identifiers,
+            api_subversion="alpha",
+        )
+
+    def retrieve_multiple(
+        self,
+        ids: Sequence[int] | None = None,
+        external_ids: SequenceNotStr[str] | None = None,
+        instance_ids: Sequence[NodeId] | None = None,
+        ignore_unknown_ids: bool = False,
+    ) -> ExtendedFileMetadataList:
+        """`Retrieve multiple file metadatas by id. <https://developer.cognite.com/api#tag/Files/operation/byIdsFiles>`_
+
+        Args:
+            ids (Sequence[int] | None): IDs
+            external_ids (SequenceNotStr[str] | None): External IDs
+            instance_ids (Sequence[NodeId] | None): Instance IDs
+            ignore_unknown_ids (bool): Ignore IDs and external IDs that are not found rather than throw an exception.
+
+        Returns:
+            FileMetadataList: The requested file metadatas.
+
+        Examples:
+
+            Get file metadatas by id:
+
+                >>> from cognite.client import CogniteClient
+                >>> client = CogniteClient()
+                >>> res = client.files.retrieve_multiple(ids=[1, 2, 3])
+
+            Get file_metadatas by external id:
+
+                >>> res = client.files.retrieve_multiple(external_ids=["abc", "def"])
+        """
+        identifiers = IdentifierSequence.load(ids=ids, external_ids=external_ids, instance_ids=instance_ids)
+        return self._retrieve_multiple(
+            list_cls=ExtendedFileMetadataList,
+            resource_cls=ExtendedFileMetadata,
+            identifiers=identifiers,
+            ignore_unknown_ids=ignore_unknown_ids,
+            api_subversion="alpha",
+        )

--- a/cognite_toolkit/_cdf_tk/client/api/extended_files.py
+++ b/cognite_toolkit/_cdf_tk/client/api/extended_files.py
@@ -9,7 +9,7 @@ from cognite.client.utils._concurrency import execute_tasks
 from cognite.client.utils._identifier import IdentifierSequence
 from cognite.client.utils.useful_types import SequenceNotStr
 
-from cognite_toolkit._cdf_tk.client.data_classes.extended_filemetdata import (
+from cognite_toolkit._cdf_tk.client.data_classes.extended_filemetadata import (
     ExtendedFileMetadata,
     ExtendedFileMetadataList,
 )
@@ -37,15 +37,15 @@ class ExtendedFileMetadataAPI(FilesAPI):
         id: int | None = None,
         external_id: str | None = None,
     ) -> ExtendedFileMetadata | ExtendedFileMetadataList:
-        """Set a pending identifier for one or more filemetadata..
+        """Set a pending identifier for one or more filemetadata.
 
         Args:
             instance_id: The pending instance ID to set.
-            id: The ID of the time series.
-            external_id: The external ID of the time series.
+            id: The ID of the files.
+            external_id: The external ID of the files.
 
         Returns:
-            ExtendedFileMetadata: If a single instance ID is provided, returns the updated ExtendedTimeSeries object.
+            ExtendedFileMetadata: If a single instance ID is provided, returns the updated ExtendedFileMetadata object.
         """
         if isinstance(instance_id, NodeId) or (
             isinstance(instance_id, tuple)
@@ -53,7 +53,9 @@ class ExtendedFileMetadataAPI(FilesAPI):
             and isinstance(instance_id[0], str)
             and isinstance(instance_id[1], str)
         ):
-            return self._set_pending_ids([PendingInstanceId(instance_id, id=id, external_id=external_id)])[0]  # type: ignore[return-value, arg-type]
+            return self._set_pending_ids([PendingInstanceId(NodeId.load(instance_id), id=id, external_id=external_id)])[
+                0
+            ]  # type: ignore[return-value, arg-type]
         elif isinstance(instance_id, Sequence) and all(isinstance(item, PendingInstanceId) for item in instance_id):
             return self._set_pending_ids(instance_id)  # type: ignore[arg-type]
         else:

--- a/cognite_toolkit/_cdf_tk/client/data_classes/extended_filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/extended_filemetadata.py
@@ -1,6 +1,6 @@
 import sys
 from collections.abc import Sequence
-from typing import Any, cast
+from typing import Any
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes import GeoLocation, Label
@@ -78,18 +78,13 @@ class ExtendedFileMetadata(FileMetadata):
             source_created_time=source_created_time,
             source_modified_time=source_modified_time,
             security_categories=security_categories,
+            id=id,
+            uploaded=uploaded,
+            uploaded_time=uploaded_time,
+            created_time=created_time,
+            last_updated_time=last_updated_time,
+            cognite_client=cognite_client,
         )
-        # id/created_time/last_updated_time are required when using the class to read,
-        # but don't make sense passing in when creating a new object. So in order to make the typing
-        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
-        # Optional[int].
-        # TODO: In the next major version we can make these properties required in the constructor
-        self.id: int = id  # type: ignore
-        self.created_time: int = created_time  # type: ignore
-        self.last_updated_time: int = last_updated_time  # type: ignore
-        self.uploaded = uploaded
-        self.uploaded_time = uploaded_time
-        self._cognite_client = cast("CogniteClient", cognite_client)
         self.pending_instance_id = pending_instance_id
 
     @classmethod

--- a/cognite_toolkit/_cdf_tk/client/data_classes/extended_filemetdata.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/extended_filemetdata.py
@@ -103,5 +103,5 @@ class ExtendedFileMetadata(FileMetadata):
         return output
 
 
-class ExtendedFileMetadataListList(FileMetadataList):
+class ExtendedFileMetadataList(FileMetadataList):
     _RESOURCE = ExtendedFileMetadata  # type: ignore[assignment]

--- a/cognite_toolkit/_cdf_tk/client/data_classes/extended_filemetdata.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/extended_filemetdata.py
@@ -1,10 +1,16 @@
+import sys
 from collections.abc import Sequence
-from typing import Any, Self, cast
+from typing import Any, cast
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes import GeoLocation, Label
 from cognite.client.data_classes.data_modeling import NodeId
 from cognite.client.data_classes.files import FileMetadata, FileMetadataList
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class ExtendedFileMetadata(FileMetadata):

--- a/cognite_toolkit/_cdf_tk/client/data_classes/extended_filemetdata.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/extended_filemetdata.py
@@ -1,0 +1,107 @@
+from collections.abc import Sequence
+from typing import Any, Self, cast
+
+from cognite.client import CogniteClient
+from cognite.client.data_classes import GeoLocation, Label
+from cognite.client.data_classes.data_modeling import NodeId
+from cognite.client.data_classes.files import FileMetadata, FileMetadataList
+
+
+class ExtendedFileMetadata(FileMetadata):
+    """Extended FileMetadata with pending instance ID support.
+    Args:
+        external_id (str | None): The external ID provided by the client. Must be unique for the resource type.
+        instance_id (NodeId | None): The Instance ID for the file. (Only applicable for files created in DMS)
+        name (str | None): Name of the file.
+        source (str | None): The source of the file.
+        mime_type (str | None): File type. E.g., text/plain, application/pdf, ...
+        metadata (dict[str, str] | None): Custom, application-specific metadata. String key -> String value. Limits: Maximum length of key is 32 bytes, value 512 bytes, up to 16 key-value pairs.
+        directory (str | None): Directory associated with the file. It must be an absolute, unix-style path.
+        asset_ids (Sequence[int] | None): No description.
+        data_set_id (int | None): The dataSet ID for the item.
+        labels (Sequence[Label] | None): A list of the labels associated with this resource item.
+        geo_location (GeoLocation | None): The geographic metadata of the file.
+        source_created_time (int | None): The timestamp for when the file was originally created in the source system.
+        source_modified_time (int | None): The timestamp for when the file was last modified in the source system.
+        security_categories (Sequence[int] | None): The security category IDs required to access this file.
+        id (int | None): A server-generated ID for the object.
+        uploaded (bool | None): Whether the actual file is uploaded. This field is returned only by the API, it has no effect in a post body.
+        uploaded_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        last_updated_time (int | None): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        pending_instance_id( NodeId | None): The pending instance ID for the file, used in upgrading files from asset centric to data modeling.
+        cognite_client (CogniteClient | None): The client to associate with this object.
+    """
+
+    def __init__(
+        self,
+        external_id: str | None = None,
+        instance_id: NodeId | None = None,
+        name: str | None = None,
+        source: str | None = None,
+        mime_type: str | None = None,
+        metadata: dict[str, str] | None = None,
+        directory: str | None = None,
+        asset_ids: Sequence[int] | None = None,
+        data_set_id: int | None = None,
+        labels: Sequence[Label] | None = None,
+        geo_location: GeoLocation | None = None,
+        source_created_time: int | None = None,
+        source_modified_time: int | None = None,
+        security_categories: Sequence[int] | None = None,
+        id: int | None = None,
+        uploaded: bool | None = None,
+        uploaded_time: int | None = None,
+        created_time: int | None = None,
+        last_updated_time: int | None = None,
+        pending_instance_id: NodeId | None = None,
+        cognite_client: CogniteClient | None = None,
+    ) -> None:
+        super().__init__(
+            external_id=external_id,
+            instance_id=instance_id,
+            name=name,
+            directory=directory,
+            source=source,
+            mime_type=mime_type,
+            metadata=metadata,
+            asset_ids=asset_ids,
+            data_set_id=data_set_id,
+            labels=labels,
+            geo_location=geo_location,
+            source_created_time=source_created_time,
+            source_modified_time=source_modified_time,
+            security_categories=security_categories,
+        )
+        # id/created_time/last_updated_time are required when using the class to read,
+        # but don't make sense passing in when creating a new object. So in order to make the typing
+        # correct here (i.e. int and not Optional[int]), we force the type to be int rather than
+        # Optional[int].
+        # TODO: In the next major version we can make these properties required in the constructor
+        self.id: int = id  # type: ignore
+        self.created_time: int = created_time  # type: ignore
+        self.last_updated_time: int = last_updated_time  # type: ignore
+        self.uploaded = uploaded
+        self.uploaded_time = uploaded_time
+        self._cognite_client = cast("CogniteClient", cognite_client)
+        self.pending_instance_id = pending_instance_id
+
+    @classmethod
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
+        instance = super()._load(resource, cognite_client)
+        if isinstance(instance.pending_instance_id, dict):
+            instance.pending_instance_id = NodeId.load(instance.pending_instance_id)
+        return instance
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        """Dump the object to a dictionary"""
+        output = super().dump(camel_case=camel_case)
+        if self.pending_instance_id is not None:
+            output["pendingInstanceId" if camel_case else "pending_instance_id"] = self.pending_instance_id.dump(
+                camel_case=camel_case, include_instance_type=False
+            )
+        return output
+
+
+class ExtendedFileMetadataListList(FileMetadataList):
+    _RESOURCE = ExtendedFileMetadata  # type: ignore[assignment]

--- a/tests/test_integration/test_toolkit_client/conftest.py
+++ b/tests/test_integration/test_toolkit_client/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+from cognite.client.data_classes.data_modeling import SpaceApply
+
+from cognite_toolkit._cdf_tk.client import ToolkitClient
+
+
+@pytest.fixture(scope="session")
+def dev_space(dev_cluster_client: ToolkitClient) -> str:
+    """Fixture to create a space for the tests."""
+    space_name = "toolkit_test_space"
+    dev_cluster_client.data_modeling.spaces.apply(SpaceApply(space=space_name))
+    return space_name

--- a/tests/test_integration/test_toolkit_client/test_extended_files.py
+++ b/tests/test_integration/test_toolkit_client/test_extended_files.py
@@ -1,0 +1,49 @@
+from cognite.client.data_classes import FileMetadata, FileMetadataWrite
+from cognite.client.data_classes.data_modeling import NodeApplyResultList
+from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteFileApply
+
+from cognite_toolkit._cdf_tk.client import ToolkitClient
+
+
+class TestExtendedFilesAPI:
+    def test_set_pending_instance_id(self, dev_cluster_client: ToolkitClient, dev_space: str) -> None:
+        """Happy path for setting a pending instance ID on a file
+
+        1. Create file with content.
+        3. Set pending instance ID.
+        4. Create a CogniteFile
+        5. Retrieve file content using the Node ID.
+        """
+        client = dev_cluster_client
+        metadata = FileMetadataWrite(
+            external_id="ts_toolkit_integration_test_happy_path_files",
+            name="Toolkit Integration Test Happy Path Files",
+            mime_type="text/plain",
+        )
+        cognite_file = CogniteFileApply(
+            space=dev_space,
+            external_id=metadata.external_id,
+            name="Toolkit Integration Test Happy Path",
+            mime_type="text/plain",
+        )
+        content = b"Hello, this is a test file's content."
+        created: FileMetadata | None = None
+        created_dm: NodeApplyResultList | None = None
+        try:
+            created, _ = client.files.create(metadata)
+            client.files.upload_content_bytes(content, external_id=created.external_id)
+
+            updated = client.files.set_pending_ids(cognite_file.as_id(), id=created.id)
+            assert updated.pending_instance_id == cognite_file.as_id()
+
+            created_dm = client.data_modeling.instances.apply(cognite_file).nodes
+
+            downloaded_bytes = client.files.download_bytes(instance_id=cognite_file.as_id())
+
+            assert downloaded_bytes == content
+        finally:
+            if created is not None and created_dm is None:
+                client.files.delete(external_id=metadata.external_id)
+            if created_dm is not None:
+                # This will delete the CogniteFile and the asset-centric file
+                client.data_modeling.instances.delete(cognite_file.as_id())

--- a/tests/test_integration/test_toolkit_client/test_extended_timeseries.py
+++ b/tests/test_integration/test_toolkit_client/test_extended_timeseries.py
@@ -1,24 +1,15 @@
 from datetime import datetime
 
-import pytest
 from cognite.client.data_classes import TimeSeries, TimeSeriesWrite
-from cognite.client.data_classes.data_modeling import NodeApplyResultList, SpaceApply
+from cognite.client.data_classes.data_modeling import NodeApplyResultList
 from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteTimeSeriesApply
 from cognite.client.utils._time import datetime_to_ms
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 
 
-@pytest.fixture(scope="session")
-def space(dev_cluster_client: ToolkitClient) -> str:
-    """Fixture to create a space for the tests."""
-    space_name = "toolkit_test_space"
-    dev_cluster_client.data_modeling.spaces.apply(SpaceApply(space=space_name))
-    return space_name
-
-
 class TestExtendedTimeSeriesAPI:
-    def test_set_pending_instance_id(self, dev_cluster_client: ToolkitClient, space: str) -> None:
+    def test_set_pending_instance_id(self, dev_cluster_client: ToolkitClient, dev_space: str) -> None:
         """Happy path for setting a pending instance ID on a time series.
 
         1. Create asset-centric time series.
@@ -37,7 +28,7 @@ class TestExtendedTimeSeriesAPI:
             is_string=False,
         )
         cognite_ts = CogniteTimeSeriesApply(
-            space=space,
+            space=dev_space,
             external_id=ts.external_id,
             is_step=False,
             time_series_type="numeric",

--- a/tests/test_unit/test_cdf_tk/test_client/test_extended_filemetadata.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_extended_filemetadata.py
@@ -1,0 +1,57 @@
+from collections.abc import Sequence
+
+import pytest
+import responses
+from cognite.client.data_classes.data_modeling import NodeId
+
+from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
+from cognite_toolkit._cdf_tk.client.data_classes.extended_filemetadata import (
+    ExtendedFileMetadataList,
+)
+from cognite_toolkit._cdf_tk.client.data_classes.pending_instances_ids import PendingInstanceId
+
+
+class TestExtendedFileMetadataAPI:
+    @pytest.mark.parametrize(
+        "instance_id, id, external_id, expected_list",
+        [
+            pytest.param(("my_space", "myExternalId"), None, "my_file", False, id="External ID with tuple"),
+            pytest.param(("my_space", "myExternalId"), 123, None, False, id="ID with tuple"),
+            pytest.param(NodeId("my_space", "myExternalId"), None, "my_file", False, id="External ID with NodeId"),
+            pytest.param(NodeId("my_space", "myExternalId"), 123, None, False, id="ID with NodeId"),
+            pytest.param(
+                [PendingInstanceId(NodeId("my_space", "myExternalId"), 123)], None, None, True, id="List of pending IDs"
+            ),
+        ],
+    )
+    def test_set_pending_instance_ids_valid_inputs(
+        self,
+        instance_id: NodeId | tuple[str, str] | Sequence[PendingInstanceId],
+        id: int | None,
+        external_id: str | None,
+        expected_list: bool,
+        toolkit_config: ToolkitClientConfig,
+    ) -> None:
+        client = ToolkitClient(config=toolkit_config, enable_set_pending_ids=True)
+        url = f"{toolkit_config.base_url}/api/v1/projects/test-project/files/set-pending-instance-ids"
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                url,
+                status=200,
+                json={"items": [{"externalId": "does-not-matter", "id": 123, "createdTime": 0, "lastUpdatedTime": 0}]},
+            )
+            result = client.files.set_pending_ids(instance_id=instance_id, id=id, external_id=external_id)
+
+        is_list = isinstance(result, ExtendedFileMetadataList)
+        assert is_list == expected_list, f"Expected result to be a list: {expected_list}, got {is_list}"
+
+    def test_set_instance_ids_invalid(self, toolkit_config: ToolkitClientConfig) -> None:
+        client = ToolkitClient(config=toolkit_config, enable_set_pending_ids=True)
+        with pytest.raises(TypeError) as excinfo:
+            client.files.set_pending_ids(("my_space", "MyExternalId", 1), id=123)
+
+        assert (
+            str(excinfo.value)
+            == "instance_id must be a NodeId, a tuple of (str, str), or a sequence of PendingIdentifier objects."
+        )


### PR DESCRIPTION
# Description

**Context**: This is part of the `alpha` migration tooling in Toolkit, for overview [see here](https://cognitedata.atlassian.net/wiki/spaces/~170890702/pages/5455773697/Migration+Tooling+in+Toolkit). This is step 3 of that process, enabling linking of asset-centric files to cognite-files, such that the new CogniteFile can point to an existing asset-centric file and thus not needing to download and reupload the file content.

In this PR, I introduce `.set_pending_ids` for files which is set on asset-centric files in preparation for the creation of a CogniteFile. **Reviewer**: This follows the same pattern that we are doing for timeseries.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip

