### PR TITLE
[prep CDF-25249] 💦 Support filtering for label listing

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils/cdf.py
+++ b/cognite_toolkit/_cdf_tk/utils/cdf.py
@@ -255,11 +255,11 @@ def metadata_key_counts(
 
 def _create_where_clause(data_sets: list[int] | None, hierarchies: list[int] | None) -> str:
     where_clause = ""
-    if data_sets is not None and hierarchies is not None:
+    if data_sets and hierarchies:
         where_clause = f"\n         WHERE dataSetId IN ({','.join(map(str, data_sets))}) AND rootId IN ({','.join(map(str, hierarchies))})"
-    elif data_sets is not None:
+    elif data_sets:
         where_clause = f"\n         WHERE dataSetId IN ({','.join(map(str, data_sets))})"
-    elif hierarchies is not None:
+    elif hierarchies:
         where_clause = f"\n         WHERE rootId IN ({','.join(map(str, hierarchies))})"
     return where_clause
 

--- a/cognite_toolkit/_cdf_tk/utils/cdf.py
+++ b/cognite_toolkit/_cdf_tk/utils/cdf.py
@@ -269,7 +269,7 @@ def label_count(
     resource: Literal["assets", "events", "files", "timeseries", "sequences"],
     data_sets: list[int] | None = None,
     hierarchies: list[int] | None = None,
-) -> list[dict[str, int | str]]:
+) -> list[tuple[str, int]]:
     """Get the label counts for a given resource.
 
     Args:
@@ -291,9 +291,9 @@ FROM labels
 GROUP BY label
 ORDER BY label_count DESC;
 """
-    results = client.transformations.preview(query, convert_to_string=False, limit=1000)
+    results = client.transformations.preview(query, convert_to_string=False, limit=None, source_limit=None)
     # We know from the SQL that the result is a list of dictionaries with string keys and int values.
-    return results.results or []
+    return [(item["label"], item["label_count"]) for item in results.results or []]
 
 
 @dataclass

--- a/cognite_toolkit/_cdf_tk/utils/cdf.py
+++ b/cognite_toolkit/_cdf_tk/utils/cdf.py
@@ -222,6 +222,8 @@ def metadata_key_counts(
     Returns:
         A dictionary with the metadata keys as keys and the counts as values.
     """
+    if hierarchies and resource != "assets":
+        raise ValueError(f"Hierarchies are only supported for assets, but {resource} was provided.")
     where_clause = _create_where_clause(data_sets, hierarchies)
 
     query = f"""WITH meta AS (
@@ -279,8 +281,10 @@ def label_count(
         hierarchies: A list of hierarchy IDs to filter by. If None, no filtering is applied.
 
     Returns:
-        A dictionary with the labels as keys and the counts as values.
+        A list of tuples with the label and its count.
     """
+    if hierarchies and resource != "assets":
+        raise ValueError(f"Hierarchies are only supported for assets, but {resource} was provided.")
     where_clause = _create_where_clause(data_sets, hierarchies)
 
     query = f"""WITH labels as (SELECT explode(labels) AS label

--- a/cognite_toolkit/_cdf_tk/utils/cdf.py
+++ b/cognite_toolkit/_cdf_tk/utils/cdf.py
@@ -265,19 +265,26 @@ def _create_where_clause(data_sets: list[int] | None, hierarchies: list[int] | N
 
 
 def label_count(
-    client: ToolkitClient, resource: Literal["assets", "events", "files", "timeseries", "sequences"]
+    client: ToolkitClient,
+    resource: Literal["assets", "events", "files", "timeseries", "sequences"],
+    data_sets: list[int] | None = None,
+    hierarchies: list[int] | None = None,
 ) -> list[dict[str, int | str]]:
     """Get the label counts for a given resource.
 
     Args:
         client: ToolkitClient instance
         resource: The resource to get the label counts for. Can be one of "assets", "events", "files", "timeseries", or "sequences".
+        data_sets: A list of data set IDs to filter by. If None, no filtering is applied.
+        hierarchies: A list of hierarchy IDs to filter by. If None, no filtering is applied.
 
     Returns:
         A dictionary with the labels as keys and the counts as values.
     """
+    where_clause = _create_where_clause(data_sets, hierarchies)
+
     query = f"""WITH labels as (SELECT explode(labels) AS label
-	FROM _cdf.{resource}
+	FROM _cdf.{resource}{where_clause}
   )
 SELECT label, COUNT(label) as label_count
 FROM labels

--- a/cognite_toolkit/_cdf_tk/utils/cdf.py
+++ b/cognite_toolkit/_cdf_tk/utils/cdf.py
@@ -222,13 +222,7 @@ def metadata_key_counts(
     Returns:
         A dictionary with the metadata keys as keys and the counts as values.
     """
-    where_clause = ""
-    if data_sets is not None and hierarchies is not None:
-        where_clause = f"\n         WHERE dataSetId IN ({','.join(map(str, data_sets))}) AND rootId IN ({','.join(map(str, hierarchies))})"
-    elif data_sets is not None:
-        where_clause = f"\n         WHERE dataSetId IN ({','.join(map(str, data_sets))})"
-    elif hierarchies is not None:
-        where_clause = f"\n         WHERE rootId IN ({','.join(map(str, hierarchies))})"
+    where_clause = _create_where_clause(data_sets, hierarchies)
 
     query = f"""WITH meta AS (
          SELECT cast_to_strings(metadata) AS metadata_array
@@ -257,6 +251,17 @@ def metadata_key_counts(
 """
     results = client.transformations.preview(query, convert_to_string=False, limit=None, source_limit=None)
     return [(item["key"], item["key_count"]) for item in results.results or []]
+
+
+def _create_where_clause(data_sets: list[int] | None, hierarchies: list[int] | None) -> str:
+    where_clause = ""
+    if data_sets is not None and hierarchies is not None:
+        where_clause = f"\n         WHERE dataSetId IN ({','.join(map(str, data_sets))}) AND rootId IN ({','.join(map(str, hierarchies))})"
+    elif data_sets is not None:
+        where_clause = f"\n         WHERE dataSetId IN ({','.join(map(str, data_sets))})"
+    elif hierarchies is not None:
+        where_clause = f"\n         WHERE rootId IN ({','.join(map(str, hierarchies))})"
+    return where_clause
 
 
 def label_count(

--- a/cognite_toolkit/_cdf_tk/utils/cdf.py
+++ b/cognite_toolkit/_cdf_tk/utils/cdf.py
@@ -259,14 +259,15 @@ def metadata_key_counts(
 
 
 def _create_where_clause(data_sets: list[int] | None, hierarchies: list[int] | None) -> str:
-    where_clause = ""
-    if data_sets and hierarchies:
-        where_clause = f"\n         WHERE dataSetId IN ({','.join(map(str, data_sets))}) AND rootId IN ({','.join(map(str, hierarchies))})"
-    elif data_sets:
-        where_clause = f"\n         WHERE dataSetId IN ({','.join(map(str, data_sets))})"
-    elif hierarchies:
-        where_clause = f"\n         WHERE rootId IN ({','.join(map(str, hierarchies))})"
-    return where_clause
+    conditions = []
+    if data_sets:
+        conditions.append(f"dataSetId IN ({','.join(map(str, data_sets))})")
+    if hierarchies:
+        conditions.append(f"rootId IN ({','.join(map(str, hierarchies))})")
+
+    if not conditions:
+        return ""
+    return f"\n         WHERE {' AND '.join(conditions)}"
 
 
 def label_count(

--- a/cognite_toolkit/_cdf_tk/utils/cdf.py
+++ b/cognite_toolkit/_cdf_tk/utils/cdf.py
@@ -28,6 +28,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitRequiredValueError,
     ToolkitThrottledError,
     ToolkitTypeError,
+    ToolkitValueError,
 )
 from cognite_toolkit._cdf_tk.tk_warnings import (
     HighSeverityWarning,
@@ -223,7 +224,9 @@ def metadata_key_counts(
         A dictionary with the metadata keys as keys and the counts as values.
     """
     if hierarchies and resource != "assets":
-        raise ValueError(f"Hierarchies are only supported for assets, but {resource} was provided.")
+        raise ToolkitValueError(
+            f"Hierarchies filtering for metadata keys are only supported for assets, but {resource} was provided."
+        )
     where_clause = _create_where_clause(data_sets, hierarchies)
 
     query = f"""WITH meta AS (
@@ -284,7 +287,9 @@ def label_count(
         A list of tuples with the label and its count.
     """
     if hierarchies and resource != "assets":
-        raise ValueError(f"Hierarchies are only supported for assets, but {resource} was provided.")
+        raise ToolkitValueError(
+            f"Hierarchies filtering for labels are only supported for assets, but {resource} was provided."
+        )
     where_clause = _create_where_clause(data_sets, hierarchies)
 
     query = f"""WITH labels as (SELECT explode(labels) AS label

--- a/cognite_toolkit/_cdf_tk/utils/cdf.py
+++ b/cognite_toolkit/_cdf_tk/utils/cdf.py
@@ -261,8 +261,12 @@ def metadata_key_counts(
 def _create_where_clause(data_sets: list[int] | None, hierarchies: list[int] | None) -> str:
     conditions = []
     if data_sets:
+        if not all(isinstance(item, int) for item in data_sets):
+            raise ToolkitValueError("All items in data_sets must be integers for SQL filtering.")
         conditions.append(f"dataSetId IN ({','.join(map(str, data_sets))})")
     if hierarchies:
+        if not all(isinstance(item, int) for item in hierarchies):
+            raise ToolkitValueError("All items in hierarchies must be integers for SQL filtering.")
         conditions.append(f"rootId IN ({','.join(map(str, hierarchies))})")
 
     if not conditions:

--- a/tests/test_integration/test_utils/test_cdf.py
+++ b/tests/test_integration/test_utils/test_cdf.py
@@ -299,6 +299,60 @@ class TestLabelCount:
         assert len(counts) > 0, "There should be some label counts."
         assert len(ill_formed) == 0, f"Ill-formed label counts: {ill_formed}"
 
+    @pytest.mark.parametrize(
+        "hierarchies, datasets",
+        (
+            (hierarchies, datasets)
+            for hierarchies, datasets in itertools.product(
+                [
+                    None,
+                    ["toolkit_test_metadata_key_counts_root_asset_0"],
+                    ["toolkit_test_metadata_key_counts_root_asset_0", "toolkit_test_metadata_key_counts_root_asset_1"],
+                ],
+                [
+                    None,
+                    ["toolkit_test_metadata_key_counts_1"],
+                    ["toolkit_test_metadata_key_counts_1", "toolkit_test_metadata_key_counts_2"],
+                ],
+            )
+            if not (not hierarchies and not datasets)
+        ),
+        ids=(
+            f"{hierarchy_str} and {dataset_str}"
+            for hierarchy_str, dataset_str in itertools.product(
+                ["no hierarchies", "one hierarchy", "two hierarchies"],
+                ["no datasets", "one dataset", "two datasets"],
+                # We filter out this case as it will return all assets in the project as it has no filtering.
+            )
+            if not (hierarchy_str == "no hierarchies" and dataset_str == "no datasets")
+        ),
+    )
+    def test_metadata_key_counts_filtering_datasets_hierarchies(
+        self,
+        hierarchies: list[str] | None,
+        datasets: list[str] | None,
+        toolkit_client: ToolkitClient,
+        two_hierarchies: tuple[AssetList, AssetList],
+        two_datasets: DataSetList,
+    ) -> None:
+        hierarchy_external_to_internal = {assets[0].external_id: assets[0].id for assets in two_hierarchies}
+        datasets_external_to_internal = {dataset.external_id: dataset.id for dataset in two_datasets}
+        hierarchy_ids = (
+            [hierarchy_external_to_internal[external_id] for external_id in hierarchies] if hierarchies else None
+        )
+        dataset_ids = [datasets_external_to_internal[external_id] for external_id in datasets] if datasets else None
+        label_counts = label_count(toolkit_client, "assets", hierarchies=hierarchy_ids, data_sets=dataset_ids)
+
+        expected_keys = Counter()
+        for hierarchy in two_hierarchies:
+            for asset in hierarchy:
+                if (hierarchy_ids is None or asset.root_id in hierarchy_ids) and (
+                    dataset_ids is None or asset.data_set_id in dataset_ids
+                ):
+                    expected_keys.update([label.external_id for label in asset.labels or []])
+
+        assert {key: count for key, count in label_counts} == dict(expected_keys.items())
+
 
 @pytest.fixture()
 def disable_throttler(

--- a/tests/test_integration/test_utils/test_cdf.py
+++ b/tests/test_integration/test_utils/test_cdf.py
@@ -327,7 +327,7 @@ class TestLabelCount:
             if not (hierarchy_str == "no hierarchies" and dataset_str == "no datasets")
         ),
     )
-    def test_metadata_key_counts_filtering_datasets_hierarchies(
+    def test_label_count_filtering_datasets_hierarchies(
         self,
         hierarchies: list[str] | None,
         datasets: list[str] | None,

--- a/tests/test_integration/test_utils/test_cdf.py
+++ b/tests/test_integration/test_utils/test_cdf.py
@@ -63,7 +63,37 @@ def two_datasets(toolkit_client: ToolkitClient) -> DataSetList:
 
 
 @pytest.fixture(scope="session")
-def two_hierarchies(toolkit_client: ToolkitClient, two_datasets: DataSetList) -> tuple[AssetList, AssetList]:
+def two_labels(toolkit_client: ToolkitClient, two_datasets: DataSetList) -> LabelDefinitionList:
+    data_set_id = two_datasets[0].id  # Using the first dataset for labels
+    labels = LabelDefinitionWriteList(
+        [
+            LabelDefinitionWrite(
+                external_id="toolkit_test_label_aggregate_count_1",
+                name="Test Label 1",
+                description="This is a test label 1",
+                data_set_id=data_set_id,
+            ),
+            LabelDefinitionWrite(
+                external_id="toolkit_test_label_aggregate_count_2",
+                name="Test Label 2",
+                description="This is a test label 2",
+                data_set_id=data_set_id,
+            ),
+        ]
+    )
+    existing = toolkit_client.labels.retrieve(external_id=labels.as_external_ids(), ignore_unknown_ids=True)
+    if missing := [label for label in labels if label.external_id not in set(existing.as_external_ids())]:
+        created = toolkit_client.labels.create(missing)
+        existing.extend(created)
+    return existing
+
+
+@pytest.fixture(scope="session")
+def two_hierarchies(
+    toolkit_client: ToolkitClient, two_datasets: DataSetList, two_labels: LabelDefinitionList
+) -> tuple[AssetList, AssetList]:
+    all_labels = [label.external_id for label in two_labels]
+    single_label = [two_labels[0].external_id]
     hierarchies = [
         AssetWriteList(
             [
@@ -82,6 +112,7 @@ def two_hierarchies(toolkit_client: ToolkitClient, two_datasets: DataSetList) ->
                         f"metadata_key_{i}": "does not matter either",
                         f"metadata_key_extra_{i}": "does not matter either",
                     },
+                    labels=all_labels if i == 0 else single_label,
                 ),
                 AssetWrite(
                     name=f"Child Asset extra {i}",
@@ -91,6 +122,7 @@ def two_hierarchies(toolkit_client: ToolkitClient, two_datasets: DataSetList) ->
                         f"extra_key{i}": "does not matter either",
                         f"another_extra_key{i}": "does not matter either",
                     },
+                    labels=single_label,
                 ),
             ]
         )
@@ -138,32 +170,6 @@ def asset_relationships(
     )
     if missing := [rel for rel in relationships if rel.external_id not in set(existing.as_external_ids())]:
         created = toolkit_client.relationships.create(missing)
-        existing.extend(created)
-    return existing
-
-
-@pytest.fixture(scope="session")
-def two_labels(toolkit_client: ToolkitClient, two_datasets: DataSetList) -> LabelDefinitionList:
-    data_set_id = two_datasets[0].id  # Using the first dataset for labels
-    labels = LabelDefinitionWriteList(
-        [
-            LabelDefinitionWrite(
-                external_id="toolkit_test_label_aggregate_count_1",
-                name="Test Label 1",
-                description="This is a test label 1",
-                data_set_id=data_set_id,
-            ),
-            LabelDefinitionWrite(
-                external_id="toolkit_test_label_aggregate_count_2",
-                name="Test Label 2",
-                description="This is a test label 2",
-                data_set_id=data_set_id,
-            ),
-        ]
-    )
-    existing = toolkit_client.labels.retrieve(external_id=labels.as_external_ids(), ignore_unknown_ids=True)
-    if missing := [label for label in labels if label.external_id not in set(existing.as_external_ids())]:
-        created = toolkit_client.labels.create(missing)
         existing.extend(created)
     return existing
 

--- a/tests/test_integration/test_utils/test_cdf.py
+++ b/tests/test_integration/test_utils/test_cdf.py
@@ -31,6 +31,7 @@ from cognite_toolkit._cdf_tk.exceptions import ToolkitThrottledError
 from cognite_toolkit._cdf_tk.utils.cdf import (
     ThrottlerState,
     label_aggregate_count,
+    label_count,
     metadata_key_counts,
     raw_row_count,
     relationship_aggregate_count,
@@ -284,6 +285,19 @@ class TestLabelAggregateCount:
         count = label_aggregate_count(toolkit_client, [data_set_id])
 
         assert count == len(two_labels)
+
+
+class TestLabelCount:
+    def test_label_count(self, toolkit_client: ToolkitClient, two_labels: LabelDefinitionList) -> None:
+        counts = label_count(toolkit_client, "assets")
+
+        ill_formed = [
+            (label, count)
+            for label, count in counts
+            if not isinstance(label, str) or not isinstance(count, int) or count < 0
+        ]
+        assert len(counts) > 0, "There should be some label counts."
+        assert len(ill_formed) == 0, f"Ill-formed label counts: {ill_formed}"
 
 
 @pytest.fixture()

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_data.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_data.py
@@ -138,7 +138,7 @@ class TestDumpData:
             )
 
             cmd.dump_table(
-                FileMetadataFinder(client, ["rootAsset"], []),
+                FileMetadataFinder(client, [], ["my_dataset"]),
                 output_dir,
                 clean=True,
                 limit=None,


### PR DESCRIPTION
# Description

This is preparation for supporting `cdf profile assent-centric --hierarchy my_hierarchy`, i.e., enable the user to list meatdata and labels in addition to counts used for a single hierarchy.

This PR extends the `label_count` to support filtering on hierarchy and data sets.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
