### PR TITLE
[CDF-25246] 🐛Bug aggregate

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils/aggregators.py
+++ b/cognite_toolkit/_cdf_tk/utils/aggregators.py
@@ -122,20 +122,29 @@ class MetadataAggregator(AssetCentricAggregator, ABC, Generic[T_CogniteFilter]):
         cls, hierarchy: str | list[str] | None = None, data_set_external_id: str | list[str] | None = None
     ) -> T_CogniteFilter | None:
         """Creates a filter for the resource based on hierarchy and data set external ID."""
-        if hierarchy is None and data_set_external_id is None:
+        if cls._is_empty(hierarchy) and cls._is_empty(data_set_external_id):
             return None
         asset_subtree_ids: list[dict[str, str]] | None = None
         if isinstance(hierarchy, str):
             asset_subtree_ids = [{"externalId": hierarchy}]
-        elif isinstance(hierarchy, list):
+        elif isinstance(hierarchy, list) and hierarchy:
             asset_subtree_ids = [{"externalId": item} for item in hierarchy]
         data_set_ids: list[dict[str, str]] | None = None
         if isinstance(data_set_external_id, str):
             data_set_ids = [{"externalId": data_set_external_id}]
-        elif isinstance(data_set_external_id, list):
+        elif isinstance(data_set_external_id, list) and data_set_external_id:
             data_set_ids = [{"externalId": item} for item in data_set_external_id]
 
         return cls.filter_cls(asset_subtree_ids=asset_subtree_ids, data_set_ids=data_set_ids)
+
+    @classmethod
+    def _is_empty(cls, items: str | list[str] | None) -> bool:
+        """Checks if the provided items are empty."""
+        if items is None:
+            return True
+        if isinstance(items, list):
+            return not items
+        return False
 
 
 class LabelAggregator(MetadataAggregator, ABC, Generic[T_CogniteFilter]):

--- a/tests/test_unit/test_cdf_tk/test_utils/test_aggregators.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_aggregators.py
@@ -41,6 +41,20 @@ class TestAggregators:
                         {"assetSubtreeIds": [{"externalId": ""}], "dataSetIds": [{"externalId": "data_set"}]},
                     ),
                     ("", "", {"assetSubtreeIds": [{"externalId": ""}], "dataSetIds": [{"externalId": ""}]}),
+                    ([], [], None),
+                    (["hierarchy"], [], {"assetSubtreeIds": [{"externalId": "hierarchy"}]}),
+                    ([], ["data_set"], {"dataSetIds": [{"externalId": "data_set"}]}),
+                    (
+                        ["hierarchy"],
+                        ["data_set"],
+                        {"assetSubtreeIds": [{"externalId": "hierarchy"}], "dataSetIds": [{"externalId": "data_set"}]},
+                    ),
+                    (
+                        ["hierarchy"],
+                        [""],
+                        {"assetSubtreeIds": [{"externalId": "hierarchy"}], "dataSetIds": [{"externalId": ""}]},
+                    ),
+                    ([], ["data_set", ""], {"dataSetIds": [{"externalId": "data_set"}, {"externalId": ""}]}),
                 ],
             )
         ],

--- a/tests/test_unit/test_cdf_tk/test_utils/test_aggregators.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_aggregators.py
@@ -67,4 +67,6 @@ class TestAggregators:
         expected_filter: dict[str, object] | None,
     ) -> None:
         actual_filter = aggregator_class.create_filter(hierarchy, data_set_external_id)
-        assert (actual_filter is None and expected_filter is None) or actual_filter.dump() == expected_filter
+        assert (actual_filter is None and expected_filter is None) or actual_filter.dump() == expected_filter, (
+            f"Failed with {hierarchy}, {data_set_external_id} -> {actual_filter.dump()} != {expected_filter}"
+        )


### PR DESCRIPTION
# Description

Bug in how we handled empty list in the aggregate method influencing the command below.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- The `cdf dump assets/timeseries` no longer fails with `CogniteAPIError: Request had 1 constraint violations` if you use interactive selictions.

## templates

No changes.
