### PR TITLE
[prep CDF-25149] 🔨 Introduce scope logic

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/data_classes/capabilities.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/capabilities.py
@@ -68,14 +68,14 @@ def scope_intersection(scope1: T_Scope, scope2: T_Scope | None) -> Capability.Sc
         return None
     elif isinstance(scope1, TableScope) and isinstance(scope2, TableScope):
         intersection_tables = set(scope1.dbs_to_tables.keys()) & set(scope2.dbs_to_tables.keys())
-        if not intersection_tables:
-            return None
-        return TableScope(
-            dbs_to_tables={
-                db: sorted(set(scope1.dbs_to_tables[db]) & set(scope2.dbs_to_tables[db]))
-                for db in sorted(intersection_tables)
-            }
-        )
+        if intersection_tables:
+            return TableScope(
+                dbs_to_tables={
+                    db: sorted(set(scope1.dbs_to_tables[db]) & set(scope2.dbs_to_tables[db]))
+                    for db in sorted(intersection_tables)
+                }
+            )
+        return None
     elif isinstance(scope1, InstancesScope) and isinstance(scope2, InstancesScope):
         if intersection_instances := sorted(set(scope1.instances) & set(scope2.instances)):
             return InstancesScope(instances=intersection_instances)

--- a/cognite_toolkit/_cdf_tk/client/data_classes/capabilities.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/capabilities.py
@@ -1,0 +1,39 @@
+from typing import TypeVar
+
+from cognite.client.data_classes.capabilities import Capability
+
+T_Scope = TypeVar("T_Scope", bound=Capability.Scope)
+
+
+def scope_intersection(scope1: T_Scope | None, scope2: T_Scope | None) -> T_Scope | None:
+    """
+    Returns the intersection of two scopes.
+    If both scopes are None, returns None.
+    If one scope is None, returns the other scope.
+    If both scopes are the same, returns that scope.
+    If scopes are different, raises an error.
+    """
+    if scope1 is None:
+        return scope2
+    if scope2 is None:
+        return scope1
+    if scope1 == scope2:
+        return scope1
+    raise NotImplementedError()
+
+
+def scope_union(scope1: T_Scope | None, scope2: T_Scope | None) -> T_Scope | None:
+    """
+    Returns the union of two scopes.
+    If both scopes are None, returns None.
+    If one scope is None, returns the other scope.
+    If both scopes are the same, returns that scope.
+    If scopes are different, raises an error.
+    """
+    if scope1 is None:
+        return scope2
+    if scope2 is None:
+        return scope1
+    if scope1 == scope2:
+        return scope1
+    raise NotImplementedError()

--- a/cognite_toolkit/_cdf_tk/client/data_classes/capabilities.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/capabilities.py
@@ -1,13 +1,13 @@
-from typing import TypeVar, cast
+from typing import TypeVar
 
-from cognite.client.data_classes.capabilities import Capability
-from cognite_toolkit._cdf_tk.resource_classes.capabilities import (
+from cognite.client.data_classes.capabilities import (
     AllScope,
     AppConfigScope,
     AssetRootIDScope,
+    Capability,
     CurrentUserScope,
     DataSetScope,
-    ExperimentScope,
+    ExperimentsScope,
     ExtractionPipelineScope,
     IDScope,
     IDScopeLowerCase,
@@ -23,261 +23,148 @@ from cognite_toolkit._cdf_tk.resource_classes.capabilities import (
 T_Scope = TypeVar("T_Scope", bound=Capability.Scope)
 
 
-def scope_intersection(scope1: T_Scope | None, scope2: T_Scope | None) -> T_Scope | None:
-    """
-    Returns the intersection of two scopes.
+def scope_intersection(scope1: T_Scope, scope2: T_Scope | None) -> Capability.Scope | None:
+    """Returns the intersection of two scopes.
     If both scopes are None, returns None.
     If one scope is None, returns None (intersection with nothing is nothing).
     If both scopes are the same, returns that scope.
-    If scopes are different types, handles the intersection based on scope hierarchy.
+    If scopes are different types, raise an ValueError.
     """
-    if scope1 is None or scope2 is None:
+    if scope2 is None:
         return None
-    if scope1 == scope2:
-        return scope1
-    
-    # If one is AllScope, intersection is the other scope
-    if isinstance(scope1, AllScope):
-        return scope2
-    if isinstance(scope2, AllScope):
-        return scope1
-    
-    # If both are the same type, handle intersection based on scope attributes
-    if type(scope1) == type(scope2):
-        # Handle scopes with ids attribute
-        if isinstance(scope1, DataSetScope):
-            ids1 = set(scope1.ids)
-            ids2 = set(scope2.ids)
-            intersected_ids = sorted(list(ids1 & ids2))
-            return cast(T_Scope, DataSetScope(ids=intersected_ids))
-        
-        if isinstance(scope1, IDScope):
-            ids1 = set(scope1.ids)
-            ids2 = set(scope2.ids)
-            intersected_ids = list(ids1 & ids2)
-            if intersected_ids:
-                return cast(T_Scope, IDScope(ids=intersected_ids))
-            else:
-                return None
-        
-        if isinstance(scope1, IDScopeLowerCase):
-            ids1 = set(scope1.ids)
-            ids2 = set(scope2.ids)
-            intersected_ids = list(ids1 & ids2)
-            if intersected_ids:
-                return cast(T_Scope, IDScopeLowerCase(ids=intersected_ids))
-            else:
-                return None
-        
-        if isinstance(scope1, ExtractionPipelineScope):
-            ids1 = set(scope1.ids)
-            ids2 = set(scope2.ids)
-            intersected_ids = list(ids1 & ids2)
-            if intersected_ids:
-                return cast(T_Scope, ExtractionPipelineScope(ids=intersected_ids))
-            else:
-                return None
-        
-        if isinstance(scope1, SpaceIDScope):
-            ids1 = set(scope1.space_ids)
-            ids2 = set(scope2.space_ids)
-            intersected_ids = list(ids1 & ids2)
-            if intersected_ids:
-                return cast(T_Scope, SpaceIDScope(spaceIds=intersected_ids))
-            else:
-                return None
-        
-        if isinstance(scope1, AssetRootIDScope):
-            ids1 = set(scope1.root_ids)
-            ids2 = set(scope2.root_ids)
-            intersected_ids = list(ids1 & ids2)
-            if intersected_ids:
-                return cast(T_Scope, AssetRootIDScope(rootIds=intersected_ids))
-            else:
-                return None
-        
-        if isinstance(scope1, InstancesScope):
-            ids1 = set(scope1.instances)
-            ids2 = set(scope2.instances)
-            intersected_ids = list(ids1 & ids2)
-            if intersected_ids:
-                return cast(T_Scope, InstancesScope(instances=intersected_ids))
-            else:
-                return None
-        
-        if isinstance(scope1, LegacyDataModelScope):
-            ids1 = set(scope1.external_ids)
-            ids2 = set(scope2.external_ids)
-            intersected_ids = list(ids1 & ids2)
-            if intersected_ids:
-                return cast(T_Scope, LegacyDataModelScope(externalIds=intersected_ids))
-            else:
-                return None
-        
-        if isinstance(scope1, LegacySpaceScope):
-            ids1 = set(scope1.external_ids)
-            ids2 = set(scope2.external_ids)
-            intersected_ids = list(ids1 & ids2)
-            if intersected_ids:
-                return cast(T_Scope, LegacySpaceScope(externalIds=intersected_ids))
-            else:
-                return None
-        
-        if isinstance(scope1, PartitionScope):
-            ids1 = set(scope1.partition_ids)
-            ids2 = set(scope2.partition_ids)
-            intersected_ids = list(ids1 & ids2)
-            if intersected_ids:
-                return cast(T_Scope, PartitionScope(partitionIds=intersected_ids))
-            else:
-                return None
-        
-        if isinstance(scope1, PostgresGatewayUsersScope):
-            ids1 = set(scope1.usernames)
-            ids2 = set(scope2.usernames)
-            intersected_ids = list(ids1 & ids2)
-            if intersected_ids:
-                return cast(T_Scope, PostgresGatewayUsersScope(usernames=intersected_ids))
-            else:
-                return None
-        
-        if isinstance(scope1, ExperimentScope):
-            ids1 = set(scope1.experiments)
-            ids2 = set(scope2.experiments)
-            intersected_ids = list(ids1 & ids2)
-            if intersected_ids:
-                return cast(T_Scope, ExperimentScope(experiments=intersected_ids))
-            else:
-                return None
-        
-        if isinstance(scope1, AppConfigScope):
-            ids1 = set(scope1.apps)
-            ids2 = set(scope2.apps)
-            intersected_ids = list(ids1 & ids2)
-            if intersected_ids:
-                return cast(T_Scope, AppConfigScope(apps=intersected_ids))
-            else:
-                return None
-        
-        # Handle scopes without collection attributes
-        if isinstance(scope1, (AllScope, CurrentUserScope)):
-            return scope1
-        
-        # Handle TableScope - complex case, return None for now
-        if isinstance(scope1, TableScope):
+    if type(scope1) is not type(scope2):
+        raise ValueError("Cannot intersect scopes of different types")
+    if isinstance(scope1, AllScope) and isinstance(scope2, AllScope):
+        return AllScope()
+    elif isinstance(scope1, AppConfigScope) and isinstance(scope2, AppConfigScope):
+        if apps := sorted(set(scope1.apps) & set(scope2.apps)):
+            return AppConfigScope(apps=apps)
+        return None
+    elif isinstance(scope1, DataSetScope) and isinstance(scope2, DataSetScope):
+        if ids := sorted(set(scope1.ids) & set(scope2.ids)):
+            return DataSetScope(ids=ids)
+        return None
+    elif isinstance(scope1, IDScope) and isinstance(scope2, IDScope):
+        if ids := sorted(set(scope1.ids) & set(scope2.ids)):
+            return IDScope(ids=ids)
+        return None
+    elif isinstance(scope1, IDScopeLowerCase) and isinstance(scope2, IDScopeLowerCase):
+        if ids := sorted(set(scope1.ids) & set(scope2.ids)):
+            return IDScopeLowerCase(ids=ids)
+        return None
+    elif isinstance(scope1, SpaceIDScope) and isinstance(scope2, SpaceIDScope):
+        if intersection_space_ids := sorted(set(scope1.space_ids) & set(scope2.space_ids)):
+            return SpaceIDScope(space_ids=intersection_space_ids)
+        return None
+    elif isinstance(scope1, AssetRootIDScope) and isinstance(scope2, AssetRootIDScope):
+        if intersection_root_ids := sorted(set(scope1.root_ids) & set(scope2.root_ids)):
+            return AssetRootIDScope(root_ids=intersection_root_ids)
+        return None
+    elif isinstance(scope1, CurrentUserScope) and isinstance(scope2, CurrentUserScope):
+        return CurrentUserScope()
+    elif isinstance(scope1, ExtractionPipelineScope) and isinstance(scope2, ExtractionPipelineScope):
+        if intersection_ids := sorted(set(scope1.ids) & set(scope2.ids)):
+            return ExtractionPipelineScope(ids=intersection_ids)
+        return None
+    elif isinstance(scope1, TableScope) and isinstance(scope2, TableScope):
+        intersection_tables = set(scope1.dbs_to_tables.keys()) & set(scope2.dbs_to_tables.keys())
+        if not intersection_tables:
             return None
-    
-    # For different incompatible scope types, intersection is None
-    return None
+        return TableScope(
+            dbs_to_tables={
+                db: sorted(set(scope1.dbs_to_tables[db]) & set(scope2.dbs_to_tables[db]))
+                for db in sorted(intersection_tables)
+            }
+        )
+    elif isinstance(scope1, InstancesScope) and isinstance(scope2, InstancesScope):
+        if intersection_instances := sorted(set(scope1.instances) & set(scope2.instances)):
+            return InstancesScope(instances=intersection_instances)
+        return None
+    elif isinstance(scope1, PartitionScope) and isinstance(scope2, PartitionScope):
+        if intersection_partition_ids := sorted(set(scope1.partition_ids) & set(scope2.partition_ids)):
+            return PartitionScope(partition_ids=intersection_partition_ids)
+        return None
+    elif isinstance(scope1, LegacySpaceScope) and isinstance(scope2, LegacySpaceScope):
+        if intersection_external_ids := sorted(set(scope1.external_ids) & set(scope2.external_ids)):
+            return LegacySpaceScope(external_ids=intersection_external_ids)
+        return None
+    elif isinstance(scope1, LegacyDataModelScope) and isinstance(scope2, LegacyDataModelScope):
+        if intersection_external_ids := sorted(set(scope1.external_ids) & set(scope2.external_ids)):
+            return LegacyDataModelScope(external_ids=intersection_external_ids)
+        return None
+    elif isinstance(scope1, ExperimentsScope) and isinstance(scope2, ExperimentsScope):
+        if intersection_experiments := sorted(set(scope1.experiments) & set(scope2.experiments)):
+            return ExperimentsScope(experiments=intersection_experiments)
+        return None
+    elif isinstance(scope1, PostgresGatewayUsersScope) and isinstance(scope2, PostgresGatewayUsersScope):
+        if intersection_usernames := sorted(set(scope1.usernames) & set(scope2.usernames)):
+            return PostgresGatewayUsersScope(usernames=intersection_usernames)
+        return None
+    else:
+        raise TypeError(f"Unknown scope type {type(scope1)!r}")
 
 
-def scope_union(scope1: T_Scope | None, scope2: T_Scope | None) -> T_Scope | None:
+def scope_union(scope1: T_Scope, scope2: T_Scope | None) -> Capability.Scope:
     """
     Returns the union of two scopes.
     If both scopes are None, returns None.
     If one scope is None, returns the other scope.
-    If both scopes are the same, returns that scope.
-    If scopes are different types, handles the union based on scope hierarchy.
+    If both scopes are the same, returns the union of the two scopes.
+    If scopes are different types, raise an ValueError.
     """
-    if scope1 is None:
-        return scope2
     if scope2 is None:
         return scope1
-    if scope1 == scope2:
-        return scope1
-    
-    # If either is AllScope, union is AllScope
+    if type(scope1) is not type(scope2):
+        raise ValueError("Cannot union scopes of different types")
     if isinstance(scope1, AllScope) or isinstance(scope2, AllScope):
-        return cast(T_Scope, AllScope())
-    
-    # If both are the same type, handle union based on scope attributes
-    if type(scope1) == type(scope2):
-        # Handle scopes with ids attribute
-        if isinstance(scope1, DataSetScope):
-            ids1 = set(scope1.ids)
-            ids2 = set(scope2.ids)
-            union_ids = list(ids1 | ids2)
-            return cast(T_Scope, DataSetScope(ids=union_ids))
-        
-        if isinstance(scope1, IDScope):
-            ids1 = set(scope1.ids)
-            ids2 = set(scope2.ids)
-            union_ids = list(ids1 | ids2)
-            return cast(T_Scope, IDScope(ids=union_ids))
-        
-        if isinstance(scope1, IDScopeLowerCase):
-            ids1 = set(scope1.ids)
-            ids2 = set(scope2.ids)
-            union_ids = list(ids1 | ids2)
-            return cast(T_Scope, IDScopeLowerCase(ids=union_ids))
-        
-        if isinstance(scope1, ExtractionPipelineScope):
-            ids1 = set(scope1.ids)
-            ids2 = set(scope2.ids)
-            union_ids = list(ids1 | ids2)
-            return cast(T_Scope, ExtractionPipelineScope(ids=union_ids))
-        
-        if isinstance(scope1, SpaceIDScope):
-            ids1 = set(scope1.space_ids)
-            ids2 = set(scope2.space_ids)
-            union_ids = list(ids1 | ids2)
-            return cast(T_Scope, SpaceIDScope(spaceIds=union_ids))
-        
-        if isinstance(scope1, AssetRootIDScope):
-            ids1 = set(scope1.root_ids)
-            ids2 = set(scope2.root_ids)
-            union_ids = list(ids1 | ids2)
-            return cast(T_Scope, AssetRootIDScope(rootIds=union_ids))
-        
-        if isinstance(scope1, InstancesScope):
-            ids1 = set(scope1.instances)
-            ids2 = set(scope2.instances)
-            union_ids = list(ids1 | ids2)
-            return cast(T_Scope, InstancesScope(instances=union_ids))
-        
-        if isinstance(scope1, LegacyDataModelScope):
-            ids1 = set(scope1.external_ids)
-            ids2 = set(scope2.external_ids)
-            union_ids = list(ids1 | ids2)
-            return cast(T_Scope, LegacyDataModelScope(externalIds=union_ids))
-        
-        if isinstance(scope1, LegacySpaceScope):
-            ids1 = set(scope1.external_ids)
-            ids2 = set(scope2.external_ids)
-            union_ids = list(ids1 | ids2)
-            return cast(T_Scope, LegacySpaceScope(externalIds=union_ids))
-        
-        if isinstance(scope1, PartitionScope):
-            ids1 = set(scope1.partition_ids)
-            ids2 = set(scope2.partition_ids)
-            union_ids = list(ids1 | ids2)
-            return cast(T_Scope, PartitionScope(partitionIds=union_ids))
-        
-        if isinstance(scope1, PostgresGatewayUsersScope):
-            ids1 = set(scope1.usernames)
-            ids2 = set(scope2.usernames)
-            union_ids = list(ids1 | ids2)
-            return cast(T_Scope, PostgresGatewayUsersScope(usernames=union_ids))
-        
-        if isinstance(scope1, ExperimentScope):
-            ids1 = set(scope1.experiments)
-            ids2 = set(scope2.experiments)
-            union_ids = list(ids1 | ids2)
-            return cast(T_Scope, ExperimentScope(experiments=union_ids))
-        
-        if isinstance(scope1, AppConfigScope):
-            ids1 = set(scope1.apps)
-            ids2 = set(scope2.apps)
-            union_ids = list(ids1 | ids2)
-            return cast(T_Scope, AppConfigScope(apps=union_ids))
-        
-        # Handle scopes without collection attributes
-        if isinstance(scope1, (AllScope, CurrentUserScope)):
-            return scope1
-        
-        # Handle TableScope - complex case, return None for now
-        if isinstance(scope1, TableScope):
-            return None
-    
-    # For different incompatible scope types, return None
-    return None
+        return AllScope()
+    elif isinstance(scope1, AppConfigScope) and isinstance(scope2, AppConfigScope):
+        return AppConfigScope(apps=sorted(set(scope1.apps) | set(scope2.apps)))
+    elif isinstance(scope1, DataSetScope) and isinstance(scope2, DataSetScope):
+        return DataSetScope(ids=sorted(set(scope1.ids) | set(scope2.ids)))
+    elif isinstance(scope1, IDScope) and isinstance(scope2, IDScope):
+        return IDScope(ids=sorted(set(scope1.ids) | set(scope2.ids)))
+    elif isinstance(scope1, IDScopeLowerCase) and isinstance(scope2, IDScopeLowerCase):
+        return IDScopeLowerCase(ids=sorted(set(scope1.ids) | set(scope2.ids)))
+    elif isinstance(scope1, SpaceIDScope) and isinstance(scope2, SpaceIDScope):
+        return SpaceIDScope(space_ids=sorted(set(scope1.space_ids) | set(scope2.space_ids)))
+    elif isinstance(scope1, AssetRootIDScope) and isinstance(scope2, AssetRootIDScope):
+        return AssetRootIDScope(root_ids=sorted(set(scope1.root_ids) | set(scope2.root_ids)))
+    elif isinstance(scope1, CurrentUserScope) and isinstance(scope2, CurrentUserScope):
+        return CurrentUserScope()
+    elif isinstance(scope1, ExtractionPipelineScope) and isinstance(scope2, ExtractionPipelineScope):
+        return ExtractionPipelineScope(ids=sorted(set(scope1.ids) | set(scope2.ids)))
+    elif isinstance(scope1, TableScope) and isinstance(scope2, TableScope):
+        union_tables = set(scope1.dbs_to_tables.keys()) | set(scope2.dbs_to_tables.keys())
+        return TableScope(
+            dbs_to_tables={
+                db: sorted(set(scope1.dbs_to_tables.get(db, [])) | set(scope2.dbs_to_tables.get(db, [])))
+                for db in sorted(union_tables)
+            }
+        )
+    elif isinstance(scope1, InstancesScope) and isinstance(scope2, InstancesScope):
+        return InstancesScope(
+            instances=sorted(set(scope1.instances) | set(scope2.instances)),
+        )
+    elif isinstance(scope1, PartitionScope) and isinstance(scope2, PartitionScope):
+        return PartitionScope(
+            partition_ids=sorted(set(scope1.partition_ids) | set(scope2.partition_ids)),
+        )
+    elif isinstance(scope1, LegacySpaceScope) and isinstance(scope2, LegacySpaceScope):
+        return LegacySpaceScope(
+            external_ids=sorted(set(scope1.external_ids) | set(scope2.external_ids)),
+        )
+    elif isinstance(scope1, LegacyDataModelScope) and isinstance(scope2, LegacyDataModelScope):
+        return LegacyDataModelScope(
+            external_ids=sorted(set(scope1.external_ids) | set(scope2.external_ids)),
+        )
+    elif isinstance(scope1, ExperimentsScope) and isinstance(scope2, ExperimentsScope):
+        return ExperimentsScope(
+            experiments=sorted(set(scope1.experiments) | set(scope2.experiments)),
+        )
+    elif isinstance(scope1, PostgresGatewayUsersScope) and isinstance(scope2, PostgresGatewayUsersScope):
+        return PostgresGatewayUsersScope(
+            usernames=sorted(set(scope1.usernames) | set(scope2.usernames)),
+        )
+    else:
+        raise TypeError(f"Unknown scope type {type(scope1)!r}")

--- a/cognite_toolkit/_cdf_tk/client/data_classes/capabilities.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/capabilities.py
@@ -1,6 +1,24 @@
-from typing import TypeVar
+from typing import TypeVar, cast
 
 from cognite.client.data_classes.capabilities import Capability
+from cognite_toolkit._cdf_tk.resource_classes.capabilities import (
+    AllScope,
+    AppConfigScope,
+    AssetRootIDScope,
+    CurrentUserScope,
+    DataSetScope,
+    ExperimentScope,
+    ExtractionPipelineScope,
+    IDScope,
+    IDScopeLowerCase,
+    InstancesScope,
+    LegacyDataModelScope,
+    LegacySpaceScope,
+    PartitionScope,
+    PostgresGatewayUsersScope,
+    SpaceIDScope,
+    TableScope,
+)
 
 T_Scope = TypeVar("T_Scope", bound=Capability.Scope)
 
@@ -9,17 +27,148 @@ def scope_intersection(scope1: T_Scope | None, scope2: T_Scope | None) -> T_Scop
     """
     Returns the intersection of two scopes.
     If both scopes are None, returns None.
-    If one scope is None, returns the other scope.
+    If one scope is None, returns None (intersection with nothing is nothing).
     If both scopes are the same, returns that scope.
-    If scopes are different, raises an error.
+    If scopes are different types, handles the intersection based on scope hierarchy.
     """
-    if scope1 is None:
-        return scope2
-    if scope2 is None:
-        return scope1
+    if scope1 is None or scope2 is None:
+        return None
     if scope1 == scope2:
         return scope1
-    raise NotImplementedError()
+    
+    # If one is AllScope, intersection is the other scope
+    if isinstance(scope1, AllScope):
+        return scope2
+    if isinstance(scope2, AllScope):
+        return scope1
+    
+    # If both are the same type, handle intersection based on scope attributes
+    if type(scope1) == type(scope2):
+        # Handle scopes with ids attribute
+        if isinstance(scope1, DataSetScope):
+            ids1 = set(scope1.ids)
+            ids2 = set(scope2.ids)
+            intersected_ids = sorted(list(ids1 & ids2))
+            return cast(T_Scope, DataSetScope(ids=intersected_ids))
+        
+        if isinstance(scope1, IDScope):
+            ids1 = set(scope1.ids)
+            ids2 = set(scope2.ids)
+            intersected_ids = list(ids1 & ids2)
+            if intersected_ids:
+                return cast(T_Scope, IDScope(ids=intersected_ids))
+            else:
+                return None
+        
+        if isinstance(scope1, IDScopeLowerCase):
+            ids1 = set(scope1.ids)
+            ids2 = set(scope2.ids)
+            intersected_ids = list(ids1 & ids2)
+            if intersected_ids:
+                return cast(T_Scope, IDScopeLowerCase(ids=intersected_ids))
+            else:
+                return None
+        
+        if isinstance(scope1, ExtractionPipelineScope):
+            ids1 = set(scope1.ids)
+            ids2 = set(scope2.ids)
+            intersected_ids = list(ids1 & ids2)
+            if intersected_ids:
+                return cast(T_Scope, ExtractionPipelineScope(ids=intersected_ids))
+            else:
+                return None
+        
+        if isinstance(scope1, SpaceIDScope):
+            ids1 = set(scope1.space_ids)
+            ids2 = set(scope2.space_ids)
+            intersected_ids = list(ids1 & ids2)
+            if intersected_ids:
+                return cast(T_Scope, SpaceIDScope(spaceIds=intersected_ids))
+            else:
+                return None
+        
+        if isinstance(scope1, AssetRootIDScope):
+            ids1 = set(scope1.root_ids)
+            ids2 = set(scope2.root_ids)
+            intersected_ids = list(ids1 & ids2)
+            if intersected_ids:
+                return cast(T_Scope, AssetRootIDScope(rootIds=intersected_ids))
+            else:
+                return None
+        
+        if isinstance(scope1, InstancesScope):
+            ids1 = set(scope1.instances)
+            ids2 = set(scope2.instances)
+            intersected_ids = list(ids1 & ids2)
+            if intersected_ids:
+                return cast(T_Scope, InstancesScope(instances=intersected_ids))
+            else:
+                return None
+        
+        if isinstance(scope1, LegacyDataModelScope):
+            ids1 = set(scope1.external_ids)
+            ids2 = set(scope2.external_ids)
+            intersected_ids = list(ids1 & ids2)
+            if intersected_ids:
+                return cast(T_Scope, LegacyDataModelScope(externalIds=intersected_ids))
+            else:
+                return None
+        
+        if isinstance(scope1, LegacySpaceScope):
+            ids1 = set(scope1.external_ids)
+            ids2 = set(scope2.external_ids)
+            intersected_ids = list(ids1 & ids2)
+            if intersected_ids:
+                return cast(T_Scope, LegacySpaceScope(externalIds=intersected_ids))
+            else:
+                return None
+        
+        if isinstance(scope1, PartitionScope):
+            ids1 = set(scope1.partition_ids)
+            ids2 = set(scope2.partition_ids)
+            intersected_ids = list(ids1 & ids2)
+            if intersected_ids:
+                return cast(T_Scope, PartitionScope(partitionIds=intersected_ids))
+            else:
+                return None
+        
+        if isinstance(scope1, PostgresGatewayUsersScope):
+            ids1 = set(scope1.usernames)
+            ids2 = set(scope2.usernames)
+            intersected_ids = list(ids1 & ids2)
+            if intersected_ids:
+                return cast(T_Scope, PostgresGatewayUsersScope(usernames=intersected_ids))
+            else:
+                return None
+        
+        if isinstance(scope1, ExperimentScope):
+            ids1 = set(scope1.experiments)
+            ids2 = set(scope2.experiments)
+            intersected_ids = list(ids1 & ids2)
+            if intersected_ids:
+                return cast(T_Scope, ExperimentScope(experiments=intersected_ids))
+            else:
+                return None
+        
+        if isinstance(scope1, AppConfigScope):
+            ids1 = set(scope1.apps)
+            ids2 = set(scope2.apps)
+            intersected_ids = list(ids1 & ids2)
+            if intersected_ids:
+                return cast(T_Scope, AppConfigScope(apps=intersected_ids))
+            else:
+                return None
+        
+        # Handle scopes without collection attributes
+        if isinstance(scope1, (AllScope, CurrentUserScope)):
+            return scope1
+        
+        # Handle TableScope - complex case, return None for now
+        if isinstance(scope1, TableScope):
+            return None
+    
+    # For different incompatible scope types, intersection is None
+    return None
 
 
 def scope_union(scope1: T_Scope | None, scope2: T_Scope | None) -> T_Scope | None:
@@ -28,7 +177,7 @@ def scope_union(scope1: T_Scope | None, scope2: T_Scope | None) -> T_Scope | Non
     If both scopes are None, returns None.
     If one scope is None, returns the other scope.
     If both scopes are the same, returns that scope.
-    If scopes are different, raises an error.
+    If scopes are different types, handles the union based on scope hierarchy.
     """
     if scope1 is None:
         return scope2
@@ -36,4 +185,99 @@ def scope_union(scope1: T_Scope | None, scope2: T_Scope | None) -> T_Scope | Non
         return scope1
     if scope1 == scope2:
         return scope1
-    raise NotImplementedError()
+    
+    # If either is AllScope, union is AllScope
+    if isinstance(scope1, AllScope) or isinstance(scope2, AllScope):
+        return cast(T_Scope, AllScope())
+    
+    # If both are the same type, handle union based on scope attributes
+    if type(scope1) == type(scope2):
+        # Handle scopes with ids attribute
+        if isinstance(scope1, DataSetScope):
+            ids1 = set(scope1.ids)
+            ids2 = set(scope2.ids)
+            union_ids = list(ids1 | ids2)
+            return cast(T_Scope, DataSetScope(ids=union_ids))
+        
+        if isinstance(scope1, IDScope):
+            ids1 = set(scope1.ids)
+            ids2 = set(scope2.ids)
+            union_ids = list(ids1 | ids2)
+            return cast(T_Scope, IDScope(ids=union_ids))
+        
+        if isinstance(scope1, IDScopeLowerCase):
+            ids1 = set(scope1.ids)
+            ids2 = set(scope2.ids)
+            union_ids = list(ids1 | ids2)
+            return cast(T_Scope, IDScopeLowerCase(ids=union_ids))
+        
+        if isinstance(scope1, ExtractionPipelineScope):
+            ids1 = set(scope1.ids)
+            ids2 = set(scope2.ids)
+            union_ids = list(ids1 | ids2)
+            return cast(T_Scope, ExtractionPipelineScope(ids=union_ids))
+        
+        if isinstance(scope1, SpaceIDScope):
+            ids1 = set(scope1.space_ids)
+            ids2 = set(scope2.space_ids)
+            union_ids = list(ids1 | ids2)
+            return cast(T_Scope, SpaceIDScope(spaceIds=union_ids))
+        
+        if isinstance(scope1, AssetRootIDScope):
+            ids1 = set(scope1.root_ids)
+            ids2 = set(scope2.root_ids)
+            union_ids = list(ids1 | ids2)
+            return cast(T_Scope, AssetRootIDScope(rootIds=union_ids))
+        
+        if isinstance(scope1, InstancesScope):
+            ids1 = set(scope1.instances)
+            ids2 = set(scope2.instances)
+            union_ids = list(ids1 | ids2)
+            return cast(T_Scope, InstancesScope(instances=union_ids))
+        
+        if isinstance(scope1, LegacyDataModelScope):
+            ids1 = set(scope1.external_ids)
+            ids2 = set(scope2.external_ids)
+            union_ids = list(ids1 | ids2)
+            return cast(T_Scope, LegacyDataModelScope(externalIds=union_ids))
+        
+        if isinstance(scope1, LegacySpaceScope):
+            ids1 = set(scope1.external_ids)
+            ids2 = set(scope2.external_ids)
+            union_ids = list(ids1 | ids2)
+            return cast(T_Scope, LegacySpaceScope(externalIds=union_ids))
+        
+        if isinstance(scope1, PartitionScope):
+            ids1 = set(scope1.partition_ids)
+            ids2 = set(scope2.partition_ids)
+            union_ids = list(ids1 | ids2)
+            return cast(T_Scope, PartitionScope(partitionIds=union_ids))
+        
+        if isinstance(scope1, PostgresGatewayUsersScope):
+            ids1 = set(scope1.usernames)
+            ids2 = set(scope2.usernames)
+            union_ids = list(ids1 | ids2)
+            return cast(T_Scope, PostgresGatewayUsersScope(usernames=union_ids))
+        
+        if isinstance(scope1, ExperimentScope):
+            ids1 = set(scope1.experiments)
+            ids2 = set(scope2.experiments)
+            union_ids = list(ids1 | ids2)
+            return cast(T_Scope, ExperimentScope(experiments=union_ids))
+        
+        if isinstance(scope1, AppConfigScope):
+            ids1 = set(scope1.apps)
+            ids2 = set(scope2.apps)
+            union_ids = list(ids1 | ids2)
+            return cast(T_Scope, AppConfigScope(apps=union_ids))
+        
+        # Handle scopes without collection attributes
+        if isinstance(scope1, (AllScope, CurrentUserScope)):
+            return scope1
+        
+        # Handle TableScope - complex case, return None for now
+        if isinstance(scope1, TableScope):
+            return None
+    
+    # For different incompatible scope types, return None
+    return None

--- a/tests/test_unit/test_cdf_tk/test_client/test_capabilities.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_capabilities.py
@@ -1,17 +1,14 @@
 from collections.abc import Iterable
 
 import pytest
-from _pytest.mark import ParameterSet
-from cognite.client.data_classes.capabilities import Capability
-
-from cognite_toolkit._cdf_tk.client.data_classes.capabilities import scope_intersection, scope_union
-from cognite_toolkit._cdf_tk.resource_classes.capabilities import (
+from cognite.client.data_classes.capabilities import (
     AllScope,
     AppConfigScope,
     AssetRootIDScope,
+    Capability,
     CurrentUserScope,
     DataSetScope,
-    ExperimentScope,
+    ExperimentsScope,
     ExtractionPipelineScope,
     IDScope,
     IDScopeLowerCase,
@@ -22,113 +19,125 @@ from cognite_toolkit._cdf_tk.resource_classes.capabilities import (
     PostgresGatewayUsersScope,
     SpaceIDScope,
     TableScope,
+    UnknownScope,
 )
 
+from cognite_toolkit._cdf_tk.client.data_classes.capabilities import scope_intersection, scope_union
+from tests.test_unit.utils import FakeCogniteResourceGenerator
 
-def scope_logic_test_cases() -> Iterable[ParameterSet]:
-    # Basic cases - None handling
-    yield pytest.param(None, None, None, None, id="Two None scopes")
-    
+
+def scope_logic_test_cases() -> Iterable:
+    yield pytest.param(DataSetScope(ids=[1]), None, None, DataSetScope(ids=[1]), id="One None scope")
+
     # AllScope cases
     all_scope = AllScope()
     yield pytest.param(all_scope, all_scope, all_scope, all_scope, id="Two identical AllScopes")
-    
+
     # DataSetScope cases
-    ds_scope_1 = DataSetScope(ids=["dataset1", "dataset2"])
-    ds_scope_2 = DataSetScope(ids=["dataset2", "dataset3"])
-    ds_scope_empty = DataSetScope(ids=[])
-    ds_scope_intersection = DataSetScope(ids=["dataset2"])
-    ds_scope_union = DataSetScope(ids=["dataset1", "dataset2", "dataset3"])
-    
-    yield pytest.param(ds_scope_1, ds_scope_2, ds_scope_intersection, ds_scope_union, 
-                      id="DataSetScope intersection and union")
-    yield pytest.param(ds_scope_1, ds_scope_1, ds_scope_1, ds_scope_1, 
-                      id="Identical DataSetScopes")
-    yield pytest.param(ds_scope_1, ds_scope_empty, ds_scope_empty, ds_scope_1, 
-                      id="DataSetScope with empty scope")
-    
+    ds_scope_1 = DataSetScope(ids=[123, 456])
+    ds_scope_2 = DataSetScope(ids=[456, 789])
+    ds_scope_3 = DataSetScope(ids=[42])
+    ds_scope_intersection = DataSetScope(ids=[456])
+    ds_scope_union = DataSetScope(ids=[123, 456, 789])
+
+    yield pytest.param(
+        ds_scope_1, ds_scope_2, ds_scope_intersection, ds_scope_union, id="DataSetScope intersection and union"
+    )
+    yield pytest.param(ds_scope_1, ds_scope_1, ds_scope_1, ds_scope_1, id="Identical DataSetScopes")
+    yield pytest.param(
+        ds_scope_1, ds_scope_3, None, DataSetScope([42, 123, 456]), id="DataSetScope with no intersection"
+    )
+
     # IDScope cases
-    id_scope_1 = IDScope(ids=["id1", "id2"])
-    id_scope_2 = IDScope(ids=["id2", "id3"])
-    id_scope_intersection = IDScope(ids=["id2"])
-    id_scope_union = IDScope(ids=["id1", "id2", "id3"])
-    
-    yield pytest.param(id_scope_1, id_scope_2, id_scope_intersection, id_scope_union, 
-                      id="IDScope intersection and union")
-    
-    # Mixed scope types with AllScope
-    yield pytest.param(all_scope, ds_scope_1, ds_scope_1, all_scope, 
-                      id="AllScope with DataSetScope")
-    yield pytest.param(ds_scope_1, all_scope, ds_scope_1, all_scope, 
-                      id="DataSetScope with AllScope")
-    yield pytest.param(all_scope, id_scope_1, id_scope_1, all_scope, 
-                      id="AllScope with IDScope")
-    
+    id_scope_1 = IDScope(ids=[123, 456])
+    id_scope_2 = IDScope(ids=[456, 789])
+    id_scope_intersection = IDScope(ids=[456])
+    id_scope_union = IDScope(ids=[123, 456, 789])
+
+    yield pytest.param(
+        id_scope_1, id_scope_2, id_scope_intersection, id_scope_union, id="IDScope intersection and union"
+    )
+
     # SpaceIDScope cases
-    space_scope_1 = SpaceIDScope(spaceIds=["space1", "space2"])  # type: ignore
-    space_scope_2 = SpaceIDScope(spaceIds=["space2", "space3"])  # type: ignore
-    space_scope_intersection = SpaceIDScope(spaceIds=["space2"])  # type: ignore
-    space_scope_union = SpaceIDScope(spaceIds=["space1", "space2", "space3"])  # type: ignore
-    
-    yield pytest.param(space_scope_1, space_scope_2, space_scope_intersection, space_scope_union, 
-                      id="SpaceIDScope intersection and union")
-    
+    space_scope_1 = SpaceIDScope(space_ids=["space1", "space2"])
+    space_scope_2 = SpaceIDScope(space_ids=["space2", "space3"])
+    space_scope_intersection = SpaceIDScope(space_ids=["space2"])
+    space_scope_union = SpaceIDScope(space_ids=["space1", "space2", "space3"])
+
+    yield pytest.param(
+        space_scope_1,
+        space_scope_2,
+        space_scope_intersection,
+        space_scope_union,
+        id="SpaceIDScope intersection and union",
+    )
+
     # AssetRootIDScope cases
-    asset_scope_1 = AssetRootIDScope(rootIds=["root1", "root2"])  # type: ignore
-    asset_scope_2 = AssetRootIDScope(rootIds=["root2", "root3"])  # type: ignore
-    asset_scope_intersection = AssetRootIDScope(rootIds=["root2"])  # type: ignore
-    asset_scope_union = AssetRootIDScope(rootIds=["root1", "root2", "root3"])  # type: ignore
-    
-    yield pytest.param(asset_scope_1, asset_scope_2, asset_scope_intersection, asset_scope_union, 
-                      id="AssetRootIDScope intersection and union")
-    
+    asset_scope_1 = AssetRootIDScope(root_ids=[123, 456])
+    asset_scope_2 = AssetRootIDScope(root_ids=[456, 789])
+    asset_scope_intersection = AssetRootIDScope(root_ids=[456])
+    asset_scope_union = AssetRootIDScope(root_ids=[123, 456, 789])
+
+    yield pytest.param(
+        asset_scope_1,
+        asset_scope_2,
+        asset_scope_intersection,
+        asset_scope_union,
+        id="AssetRootIDScope intersection and union",
+    )
+
     # ExtractionPipelineScope cases
-    ep_scope_1 = ExtractionPipelineScope(ids=["ep1", "ep2"])
-    ep_scope_2 = ExtractionPipelineScope(ids=["ep2", "ep3"])
-    ep_scope_intersection = ExtractionPipelineScope(ids=["ep2"])
-    ep_scope_union = ExtractionPipelineScope(ids=["ep1", "ep2", "ep3"])
-    
-    yield pytest.param(ep_scope_1, ep_scope_2, ep_scope_intersection, ep_scope_union, 
-                      id="ExtractionPipelineScope intersection and union")
-    
-    # None cases with other scopes
-    yield pytest.param(None, ds_scope_1, None, ds_scope_1, id="None with DataSetScope")
-    yield pytest.param(ds_scope_1, None, None, ds_scope_1, id="DataSetScope with None")
-    yield pytest.param(None, all_scope, None, all_scope, id="None with AllScope")
-    yield pytest.param(all_scope, None, None, all_scope, id="AllScope with None")
-    
-    # Incompatible scope types (different scope types without AllScope)
-    yield pytest.param(ds_scope_1, id_scope_1, None, None, 
-                      id="Incompatible DataSetScope and IDScope")
-    yield pytest.param(space_scope_1, asset_scope_1, None, None, 
-                      id="Incompatible SpaceIDScope and AssetRootIDScope")
-    
-    # No common elements
-    ds_scope_no_common = DataSetScope(ids=["dataset4", "dataset5"])
-    yield pytest.param(ds_scope_1, ds_scope_no_common, ds_scope_empty, 
-                      DataSetScope(ids=["dataset1", "dataset2", "dataset4", "dataset5"]), 
-                      id="DataSetScope with no common elements")
-    
+    ep_scope_1 = ExtractionPipelineScope(ids=[123, 456])
+    ep_scope_2 = ExtractionPipelineScope(ids=[456, 789])
+    ep_scope_intersection = ExtractionPipelineScope(ids=[456])
+    ep_scope_union = ExtractionPipelineScope(ids=[123, 456, 789])
+
+    yield pytest.param(
+        ep_scope_1,
+        ep_scope_2,
+        ep_scope_intersection,
+        ep_scope_union,
+        id="ExtractionPipelineScope intersection and union",
+    )
+
     # Special scopes without common collection attributes
     current_user_scope = CurrentUserScope()
-    yield pytest.param(current_user_scope, current_user_scope, current_user_scope, current_user_scope, 
-                      id="CurrentUserScope identical")
-    yield pytest.param(all_scope, current_user_scope, current_user_scope, all_scope, 
-                      id="AllScope with CurrentUserScope")
-    
+    yield pytest.param(
+        current_user_scope, current_user_scope, current_user_scope, current_user_scope, id="CurrentUserScope identical"
+    )
+
     # Complex scopes
-    table_scope_1 = TableScope(dbsToTables={"db1": ["table1", "table2"], "db2": ["table3"]})  # type: ignore
-    table_scope_2 = TableScope(dbsToTables={"db1": ["table2", "table3"], "db3": ["table4"]})  # type: ignore
-    
-    yield pytest.param(table_scope_1, table_scope_2, None, None, 
-                      id="TableScope complex intersection")
-    
+    table_scope_1 = TableScope(dbs_to_tables={"db1": ["table1", "table2"], "db2": ["table3"]})
+    table_scope_2 = TableScope(dbs_to_tables={"db1": ["table2", "table3"], "db3": ["table4"]})
+
+    yield pytest.param(
+        table_scope_1,
+        table_scope_2,
+        TableScope(
+            dbs_to_tables={"db1": ["table2"]},
+        ),
+        TableScope(
+            dbs_to_tables={
+                "db1": ["table1", "table2", "table3"],
+                "db2": ["table3"],
+                "db3": ["table4"],
+            }
+        ),
+        id="TableScope complex intersection",
+    )
+    yield pytest.param(
+        TableScope(dbs_to_tables={"db1": ["table1"]}),
+        TableScope(dbs_to_tables={"db2": ["table1"]}),
+        None,
+        TableScope(dbs_to_tables={"db1": ["table1"], "db2": ["table1"]}),
+        id="TableScope no intersection",
+    )
+
     # AppConfigScope
     app_scope_1 = AppConfigScope(apps=["SEARCH"])
     app_scope_2 = AppConfigScope(apps=["SEARCH"])
-    
-    yield pytest.param(app_scope_1, app_scope_2, app_scope_1, app_scope_1, 
-                      id="AppConfigScope identical")
+
+    yield pytest.param(app_scope_1, app_scope_2, app_scope_1, app_scope_1, id="AppConfigScope identical")
 
 
 class TestScopeLogic:
@@ -154,52 +163,56 @@ class TestScopeLogic:
         result = scope_union(scope1, scope2)
         assert result == union
 
-    def test_all_scope_subclasses_supported(self) -> None:
-        """Test that union and intersection methods support all subclasses of Capability.Scope"""
-        # Create instances of all scope types
-        scope_instances = [
-            AllScope(),
-            AppConfigScope(apps=["SEARCH"]),
-            AssetRootIDScope(rootIds=["root1"]),  # type: ignore
-            CurrentUserScope(),
-            DataSetScope(ids=["ds1"]),
-            ExperimentScope(experiments=["exp1"]),
-            ExtractionPipelineScope(ids=["ep1"]),
-            IDScope(ids=["id1"]),
-            IDScopeLowerCase(ids=["id1"]),
-            InstancesScope(instances=["inst1"]),
-            LegacyDataModelScope(externalIds=["dm1"]),  # type: ignore
-            LegacySpaceScope(externalIds=["space1"]),  # type: ignore
-            PartitionScope(partitionIds=[1]),  # type: ignore
-            PostgresGatewayUsersScope(usernames=["user1"]),
-            SpaceIDScope(spaceIds=["space1"]),  # type: ignore
-            TableScope(dbsToTables={"db1": ["table1"]}),  # type: ignore
-        ]
-        
-        all_scope = AllScope()
-        
-        # Test that each scope type can be used in intersection and union operations
-        for scope in scope_instances:
-            # Test intersection with AllScope
-            intersection_result = scope_intersection(scope, all_scope)  # type: ignore
-            assert intersection_result == scope, f"Intersection of {type(scope).__name__} with AllScope failed"
-            
-            # Test union with AllScope
-            union_result = scope_union(scope, all_scope)  # type: ignore
-            assert union_result == all_scope, f"Union of {type(scope).__name__} with AllScope failed"
-            
-            # Test intersection with itself
-            self_intersection = scope_intersection(scope, scope)
-            assert self_intersection == scope, f"Self-intersection of {type(scope).__name__} failed"
-            
-            # Test union with itself
-            self_union = scope_union(scope, scope)
-            assert self_union == scope, f"Self-union of {type(scope).__name__} failed"
-            
-            # Test intersection with None
-            none_intersection = scope_intersection(scope, None)
-            assert none_intersection is None, f"Intersection of {type(scope).__name__} with None failed"
-            
-            # Test union with None
-            none_union = scope_union(scope, None)
-            assert none_union == scope, f"Union of {type(scope).__name__} with None failed"
+    @pytest.mark.parametrize(
+        "scope_cls", [scope_cls for scope_cls in Capability.Scope.__subclasses__() if scope_cls is not UnknownScope]
+    )
+    def test_support_all_scopes(self, scope_cls: type[Capability.Scope]) -> None:
+        """Ensure all scope classes are supported by the intersection and union functions."""
+        instance = FakeCogniteResourceGenerator(seed=42).create_instance(scope_cls)
+
+        # Checking that no exceptions are raised for any scope type
+        _ = scope_intersection(instance, instance)
+        _ = scope_union(instance, instance)
+
+    def test_raises_unknown_scope_intersection(self) -> None:
+        instance = FakeCogniteResourceGenerator(seed=42).create_instance(UnknownScope)
+        with pytest.raises(TypeError, match="Unknown scope type"):
+            scope_intersection(instance, instance)
+
+    def test_raises_unknown_scope_union(self) -> None:
+        instance = FakeCogniteResourceGenerator(seed=42).create_instance(UnknownScope)
+        with pytest.raises(TypeError, match="Unknown scope type"):
+            scope_union(instance, instance)
+
+    def test_raise_different_scope_types_intersection(self) -> None:
+        with pytest.raises(ValueError, match="Cannot intersect scopes of different types"):
+            scope_intersection(DataSetScope(ids=[1, 2]), IDScope(ids=[3, 4]))
+
+    def test_raise_different_scope_types_union(self) -> None:
+        with pytest.raises(ValueError, match="Cannot union scopes of different types"):
+            scope_union(DataSetScope(ids=[1, 2]), IDScope(ids=[3, 4]))
+
+    @pytest.mark.parametrize(
+        "scope1, scope2",
+        [
+            (DataSetScope(ids=[1, 2]), DataSetScope(ids=[3, 4])),
+            (IDScope(ids=[10]), IDScope(ids=[20])),
+            (SpaceIDScope(space_ids=["a"]), SpaceIDScope(space_ids=["b"])),
+            (AssetRootIDScope(root_ids=[100]), AssetRootIDScope(root_ids=[200])),
+            (ExtractionPipelineScope(ids=[5]), ExtractionPipelineScope(ids=[6])),
+            (
+                TableScope(dbs_to_tables={"db1": ["t1"]}),
+                TableScope(dbs_to_tables={"db2": ["t2"]}),
+            ),
+            (AppConfigScope(apps=["A"]), AppConfigScope(apps=["B"])),
+            (ExperimentsScope(experiments=["exp1"]), ExperimentsScope(experiments=["exp2"])),
+            (LegacySpaceScope(external_ids=["space1"]), LegacySpaceScope(external_ids=["space2"])),
+            (LegacyDataModelScope(external_ids=["model1"]), LegacyDataModelScope(external_ids=["model2"])),
+            (PartitionScope(partition_ids=[1]), PartitionScope(partition_ids=[2])),
+            (InstancesScope(instances=["inst1"]), InstancesScope(instances=["inst2"])),
+            (PostgresGatewayUsersScope(usernames=["user1"]), PostgresGatewayUsersScope(usernames=["user2"])),
+            (IDScopeLowerCase(ids=[1]), IDScopeLowerCase(ids=[2])),
+        ],
+    )
+    def test_scope_no_intersection(self, scope1: Capability.Scope, scope2: Capability.Scope) -> None:
+        assert scope_intersection(scope1, scope2) is None

--- a/tests/test_unit/test_cdf_tk/test_client/test_capabilities.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_capabilities.py
@@ -1,0 +1,35 @@
+from collections.abc import Iterable
+
+import pytest
+from _pytest.mark import ParameterSet
+from cognite.client.data_classes.capabilities import Capability
+
+from cognite_toolkit._cdf_tk.client.data_classes.capabilities import scope_intersection, scope_union
+
+
+def scope_logic_test_cases() -> Iterable[ParameterSet]:
+    yield pytest.param(None, None, None, None, id="Two None scopes")
+
+
+class TestScopeLogic:
+    @pytest.mark.parametrize("scope1, scope2, intersection, union", list(scope_logic_test_cases()))
+    def test_scope_intersection(
+        self,
+        scope1: Capability.Scope | None,
+        scope2: Capability | None,
+        intersection: Capability.Scope | None,
+        union: Capability.Scope | None,
+    ) -> None:
+        result = scope_intersection(scope1, scope2)
+        assert result == intersection
+
+    @pytest.mark.parametrize("scope1, scope2, intersection, union", list(scope_logic_test_cases()))
+    def test_scope_union(
+        self,
+        scope1: Capability.Scope | None,
+        scope2: Capability | None,
+        intersection: Capability.Scope | None,
+        union: Capability.Scope | None,
+    ) -> None:
+        result = scope_union(scope1, scope2)
+        assert result == union

--- a/tests/test_unit/test_cdf_tk/test_client/test_capabilities.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_capabilities.py
@@ -5,10 +5,130 @@ from _pytest.mark import ParameterSet
 from cognite.client.data_classes.capabilities import Capability
 
 from cognite_toolkit._cdf_tk.client.data_classes.capabilities import scope_intersection, scope_union
+from cognite_toolkit._cdf_tk.resource_classes.capabilities import (
+    AllScope,
+    AppConfigScope,
+    AssetRootIDScope,
+    CurrentUserScope,
+    DataSetScope,
+    ExperimentScope,
+    ExtractionPipelineScope,
+    IDScope,
+    IDScopeLowerCase,
+    InstancesScope,
+    LegacyDataModelScope,
+    LegacySpaceScope,
+    PartitionScope,
+    PostgresGatewayUsersScope,
+    SpaceIDScope,
+    TableScope,
+)
 
 
 def scope_logic_test_cases() -> Iterable[ParameterSet]:
+    # Basic cases - None handling
     yield pytest.param(None, None, None, None, id="Two None scopes")
+    
+    # AllScope cases
+    all_scope = AllScope()
+    yield pytest.param(all_scope, all_scope, all_scope, all_scope, id="Two identical AllScopes")
+    
+    # DataSetScope cases
+    ds_scope_1 = DataSetScope(ids=["dataset1", "dataset2"])
+    ds_scope_2 = DataSetScope(ids=["dataset2", "dataset3"])
+    ds_scope_empty = DataSetScope(ids=[])
+    ds_scope_intersection = DataSetScope(ids=["dataset2"])
+    ds_scope_union = DataSetScope(ids=["dataset1", "dataset2", "dataset3"])
+    
+    yield pytest.param(ds_scope_1, ds_scope_2, ds_scope_intersection, ds_scope_union, 
+                      id="DataSetScope intersection and union")
+    yield pytest.param(ds_scope_1, ds_scope_1, ds_scope_1, ds_scope_1, 
+                      id="Identical DataSetScopes")
+    yield pytest.param(ds_scope_1, ds_scope_empty, ds_scope_empty, ds_scope_1, 
+                      id="DataSetScope with empty scope")
+    
+    # IDScope cases
+    id_scope_1 = IDScope(ids=["id1", "id2"])
+    id_scope_2 = IDScope(ids=["id2", "id3"])
+    id_scope_intersection = IDScope(ids=["id2"])
+    id_scope_union = IDScope(ids=["id1", "id2", "id3"])
+    
+    yield pytest.param(id_scope_1, id_scope_2, id_scope_intersection, id_scope_union, 
+                      id="IDScope intersection and union")
+    
+    # Mixed scope types with AllScope
+    yield pytest.param(all_scope, ds_scope_1, ds_scope_1, all_scope, 
+                      id="AllScope with DataSetScope")
+    yield pytest.param(ds_scope_1, all_scope, ds_scope_1, all_scope, 
+                      id="DataSetScope with AllScope")
+    yield pytest.param(all_scope, id_scope_1, id_scope_1, all_scope, 
+                      id="AllScope with IDScope")
+    
+    # SpaceIDScope cases
+    space_scope_1 = SpaceIDScope(spaceIds=["space1", "space2"])  # type: ignore
+    space_scope_2 = SpaceIDScope(spaceIds=["space2", "space3"])  # type: ignore
+    space_scope_intersection = SpaceIDScope(spaceIds=["space2"])  # type: ignore
+    space_scope_union = SpaceIDScope(spaceIds=["space1", "space2", "space3"])  # type: ignore
+    
+    yield pytest.param(space_scope_1, space_scope_2, space_scope_intersection, space_scope_union, 
+                      id="SpaceIDScope intersection and union")
+    
+    # AssetRootIDScope cases
+    asset_scope_1 = AssetRootIDScope(rootIds=["root1", "root2"])  # type: ignore
+    asset_scope_2 = AssetRootIDScope(rootIds=["root2", "root3"])  # type: ignore
+    asset_scope_intersection = AssetRootIDScope(rootIds=["root2"])  # type: ignore
+    asset_scope_union = AssetRootIDScope(rootIds=["root1", "root2", "root3"])  # type: ignore
+    
+    yield pytest.param(asset_scope_1, asset_scope_2, asset_scope_intersection, asset_scope_union, 
+                      id="AssetRootIDScope intersection and union")
+    
+    # ExtractionPipelineScope cases
+    ep_scope_1 = ExtractionPipelineScope(ids=["ep1", "ep2"])
+    ep_scope_2 = ExtractionPipelineScope(ids=["ep2", "ep3"])
+    ep_scope_intersection = ExtractionPipelineScope(ids=["ep2"])
+    ep_scope_union = ExtractionPipelineScope(ids=["ep1", "ep2", "ep3"])
+    
+    yield pytest.param(ep_scope_1, ep_scope_2, ep_scope_intersection, ep_scope_union, 
+                      id="ExtractionPipelineScope intersection and union")
+    
+    # None cases with other scopes
+    yield pytest.param(None, ds_scope_1, None, ds_scope_1, id="None with DataSetScope")
+    yield pytest.param(ds_scope_1, None, None, ds_scope_1, id="DataSetScope with None")
+    yield pytest.param(None, all_scope, None, all_scope, id="None with AllScope")
+    yield pytest.param(all_scope, None, None, all_scope, id="AllScope with None")
+    
+    # Incompatible scope types (different scope types without AllScope)
+    yield pytest.param(ds_scope_1, id_scope_1, None, None, 
+                      id="Incompatible DataSetScope and IDScope")
+    yield pytest.param(space_scope_1, asset_scope_1, None, None, 
+                      id="Incompatible SpaceIDScope and AssetRootIDScope")
+    
+    # No common elements
+    ds_scope_no_common = DataSetScope(ids=["dataset4", "dataset5"])
+    yield pytest.param(ds_scope_1, ds_scope_no_common, ds_scope_empty, 
+                      DataSetScope(ids=["dataset1", "dataset2", "dataset4", "dataset5"]), 
+                      id="DataSetScope with no common elements")
+    
+    # Special scopes without common collection attributes
+    current_user_scope = CurrentUserScope()
+    yield pytest.param(current_user_scope, current_user_scope, current_user_scope, current_user_scope, 
+                      id="CurrentUserScope identical")
+    yield pytest.param(all_scope, current_user_scope, current_user_scope, all_scope, 
+                      id="AllScope with CurrentUserScope")
+    
+    # Complex scopes
+    table_scope_1 = TableScope(dbsToTables={"db1": ["table1", "table2"], "db2": ["table3"]})  # type: ignore
+    table_scope_2 = TableScope(dbsToTables={"db1": ["table2", "table3"], "db3": ["table4"]})  # type: ignore
+    
+    yield pytest.param(table_scope_1, table_scope_2, None, None, 
+                      id="TableScope complex intersection")
+    
+    # AppConfigScope
+    app_scope_1 = AppConfigScope(apps=["SEARCH"])
+    app_scope_2 = AppConfigScope(apps=["SEARCH"])
+    
+    yield pytest.param(app_scope_1, app_scope_2, app_scope_1, app_scope_1, 
+                      id="AppConfigScope identical")
 
 
 class TestScopeLogic:
@@ -16,7 +136,7 @@ class TestScopeLogic:
     def test_scope_intersection(
         self,
         scope1: Capability.Scope | None,
-        scope2: Capability | None,
+        scope2: Capability.Scope | None,
         intersection: Capability.Scope | None,
         union: Capability.Scope | None,
     ) -> None:
@@ -27,9 +147,59 @@ class TestScopeLogic:
     def test_scope_union(
         self,
         scope1: Capability.Scope | None,
-        scope2: Capability | None,
+        scope2: Capability.Scope | None,
         intersection: Capability.Scope | None,
         union: Capability.Scope | None,
     ) -> None:
         result = scope_union(scope1, scope2)
         assert result == union
+
+    def test_all_scope_subclasses_supported(self) -> None:
+        """Test that union and intersection methods support all subclasses of Capability.Scope"""
+        # Create instances of all scope types
+        scope_instances = [
+            AllScope(),
+            AppConfigScope(apps=["SEARCH"]),
+            AssetRootIDScope(rootIds=["root1"]),  # type: ignore
+            CurrentUserScope(),
+            DataSetScope(ids=["ds1"]),
+            ExperimentScope(experiments=["exp1"]),
+            ExtractionPipelineScope(ids=["ep1"]),
+            IDScope(ids=["id1"]),
+            IDScopeLowerCase(ids=["id1"]),
+            InstancesScope(instances=["inst1"]),
+            LegacyDataModelScope(externalIds=["dm1"]),  # type: ignore
+            LegacySpaceScope(externalIds=["space1"]),  # type: ignore
+            PartitionScope(partitionIds=[1]),  # type: ignore
+            PostgresGatewayUsersScope(usernames=["user1"]),
+            SpaceIDScope(spaceIds=["space1"]),  # type: ignore
+            TableScope(dbsToTables={"db1": ["table1"]}),  # type: ignore
+        ]
+        
+        all_scope = AllScope()
+        
+        # Test that each scope type can be used in intersection and union operations
+        for scope in scope_instances:
+            # Test intersection with AllScope
+            intersection_result = scope_intersection(scope, all_scope)  # type: ignore
+            assert intersection_result == scope, f"Intersection of {type(scope).__name__} with AllScope failed"
+            
+            # Test union with AllScope
+            union_result = scope_union(scope, all_scope)  # type: ignore
+            assert union_result == all_scope, f"Union of {type(scope).__name__} with AllScope failed"
+            
+            # Test intersection with itself
+            self_intersection = scope_intersection(scope, scope)
+            assert self_intersection == scope, f"Self-intersection of {type(scope).__name__} failed"
+            
+            # Test union with itself
+            self_union = scope_union(scope, scope)
+            assert self_union == scope, f"Self-union of {type(scope).__name__} failed"
+            
+            # Test intersection with None
+            none_intersection = scope_intersection(scope, None)
+            assert none_intersection is None, f"Intersection of {type(scope).__name__} with None failed"
+            
+            # Test union with None
+            none_union = scope_union(scope, None)
+            assert none_union == scope, f"Union of {type(scope).__name__} with None failed"


### PR DESCRIPTION
# Description

**Context**: Toolkit has functionality such as profiling and auth that depends on the access level of the user. This PR prepares for a `get_scope()` method that returns the scope given an action. 

For example, in `cdf profile assets` we can input `get_scope(AssetsAcl.Action.Read)` and know whether the user has access to all assets, specific datasets or nothing.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip

