### PR TITLE
[CDF-25194] 👷‍♂️ Update instance source API

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/api/migration.py
+++ b/cognite_toolkit/_cdf_tk/client/api/migration.py
@@ -16,10 +16,10 @@ class InstanceSourceAPI:
         self._view_id = InstanceSource.get_source()
 
     def retrieve(self, ids: Sequence[AssetCentricId]) -> NodeList[InstanceSource]:
-        """Retrieve a list of mappings by their IDs.
+        """Retrieve a list of instance sources by their IDs.
 
         Args:
-            ids (Sequence[AssetCentricId]): A sequence of AssetCentricId objects representing the IDs of the mappings to retrieve.
+            ids (Sequence[AssetCentricId]): A sequence of AssetCentricId objects representing the IDs of the instance sources to retrieve.
         """
         results: NodeList[InstanceSource] = NodeList[InstanceSource]([])
         for chunk in chunker_sequence(ids, self._RETRIEVE_LIMIT):

--- a/cognite_toolkit/_cdf_tk/client/api/migration.py
+++ b/cognite_toolkit/_cdf_tk/client/api/migration.py
@@ -3,37 +3,37 @@ from itertools import groupby
 
 from cognite.client.data_classes.data_modeling import NodeList, filters, query
 
-from cognite_toolkit._cdf_tk.client.data_classes.migration import AssetCentricId, Mapping
+from cognite_toolkit._cdf_tk.client.data_classes.migration import AssetCentricId, InstanceSource
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 
 from .extended_data_modeling import ExtendedInstancesAPI
 
 
-class MappingAPI:
+class InstanceSourceAPI:
     def __init__(self, instance_api: ExtendedInstancesAPI) -> None:
         self._instance_api = instance_api
         self._RETRIEVE_LIMIT = 1000
-        self._view_id = Mapping.get_source()
+        self._view_id = InstanceSource.get_source()
 
-    def retrieve(self, ids: Sequence[AssetCentricId]) -> NodeList[Mapping]:
+    def retrieve(self, ids: Sequence[AssetCentricId]) -> NodeList[InstanceSource]:
         """Retrieve a list of mappings by their IDs.
 
         Args:
             ids (Sequence[AssetCentricId]): A sequence of AssetCentricId objects representing the IDs of the mappings to retrieve.
         """
-        results: NodeList[Mapping] = NodeList[Mapping]([])
+        results: NodeList[InstanceSource] = NodeList[InstanceSource]([])
         for chunk in chunker_sequence(ids, self._RETRIEVE_LIMIT):
             retrieve_query = query.Query(
                 with_={
-                    "mappings": query.NodeResultSetExpression(
+                    "instanceSource": query.NodeResultSetExpression(
                         filter=filters.And(filters.HasData(views=[self._view_id]), self._create_dms_filter(ids)),
                         limit=len(chunk),
                     ),
                 },
-                select={"mappings": query.Select([query.SourceSelector(self._view_id, ["*"])])},
+                select={"instanceSource": query.Select([query.SourceSelector(self._view_id, ["*"])])},
             )
             chunk_response = self._instance_api.query(retrieve_query)
-            results.extend([Mapping._load(item.dump()) for item in chunk_response.get("mappings", [])])
+            results.extend([InstanceSource._load(item.dump()) for item in chunk_response.get("instanceSource", [])])
         return results
 
     @staticmethod
@@ -42,16 +42,18 @@ class MappingAPI:
         if not ids:
             raise ValueError("Cannot create a filter from an empty AssetCentricIdList.")
         to_or_filters: list[filters.Filter] = []
-        mapping_view = Mapping.get_source()
+        instance_source_view = InstanceSource.get_source()
         for resource_type, resource_ids in groupby(
             sorted(ids, key=lambda x: x.resource_type), key=lambda x: x.resource_type
         ):
-            is_resource = filters.Equals(mapping_view.as_property_ref("resourceType"), resource_type)
-            is_id = filters.In(mapping_view.as_property_ref("id"), [resource_id.id_ for resource_id in resource_ids])
+            is_resource = filters.Equals(instance_source_view.as_property_ref("resourceType"), resource_type)
+            is_id = filters.In(
+                instance_source_view.as_property_ref("id"), [resource_id.id_ for resource_id in resource_ids]
+            )
             to_or_filters.append(filters.And(is_resource, is_id))
         return filters.Or(*to_or_filters)
 
 
 class MigrationAPI:
     def __init__(self, instance_api: ExtendedInstancesAPI) -> None:
-        self.mapping = MappingAPI(instance_api)
+        self.instance_source = InstanceSourceAPI(instance_api)

--- a/cognite_toolkit/_cdf_tk/client/data_classes/migration.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/migration.py
@@ -42,27 +42,29 @@ class AssetCentricId(CogniteObject):
         return f"{self.resource_type}(id={self.id_})"
 
 
-class _MappingProperties:
+class _InstanceSourceProperties:
     resource_type = PropertyOptions("resourceType")
     id_ = PropertyOptions("id")
     data_set_id = PropertyOptions("dataSetId")
     classic_external_id = PropertyOptions("classicExternalId")
+    preferred_consumer_view_id = PropertyOptions("preferredConsumerViewId")
+    ingestion_view = PropertyOptions("ingestionView")
 
     @classmethod
     def get_source(cls) -> ViewId:
-        return ViewId("cognite_migration", "Mapping", "v1")
+        return ViewId("cognite_migration", "InstanceSource", "v1")
 
 
-class Mapping(_MappingProperties, TypedNode):
-    """This represents the reading format of mapping.
+class InstanceSource(_InstanceSourceProperties, TypedNode):
+    """This represents the reading format of instance source.
 
     It is used to when data is read from CDF.
 
-    The mapping between asset-centric and data modeling resources
+    The source of the instance in asset-centric resources.
 
     Args:
         space: The space where the node is located.
-        external_id: The external id of the mapping.
+        external_id: The external id of the instance source.
         version (int): DMS version.
         last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970,
             Coordinated Universal Time (UTC), minus leap seconds.
@@ -72,6 +74,8 @@ class Mapping(_MappingProperties, TypedNode):
         id_: The id field.
         data_set_id: The data set id field.
         classic_external_id: The classic external id field.
+        preferred_consumer_view_id: The preferred consumer view id field.
+        ingestion_view: The ingestion view field.
         type: Direct relation pointing to the type node.
         deleted_time: The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time
             (UTC), minus leap seconds. Timestamp when the instance was soft deleted. Note that deleted instances
@@ -90,6 +94,8 @@ class Mapping(_MappingProperties, TypedNode):
         id_: int,
         data_set_id: int | None = None,
         classic_external_id: str | None = None,
+        preferred_consumer_view_id: dict | None = None,
+        ingestion_view: DirectRelationReference | None = None,
         type: DirectRelationReference | None = None,
         deleted_time: int | None = None,
     ) -> None:
@@ -98,6 +104,8 @@ class Mapping(_MappingProperties, TypedNode):
         self.id_ = id_
         self.data_set_id = data_set_id
         self.classic_external_id = classic_external_id
+        self.preferred_consumer_view_id = preferred_consumer_view_id
+        self.ingestion_view = DirectRelationReference.load(ingestion_view) if ingestion_view else None
 
     def as_asset_centric_id(self) -> AssetCentricId:
         """Return the AssetCentricId representation of the mapping."""

--- a/cognite_toolkit/_cdf_tk/client/testing.py
+++ b/cognite_toolkit/_cdf_tk/client/testing.py
@@ -59,7 +59,7 @@ class ToolkitClientMock(CogniteClientMock):
         self.lookup.location_filters = MagicMock(spec_set=LocationFiltersLookUpAPI)
         self.lookup.extraction_pipelines = MagicMock(spec_set=ExtractionPipelineLookUpAPI)
         self.migration = MagicMock(spec=MigrationAPI)
-        self.migration.mapping = MagicMock(spec_set=InstanceSourceAPI)
+        self.migration.instance_source = MagicMock(spec_set=InstanceSourceAPI)
 
         self.robotics = MagicMock()
         self.robotics.robots = MagicMock(spec=RoboticsAPI)

--- a/cognite_toolkit/_cdf_tk/client/testing.py
+++ b/cognite_toolkit/_cdf_tk/client/testing.py
@@ -19,7 +19,7 @@ from .api.lookup import (
     SecurityCategoriesLookUpAPI,
     TimeSeriesLookUpAPI,
 )
-from .api.migration import MappingAPI, MigrationAPI
+from .api.migration import InstanceSourceAPI, MigrationAPI
 from .api.robotics import RoboticsAPI
 from .api.robotics.capabilities import CapabilitiesAPI
 from .api.robotics.data_postprocessing import DataPostProcessingAPI
@@ -59,7 +59,7 @@ class ToolkitClientMock(CogniteClientMock):
         self.lookup.location_filters = MagicMock(spec_set=LocationFiltersLookUpAPI)
         self.lookup.extraction_pipelines = MagicMock(spec_set=ExtractionPipelineLookUpAPI)
         self.migration = MagicMock(spec=MigrationAPI)
-        self.migration.mapping = MagicMock(spec_set=MappingAPI)
+        self.migration.mapping = MagicMock(spec_set=InstanceSourceAPI)
 
         self.robotics = MagicMock()
         self.robotics.robots = MagicMock(spec=RoboticsAPI)

--- a/tests/test_integration/test_toolkit_client/test_migration.py
+++ b/tests/test_integration/test_toolkit_client/test_migration.py
@@ -2,11 +2,11 @@ import pytest
 from cognite.client.data_classes.data_modeling import NodeApply, NodeApplyList, NodeList, NodeOrEdgeData, Space
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
-from cognite_toolkit._cdf_tk.client.data_classes.migration import Mapping
+from cognite_toolkit._cdf_tk.client.data_classes.migration import InstanceSource
 
 
 @pytest.fixture(scope="session")
-def three_mappings(toolkit_client: ToolkitClient, toolkit_space: Space) -> NodeList[Mapping]:
+def three_sources(toolkit_client: ToolkitClient, toolkit_space: Space) -> NodeList[InstanceSource]:
     nodes = NodeApplyList(
         [
             NodeApply(
@@ -14,7 +14,7 @@ def three_mappings(toolkit_client: ToolkitClient, toolkit_space: Space) -> NodeL
                 external_id=f"toolkit_test_migration_{i}",
                 sources=[
                     NodeOrEdgeData(
-                        Mapping.get_source(),
+                        InstanceSource.get_source(),
                         {
                             "resourceType": "asset",
                             "id": i,
@@ -28,18 +28,15 @@ def three_mappings(toolkit_client: ToolkitClient, toolkit_space: Space) -> NodeL
 
     _ = toolkit_client.data_modeling.instances.apply(nodes)
 
-    created = toolkit_client.data_modeling.instances.retrieve_nodes(nodes.as_ids(), node_cls=Mapping)
+    created = toolkit_client.data_modeling.instances.retrieve_nodes(nodes.as_ids(), node_cls=InstanceSource)
     assert len(created) == 3, "Expected 3 mappings to be created"
     return created
 
 
-class TestMappingAPI:
-    @pytest.mark.skip(
-        reason="The mapping API is outdated and needs to be updated with the round 2 of the Migration model."
-    )
-    def test_retrieve_mappings(self, toolkit_client: ToolkitClient, three_mappings: NodeList[Mapping]) -> None:
-        ids = [mapping.as_asset_centric_id() for mapping in three_mappings]
+class TestInstanceSourceAPI:
+    def test_retrieve_mappings(self, toolkit_client: ToolkitClient, three_sources) -> None:
+        ids = [instance_source.as_asset_centric_id() for instance_source in three_sources]
 
         retrieved = toolkit_client.migration.instance_source.retrieve(ids)
 
-        assert retrieved.dump() == three_mappings.dump(), "Failed to retrieve mappings using asset-centric IDs"
+        assert retrieved.dump() == three_sources.dump(), "Failed to retrieve instance source using asset-centric IDs"

--- a/tests/test_integration/test_toolkit_client/test_migration.py
+++ b/tests/test_integration/test_toolkit_client/test_migration.py
@@ -40,6 +40,6 @@ class TestMappingAPI:
     def test_retrieve_mappings(self, toolkit_client: ToolkitClient, three_mappings: NodeList[Mapping]) -> None:
         ids = [mapping.as_asset_centric_id() for mapping in three_mappings]
 
-        retrieved = toolkit_client.migration.mapping.retrieve(ids)
+        retrieved = toolkit_client.migration.instance_source.retrieve(ids)
 
         assert retrieved.dump() == three_mappings.dump(), "Failed to retrieve mappings using asset-centric IDs"

--- a/tests/test_integration/test_toolkit_client/test_migration.py
+++ b/tests/test_integration/test_toolkit_client/test_migration.py
@@ -3,6 +3,7 @@ from cognite.client.data_classes.data_modeling import NodeApply, NodeApplyList, 
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.data_classes.migration import InstanceSource
+from cognite_toolkit._cdf_tk.tk_warnings import IgnoredValueWarning, catch_warnings
 
 
 @pytest.fixture(scope="session")
@@ -18,6 +19,13 @@ def three_sources(toolkit_client: ToolkitClient, toolkit_space: Space) -> NodeLi
                         {
                             "resourceType": "asset",
                             "id": i,
+                            "preferredConsumerViewId": {
+                                "space": "cdf_cdm",
+                                "externalId": "CogniteAsset",
+                                "version": "v1",
+                            }
+                            if i < 2
+                            else {"invalid": "json"},
                         },
                     )
                 ],
@@ -34,9 +42,19 @@ def three_sources(toolkit_client: ToolkitClient, toolkit_space: Space) -> NodeLi
 
 
 class TestInstanceSourceAPI:
-    def test_retrieve_mappings(self, toolkit_client: ToolkitClient, three_sources) -> None:
+    def test_retrieve_mappings(self, toolkit_client: ToolkitClient, three_sources: NodeList[InstanceSource]) -> None:
         ids = [instance_source.as_asset_centric_id() for instance_source in three_sources]
 
-        retrieved = toolkit_client.migration.instance_source.retrieve(ids)
+        with catch_warnings(IgnoredValueWarning) as warnings:
+            retrieved = toolkit_client.migration.instance_source.retrieve(ids)
 
         assert retrieved.dump() == three_sources.dump(), "Failed to retrieve instance source using asset-centric IDs"
+        assert len(warnings) == 1, "Expected one warning about invalid JSON in preferredConsumerViewId"
+        has_preferred_consumer_view = [
+            item.as_id() for item in retrieved if item.preferred_consumer_view_id is not None
+        ]
+        assert has_preferred_consumer_view == [item.as_id() for item in three_sources[:2]]
+        no_preferred_consumer_view = [item.as_id() for item in retrieved if item.preferred_consumer_view_id is None]
+        assert no_preferred_consumer_view == [three_sources[2].as_id()], (
+            "Expected last item to have no preferred consumer view"
+        )


### PR DESCRIPTION
# Description

Context: This is part of the alpha migration tooling in Toolkit, for overview [see here](https://cognitedata.atlassian.net/wiki/spaces/~170890702/pages/5455773697/Migration+Tooling+in+Toolkit). This is step 4 of that process, enabling downloading the instance source of migrated resources. This will, for example, be used by the Canvas migration to lookup the instance Id of asset-centric resources in a Chart.

Note the `InstanceSource` classes are generated by `pygen`.
![image](https://github.com/user-attachments/assets/39339156-9f03-4ddf-92b0-7b2c8be76e87)


## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip

