### PR TITLE
[CDF-25033] 🏗 Refactor interactive select

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -488,7 +488,7 @@ class DumpDataApp(typer.Typer):
         cmd = DumpDataCommand()
         client = EnvironmentVariables.create_from_environment().get_client()
         if hierarchy is None and data_set is None:
-            hierarchy, data_set = AssetInteractiveSelect(client).interactive_select_hierarchy_datasets()
+            hierarchy, data_set = AssetInteractiveSelect(client, "dump").interactive_select_hierarchy_datasets()
 
         cmd.run(
             lambda: cmd.dump_table(
@@ -567,7 +567,7 @@ class DumpDataApp(typer.Typer):
         cmd.validate_directory(output_dir, clean)
         client = EnvironmentVariables.create_from_environment().get_client()
         if hierarchy is None and data_set is None:
-            hierarchy, data_set = FileMetadataInteractiveSelect(client).interactive_select_hierarchy_datasets()
+            hierarchy, data_set = FileMetadataInteractiveSelect(client, "dump").interactive_select_hierarchy_datasets()
         cmd.run(
             lambda: cmd.dump_table(
                 FileMetadataFinder(client, hierarchy or [], data_set or []),
@@ -644,7 +644,7 @@ class DumpDataApp(typer.Typer):
         cmd = DumpDataCommand()
         client = EnvironmentVariables.create_from_environment().get_client()
         if hierarchy is None and data_set is None:
-            hierarchy, data_set = TimeSeriesInteractiveSelect(client).interactive_select_hierarchy_datasets()
+            hierarchy, data_set = TimeSeriesInteractiveSelect(client, "dump").interactive_select_hierarchy_datasets()
         cmd.run(
             lambda: cmd.dump_table(
                 TimeSeriesFinder(client, hierarchy or [], data_set or []),
@@ -722,7 +722,7 @@ class DumpDataApp(typer.Typer):
         cmd.validate_directory(output_dir, clean)
         client = EnvironmentVariables.create_from_environment().get_client()
         if hierarchy is None and data_set is None:
-            hierarchy, data_set = EventInteractiveSelect(client).interactive_select_hierarchy_datasets()
+            hierarchy, data_set = EventInteractiveSelect(client, "dump").interactive_select_hierarchy_datasets()
         cmd.run(
             lambda: cmd.dump_table(
                 EventFinder(client, hierarchy or [], data_set or []),

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -28,8 +28,9 @@ from .aggregators import (
 
 
 class AssetCentricInteractiveSelect(ABC):
-    def __init__(self, client: ToolkitClient) -> None:
+    def __init__(self, client: ToolkitClient, operation: str) -> None:
         self.client = client
+        self.operation = operation
         self._aggregator = self._get_aggregator(client)
 
     @abstractmethod
@@ -88,7 +89,7 @@ class AssetCentricInteractiveSelect(ABC):
                 selected.append("No data set selected.")
             selected_str = "\n".join(selected)
             what = questionary.select(
-                f"\n{selected_str}\nSelect a hierarchy or data set to dump",
+                f"\n{selected_str}\nSelect a hierarchy or data set to {self.operation}",
                 choices=["Hierarchy", "Data Set", "Done", "Abort"],
             ).ask()
 

--- a/tests/test_unit/test_cdf_tk/test_utils/test_interactive_select.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_interactive_select.py
@@ -47,7 +47,7 @@ class TestInteractiveSelect:
                 DataSet(id=3, external_id="dataset3"),
             ]
 
-            selector = AssetInteractiveSelect(client)
+            selector = AssetInteractiveSelect(client, "test_operation")
             selected_hierarchy, selected_dataset = selector.interactive_select_hierarchy_datasets()
 
         assert selected_hierarchy == ["Root2"]
@@ -77,7 +77,7 @@ class TestInteractiveSelect:
                 Asset(id=2, external_id="Root2", name="Root 2"),
             ]
             client.files.aggregate.return_value = [CountAggregate(100)]
-            selector = FileMetadataInteractiveSelect(client)
+            selector = FileMetadataInteractiveSelect(client, "test_operation")
             selected_hierarchy, selected_dataset = selector.interactive_select_hierarchy_datasets()
 
         assert selected_hierarchy == ["Root2"]
@@ -100,7 +100,7 @@ class TestInteractiveSelect:
             client.data_sets.list.return_value = []
             client.assets.list.return_value = []
             client.files.aggregate.return_value = [CountAggregate(100)]
-            selector = FileMetadataInteractiveSelect(client)
+            selector = FileMetadataInteractiveSelect(client, "test_operation")
             selected_hierarchy, selected_dataset = selector.interactive_select_hierarchy_datasets()
 
         assert selected_hierarchy == []
@@ -130,7 +130,7 @@ class TestInteractiveSelect:
                 Asset(id=2, external_id="Root2", name="Root 2"),
             ]
             client.time_series.aggregate_count.return_value = 100
-            selector = TimeSeriesInteractiveSelect(client)
+            selector = TimeSeriesInteractiveSelect(client, "test_operation")
             selected_hierarchy, selected_dataset = selector.interactive_select_hierarchy_datasets()
 
         assert selected_hierarchy == ["Root2"]
@@ -160,7 +160,7 @@ class TestInteractiveSelect:
                 Asset(id=2, external_id="Root2", name="Root 2"),
             ]
             client.events.aggregate_count.return_value = 100
-            selector = EventInteractiveSelect(client)
+            selector = EventInteractiveSelect(client, "test_operation")
             selected_hierarchy, selected_dataset = selector.interactive_select_hierarchy_datasets()
 
         assert selected_hierarchy == ["Root2"]


### PR DESCRIPTION
# Description

* Reuse the aggregators in the interactive select implementations. 
* Introduce `operation` parameter so that the interactive select can be used for other operations than `dump`. 

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
