### PR TITLE
[CDF-25200]🧹Cleanup from future import __annotations__

### DIFF
--- a/cognite_toolkit/_cdf_tk/_parameters/data_classes.py
+++ b/cognite_toolkit/_cdf_tk/_parameters/data_classes.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 import dataclasses
+import sys
 import typing
 from collections.abc import Hashable, Iterable, MutableSet
 from dataclasses import dataclass
@@ -11,6 +10,10 @@ from typing import AbstractSet, Generic, TypeVar, final  # noqa: UP035
 
 from cognite.client.utils._text import to_camel_case
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 from .constants import ANYTHING, SINGLETONS
 
 
@@ -26,7 +29,7 @@ class Parameter:
         else:
             return str(self.path[-1])
 
-    def __lt__(self, other: Parameter) -> bool:
+    def __lt__(self, other: Self) -> bool:
         if not isinstance(other, Parameter):
             return NotImplemented
         return self.path < other.path
@@ -94,7 +97,7 @@ class ParameterSet(Hashable, MutableSet, Generic[T_Parameter]):
     def __init__(self, iterable: Iterable[T_Parameter] = ()) -> None:
         self.data: set[T_Parameter] = set(iterable)
 
-    def as_camel_case(self) -> ParameterSet[T_Parameter]:
+    def as_camel_case(self) -> "ParameterSet[T_Parameter]":
         output = type(self)()
         for parameter in self:
             new_path = tuple(
@@ -110,13 +113,13 @@ class ParameterSet(Hashable, MutableSet, Generic[T_Parameter]):
     def has_any_type(self) -> bool:
         return any(parameter.has_any_type for parameter in self)
 
-    def subset_any_type_paths(self) -> ParameterSet[T_Parameter]:
+    def subset_any_type_paths(self) -> "ParameterSet[T_Parameter]":
         return type(self)(parameter for parameter in self if parameter.has_any_type)
 
-    def subset_anything_paths(self) -> ParameterSet[T_Parameter]:
+    def subset_anything_paths(self) -> "ParameterSet[T_Parameter]":
         return type(self)(parameter for parameter in self if parameter.path[-1] is ANYTHING)
 
-    def subset(self, path: tuple[str | int, ...] | int) -> ParameterSet[T_Parameter]:
+    def subset(self, path: tuple[str | int, ...] | int) -> "ParameterSet[T_Parameter]":
         if isinstance(path, tuple):
             return type(self)(parameter for parameter in self if parameter.path[: len(path)] == path)
         elif isinstance(path, int):
@@ -144,10 +147,10 @@ class ParameterSet(Hashable, MutableSet, Generic[T_Parameter]):
     def discard(self, item: T_Parameter) -> None:
         self.data.discard(item)
 
-    def update(self, other: ParameterSet[T_Parameter]) -> None:
+    def update(self, other: "ParameterSet[T_Parameter]") -> None:
         self.data.update(other.data)
 
-    def difference(self, other: ParameterSet[T_Parameter]) -> ParameterSet[T_Parameter]:
+    def difference(self, other: "ParameterSet[T_Parameter]") -> "ParameterSet[T_Parameter]":
         output = type(self)(self.data.difference(other.data))
         other_any = other.subset_any_type_paths()
         other_anything = other.subset_anything_paths()
@@ -168,7 +171,7 @@ class ParameterSet(Hashable, MutableSet, Generic[T_Parameter]):
             output.discard(d)
         return output
 
-    def __sub__(self, other: AbstractSet) -> ParameterSet[T_Parameter]:
+    def __sub__(self, other: AbstractSet) -> "ParameterSet[T_Parameter]":
         return self.difference(type(self)(other))
 
 
@@ -186,7 +189,7 @@ class ParameterSpecSet(ParameterSet[ParameterSpec]):
                 parameter for parameter in self if len(parameter.path) <= level and parameter.is_required
             )
 
-    def as_camel_case(self) -> ParameterSpecSet:
+    def as_camel_case(self) -> "ParameterSpecSet":
         output = typing.cast(ParameterSpecSet, super().as_camel_case())
         output.is_complete = self.is_complete
         return output

--- a/cognite_toolkit/_cdf_tk/_parameters/functions.py
+++ b/cognite_toolkit/_cdf_tk/_parameters/functions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import inspect
 from typing import Any, Literal, get_args, get_origin
 

--- a/cognite_toolkit/_cdf_tk/_parameters/get_type_hints.py
+++ b/cognite_toolkit/_cdf_tk/_parameters/get_type_hints.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import abc
 import importlib
 import inspect

--- a/cognite_toolkit/_cdf_tk/_parameters/type_hint.py
+++ b/cognite_toolkit/_cdf_tk/_parameters/type_hint.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import enum
 import inspect
 import itertools
@@ -111,7 +109,7 @@ class TypeHint:
         return repr(self.raw)
 
     @property
-    def sub_hints(self) -> Iterable[TypeHint]:
+    def sub_hints(self) -> "Iterable[TypeHint]":
         for arg in self.args:
             if self._is_none_type(arg):
                 continue

--- a/cognite_toolkit/_cdf_tk/apps/_landing_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_landing_app.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import typer
 
 from cognite_toolkit._cdf_tk.commands import InitCommand

--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import re
 import sys
 import urllib
