### PR TITLE
[CDF-25166] 🗒 Allow module documentation

### DIFF
--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -28,6 +28,8 @@ CONFIG_FILE_SUFFIX = "config.yaml"
 # The global config file
 GLOBAL_CONFIG_FILE = "global.yaml"
 
+# 01 to ensure that the documentation folder is always first in the list.
+MODULE_DOCS_FOLDER = "01_documentation"
 BUILTIN_MODULES = "_builtin_modules"
 COGNITE_MODULES = "cognite_modules"
 CUSTOM_MODULES = "custom_modules"

--- a/cognite_toolkit/_cdf_tk/hints.py
+++ b/cognite_toolkit/_cdf_tk/hints.py
@@ -10,7 +10,7 @@ from rich.panel import Panel
 
 from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 
-from .constants import COGNITE_MODULES, CUSTOM_MODULES, HINT_LEAD_TEXT, MODULES, ROOT_MODULES, URL
+from .constants import COGNITE_MODULES, CUSTOM_MODULES, HINT_LEAD_TEXT, MODULE_DOCS_FOLDER, MODULES, ROOT_MODULES, URL
 from .exceptions import ToolkitFileNotFoundError, ToolkitNotADirectoryError
 from .loaders import LOADER_BY_FOLDER_NAME
 from .tk_warnings import MediumSeverityWarning
@@ -47,7 +47,11 @@ class Hint:
 class ModuleDefinition(Hint):
     @classmethod
     def _short(cls) -> str:
-        return f"Available resource directories are {sorted(LOADER_BY_FOLDER_NAME)}. {cls.link(URL.configs)} to learn more."
+        return (
+            f"Available resource directories are {sorted(LOADER_BY_FOLDER_NAME)}. {cls.link(URL.configs)} to learn more. "
+            f"If you have documentation you can put it in {MODULE_DOCS_FOLDER!r} directory in your module to "
+            "avoid this warning."
+        )
 
     @classmethod
     def long(cls, missing_modules: set[str | Path] | None = None, organization_dir: Path | None = None) -> str:  # type: ignore[override]


### PR DESCRIPTION
# Description

Currently, the user gets this warning if they have any folder inside a module that is not a [resource directory](https://docs.cognite.com/cdf/deploy/cdf_toolkit/references/resource_library):
![image](https://github.com/user-attachments/assets/451fe305-7fbf-4668-9caa-102c07aca293)

This PR allows the name `01_documentation and gives this warning instead:
![image](https://github.com/user-attachments/assets/fbf905fe-a5e7-4a89-87c9-a6afeb46ef17)



## Changelog

- [ ] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Improved

- When running `cdf build`, Toolkit will no longer give you a waning if you have a folder `01_documentation` in your module.

## templates

No changes.
