### PR TITLE
[CDF-25193] 🧑‍🎨 cdf profile nicer terminal output

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_profile.py
+++ b/cognite_toolkit/_cdf_tk/commands/_profile.py
@@ -9,6 +9,8 @@ from functools import cached_property, partial
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Generic, Literal, TypeAlias, TypeVar, overload
 from zipfile import BadZipFile
+from itertools import zip_longest
+from typing import ClassVar, Generic, Literal, TypeAlias, TypeVar, overload
 
 from cognite.client.data_classes import Transformation
 from cognite.client.exceptions import CogniteException
@@ -84,7 +86,7 @@ class ProfileCommand(ToolkitCommand, ABC, Generic[T_Index]):
     @cached_property
     def columns(self) -> tuple[str, ...]:
         return (
-            tuple([attr for attr in self.Columns.__dict__.keys() if not attr.startswith("_")])
+            tuple([value for attr, value in self.Columns.__dict__.items() if not attr.startswith("_")])
             if hasattr(self, "Columns")
             else tuple()
         )
@@ -172,9 +174,35 @@ class ProfileCommand(ToolkitCommand, ABC, Generic[T_Index]):
 
         rows = self.as_record_format(table)
 
+        last_row: list[str | Spinner] = []
         for row in rows:
-            rich_table.add_row(*[self._as_cell(value) for value in row.values()])
+            this_row = [self._as_cell(value) for value in row.values()]
+            draw_row = self._create_draw_row(this_row, last_row, self.columns)
+            rich_table.add_row(*draw_row)
+            last_row = this_row
         return rich_table
+
+    @classmethod
+    def _create_draw_row(
+        cls, this_row: list[str | Spinner], last_row: list[str | Spinner], columns: tuple[str, ...]
+    ) -> list[str | Spinner]:
+        """Creates the row to be drawn. This skips sequential cells that have not changed
+        such that the table does not have too many repeated values and thus becomes easier to read.
+        """
+        draw_row: list[str | Spinner] = []
+        row_has_changed = False
+        for cell, col, last_cell in zip_longest(this_row, columns, last_row, fillvalue=""):
+            if not row_has_changed and cls._should_skip_drawing(cell, col, last_cell):
+                cell = ""
+            else:
+                # If the first cell in the row has changed, all remaining cells in the row should be drawn.
+                row_has_changed = True
+            draw_row.append(cell)
+        return draw_row
+
+    @classmethod
+    def _should_skip_drawing(cls, cell: str | Spinner, col: str, last_cell: str | Spinner) -> bool:
+        return cell == last_cell or (isinstance(cell, Spinner) and isinstance(last_cell, Spinner))
 
     @classmethod
     @overload

--- a/cognite_toolkit/_cdf_tk/commands/_profile.py
+++ b/cognite_toolkit/_cdf_tk/commands/_profile.py
@@ -177,22 +177,20 @@ class ProfileCommand(ToolkitCommand, ABC, Generic[T_Index]):
         last_row: list[str | Spinner] = []
         for row in rows:
             this_row = [self._as_cell(value) for value in row.values()]
-            draw_row = self._create_draw_row(this_row, last_row, self.columns)
+            draw_row = self._create_draw_row(this_row, last_row)
             rich_table.add_row(*draw_row)
             last_row = this_row
         return rich_table
 
     @classmethod
-    def _create_draw_row(
-        cls, this_row: list[str | Spinner], last_row: list[str | Spinner], columns: tuple[str, ...]
-    ) -> list[str | Spinner]:
+    def _create_draw_row(cls, this_row: list[str | Spinner], last_row: list[str | Spinner]) -> list[str | Spinner]:
         """Creates the row to be drawn. This skips sequential cells that have not changed
         such that the table does not have too many repeated values and thus becomes easier to read.
         """
         draw_row: list[str | Spinner] = []
         row_has_changed = False
-        for cell, col, last_cell in zip_longest(this_row, columns, last_row, fillvalue=""):
-            if not row_has_changed and cls._should_skip_drawing(cell, col, last_cell):
+        for cell, last_cell in zip_longest(this_row, last_row, fillvalue=""):
+            if not row_has_changed and cls._should_skip_drawing(cell, last_cell):
                 cell = ""
             else:
                 # If the first cell in the row has changed, all remaining cells in the row should be drawn.
@@ -201,7 +199,7 @@ class ProfileCommand(ToolkitCommand, ABC, Generic[T_Index]):
         return draw_row
 
     @classmethod
-    def _should_skip_drawing(cls, cell: str | Spinner, col: str, last_cell: str | Spinner) -> bool:
+    def _should_skip_drawing(cls, cell: str | Spinner, last_cell: str | Spinner) -> bool:
         return cell == last_cell or (isinstance(cell, Spinner) and isinstance(last_cell, Spinner))
 
     @classmethod

--- a/cognite_toolkit/_cdf_tk/commands/_profile.py
+++ b/cognite_toolkit/_cdf_tk/commands/_profile.py
@@ -6,11 +6,10 @@ from collections.abc import Callable, Hashable, Iterable, Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from functools import cached_property, partial
+from itertools import zip_longest
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Generic, Literal, TypeAlias, TypeVar, overload
 from zipfile import BadZipFile
-from itertools import zip_longest
-from typing import ClassVar, Generic, Literal, TypeAlias, TypeVar, overload
 
 from cognite.client.data_classes import Transformation
 from cognite.client.exceptions import CogniteException

--- a/tests/test_unit/test_cdf_tk/test_commands/test_profile.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_profile.py
@@ -1,0 +1,61 @@
+import pytest
+from rich.spinner import Spinner
+
+from cognite_toolkit._cdf_tk.commands import ProfileRawCommand
+
+
+class TestProfileCommand:
+    @pytest.mark.parametrize(
+        "this_row, last_row, expected",
+        [
+            pytest.param(
+                ["MyTable", "13", "2", "-", "-", "-"],
+                ["MyTable", "12", "1", "-", "-", "-"],
+                ["", "13", "2", "-", "-", "-"],
+                id="No change in table name",
+            ),
+            pytest.param(
+                ["MyTable", "13", "2", "-", "-", "-"],
+                [],
+                ["MyTable", "13", "2", "-", "-", "-"],
+                id="Empty last row",
+            ),
+            pytest.param(
+                ["MyTable", "13", "2", "my_transformation", "assets", "upsert"],
+                ["OtherTable", "13", "2", "my_transformation", "assets", "upsert"],
+                ["MyTable", "13", "2", "my_transformation", "assets", "upsert"],
+                id="Change in table name with transformation",
+            ),
+            pytest.param(
+                [
+                    "MyTable",
+                    Spinner(**ProfileRawCommand.spinner_args),
+                    Spinner(**ProfileRawCommand.spinner_args),
+                    "-",
+                    "-",
+                    "-",
+                ],
+                [
+                    "MyTable",
+                    Spinner(**ProfileRawCommand.spinner_args),
+                    Spinner(**ProfileRawCommand.spinner_args),
+                    "-",
+                    "-",
+                    "-",
+                ],
+                ["", "", "", "", "", ""],
+                id="Spinner in both rows",
+            ),
+        ],
+    )
+    def test_create_draw_row(
+        self, this_row: list[str | Spinner], last_row: list[str | Spinner], expected: list[str | Spinner]
+    ) -> None:
+        cmd = ProfileRawCommand()
+        assert len(this_row) == len(cmd.columns), (
+            "Invalid test data. The number of columns in this_row must match cmd.columns."
+        )
+
+        draw_row = cmd._create_draw_row(this_row, last_row, cmd.columns)
+
+        assert draw_row == expected

--- a/tests/test_unit/test_cdf_tk/test_commands/test_profile.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_profile.py
@@ -51,11 +51,6 @@ class TestProfileCommand:
     def test_create_draw_row(
         self, this_row: list[str | Spinner], last_row: list[str | Spinner], expected: list[str | Spinner]
     ) -> None:
-        cmd = ProfileRawCommand()
-        assert len(this_row) == len(cmd.columns), (
-            "Invalid test data. The number of columns in this_row must match cmd.columns."
-        )
-
-        draw_row = cmd._create_draw_row(this_row, last_row, cmd.columns)
+        draw_row = ProfileRawCommand._create_draw_row(this_row, last_row)
 
         assert draw_row == expected


### PR DESCRIPTION
# Description



## <code>cdf profile raw</code> Before
<img width="2164" height="231" alt="image" src="https://github.com/user-attachments/assets/32eb8d76-7cea-457a-9dcf-9824a315c46c" />

## <code>cdf profile raw</code>After
<img width="2177" height="205" alt="image" src="https://github.com/user-attachments/assets/742a3ca4-46da-42ce-aa2b-f21bd7eeb854" />

On `cdf profile assets`

## <code>cdf profile assets</code>Before
<img width="2545" height="568" alt="image" src="https://github.com/user-attachments/assets/39beb8a3-a76e-4a52-b515-e983cc52fd95" />

## <code>cdf profile assets</code>After
<img width="2749" height="566" alt="image" src="https://github.com/user-attachments/assets/38992831-8f30-483b-a1cd-182ca1aa6bd9" />



## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Improved

- [alpha] The `cdf profile` commands now skips repeated values in the table terminal output. This is to increase the readability.

## templates

No changes.
