### PR TITLE
[CDF-25165] ⛓Fix 404 links

### DIFF
--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -129,9 +129,9 @@ def clean_name(name: str) -> str:
 
 class URL:
     configure_access = "https://docs.cognite.com/cdf/deploy/cdf_deploy/cdf_deploy_access_management"
-    auth_toolkit = "https://docs.cognite.com/cdf/deploy/cdf_toolkit/guides/configure_deploy_modules#configure-the-cdf-toolkit-authentication"
+    auth_toolkit = "https://docs.cognite.com/cdf/deploy/cdf_toolkit/guides/auth"
     docs = "https://docs.cognite.com/"
-    configs = "https://docs.cognite.com/cdf/deploy/cdf_toolkit/references/configs"
+    configs = "https://docs.cognite.com/cdf/deploy/cdf_toolkit/references/resource_library"
     plugins = "https://docs.cognite.com/cdf/deploy/cdf_toolkit/guides/plugins/"
     libyaml = "https://pyyaml.org/wiki/PyYAMLDocumentation"
     build_variables = "https://docs.cognite.com/cdf/deploy/cdf_toolkit/api/config_yaml#the-variables-section"

--- a/tests/test_unit/test_cdf_tk/tests_constants.py
+++ b/tests/test_unit/test_cdf_tk/tests_constants.py
@@ -6,7 +6,7 @@ from cognite_toolkit._cdf_tk.constants import URL
 
 @pytest.mark.parametrize(
     "url, name",
-    [pytest.param(url, id=name) for name, url in vars(URL).items() if not name.startswith("_")],
+    [pytest.param(url, name, id=name) for name, url in vars(URL).items() if not name.startswith("_")],
 )
 def test_url_returns_200(url: str, name: str) -> None:
     assert requests.get(url).status_code == 200, f"Failed to get a 200 response from the URL.{name}."


### PR DESCRIPTION
# Description

We have a tests that picks up broken links, but that test was broken so it did not run or report back. Fixed it.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- Warnings that contains the URL to to auth and config docs no longer gives 404.

## templates

No changes.
