### PR TITLE
[CDF-25101] 🪲 Fix/workflow version dependency ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -311,3 +311,6 @@ my_*/
 function_local_venvs*/
 qa_pending_id/
 tests/**/cdf.toml
+
+# Temporarily ignoring while experimenting
+.cursor


### PR DESCRIPTION
# Description

See below.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- When running `cdf deploy`, Toolkit now accounts for dependencies between workflow versions.

## templates

No changes.
