### PR TITLE
Extend assent centric profiling

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_profile_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_profile_app.py
@@ -58,6 +58,15 @@ class ProfileApp(typer.Typer):
     @staticmethod
     def asset_centric(
         ctx: typer.Context,
+        hierarchy: Annotated[
+            str | None,
+            typer.Option(
+                "--hierarchy",
+                "-h",
+                help="The asset hierarchy to profile. This should be the externalId of the root asset. If not provided,"
+                " an interactive prompt will be used to select the hierarchy.",
+            ),
+        ] = None,
         verbose: bool = False,
     ) -> None:
         """This command gives an overview over the metadata and labels for each of the asset-centric resources.
@@ -68,6 +77,7 @@ class ProfileApp(typer.Typer):
         cmd.run(
             lambda: cmd.asset_centric(
                 client,
+                hierarchy,
                 verbose,
             )
         )

--- a/cognite_toolkit/_cdf_tk/commands/_profile.py
+++ b/cognite_toolkit/_cdf_tk/commands/_profile.py
@@ -457,6 +457,7 @@ class ProfileAssetCommand(ProfileCommand[AssetIndex]):
 class ProfileAssetCentricCommand(ProfileCommand[str]):
     def __init__(self, print_warning: bool = True, skip_tracking: bool = False, silent: bool = False) -> None:
         super().__init__(print_warning, skip_tracking, silent)
+        self.hierarchy: str | None = None
         self.table_title = "Asset Centric Profile"
         self.aggregators: dict[str, AssetCentricAggregator] = {}
 
@@ -467,7 +468,15 @@ class ProfileAssetCentricCommand(ProfileCommand[str]):
         LabelCount = "Label Count"
         Transformation = "Transformations"
 
-    def asset_centric(self, client: ToolkitClient, verbose: bool = False) -> list[dict[str, CellValue]]:
+    def asset_centric(
+        self, client: ToolkitClient, hierarchy: str | None = None, verbose: bool = False
+    ) -> list[dict[str, CellValue]]:
+        if hierarchy is None:
+            self.hierarchy = AssetInteractiveSelect(client, "profile").select_hierarchy(allow_empty=True)
+        else:
+            self.hierarchy = hierarchy
+        if self.hierarchy is not None:
+            self.table_title = f"Asset Centric Profile: {self.hierarchy}"
         self.aggregators.update(
             {
                 agg.display_name: agg

--- a/cognite_toolkit/_cdf_tk/commands/_profile.py
+++ b/cognite_toolkit/_cdf_tk/commands/_profile.py
@@ -32,6 +32,7 @@ from cognite_toolkit._cdf_tk.utils.aggregators import (
     TimeSeriesAggregator,
 )
 from cognite_toolkit._cdf_tk.utils.cdf import get_transformation_sources
+from cognite_toolkit._cdf_tk.utils.interactive_select import AssetInteractiveSelect
 from cognite_toolkit._cdf_tk.utils.sql_parser import SQLParser, SQLTable
 
 from ._base import ToolkitCommand
@@ -231,9 +232,10 @@ class ProfileAssetCommand(ProfileCommand[AssetIndex]):
         relationships, and labels in the specified hierarchy.
         """
         if hierarchy is None:
-            raise NotImplementedError("Interactive mode is not implemented yet. Please provide a hierarchy.")
-        self.hierarchy = hierarchy
-        self.table_title = f"Asset Profile for Hierarchy: {hierarchy}"
+            self.hierarchy = AssetInteractiveSelect(client, "profile").select_hierarchy(allow_empty=False)
+        else:
+            self.hierarchy = hierarchy
+        self.table_title = f"Asset Profile for Hierarchy: {self.hierarchy}"
         self.aggregators = {
             agg.display_name: agg
             for agg in [


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- [alpha] Add support for running `cdf profile asset-centric` for  a single hierarchy.

## templates

No changes.