@@ -20,11 +18,14 @@ from cognite_toolkit._cdf_tk.exceptions import (
 from cognite_toolkit._cdf_tk.tk_warnings import MediumSeverityWarning
 
 if sys.version_info >= (3, 11):
+    from typing import Self
+
     import tomllib
     from tomllib import TOMLDecodeError
 else:
     import tomli as tomllib
     from tomli import TOMLDecodeError
+    from typing_extensions import Self
 
 
 @dataclass
@@ -36,7 +37,7 @@ class CLIConfig:
     has_user_set_default_env: bool = False
 
     @classmethod
-    def load(cls, raw: dict[str, Any], cwd: Path) -> CLIConfig:
+    def load(cls, raw: dict[str, Any], cwd: Path) -> Self:
         has_user_set_default_org = "default_organization_dir" in raw
         has_user_set_default_env = "default_env" in raw
         default_organization_dir = cwd / raw["default_organization_dir"] if has_user_set_default_org else Path.cwd()
@@ -55,7 +56,7 @@ class ModulesConfig:
     packages: dict[str, list[str]] = field(default_factory=dict)
 
     @classmethod
-    def load(cls, raw: dict[str, Any]) -> ModulesConfig:
+    def load(cls, raw: dict[str, Any]) -> Self:
         version = raw["version"]
         packages = raw.get("packages", {})
         if (
@@ -78,7 +79,7 @@ class Library:
     checksum: str
 
     @classmethod
-    def load(cls, raw: dict[str, Any]) -> Library:
+    def load(cls, raw: dict[str, Any]) -> Self:
         if "url" not in raw:
             raise ValueError("Library configuration must contain 'url' field.")
 
@@ -114,7 +115,7 @@ class CDFToml:
     is_loaded_from_file: bool = False
 
     @classmethod
-    def load(cls, cwd: Path | None = None, use_singleton: bool = True) -> CDFToml:
+    def load(cls, cwd: Path | None = None, use_singleton: bool = True) -> "CDFToml":
         """Loads the cdf.toml file from the given path. If use_singleton is True, the instance will be stored as a
         singleton and returned on subsequent calls."""
         global _CDF_TOML

--- a/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
+++ b/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Literal, cast
 
 from cognite.client import ClientConfig, CogniteClient

--- a/cognite_toolkit/_cdf_tk/client/api/agents/agents.py
+++ b/cognite_toolkit/_cdf_tk/client/api/agents/agents.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Iterator, Sequence
 from typing import overload
 

--- a/cognite_toolkit/_cdf_tk/client/api/agents/api.py
+++ b/cognite_toolkit/_cdf_tk/client/api/agents/api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from cognite.client import ClientConfig, CogniteClient
 from cognite.client._api_client import APIClient
 

--- a/cognite_toolkit/_cdf_tk/client/api/fixed_transformations.py
+++ b/cognite_toolkit/_cdf_tk/client/api/fixed_transformations.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import gzip
 from typing import Any
 

--- a/cognite_toolkit/_cdf_tk/client/api/location_filters.py
+++ b/cognite_toolkit/_cdf_tk/client/api/location_filters.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Iterator
 from typing import overload
 

--- a/cognite_toolkit/_cdf_tk/client/api/robotics/api.py
+++ b/cognite_toolkit/_cdf_tk/client/api/robotics/api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from cognite.client import ClientConfig, CogniteClient
 from cognite.client._api_client import APIClient
 

--- a/cognite_toolkit/_cdf_tk/client/api/robotics/capabilities.py
+++ b/cognite_toolkit/_cdf_tk/client/api/robotics/capabilities.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Iterator, Sequence
 from typing import overload
 

--- a/cognite_toolkit/_cdf_tk/client/api/robotics/data_postprocessing.py
+++ b/cognite_toolkit/_cdf_tk/client/api/robotics/data_postprocessing.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Iterator, Sequence
 from typing import overload
 

--- a/cognite_toolkit/_cdf_tk/client/api/robotics/frames.py
+++ b/cognite_toolkit/_cdf_tk/client/api/robotics/frames.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Iterator, Sequence
 from typing import overload
 

--- a/cognite_toolkit/_cdf_tk/client/api/robotics/locations.py
+++ b/cognite_toolkit/_cdf_tk/client/api/robotics/locations.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Iterator, Sequence
 from typing import overload
 

--- a/cognite_toolkit/_cdf_tk/client/api/robotics/maps.py
+++ b/cognite_toolkit/_cdf_tk/client/api/robotics/maps.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Iterator, Sequence
 from typing import overload
 

--- a/cognite_toolkit/_cdf_tk/client/api/robotics/robots.py
+++ b/cognite_toolkit/_cdf_tk/client/api/robotics/robots.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Iterator, Sequence
 from typing import overload
 

--- a/cognite_toolkit/_cdf_tk/client/api/search_config.py
+++ b/cognite_toolkit/_cdf_tk/client/api/search_config.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from urllib.parse import urljoin
 
 from cognite.client import CogniteClient

--- a/cognite_toolkit/_cdf_tk/client/data_classes/agent_tools.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/agent_tools.py
@@ -1,5 +1,4 @@
-from __future__ import annotations
-
+import sys
 from abc import ABC
 from dataclasses import dataclass
 from typing import Any
@@ -11,6 +10,11 @@ from cognite.client.data_classes._base import (
     WriteableCogniteResource,
     WriteableCogniteResourceList,
 )
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 @dataclass
@@ -30,7 +34,7 @@ class AgentToolCore(WriteableCogniteResource["AgentToolWrite"], ABC):
     description: str
     configuration: dict[str, Any] | None = None
 
-    def as_write(self) -> AgentToolWrite:
+    def as_write(self) -> "AgentToolWrite":
         return AgentToolWrite(
             name=self.name,
             type=self.type,
@@ -53,7 +57,7 @@ class AgentTool(AgentToolCore):
     """
 
     @classmethod
-    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> AgentTool:
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         return cls(
             name=resource["name"],
             type=resource["type"],

--- a/cognite_toolkit/_cdf_tk/client/data_classes/agents.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/agents.py
@@ -1,5 +1,4 @@
-from __future__ import annotations
-
+import sys
 from abc import ABC
 from dataclasses import dataclass
 from typing import Any
@@ -13,6 +12,11 @@ from cognite.client.data_classes._base import (
 )
 
 from cognite_toolkit._cdf_tk.client.data_classes.agent_tools import AgentTool
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 @dataclass
@@ -46,7 +50,7 @@ class AgentCore(WriteableCogniteResource["AgentWrite"], ABC):
             result["instructions"] = ""  # match API behavior
         return result
 
-    def as_write(self) -> AgentWrite:
+    def as_write(self) -> "AgentWrite":
         return AgentWrite(
             external_id=self.external_id,
             name=self.name,
@@ -74,7 +78,7 @@ class Agent(AgentCore):
     """
 
     @classmethod
-    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Agent:
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         tools = (
             [AgentTool._load(item) for item in resource.get("tools", [])]
             if isinstance(resource.get("tools"), list)
@@ -108,7 +112,7 @@ class AgentWrite(AgentCore):
     """
 
     @classmethod
-    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> AgentWrite:
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         tools = (
             [AgentTool._load(item) for item in resource.get("tools", [])]
             if isinstance(resource.get("tools"), list)

--- a/cognite_toolkit/_cdf_tk/client/data_classes/extendable_cognite_file.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/extendable_cognite_file.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 import itertools
+import sys
 from datetime import datetime
 from typing import Any, Literal
 
@@ -9,6 +8,11 @@ from cognite.client.data_classes._base import CogniteResourceList, WriteableCogn
 from cognite.client.data_classes.data_modeling import DirectRelationReference, ViewId
 from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteFile, CogniteFileApply
 from cognite.client.utils._text import to_camel_case
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class ExtendableCogniteFileApply(CogniteFileApply):
@@ -118,7 +122,7 @@ class ExtendableCogniteFileApply(CogniteFileApply):
         return output
 
     @classmethod
-    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> ExtendableCogniteFileApply:
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         base_props = cls._load_base_properties(resource)
         properties = cls._load_properties(resource)
         loaded_keys = {to_camel_case(p) for p in itertools.chain(base_props.keys(), properties.keys())} | {
@@ -198,7 +202,7 @@ class ExtendableCogniteFile(CogniteFile):
         return ViewId(space="cdf_cdm", external_id="CogniteFile", version="v1")
 
     @classmethod
-    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> ExtendableCogniteFile:
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         base_props = cls._load_base_properties(resource)
         all_properties = resource.get("properties", {})
         # There should only be one source in one view

--- a/cognite_toolkit/_cdf_tk/client/data_classes/functions.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/functions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any
 

--- a/cognite_toolkit/_cdf_tk/client/data_classes/graphql_data_models.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/graphql_data_models.py
@@ -1,5 +1,4 @@
-from __future__ import annotations
-
+import sys
 from abc import ABC
 from typing import Any
 
@@ -7,6 +6,11 @@ from cognite.client import CogniteClient
 from cognite.client.data_classes._base import CogniteResourceList, WriteableCogniteResourceList
 from cognite.client.data_classes.data_modeling import DataModelId, ViewId
 from cognite.client.data_classes.data_modeling.core import DataModelingSchemaResource
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class _GraphQLDataModelCore(DataModelingSchemaResource["GraphQLDataModelWrite"], ABC):
@@ -38,7 +42,7 @@ class GraphQLDataModelWrite(_GraphQLDataModelCore):
         self.preserve_dml = preserve_dml
 
     @classmethod
-    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> GraphQLDataModelWrite:
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         return cls(
             space=resource["space"],
             external_id=resource["externalId"],
@@ -50,7 +54,7 @@ class GraphQLDataModelWrite(_GraphQLDataModelCore):
             preserve_dml=resource.get("preserveDml"),
         )
 
-    def as_write(self) -> GraphQLDataModelWrite:
+    def as_write(self) -> Self:
         return self
 
 
@@ -83,7 +87,7 @@ class GraphQLDataModel(_GraphQLDataModelCore):
         )
 
     @classmethod
-    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> GraphQLDataModel:
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         return cls(
             space=resource["space"],
             external_id=resource["externalId"],

--- a/cognite_toolkit/_cdf_tk/client/data_classes/location_filters.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/location_filters.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC
 from dataclasses import dataclass
 
@@ -94,7 +92,7 @@ class AssetCentricFilter(CogniteObject):
         return None
 
     @classmethod
-    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> AssetCentricFilter:
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         return cls(
             assets=cls._load_subfilter(resource, "assets"),
             events=cls._load_subfilter(resource, "events"),
@@ -163,7 +161,7 @@ class LocationFilterCore(WriteableCogniteResource["LocationFilterWrite"], ABC):
         self.data_modeling_type = data_modeling_type
         self._parent_external_id = _parent_external_id  # This is an internal property used to temporarily hold the parentExternalId when lookup is deferred
 
-    def as_write(self) -> LocationFilterWrite:
+    def as_write(self) -> "LocationFilterWrite":
         return LocationFilterWrite(
             external_id=self.external_id,
             name=self.name,
@@ -253,7 +251,7 @@ class LocationFilter(LocationFilterCore):
         asset_centric: AssetCentricFilter | None = None,
         views: list[LocationFilterView] | None = None,
         data_modeling_type: Literal["HYBRID", "DATA_MODELING_ONLY"] | None = None,
-        locations: LocationFilterList | None = None,
+        locations: "LocationFilterList | None" = None,
     ) -> None:
         super().__init__(
             external_id,

--- a/cognite_toolkit/_cdf_tk/client/data_classes/migration.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/migration.py
@@ -1,5 +1,4 @@
-from __future__ import annotations
-
+import sys
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -12,6 +11,11 @@ from cognite.client.data_classes.data_modeling.instances import (
     TypedNode,
 )
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 
 @dataclass(frozen=True)
 class AssetCentricId(CogniteObject):
@@ -19,7 +23,7 @@ class AssetCentricId(CogniteObject):
     id_: int
 
     @classmethod
-    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> AssetCentricId:
+    def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         """Load an AssetCentricId from a dictionary."""
         return cls(
             resource_type=resource["resourceType"],

--- a/cognite_toolkit/_cdf_tk/client/data_classes/robotics.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/robotics.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC
 from typing import Any, Literal, TypeAlias
 
@@ -73,7 +71,7 @@ class RobotCapabilityWrite(RobotCapabilityCore):
         self.input_schema = input_schema
         self.data_handling_schema = data_handling_schema
 
-    def as_write(self) -> RobotCapabilityWrite:
+    def as_write(self) -> Self:
         return self
 
     @classmethod
@@ -209,7 +207,7 @@ class RobotCore(WriteableCogniteResource["RobotWrite"], ABC):
         self.metadata = metadata
         self.location_external_id = location_external_id
 
-    def as_write(self) -> RobotWrite:
+    def as_write(self) -> "RobotWrite":
         return RobotWrite(
             name=self.name,
             capabilities=self.capabilities,
@@ -370,7 +368,7 @@ class DataPostProcessingWrite(DataPostProcessingCore):
         super().__init__(name, external_id, method, description)
         self.input_schema = input_schema
 
-    def as_write(self) -> DataPostProcessingWrite:
+    def as_write(self) -> Self:
         return self
 
     @classmethod
@@ -501,7 +499,7 @@ class LocationWrite(LocationCore):
     ) -> None:
         super().__init__(name, external_id, description)
 
-    def as_write(self) -> LocationWrite:
+    def as_write(self) -> Self:
         return self
 
     @classmethod
@@ -704,7 +702,7 @@ class FrameWrite(FrameCore):
     ) -> None:
         super().__init__(name, external_id, transform)
 
-    def as_write(self) -> FrameWrite:
+    def as_write(self) -> Self:
         return self
 
     @classmethod
@@ -860,7 +858,7 @@ class MapWrite(MapCore):
     ) -> None:
         super().__init__(name, external_id, map_type, description, frame_external_id, data, location_external_id, scale)
 
-    def as_write(self) -> MapWrite:
+    def as_write(self) -> Self:
         return self
 
     @classmethod

--- a/cognite_toolkit/_cdf_tk/client/data_classes/search_config.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/search_config.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC
 from dataclasses import dataclass
 from typing import Any
@@ -76,7 +74,7 @@ class SearchConfigCore(WriteableCogniteResource["SearchConfigWrite"], ABC):
         self.filter_layout = filter_layout
         self.properties_layout = properties_layout
 
-    def as_write(self) -> SearchConfigWrite:
+    def as_write(self) -> "SearchConfigWrite":
         return SearchConfigWrite(
             view=self.view,
             id=self.id,

--- a/cognite_toolkit/_cdf_tk/commands/_base.py
+++ b/cognite_toolkit/_cdf_tk/commands/_base.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 from collections.abc import Callable
 from typing import Any

--- a/cognite_toolkit/_cdf_tk/commands/_changes.py
+++ b/cognite_toolkit/_cdf_tk/commands/_changes.py
@@ -1,7 +1,8 @@
-from __future__ import annotations
+
 
 import itertools
 import re
+import sys
 from collections.abc import Iterator, MutableSequence
 from functools import lru_cache
 from pathlib import Path
@@ -16,6 +17,10 @@ from cognite_toolkit._cdf_tk.data_classes import ModuleDirectories
 from cognite_toolkit._cdf_tk.utils import iterate_modules, read_yaml_file, safe_read, safe_write
 from cognite_toolkit._version import __version__
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 class Change:
     """A change is a single migration step that can be applied to a project."""
@@ -716,15 +721,15 @@ _CHANGES: list[type[Change]] = [
 
 class Changes(list, MutableSequence[Change]):
     @classmethod
-    def load(cls, module_version: Version, project_path: Path, workflow_dir: Path | None) -> Changes:
+    def load(cls, module_version: Version, project_path: Path, workflow_dir: Path | None) -> Self:
         return cls([change(project_path, workflow_dir) for change in _CHANGES if change.deprecated_from >= module_version])
 
     @property
-    def required_changes(self) -> Changes:
+    def required_changes(self) -> "Changes":
         return Changes([change for change in self if change.required_from is not None])
 
     @property
-    def optional_changes(self) -> Changes:
+    def optional_changes(self) -> "Changes":
         return Changes([change for change in self if change.required_from is None])
 
     def __iter__(self) -> Iterator[Change]:

--- a/cognite_toolkit/_cdf_tk/commands/_cli_commands.py
+++ b/cognite_toolkit/_cdf_tk/commands/_cli_commands.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import shutil
 import subprocess
 from contextlib import suppress

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import uuid
 from collections.abc import Hashable
 from graphlib import CycleError, TopologicalSorter

--- a/cognite_toolkit/_cdf_tk/commands/_utils.py
+++ b/cognite_toolkit/_cdf_tk/commands/_utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from cognite.client.data_classes._base import T_CogniteResourceList, T_WritableCogniteResource, T_WriteClass
 from cognite.client.utils.useful_types import SequenceNotStr
 

--- a/cognite_toolkit/_cdf_tk/commands/_virtual_env.py
+++ b/cognite_toolkit/_cdf_tk/commands/_virtual_env.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import shutil
 import sys
 import venv

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
+
 
 import itertools
 import shutil

--- a/cognite_toolkit/_cdf_tk/commands/build_cmd.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_cmd.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import contextlib
 import re
 from collections import defaultdict

--- a/cognite_toolkit/_cdf_tk/commands/clean.py
+++ b/cognite_toolkit/_cdf_tk/commands/clean.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import traceback
 from graphlib import TopologicalSorter
 from pathlib import Path

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Hashable
 from graphlib import TopologicalSorter
 from pathlib import Path

--- a/cognite_toolkit/_cdf_tk/commands/featureflag.py
+++ b/cognite_toolkit/_cdf_tk/commands/featureflag.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from rich import print
 from rich.table import Table
 

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 import shutil
+import sys
 import tempfile
 import zipfile
 from collections import Counter
@@ -62,6 +61,10 @@ from cognite_toolkit._cdf_tk.utils.modules import module_directory_from_path
 from cognite_toolkit._cdf_tk.utils.repository import FileDownloader
 from cognite_toolkit._version import __version__
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 custom_style_fancy = questionary.Style(
     [
         ("qmark", "fg:#673ab7"),  # token in front of the question
@@ -95,7 +98,7 @@ class ModulesCommand(ToolkitCommand):
         if not self._temp_download_dir.exists():
             self._temp_download_dir.mkdir(parents=True, exist_ok=True)
 
-    def __enter__(self) -> ModulesCommand:
+    def __enter__(self) -> Self:
         """
         Context manager to ensure the temporary download directory is cleaned up after use. It requires the command to be used in a `with` block.
         """

--- a/cognite_toolkit/_cdf_tk/commands/pull.py
+++ b/cognite_toolkit/_cdf_tk/commands/pull.py
@@ -1,8 +1,7 @@
-from __future__ import annotations
-
 import dataclasses
 import itertools
 import re
+import sys
 import tempfile
 import uuid
 from collections import UserList
@@ -64,6 +63,11 @@ from cognite_toolkit._cdf_tk.utils.modules import (
 from ._base import ToolkitCommand
 from .build_cmd import BuildCommand
 from .clean import CleanCommand
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 _VARIABLE_PATTERN = re.compile(r"\{\{(.+?)\}\}")
 # The encoding and newline characters to use when writing files
@@ -159,7 +163,7 @@ class ResourceYAMLDifference(YAMLWithComments[tuple[Union[str, int], ...], Resou
         return self._comments.get(key)
 
     @classmethod
-    def load(cls, build_content: str, source_content: str) -> ResourceYAMLDifference:
+    def load(cls, build_content: str, source_content: str) -> Self:
         comments = cls._extract_comments(build_content)
         build = read_yaml_content(build_content)
         build_flatten = cls._flatten(build)
@@ -344,7 +348,7 @@ class TextFileDifference(UserList):
         super().__init__(lines or [])
 
     @classmethod
-    def load(cls, build_content: str, source_content: str) -> TextFileDifference:
+    def load(cls, build_content: str, source_content: str) -> Self:
         lines = []
         # Build and source content should have the same number of lines
         for no, (build, source) in enumerate(zip(build_content.splitlines(), source_content.splitlines())):
@@ -739,7 +743,7 @@ class PullCommand(ToolkitCommand):
         loaded_with_placeholder: dict[str, Any],
         to_write: dict[T_ID, dict[str, Any]],
         built_by_identifier: dict[T_ID, BuiltResourceFull[T_ID]],
-        replacer: ResourceReplacer,
+        replacer: "ResourceReplacer",
         extra_files: dict[Path, str],
     ) -> dict[str, Any]:
         if item_id not in to_write:

--- a/cognite_toolkit/_cdf_tk/commands/run.py
+++ b/cognite_toolkit/_cdf_tk/commands/run.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import ast
 import datetime
 import json

--- a/cognite_toolkit/_cdf_tk/data_classes/_base.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_base.py
@@ -1,5 +1,4 @@
-from __future__ import annotations
-
+import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
@@ -9,6 +8,11 @@ from cognite_toolkit import _version
 from cognite_toolkit._cdf_tk.constants import BUILD_ENVIRONMENT_FILE
 from cognite_toolkit._cdf_tk.exceptions import ToolkitFileNotFoundError, ToolkitRequiredValueError, ToolkitVersionError
 from cognite_toolkit._cdf_tk.utils import read_yaml_file
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 @dataclass
@@ -23,7 +27,7 @@ class ConfigCore(ABC):
         return cls.filename.format(build_env=build_env)
 
     @classmethod
-    def load_from_directory(cls: type[T_BuildConfig], organization_dir: Path, build_env: str) -> T_BuildConfig:
+    def load_from_directory(cls, organization_dir: Path, build_env: str) -> Self:
         filename = cls.get_filename(build_env)
         filepath = organization_dir / filename
         filepath = filepath if filepath.is_file() else Path.cwd() / filename
@@ -37,7 +41,7 @@ class ConfigCore(ABC):
 
     @classmethod
     @abstractmethod
-    def load(cls: type[T_BuildConfig], data: dict[str, Any], build_env: str, filepath: Path) -> T_BuildConfig:
+    def load(cls, data: dict[str, Any], build_env: str, filepath: Path) -> Self:
         raise NotImplementedError
 
 

--- a/cognite_toolkit/_cdf_tk/data_classes/_built_modules.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_built_modules.py
@@ -1,5 +1,4 @@
-from __future__ import annotations
-
+import sys
 from collections.abc import Callable, Collection, Iterator, MutableSequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,6 +15,11 @@ from ._built_resources import (
     SourceLocation,
 )
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 
 @dataclass
 class BuiltModule:
@@ -28,7 +32,7 @@ class BuiltModule:
     iteration: int
 
     @classmethod
-    def load(cls, data: dict[str, Any]) -> BuiltModule:
+    def load(cls, data: dict[str, Any]) -> Self:
         return cls(
             name=data["name"],
             location=SourceLocation.load(data["location"]),
@@ -69,9 +73,9 @@ class BuiltModuleList(list, MutableSequence[BuiltModule]):
     def __getitem__(self, index: SupportsIndex) -> BuiltModule: ...
 
     @overload
-    def __getitem__(self, index: slice) -> BuiltModuleList: ...
+    def __getitem__(self, index: slice) -> Self: ...
 
-    def __getitem__(self, index: SupportsIndex | slice, /) -> BuiltModule | BuiltModuleList:
+    def __getitem__(self, index: SupportsIndex | slice, /) -> "BuiltModule | BuiltModuleList":
         if isinstance(index, slice):
             return BuiltModuleList(super().__getitem__(index))
         return super().__getitem__(index)
@@ -83,7 +87,7 @@ class BuiltModuleList(list, MutableSequence[BuiltModule]):
         kind: str | None = None,
         selected: Path | str | None = None,
         is_supported_file: Callable[[Path], bool] | None = None,
-    ) -> BuiltFullResourceList[T_ID]:
+    ) -> "BuiltFullResourceList[T_ID]":
         resources = (
             resource.create_full(module, resource_dir)
             for module in self

--- a/cognite_toolkit/_cdf_tk/data_classes/_built_resources.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_built_resources.py
@@ -131,7 +131,7 @@ class BuiltResource(Generic[T_ID]):
             output["extra_sources"] = [source.dump() for source in self.extra_sources]
         return output
 
-    def create_full(self, module: BuiltModule, resource_dir: str) -> "BuiltResourceFull":
+    def create_full(self, module: "BuiltModule", resource_dir: str) -> "BuiltResourceFull":
         return BuiltResourceFull(
             identifier=self.identifier,
             source=self.source,

--- a/cognite_toolkit/_cdf_tk/data_classes/_built_resources.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_built_resources.py
@@ -1,5 +1,4 @@
-from __future__ import annotations
-
+import sys
 from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Collection, Iterator, MutableSequence
@@ -20,6 +19,10 @@ from cognite_toolkit._cdf_tk.utils import (
 
 from ._build_variables import BuildVariables
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 if TYPE_CHECKING:
     from ._built_modules import BuiltModule
 
@@ -47,7 +50,7 @@ class SourceLocation:
         }
 
     @classmethod
-    def load(cls, data: dict[str, Any]) -> SourceLocation:
+    def load(cls, data: dict[str, Any]) -> "SourceLocationEager":
         return SourceLocationEager(
             path=Path(data["path"]),
             _hash=str(data["hash"]),
@@ -96,7 +99,7 @@ class BuiltResource(Generic[T_ID]):
     extra_sources: list[SourceLocation] | None
 
     @classmethod
-    def load(cls: type[T_BuiltResource], data: dict[str, Any], resource_folder: str) -> T_BuiltResource:
+    def load(cls, data: dict[str, Any], resource_folder: str) -> Self:
         from cognite_toolkit._cdf_tk.loaders import ResourceLoader, get_loader
 
         kind = data["kind"]
@@ -128,7 +131,7 @@ class BuiltResource(Generic[T_ID]):
             output["extra_sources"] = [source.dump() for source in self.extra_sources]
         return output
 
-    def create_full(self, module: BuiltModule, resource_dir: str) -> BuiltResourceFull[T_ID]:
+    def create_full(self, module: BuiltModule, resource_dir: str) -> "BuiltResourceFull":
         return BuiltResourceFull(
             identifier=self.identifier,
             source=self.source,
@@ -184,9 +187,9 @@ class BuiltResourceList(list, MutableSequence[BuiltResource[T_ID]], Generic[T_ID
     def __getitem__(self, index: SupportsIndex) -> BuiltResource[T_ID]: ...
 
     @overload
-    def __getitem__(self, index: slice) -> BuiltResourceList[T_ID]: ...
+    def __getitem__(self, index: slice) -> "BuiltResourceList[T_ID]": ...
 
-    def __getitem__(self, index: SupportsIndex | slice, /) -> BuiltResource[T_ID] | BuiltResourceList[T_ID]:
+    def __getitem__(self, index: SupportsIndex | slice, /) -> "BuiltResource[T_ID] | BuiltResourceList[T_ID]":
         if isinstance(index, slice):
             return BuiltResourceList[T_ID](super().__getitem__(index))
         return super().__getitem__(index)
@@ -196,7 +199,7 @@ class BuiltResourceList(list, MutableSequence[BuiltResource[T_ID]], Generic[T_ID
         return [resource.identifier for resource in self]
 
     @classmethod
-    def load(cls, data: list[dict[str, Any]], resource_folder: str) -> BuiltResourceList[T_ID]:
+    def load(cls, data: list[dict[str, Any]], resource_folder: str) -> "BuiltResourceList[T_ID]":
         return cls([BuiltResource.load(resource_data, resource_folder) for resource_data in data])
 
     def dump(self, resource_folder: str, include_destination: bool = False) -> list[dict[str, Any]]:
@@ -226,14 +229,14 @@ class BuiltFullResourceList(BuiltResourceList[T_ID]):
     def __getitem__(self, index: SupportsIndex) -> BuiltResourceFull[T_ID]: ...
 
     @overload
-    def __getitem__(self, index: slice) -> BuiltFullResourceList[T_ID]: ...
+    def __getitem__(self, index: slice) -> "BuiltFullResourceList[T_ID]": ...
 
-    def __getitem__(self, index: SupportsIndex | slice, /) -> BuiltResourceFull[T_ID] | BuiltFullResourceList[T_ID]:
+    def __getitem__(self, index: SupportsIndex | slice, /) -> "BuiltResourceFull[T_ID] | BuiltFullResourceList[T_ID]":
         if isinstance(index, slice):
             return BuiltFullResourceList[T_ID](super().__getitem__(index))
         return cast(BuiltResourceFull[T_ID], super().__getitem__(index))
 
-    def by_file(self) -> dict[Path, BuiltFullResourceList[T_ID]]:
+    def by_file(self) -> "dict[Path, BuiltFullResourceList[T_ID]]":
         resources_by_file: dict[Path, BuiltFullResourceList[T_ID]] = defaultdict(lambda: BuiltFullResourceList())
         for resource in self:
             resources_by_file[resource.source.path].append(resource)

--- a/cognite_toolkit/_cdf_tk/data_classes/_deploy_results.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_deploy_results.py
@@ -1,5 +1,4 @@
-from __future__ import annotations
-
+import sys
 from abc import ABC
 from collections import UserDict
 from collections.abc import Iterable
@@ -8,6 +7,11 @@ from functools import total_ordering
 from typing import Literal
 
 from rich.table import Table
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 @total_ordering
@@ -40,7 +44,7 @@ class ResourceDeployResult(DeployResult):
     def calculated_total(self) -> int:
         return self.created + self.deleted + self.changed + self.unchanged
 
-    def __iadd__(self, other: ResourceDeployResult) -> ResourceDeployResult:
+    def __iadd__(self, other: "ResourceDeployResult") -> "ResourceDeployResult":
         if self.name != other.name:
             raise ValueError("Cannot add two DeployResult objects with different names")
         self.created += other.created
@@ -69,7 +73,7 @@ class ResourceContainerDeployResult(ResourceDeployResult):
     item_name: str = ""
     dropped_datapoints: int = 0
 
-    def __iadd__(self, other: ResourceDeployResult) -> ResourceContainerDeployResult:
+    def __iadd__(self, other: ResourceDeployResult) -> "ResourceContainerDeployResult":
         if self.name != other.name:
             raise ValueError("Cannot add two ResourceContainerDeployResult objects with different names")
         super().__iadd__(other)
@@ -80,7 +84,7 @@ class ResourceContainerDeployResult(ResourceDeployResult):
     @classmethod
     def from_resource_deploy_result(
         cls, result: ResourceDeployResult, item_name: str = "", dropped_datapoints: int = 0
-    ) -> ResourceContainerDeployResult:
+    ) -> Self:
         return cls(
             name=result.name,
             created=result.created,
@@ -98,7 +102,7 @@ class UploadDeployResult(DeployResult):
     uploaded: int = 0
     item_name: str = ""
 
-    def __iadd__(self, other: UploadDeployResult) -> UploadDeployResult:
+    def __iadd__(self, other: "UploadDeployResult") -> "UploadDeployResult":
         if self.name != other.name:
             raise ValueError("Cannot add two DeployResult objects with different names")
         self.uploaded += other.uploaded

--- a/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_module_directories.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 import shutil
+import sys
 from collections import defaultdict
 from collections.abc import Collection, Iterator, Sequence
 from dataclasses import dataclass
@@ -12,6 +11,11 @@ from cognite_toolkit._cdf_tk.constants import INDEX_PATTERN
 from cognite_toolkit._cdf_tk.utils import calculate_directory_hash, iterate_modules, resource_folder_from_path
 
 from ._module_toml import ModuleToml
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 @dataclass(frozen=True)
@@ -142,7 +146,7 @@ class ModuleLocation:
     def __str__(self) -> str:
         return self.name
 
-    def as_read_module(self) -> ReadModule:
+    def as_read_module(self) -> "ReadModule":
         return ReadModule(
             dir=self.dir,
             resource_directories=tuple(self.resource_directories),
@@ -176,7 +180,7 @@ class ReadModule:
         return None
 
     @classmethod
-    def load(cls, data: dict[str, Any]) -> ReadModule:
+    def load(cls, data: dict[str, Any]) -> Self:
         return cls(
             dir=Path(data["dir"]),
             resource_directories=tuple(data["resource_directories"]),
@@ -197,7 +201,7 @@ class ModuleDirectories(tuple, Sequence[ModuleLocation]):
 
     # Subclassing tuple to make the class immutable. ModuleDirectories is expected to be initialized and
     # then used as a read-only object.
-    def __new__(cls, collection: Collection[ModuleLocation] | None) -> ModuleDirectories:
+    def __new__(cls, collection: Collection[ModuleLocation] | None) -> Self:
         # Need to override __new__ to as we are subclassing a tuple:
         #   https://stackoverflow.com/questions/1565374/subclassing-tuple-with-multiple-init-arguments
         return super().__new__(cls, tuple(collection or []))
@@ -209,7 +213,7 @@ class ModuleDirectories(tuple, Sequence[ModuleLocation]):
         return {selection for module_location in self for selection in module_location.module_selections}
 
     @cached_property
-    def selected(self) -> ModuleDirectories:
+    def selected(self) -> "ModuleDirectories":
         return ModuleDirectories([module for module in self if module.is_selected])
 
     @cached_property
@@ -225,7 +229,7 @@ class ModuleDirectories(tuple, Sequence[ModuleLocation]):
         cls,
         organization_dir: Path,
         user_selected_modules: set[str | Path] | None = None,
-    ) -> ModuleDirectories:
+    ) -> Self:
         """Loads the modules in the source directory.
 
         Args:
@@ -293,9 +297,9 @@ class ModuleDirectories(tuple, Sequence[ModuleLocation]):
     def __getitem__(self, index: SupportsIndex) -> ModuleLocation: ...
 
     @overload
-    def __getitem__(self, index: slice) -> ModuleDirectories: ...
+    def __getitem__(self, index: slice) -> "ModuleDirectories": ...
 
-    def __getitem__(self, index: SupportsIndex | slice, /) -> ModuleLocation | ModuleDirectories:
+    def __getitem__(self, index: SupportsIndex | slice, /) -> "ModuleLocation | ModuleDirectories":
         if isinstance(index, slice):
             return ModuleDirectories(super().__getitem__(index))
         return super().__getitem__(index)

--- a/cognite_toolkit/_cdf_tk/data_classes/_module_resources.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_module_resources.py
@@ -1,5 +1,4 @@
-from __future__ import annotations
-
+import sys
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
@@ -25,6 +24,11 @@ from ._built_resources import BuiltFullResourceList
 from ._config_yaml import BuildConfigYAML
 from ._module_directories import ModuleDirectories
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 
 @dataclass
 class ModulesInfo:
@@ -32,7 +36,7 @@ class ModulesInfo:
     modules: BuiltModuleList
 
     @classmethod
-    def load(cls, data: dict[str, Any]) -> ModulesInfo:
+    def load(cls, data: dict[str, Any]) -> Self:
         return cls(
             version=data["version"],
             modules=BuiltModuleList([BuiltModule.load(module_data) for module_data in data["modules"]]),
@@ -52,13 +56,11 @@ class BuildInfo(ConfigCore):
     modules: ModulesInfo
 
     @classmethod
-    def load(cls, data: dict[str, Any], build_env: str, filepath: Path) -> BuildInfo:
+    def load(cls, data: dict[str, Any], build_env: str, filepath: Path) -> Self:
         return cls(filepath, ModulesInfo.load(data["modules"]))
 
     @classmethod
-    def rebuild(
-        cls, organization_dir: Path, build_env: str | None, needs_rebuild: set[Path] | None = None
-    ) -> BuildInfo:
+    def rebuild(cls, organization_dir: Path, build_env: str | None, needs_rebuild: set[Path] | None = None) -> Self:
         # To avoid circular imports
         # Ideally, this class should be in a separate module
         from cognite_toolkit._cdf_tk.commands.build_cmd import BuildCommand
@@ -110,7 +112,7 @@ class BuildInfo(ConfigCore):
         return new_build
 
     @classmethod
-    def _get_existing(cls, organization_dir: Path, build_env: str) -> BuildInfo | None:
+    def _get_existing(cls, organization_dir: Path, build_env: str) -> Self | None:
         try:
             existing = cls.load_from_directory(organization_dir, build_env)
         except FileNotFoundError:

--- a/cognite_toolkit/_cdf_tk/data_classes/_module_toml.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_module_toml.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -8,9 +6,12 @@ from typing import Any, ClassVar
 from cognite_toolkit._cdf_tk.exceptions import ToolkitFileExistsError
 
 if sys.version_info >= (3, 11):
+    from typing import Self
+
     import toml
 else:
     import tomli as toml
+    from typing_extensions import Self
 
 
 @dataclass(frozen=True)
@@ -21,7 +22,7 @@ class ExampleData:
     destination: Path
 
     @classmethod
-    def load(cls, data: dict[str, Any]) -> ExampleData:
+    def load(cls, data: dict[str, Any]) -> Self:
         return cls(
             repo_type=data["repoType"],
             repo=data["repo"],
@@ -45,7 +46,7 @@ class ModuleToml:
                 raise ToolkitFileExistsError(f"Extra resource {extra} must be a relative path")
 
     @classmethod
-    def load(cls, data: dict[str, Any] | Path) -> ModuleToml:
+    def load(cls, data: dict[str, Any] | Path) -> Self:
         if isinstance(data, Path):
             return cls.load(toml.loads(data.read_text(encoding="utf-8")))
 

--- a/cognite_toolkit/_cdf_tk/data_classes/_packages.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_packages.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 from collections.abc import ItemsView, Iterable, Iterator, KeysView, Mapping, MutableMapping, ValuesView
 from dataclasses import dataclass, field
@@ -10,9 +8,12 @@ from cognite_toolkit._cdf_tk.exceptions import ToolkitFileNotFoundError, Toolkit
 from ._module_directories import ModuleDirectories, ModuleLocation
 
 if sys.version_info >= (3, 11):
+    from typing import Self
+
     import toml
 else:
     import tomli as toml
+    from typing_extensions import Self
 
 
 @dataclass
@@ -37,7 +38,7 @@ class Package:
         return {module.name for module in self.modules}
 
     @classmethod
-    def load(cls, name: str, package_definition: dict) -> Package:
+    def load(cls, name: str, package_definition: dict) -> Self:
         return cls(
             name=name,
             title=package_definition["title"],
@@ -59,7 +60,7 @@ class Packages(dict, MutableMapping[str, Package]):
     def load(
         cls,
         root_module_dir: Path,
-    ) -> Packages:
+    ) -> Self:
         """Loads the packages in the source directory.
 
         Args:

--- a/cognite_toolkit/_cdf_tk/exceptions.py
+++ b/cognite_toolkit/_cdf_tk/exceptions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 from collections.abc import Mapping
 from graphlib import CycleError

--- a/cognite_toolkit/_cdf_tk/feature_flags.py
+++ b/cognite_toolkit/_cdf_tk/feature_flags.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from enum import Enum
 from functools import lru_cache
 from typing import Any, ClassVar

--- a/cognite_toolkit/_cdf_tk/hints.py
+++ b/cognite_toolkit/_cdf_tk/hints.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 from abc import abstractmethod
 from pathlib import Path

--- a/cognite_toolkit/_cdf_tk/loaders/_base_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_base_loaders.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 import re
+import sys
 from abc import ABC, abstractmethod
 from collections.abc import Hashable, Iterable, Sequence, Set, Sized
 from functools import lru_cache
@@ -27,6 +26,11 @@ from cognite_toolkit._cdf_tk.utils import load_yaml_inject_variables, safe_read,
 if TYPE_CHECKING:
     from cognite_toolkit._cdf_tk.data_classes import BuildEnvironment
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 T_ID = TypeVar("T_ID", bound=Hashable)
 T_WritableCogniteResourceList = TypeVar("T_WritableCogniteResourceList", bound=WriteableCogniteResourceList)
 _COMPILED_PATTERN: dict[str, re.Pattern] = {}
@@ -52,7 +56,7 @@ class Loader(ABC):
     folder_name: str
     kind: str
     filename_pattern: str = ""
-    dependencies: frozenset[type[ResourceLoader]] = frozenset()
+    dependencies: "frozenset[type[ResourceLoader]]" = frozenset()
     exclude_filetypes: frozenset[str] = frozenset()
     _doc_base_url: str = "https://api-docs.cognite.com/20230101/tag/"
     _doc_url: str = ""
@@ -68,11 +72,11 @@ class Loader(ABC):
 
     @classmethod
     def create_loader(
-        cls: type[T_Loader],
+        cls,
         client: ToolkitClient,
         build_dir: Path | None = None,
         console: Console | None = None,
-    ) -> T_Loader:
+    ) -> Self:
         return cls(client, build_dir, console)
 
     @property
@@ -182,11 +186,11 @@ class ResourceLoader(
     support_drop = True
     support_update = True
     filetypes = frozenset({"yaml", "yml"})
-    dependencies: frozenset[type[ResourceLoader]] = frozenset()
+    dependencies: "frozenset[type[ResourceLoader]]" = frozenset()
     # For example, TransformationNotification and Schedule has Transformation as the parent resource
     # This is used in the iterate method to ensure that nothing is returned if
     # the resource type does not have a parent resource.
-    parent_resource: frozenset[type[ResourceLoader]] = frozenset()
+    parent_resource: "frozenset[type[ResourceLoader]]" = frozenset()
 
     # The methods that must be implemented in the subclass
     @classmethod
@@ -259,7 +263,7 @@ class ResourceLoader(
         return read_parameter_from_init_type_hints(cls.resource_write_cls).as_camel_case()
 
     @classmethod
-    def get_dependent_items(cls, item: dict) -> Iterable[tuple[type[ResourceLoader], Hashable]]:
+    def get_dependent_items(cls, item: dict) -> "Iterable[tuple[type[ResourceLoader], Hashable]]":
         """Returns all items that this item requires.
 
         For example, a TimeSeries requires a DataSet, so this method would return the

--- a/cognite_toolkit/_cdf_tk/loaders/_base_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_base_loaders.py
@@ -479,7 +479,7 @@ class DataLoader(Loader, ABC):
     item_name: str
 
     @abstractmethod
-    def upload(self, state: BuildEnvironment, dry_run: bool) -> Iterable[tuple[str, int]]:
+    def upload(self, state: "BuildEnvironment", dry_run: bool) -> Iterable[tuple[str, int]]:
         raise NotImplementedError
 
     def _find_data_files(self, directory: Path) -> list[Path]:

--- a/cognite_toolkit/_cdf_tk/loaders/_data_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_data_loaders.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import io
 from collections.abc import Iterable
 from pathlib import Path

--- a/cognite_toolkit/_cdf_tk/loaders/_data_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_data_loaders.py
@@ -33,7 +33,7 @@ class DatapointsLoader(DataLoader):
     def display_name(self) -> str:
         return "timeseries datapoints"
 
-    def upload(self, state: BuildEnvironment, dry_run: bool) -> Iterable[tuple[str, int]]:
+    def upload(self, state: "BuildEnvironment", dry_run: bool) -> Iterable[tuple[str, int]]:
         if self.folder_name not in state.built_resources:
             return
 
@@ -97,7 +97,7 @@ class FileLoader(DataLoader):
     def display_name(self) -> str:
         return "file content"
 
-    def upload(self, state: BuildEnvironment, dry_run: bool) -> Iterable[tuple[str, int]]:
+    def upload(self, state: "BuildEnvironment", dry_run: bool) -> Iterable[tuple[str, int]]:
         if self.folder_name not in state.built_resources:
             return
 
@@ -162,7 +162,7 @@ class RawFileLoader(DataLoader):
     def display_name(self) -> str:
         return "raw rows"
 
-    def upload(self, state: BuildEnvironment, dry_run: bool) -> Iterable[tuple[str, int]]:
+    def upload(self, state: "BuildEnvironment", dry_run: bool) -> Iterable[tuple[str, int]]:
         if self.folder_name not in state.built_resources:
             return
 

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Hashable, Iterable, Sequence
 from functools import lru_cache
 from typing import Any

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/auth_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/auth_loaders.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
+
 
 import difflib
 from collections import defaultdict

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/classic_loaders.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import collections.abc
 import io
 from collections.abc import Hashable, Iterable

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/data_organization_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/data_organization_loaders.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
+
 
 import json
 from collections.abc import Hashable, Iterable, Sequence

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/datamodel_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/datamodel_loaders.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
+
 
 import re
 import sys

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/extraction_pipeline_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/extraction_pipeline_loaders.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
+
 
 import re
 from collections.abc import Hashable, Iterable, Sequence

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/file_loader.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/file_loader.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
+
 
 from collections.abc import Hashable, Iterable, Sequence
 from datetime import date, datetime

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/group_scoped_loader.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/group_scoped_loader.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
+
 
 from pathlib import Path
 from typing import final

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/hosted_extractors.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/hosted_extractors.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Hashable, Iterable, Sequence
 from functools import lru_cache
 from pathlib import Path

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/location_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/location_loaders.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Hashable, Iterable, Sequence
 from functools import lru_cache
 from pathlib import Path

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/raw_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/raw_loaders.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
+
 
 import itertools
 from collections import defaultdict

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/robotics_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/robotics_loaders.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 from collections.abc import Callable, Hashable, Iterable, Sequence
 from contextlib import suppress

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/three_d_model_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/three_d_model_loaders.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Hashable, Iterable, Sequence
 from functools import lru_cache
 from typing import Any, final

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/transformation_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/transformation_loaders.py
@@ -24,7 +24,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
+
 
 import warnings
 from collections import defaultdict

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/workflow_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/workflow_loaders.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
+
 
 import json
 from collections.abc import Hashable, Iterable, Sequence

--- a/cognite_toolkit/_cdf_tk/loaders/_worker.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_worker.py
@@ -52,7 +52,7 @@ class ResourceWorker(
         self.action = action
 
     def load_files(
-        self, sort: bool = True, directory: Path | None = None, read_modules: list[ReadModule] | None = None
+        self, sort: bool = True, directory: Path | None = None, read_modules: "list[ReadModule] | None" = None
     ) -> list[Path]:
         filepaths = self.loader.find_files(directory)
 

--- a/cognite_toolkit/_cdf_tk/loaders/_worker.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_worker.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import re
 import warnings
 from collections.abc import Hashable

--- a/cognite_toolkit/_cdf_tk/plugins.py
+++ b/cognite_toolkit/_cdf_tk/plugins.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from enum import Enum
 

--- a/cognite_toolkit/_cdf_tk/prototypes/_packages/update_references.py
+++ b/cognite_toolkit/_cdf_tk/prototypes/_packages/update_references.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import inspect
 import itertools
 import re

--- a/cognite_toolkit/_cdf_tk/prototypes/commands/import_.py
+++ b/cognite_toolkit/_cdf_tk/prototypes/commands/import_.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import shutil
 from collections import defaultdict
 from collections.abc import Callable

--- a/cognite_toolkit/_cdf_tk/tk_warnings/base.py
+++ b/cognite_toolkit/_cdf_tk/tk_warnings/base.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import dataclasses
 import itertools
 import warnings
@@ -54,7 +52,7 @@ class ToolkitWarning(ABC, UserWarning):
     def as_tuple(self) -> tuple[Any, ...]:
         return type(self).__name__, *dataclasses.astuple(self)
 
-    def __lt__(self, other: ToolkitWarning) -> bool:
+    def __lt__(self, other: "ToolkitWarning") -> bool:
         if not isinstance(other, ToolkitWarning):
             return NotImplemented
         return self.as_tuple() < other.as_tuple()

--- a/cognite_toolkit/_cdf_tk/tk_warnings/fileread.py
+++ b/cognite_toolkit/_cdf_tk/tk_warnings/fileread.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 from collections.abc import Hashable
 from dataclasses import dataclass

--- a/cognite_toolkit/_cdf_tk/tk_warnings/other.py
+++ b/cognite_toolkit/_cdf_tk/tk_warnings/other.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Hashable
 from dataclasses import dataclass
 from pathlib import Path

--- a/cognite_toolkit/_cdf_tk/tracker.py
+++ b/cognite_toolkit/_cdf_tk/tracker.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import platform
 import sys

--- a/cognite_toolkit/_cdf_tk/validation.py
+++ b/cognite_toolkit/_cdf_tk/validation.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import inspect
 import re
 from pathlib import Path


### PR DESCRIPTION
# Description

We have switched our code base a while back from having lower bound on `3.8` to now having lower bound on `3.10`. This makes `__from__ future import annotations` no longer necessary. This PR removes it. A benefit of this is that AI tools gets (hopefully) less confused in the code base as it no longer sees 3.9 and earlier syntax for Python.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip

