### PR TITLE
External libraries hardening

### DIFF
--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -62,6 +62,7 @@ class ModulesConfig:
             version != _version.__version__
             and (len(sys.argv) > 2 and sys.argv[1:3] != ["modules", "upgrade"])
             and "--help" not in sys.argv
+            and version != "0.0.0"  # debugging state
         ):
             raise ToolkitVersionError(
                 f"The version of the modules ({version}) does not match the version of the installed CLI "

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -749,9 +749,13 @@ default_organization_dir = "{organization_dir.name}"''',
     def _download(self, url: str, file_path: Path) -> None:
         """
         Downloads a file from a URL to the specified output path.
-        If the file already exists, it skips the download.
+        If the file already exists, it deletes it before downloading.
         """
         try:
+            # normally the context manager exit should handle this, but if the process is killed the file will not be deleted
+            if file_path.exists():
+                file_path.unlink()
+
             response = requests.get(url, stream=True)
             response.raise_for_status()  # Raise an exception for HTTP errors
 


### PR DESCRIPTION
# Description

In some cases, the downloaded zip file was stale. The context manager should clean up on exit, but sometimes fails when process is aborted

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- Stale deployment packs zips removed

## templates

No changes.
