### PR TITLE
[CDF-25248] 🤌 Extend asset centric

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -488,7 +488,7 @@ class DumpDataApp(typer.Typer):
         cmd = DumpDataCommand()
         client = EnvironmentVariables.create_from_environment().get_client()
         if hierarchy is None and data_set is None:
-            hierarchy, data_set = AssetInteractiveSelect(client, "dump").interactive_select_hierarchy_datasets()
+            hierarchy, data_set = AssetInteractiveSelect(client, "dump").select_hierarchies_and_data_sets()
 
         cmd.run(
             lambda: cmd.dump_table(
@@ -567,7 +567,7 @@ class DumpDataApp(typer.Typer):
         cmd.validate_directory(output_dir, clean)
         client = EnvironmentVariables.create_from_environment().get_client()
         if hierarchy is None and data_set is None:
-            hierarchy, data_set = FileMetadataInteractiveSelect(client, "dump").interactive_select_hierarchy_datasets()
+            hierarchy, data_set = FileMetadataInteractiveSelect(client, "dump").select_hierarchies_and_data_sets()
         cmd.run(
             lambda: cmd.dump_table(
                 FileMetadataFinder(client, hierarchy or [], data_set or []),
@@ -644,7 +644,7 @@ class DumpDataApp(typer.Typer):
         cmd = DumpDataCommand()
         client = EnvironmentVariables.create_from_environment().get_client()
         if hierarchy is None and data_set is None:
-            hierarchy, data_set = TimeSeriesInteractiveSelect(client, "dump").interactive_select_hierarchy_datasets()
+            hierarchy, data_set = TimeSeriesInteractiveSelect(client, "dump").select_hierarchies_and_data_sets()
         cmd.run(
             lambda: cmd.dump_table(
                 TimeSeriesFinder(client, hierarchy or [], data_set or []),
@@ -722,7 +722,7 @@ class DumpDataApp(typer.Typer):
         cmd.validate_directory(output_dir, clean)
         client = EnvironmentVariables.create_from_environment().get_client()
         if hierarchy is None and data_set is None:
-            hierarchy, data_set = EventInteractiveSelect(client, "dump").interactive_select_hierarchy_datasets()
+            hierarchy, data_set = EventInteractiveSelect(client, "dump").select_hierarchies_and_data_sets()
         cmd.run(
             lambda: cmd.dump_table(
                 EventFinder(client, hierarchy or [], data_set or []),

--- a/cognite_toolkit/_cdf_tk/apps/_profile_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_profile_app.py
@@ -35,7 +35,7 @@ class ProfileApp(typer.Typer):
                 "--hierarchy",
                 "-h",
                 help="The asset hierarchy to profile. This should be the externalId of the root asset. If not provided,"
-                " ",
+                " an interactive prompt will be used to select the hierarchy.",
             ),
         ] = None,
         verbose: bool = False,
@@ -43,7 +43,7 @@ class ProfileApp(typer.Typer):
         """This command gives an overview over the assets in the given hierarchy.
         It works by listing all assets, events, files, timeseries, and sequences related to the given hierarchy.
         In addition, it lists the data sets that is used for each of the resources, the transformations that writes to
-        these data sets, and the RAW tables that is used in these transformations..
+        these data sets, and the RAW tables that is used in these transformations.
         """
         client = EnvironmentVariables.create_from_environment().get_client()
         cmd = ProfileAssetCommand()

--- a/cognite_toolkit/_cdf_tk/commands/_profile.py
+++ b/cognite_toolkit/_cdf_tk/commands/_profile.py
@@ -32,6 +32,7 @@ from cognite_toolkit._cdf_tk.utils.aggregators import (
     TimeSeriesAggregator,
 )
 from cognite_toolkit._cdf_tk.utils.cdf import get_transformation_sources
+from cognite_toolkit._cdf_tk.utils.interactive_select import AssetInteractiveSelect
 from cognite_toolkit._cdf_tk.utils.sql_parser import SQLParser, SQLTable
 
 from ._base import ToolkitCommand
@@ -231,9 +232,10 @@ class ProfileAssetCommand(ProfileCommand[AssetIndex]):
         relationships, and labels in the specified hierarchy.
         """
         if hierarchy is None:
-            raise NotImplementedError("Interactive mode is not implemented yet. Please provide a hierarchy.")
-        self.hierarchy = hierarchy
-        self.table_title = f"Asset Profile for Hierarchy: {hierarchy}"
+            self.hierarchy = AssetInteractiveSelect(client, "profile").select_hierarchy(allow_empty=False)
+        else:
+            self.hierarchy = hierarchy
+        self.table_title = f"Asset Profile for Hierarchy: {self.hierarchy}"
         self.aggregators = {
             agg.display_name: agg
             for agg in [

--- a/cognite_toolkit/_cdf_tk/utils/aggregators.py
+++ b/cognite_toolkit/_cdf_tk/utils/aggregators.py
@@ -122,20 +122,29 @@ class MetadataAggregator(AssetCentricAggregator, ABC, Generic[T_CogniteFilter]):
         cls, hierarchy: str | list[str] | None = None, data_set_external_id: str | list[str] | None = None
     ) -> T_CogniteFilter | None:
         """Creates a filter for the resource based on hierarchy and data set external ID."""
-        if hierarchy is None and data_set_external_id is None:
+        if cls._is_empty(hierarchy) and cls._is_empty(data_set_external_id):
             return None
         asset_subtree_ids: list[dict[str, str]] | None = None
         if isinstance(hierarchy, str):
             asset_subtree_ids = [{"externalId": hierarchy}]
-        elif isinstance(hierarchy, list):
+        elif isinstance(hierarchy, list) and hierarchy:
             asset_subtree_ids = [{"externalId": item} for item in hierarchy]
         data_set_ids: list[dict[str, str]] | None = None
         if isinstance(data_set_external_id, str):
             data_set_ids = [{"externalId": data_set_external_id}]
-        elif isinstance(data_set_external_id, list):
+        elif isinstance(data_set_external_id, list) and data_set_external_id:
             data_set_ids = [{"externalId": item} for item in data_set_external_id]
 
         return cls.filter_cls(asset_subtree_ids=asset_subtree_ids, data_set_ids=data_set_ids)
+
+    @classmethod
+    def _is_empty(cls, items: str | list[str] | None) -> bool:
+        """Checks if the provided items are empty."""
+        if items is None:
+            return True
+        if isinstance(items, list):
+            return not items
+        return False
 
 
 class LabelAggregator(MetadataAggregator, ABC, Generic[T_CogniteFilter]):

--- a/cognite_toolkit/_cdf_tk/utils/cdf.py
+++ b/cognite_toolkit/_cdf_tk/utils/cdf.py
@@ -21,6 +21,7 @@ from cognite_toolkit._cdf_tk.constants import ENV_VAR_PATTERN, MAX_ROW_ITERATION
 from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitRequiredValueError,
     ToolkitTypeError,
+    ToolkitValueError,
 )
 from cognite_toolkit._cdf_tk.tk_warnings import (
     HighSeverityWarning,
@@ -214,13 +215,11 @@ def metadata_key_counts(
     Returns:
         A dictionary with the metadata keys as keys and the counts as values.
     """
-    where_clause = ""
-    if data_sets is not None and hierarchies is not None:
-        where_clause = f"\n         WHERE dataSetId IN ({','.join(map(str, data_sets))}) AND rootId IN ({','.join(map(str, hierarchies))})"
-    elif data_sets is not None:
-        where_clause = f"\n         WHERE dataSetId IN ({','.join(map(str, data_sets))})"
-    elif hierarchies is not None:
-        where_clause = f"\n         WHERE rootId IN ({','.join(map(str, hierarchies))})"
+    if hierarchies and resource != "assets":
+        raise ToolkitValueError(
+            f"Hierarchies filtering for metadata keys are only supported for assets, but {resource} was provided."
+        )
+    where_clause = _create_where_clause(data_sets, hierarchies)
 
     query = f"""WITH meta AS (
          SELECT cast_to_strings(metadata) AS metadata_array
@@ -251,29 +250,56 @@ def metadata_key_counts(
     return [(item["key"], item["key_count"]) for item in results.results or []]
 
 
+def _create_where_clause(data_sets: list[int] | None, hierarchies: list[int] | None) -> str:
+    conditions = []
+    if data_sets:
+        if not all(isinstance(item, int) for item in data_sets):
+            raise ToolkitValueError("All items in data_sets must be integers for SQL filtering.")
+        conditions.append(f"dataSetId IN ({','.join(map(str, data_sets))})")
+    if hierarchies:
+        if not all(isinstance(item, int) for item in hierarchies):
+            raise ToolkitValueError("All items in hierarchies must be integers for SQL filtering.")
+        conditions.append(f"rootId IN ({','.join(map(str, hierarchies))})")
+
+    if not conditions:
+        return ""
+    return f"\n         WHERE {' AND '.join(conditions)}"
+
+
 def label_count(
-    client: ToolkitClient, resource: Literal["assets", "events", "files", "timeseries", "sequences"]
-) -> list[dict[str, int | str]]:
+    client: ToolkitClient,
+    resource: Literal["assets", "events", "files", "timeseries", "sequences"],
+    data_sets: list[int] | None = None,
+    hierarchies: list[int] | None = None,
+) -> list[tuple[str, int]]:
     """Get the label counts for a given resource.
 
     Args:
         client: ToolkitClient instance
         resource: The resource to get the label counts for. Can be one of "assets", "events", "files", "timeseries", or "sequences".
+        data_sets: A list of data set IDs to filter by. If None, no filtering is applied.
+        hierarchies: A list of hierarchy IDs to filter by. If None, no filtering is applied.
 
     Returns:
-        A dictionary with the labels as keys and the counts as values.
+        A list of tuples with the label and its count.
     """
+    if hierarchies and resource != "assets":
+        raise ToolkitValueError(
+            f"Hierarchies filtering for labels are only supported for assets, but {resource} was provided."
+        )
+    where_clause = _create_where_clause(data_sets, hierarchies)
+
     query = f"""WITH labels as (SELECT explode(labels) AS label
-	FROM _cdf.{resource}
+	FROM _cdf.{resource}{where_clause}
   )
 SELECT label, COUNT(label) as label_count
 FROM labels
 GROUP BY label
 ORDER BY label_count DESC;
 """
-    results = client.transformations.preview(query, convert_to_string=False, limit=1000)
+    results = client.transformations.preview(query, convert_to_string=False, limit=None, source_limit=None)
     # We know from the SQL that the result is a list of dictionaries with string keys and int values.
-    return results.results or []
+    return [(item["label"], item["label_count"]) for item in results.results or []]
 
 
 @dataclass

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -60,16 +60,14 @@ class AssetCentricInteractiveSelect(ABC):
 
     def _create_choice(self, item: Asset | DataSet) -> tuple[questionary.Choice, int]:
         """Create a questionary choice for the given item."""
-        args: dict[str, tuple[str, ...]] = dict(hierarchies=tuple(), data_sets=tuple())
-        if isinstance(item, Asset) and item.external_id is not None:
-            args["hierarchies"] = (item.external_id,)
-        elif isinstance(item, DataSet) and item.external_id is not None:
-            args["data_sets"] = (item.external_id,)
-
         if item.external_id is None:
             item_count = -1  # No count available for DataSet/Assets without external_id
+        elif isinstance(item, DataSet):
+            item_count = self.aggregate_count(tuple(), (item.external_id,))
+        elif isinstance(item, Asset):
+            item_count = self.aggregate_count((item.external_id,), tuple())
         else:
-            item_count = self.aggregate_count(**args)
+            raise ToolkitValueError(f"Unexpected item type: {type(item)}. Expected Asset or DataSet.")
 
         return questionary.Choice(
             title=f"{item.name} ({item.external_id}) [{item_count:,}]"

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -60,10 +60,16 @@ class AssetCentricInteractiveSelect(ABC):
 
     def _create_choice(self, item: Asset | DataSet) -> tuple[questionary.Choice, int]:
         """Create a questionary choice for the given item."""
+        args: dict[str, tuple[str, ...]] = dict(hierarchies=tuple(), data_sets=tuple())
+        if isinstance(item, Asset) and item.external_id is not None:
+            args["hierarchies"] = (item.external_id,)
+        elif isinstance(item, DataSet) and item.external_id is not None:
+            args["data_sets"] = (item.external_id,)
+
         if item.external_id is None:
             item_count = -1  # No count available for DataSet/Assets without external_id
         else:
-            item_count = self.aggregate_count(tuple(), (item.external_id,))
+            item_count = self.aggregate_count(**args)
 
         return questionary.Choice(
             title=f"{item.name} ({item.external_id}) [{item_count:,}]"

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -1,15 +1,14 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import ClassVar, Literal
+from typing import ClassVar, Literal, TypeVar, overload
 
 import questionary
 from cognite.client.data_classes import (
     Asset,
-    AssetList,
     DataSet,
-    DataSetList,
     filters,
 )
 from cognite.client.data_classes.data_modeling import NodeList
@@ -25,6 +24,8 @@ from .aggregators import (
     FileAggregator,
     TimeSeriesAggregator,
 )
+
+T_Type = TypeVar("T_Type", bound=Asset | DataSet)
 
 
 class AssetCentricInteractiveSelect(ABC):
@@ -44,13 +45,18 @@ class AssetCentricInteractiveSelect(ABC):
     def _aggregate_count(self, hierarchies: list[str], data_sets: list[str]) -> int:
         return self._aggregator.count(hierarchies, data_sets)
 
-    @lru_cache(maxsize=1)
-    def _get_available_data_sets(self) -> DataSetList:
-        return self.client.data_sets.list(limit=-1)
+    @lru_cache
+    def _get_available_data_sets(self, hierarchy: str | None = None) -> list[DataSet]:
+        if hierarchy is not None:
+            datasets = self._aggregator.used_data_sets(hierarchy)
+            return list(self.client.data_sets.retrieve_multiple(external_ids=datasets))
+        else:
+            return list(self.client.data_sets.list(limit=-1))
 
-    @lru_cache(maxsize=1)
-    def _get_available_hierarchies(self) -> AssetList:
-        return self.client.assets.list(root=True, limit=-1)
+    @lru_cache
+    def _get_available_hierarchies(self, data_set: str | None = None) -> list[Asset]:
+        data_set_external_ids = [data_set] if data_set else None
+        return list(self.client.assets.list(root=True, limit=-1, data_set_external_ids=data_set_external_ids))
 
     def _create_choice(self, item: Asset | DataSet) -> tuple[questionary.Choice, int]:
         """Create a questionary choice for the given item."""
@@ -73,61 +79,130 @@ class AssetCentricInteractiveSelect(ABC):
             value=item.external_id,
         ), item_count
 
-    def interactive_select_hierarchy_datasets(self) -> tuple[list[str], list[str]]:
-        """Interactively select hierarchies and data sets."""
-        hierarchies: set[str] = set()
-        data_sets: set[str] = set()
-        while True:
-            selected: list[str] = []
-            if hierarchies:
-                selected.append(f"Selected hierarchies: {sorted(hierarchies)}")
-            else:
-                selected.append("No hierarchy selected.")
-            if data_sets:
-                selected.append(f"Selected data sets: {sorted(data_sets)}")
-            else:
-                selected.append("No data set selected.")
-            selected_str = "\n".join(selected)
-            what = questionary.select(
-                f"\n{selected_str}\nSelect a hierarchy or data set to {self.operation}",
-                choices=["Hierarchy", "Data Set", "Done", "Abort"],
-            ).ask()
+    @overload
+    def select_hierarchy(self, allow_empty: Literal[False] = False) -> str: ...
 
-            if what == "Done":
-                break
-            elif what == "Abort":
-                return [], []
-            elif what == "Hierarchy":
-                options = [asset for asset in self._get_available_hierarchies() if asset.external_id not in hierarchies]
-                selected_hierarchy = self._select(what, options)
-                if selected_hierarchy:
-                    hierarchies.update(selected_hierarchy)
-                else:
-                    print("No hierarchy selected.")
-            elif what == "Data Set":
-                available_data_sets = [
-                    data_set for data_set in self._get_available_data_sets() if data_set.external_id not in data_sets
-                ]
-                selected_data_set = self._select(what, available_data_sets)
-                if selected_data_set:
-                    data_sets.update(selected_data_set)
-                else:
-                    print("No data set selected.")
-        return list(hierarchies), list(data_sets)
+    @overload
+    def select_hierarchy(self, allow_empty: Literal[True]) -> str | None: ...
 
-    def _select(self, what: str, options: list[Asset] | list[DataSet]) -> str | None:
-        return questionary.checkbox(
-            f"Select a {what} listed as 'name (external_id) [count]'",
-            choices=[
-                choice
-                for choice, count in (
-                    # MyPy does not seem to understand that item is Asset | DataSet
-                    self._create_choice(item)  # type: ignore[arg-type]
-                    for item in sorted(options, key=lambda x: x.name or x.external_id)
-                )
-                if count > 0
-            ],
+    def select_hierarchy(self, allow_empty: Literal[False, True] = False) -> str | None:
+        """Select a hierarchy interactively."""
+        options = self._get_available_hierarchies()
+        return self._select("hierarchy", options, allow_empty, "single")
+
+    def select_hierarchies(self) -> list[str]:
+        options = self._get_available_hierarchies()
+        return self._select("hierarchies", options, False, "multiple")
+
+    @overload
+    def select_data_set(self, allow_empty: Literal[False] = False) -> str: ...
+
+    @overload
+    def select_data_set(self, allow_empty: Literal[True]) -> str | None: ...
+
+    def select_data_set(self, allow_empty: Literal[False, True] = False) -> str | None:
+        """Select a data set interactively."""
+        options = self._get_available_data_sets()
+        return self._select("data set", options, allow_empty, "single")
+
+    def select_data_sets(self) -> list[str]:
+        """Select multiple data sets interactively."""
+        options = self._get_available_data_sets()
+        return self._select("data sets", options, False, "multiple")
+
+    def select_hierarchies_and_data_sets(self) -> tuple[list[str], list[str]]:
+        what = questionary.select(
+            f"Do you want to {self.operation} a hierarchy or a data set?", choices=["Hierarchy", "Data Set"]
         ).ask()
+        if what is None:
+            raise ToolkitValueError("No selection made. Aborting.")
+        if what == "Hierarchy":
+            hierarchy = self._select("hierarchy", self._get_available_hierarchies(), False, "single")
+            data_sets = self._get_available_data_sets(hierarchy=hierarchy)
+            if not data_sets:
+                return [hierarchy], []
+            selected_data_sets = self._select(f"data sets in hierarchy {hierarchy!r}", data_sets, True, "multiple")
+            return [hierarchy], selected_data_sets or []
+        elif what == "Data Set":
+            data_set = self._select("data Set", self._get_available_data_sets(), False, "single")
+            hierarchies = self._get_available_hierarchies(data_set=data_set)
+            if not hierarchies:
+                return [], [data_set]
+            selected_hierarchies = self._select(f"hierarchies in data set {data_set!r} ", hierarchies, True, "multiple")
+            return selected_hierarchies or [], [data_set]
+        else:
+            raise ToolkitValueError(f"Unexpected selection: {what}. Aborting.")
+
+    @overload
+    def _select(
+        self,
+        what: str,
+        options: Sequence[T_Type],
+        allow_empty: Literal[False],
+        plurality: Literal["single"],
+    ) -> str: ...
+
+    @overload
+    def _select(
+        self,
+        what: str,
+        options: Sequence[T_Type],
+        allow_empty: Literal[True],
+        plurality: Literal["single"],
+    ) -> str | None: ...
+
+    @overload
+    def _select(
+        self,
+        what: str,
+        options: Sequence[T_Type],
+        allow_empty: Literal[False],
+        plurality: Literal["multiple"],
+    ) -> list[str]: ...
+
+    @overload
+    def _select(
+        self,
+        what: str,
+        options: Sequence[T_Type],
+        allow_empty: Literal[True],
+        plurality: Literal["multiple"],
+    ) -> list[str] | None: ...
+
+    def _select(
+        self,
+        what: str,
+        options: Sequence[Asset | DataSet],
+        allow_empty: Literal[True, False],
+        plurality: Literal["single", "multiple"],
+    ) -> str | list[str] | None:
+        """Select a single item interactively."""
+        if not options and not allow_empty:
+            raise ToolkitValueError(f"No {what} available to select.")
+
+        choices: list[questionary.Choice] = []
+        none_sentinel = object()
+        if allow_empty:
+            choices.append(questionary.Choice(title=f"All {what}", value=none_sentinel))
+
+        for choice, count in sorted(
+            (self._create_choice(item) for item in options), key=lambda x: (-x[1], x[0].title)
+        ):  # cont, choice.title
+            if count > 0:
+                choices.append(choice)
+        if not choices and not allow_empty:
+            raise ToolkitValueError(f"No {what} available with data to select.")
+
+        message = f"Select a {what} to {self.operation} listed as 'name (external_id) [count]'"
+        if plurality == "multiple":
+            selected = questionary.checkbox(message, choices=choices).ask()
+        else:
+            selected = questionary.select(message, choices=choices).ask()
+        if selected is None:
+            raise ToolkitValueError(f"No {what} selected. Aborting.")
+        elif selected is none_sentinel or (isinstance(selected, list) and none_sentinel in selected):
+            return None
+        return selected
 
 
 class AssetInteractiveSelect(AssetCentricInteractiveSelect):

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -60,17 +60,10 @@ class AssetCentricInteractiveSelect(ABC):
 
     def _create_choice(self, item: Asset | DataSet) -> tuple[questionary.Choice, int]:
         """Create a questionary choice for the given item."""
-
-        if isinstance(item, DataSet):
-            if item.external_id is None:
-                raise ValueError(f"Missing external ID for DataSet {item.id}")
-            item_count = self.aggregate_count(tuple(), (item.external_id,))
-        elif isinstance(item, Asset):
-            if item.external_id is None:
-                raise ValueError(f"Missing external ID for Asset {item.id}")
-            item_count = self.aggregate_count((item.external_id,), tuple())
+        if item.external_id is None:
+            item_count = -1  # No count available for DataSet/Assets without external_id
         else:
-            raise TypeError(f"Unsupported item type: {type(item)}")
+            item_count = self.aggregate_count(tuple(), (item.external_id,))
 
         return questionary.Choice(
             title=f"{item.name} ({item.external_id}) [{item_count:,}]"

--- a/tests/test_integration/test_utils/test_cdf.py
+++ b/tests/test_integration/test_utils/test_cdf.py
@@ -22,6 +22,7 @@ from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.data_classes.raw import RawTable
 from cognite_toolkit._cdf_tk.utils.cdf import (
     label_aggregate_count,
+    label_count,
     metadata_key_counts,
     raw_row_count,
     relationship_aggregate_count,
@@ -54,7 +55,37 @@ def two_datasets(toolkit_client: ToolkitClient) -> DataSetList:
 
 
 @pytest.fixture(scope="session")
-def two_hierarchies(toolkit_client: ToolkitClient, two_datasets: DataSetList) -> tuple[AssetList, AssetList]:
+def two_labels(toolkit_client: ToolkitClient, two_datasets: DataSetList) -> LabelDefinitionList:
+    data_set_id = two_datasets[0].id  # Using the first dataset for labels
+    labels = LabelDefinitionWriteList(
+        [
+            LabelDefinitionWrite(
+                external_id="toolkit_test_label_aggregate_count_1",
+                name="Test Label 1",
+                description="This is a test label 1",
+                data_set_id=data_set_id,
+            ),
+            LabelDefinitionWrite(
+                external_id="toolkit_test_label_aggregate_count_2",
+                name="Test Label 2",
+                description="This is a test label 2",
+                data_set_id=data_set_id,
+            ),
+        ]
+    )
+    existing = toolkit_client.labels.retrieve(external_id=labels.as_external_ids(), ignore_unknown_ids=True)
+    if missing := [label for label in labels if label.external_id not in set(existing.as_external_ids())]:
+        created = toolkit_client.labels.create(missing)
+        existing.extend(created)
+    return existing
+
+
+@pytest.fixture(scope="session")
+def two_hierarchies(
+    toolkit_client: ToolkitClient, two_datasets: DataSetList, two_labels: LabelDefinitionList
+) -> tuple[AssetList, AssetList]:
+    all_labels = [label.external_id for label in two_labels]
+    single_label = [two_labels[0].external_id]
     hierarchies = [
         AssetWriteList(
             [
@@ -73,6 +104,7 @@ def two_hierarchies(toolkit_client: ToolkitClient, two_datasets: DataSetList) ->
                         f"metadata_key_{i}": "does not matter either",
                         f"metadata_key_extra_{i}": "does not matter either",
                     },
+                    labels=all_labels if i == 0 else single_label,
                 ),
                 AssetWrite(
                     name=f"Child Asset extra {i}",
@@ -82,6 +114,7 @@ def two_hierarchies(toolkit_client: ToolkitClient, two_datasets: DataSetList) ->
                         f"extra_key{i}": "does not matter either",
                         f"another_extra_key{i}": "does not matter either",
                     },
+                    labels=single_label,
                 ),
             ]
         )
@@ -129,32 +162,6 @@ def asset_relationships(
     )
     if missing := [rel for rel in relationships if rel.external_id not in set(existing.as_external_ids())]:
         created = toolkit_client.relationships.create(missing)
-        existing.extend(created)
-    return existing
-
-
-@pytest.fixture(scope="session")
-def two_labels(toolkit_client: ToolkitClient, two_datasets: DataSetList) -> LabelDefinitionList:
-    data_set_id = two_datasets[0].id  # Using the first dataset for labels
-    labels = LabelDefinitionWriteList(
-        [
-            LabelDefinitionWrite(
-                external_id="toolkit_test_label_aggregate_count_1",
-                name="Test Label 1",
-                description="This is a test label 1",
-                data_set_id=data_set_id,
-            ),
-            LabelDefinitionWrite(
-                external_id="toolkit_test_label_aggregate_count_2",
-                name="Test Label 2",
-                description="This is a test label 2",
-                data_set_id=data_set_id,
-            ),
-        ]
-    )
-    existing = toolkit_client.labels.retrieve(external_id=labels.as_external_ids(), ignore_unknown_ids=True)
-    if missing := [label for label in labels if label.external_id not in set(existing.as_external_ids())]:
-        created = toolkit_client.labels.create(missing)
         existing.extend(created)
     return existing
 
@@ -269,6 +276,73 @@ class TestLabelAggregateCount:
         count = label_aggregate_count(toolkit_client, [data_set_id])
 
         assert count == len(two_labels)
+
+
+class TestLabelCount:
+    def test_label_count(self, toolkit_client: ToolkitClient, two_labels: LabelDefinitionList) -> None:
+        counts = label_count(toolkit_client, "assets")
+
+        ill_formed = [
+            (label, count)
+            for label, count in counts
+            if not isinstance(label, str) or not isinstance(count, int) or count < 0
+        ]
+        assert len(counts) > 0, "There should be some label counts."
+        assert len(ill_formed) == 0, f"Ill-formed label counts: {ill_formed}"
+
+    @pytest.mark.parametrize(
+        "hierarchies, datasets",
+        (
+            (hierarchies, datasets)
+            for hierarchies, datasets in itertools.product(
+                [
+                    None,
+                    ["toolkit_test_metadata_key_counts_root_asset_0"],
+                    ["toolkit_test_metadata_key_counts_root_asset_0", "toolkit_test_metadata_key_counts_root_asset_1"],
+                ],
+                [
+                    None,
+                    ["toolkit_test_metadata_key_counts_1"],
+                    ["toolkit_test_metadata_key_counts_1", "toolkit_test_metadata_key_counts_2"],
+                ],
+            )
+            if not (not hierarchies and not datasets)
+        ),
+        ids=(
+            f"{hierarchy_str} and {dataset_str}"
+            for hierarchy_str, dataset_str in itertools.product(
+                ["no hierarchies", "one hierarchy", "two hierarchies"],
+                ["no datasets", "one dataset", "two datasets"],
+                # We filter out this case as it will return all assets in the project as it has no filtering.
+            )
+            if not (hierarchy_str == "no hierarchies" and dataset_str == "no datasets")
+        ),
+    )
+    def test_label_count_filtering_datasets_hierarchies(
+        self,
+        hierarchies: list[str] | None,
+        datasets: list[str] | None,
+        toolkit_client: ToolkitClient,
+        two_hierarchies: tuple[AssetList, AssetList],
+        two_datasets: DataSetList,
+    ) -> None:
+        hierarchy_external_to_internal = {assets[0].external_id: assets[0].id for assets in two_hierarchies}
+        datasets_external_to_internal = {dataset.external_id: dataset.id for dataset in two_datasets}
+        hierarchy_ids = (
+            [hierarchy_external_to_internal[external_id] for external_id in hierarchies] if hierarchies else None
+        )
+        dataset_ids = [datasets_external_to_internal[external_id] for external_id in datasets] if datasets else None
+        label_counts = label_count(toolkit_client, "assets", hierarchies=hierarchy_ids, data_sets=dataset_ids)
+
+        expected_keys = Counter()
+        for hierarchy in two_hierarchies:
+            for asset in hierarchy:
+                if (hierarchy_ids is None or asset.root_id in hierarchy_ids) and (
+                    dataset_ids is None or asset.data_set_id in dataset_ids
+                ):
+                    expected_keys.update([label.external_id for label in asset.labels or []])
+
+        assert {key: count for key, count in label_counts} == dict(expected_keys.items())
 
 
 class TestRawTableRowCount:

--- a/tests/test_unit/approval_client/client.py
+++ b/tests/test_unit/approval_client/client.py
@@ -93,7 +93,7 @@ class LookUpAPIMock:
         self._generate_random_external_id_on_lookup_failure = allow_reverse_lookup
 
     @staticmethod
-    def _create_id(string: str, allow_empty: bool = False) -> int:
+    def create_id(string: str, allow_empty: bool = False) -> int:
         if allow_empty and string == "":
             return 0
         # This simulates CDF setting the internal ID.
@@ -108,13 +108,13 @@ class LookUpAPIMock:
         self, external_id: str | SequenceNotStr[str], is_dry_run: bool = False, allow_empty: bool = False
     ) -> int | list[int]:
         if isinstance(external_id, str):
-            id_ = self._create_id(external_id, allow_empty)
+            id_ = self.create_id(external_id, allow_empty)
             if id_ not in self._reverse_cache:
                 self._reverse_cache[id_] = external_id
             return id_
         output: list[int] = []
         for ext_id in external_id:
-            id_ = self._create_id(ext_id, allow_empty)
+            id_ = self.create_id(ext_id, allow_empty)
             if id_ not in self._reverse_cache:
                 self._reverse_cache[id_] = ext_id
             output.append(id_)

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_data.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_data.py
@@ -138,7 +138,7 @@ class TestDumpData:
             )
 
             cmd.dump_table(
-                FileMetadataFinder(client, ["rootAsset"], []),
+                FileMetadataFinder(client, [], ["my_dataset"]),
                 output_dir,
                 clean=True,
                 limit=None,

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_file_metadata_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_file_metadata_loader.py
@@ -26,7 +26,7 @@ source: sharepointABC
                     external_id="sharepointABC",
                     source="sharepointABC",
                     name="A file.txt",
-                    data_set_id=LookUpAPIMock._create_id("ds_files"),
+                    data_set_id=LookUpAPIMock.create_id("ds_files"),
                 )
             ]
         ),
@@ -49,13 +49,13 @@ source: sharepointABC
                     external_id="sharepointABC",
                     source="sharepointABC",
                     name="A file.txt",
-                    data_set_id=LookUpAPIMock._create_id("ds_files"),
+                    data_set_id=LookUpAPIMock.create_id("ds_files"),
                 ),
                 FileMetadataWrite(
                     external_id="sharepointABC2",
                     source="sharepointABC",
                     name="Another file.txt",
-                    data_set_id=LookUpAPIMock._create_id("ds_files"),
+                    data_set_id=LookUpAPIMock.create_id("ds_files"),
                 ),
             ]
         ),

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_time_series_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_time_series_loader.py
@@ -28,7 +28,7 @@ description: PH 1stStgSuctCool Gas Out
         loader = TimeSeriesLoader(toolkit_client_approval.mock_client, None)
         ts_dict = yaml.safe_load(self.timeseries_yaml)
         data_set_external_id = ts_dict["dataSetExternalId"]
-        expected_id = LookUpAPIMock._create_id(data_set_external_id)
+        expected_id = LookUpAPIMock.create_id(data_set_external_id)
 
         loaded = loader.load_resource(ts_dict, is_dry_run=False)
 

--- a/tests/test_unit/test_cdf_tk/test_utils/test_aggregators.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_aggregators.py
@@ -41,6 +41,20 @@ class TestAggregators:
                         {"assetSubtreeIds": [{"externalId": ""}], "dataSetIds": [{"externalId": "data_set"}]},
                     ),
                     ("", "", {"assetSubtreeIds": [{"externalId": ""}], "dataSetIds": [{"externalId": ""}]}),
+                    ([], [], None),
+                    (["hierarchy"], [], {"assetSubtreeIds": [{"externalId": "hierarchy"}]}),
+                    ([], ["data_set"], {"dataSetIds": [{"externalId": "data_set"}]}),
+                    (
+                        ["hierarchy"],
+                        ["data_set"],
+                        {"assetSubtreeIds": [{"externalId": "hierarchy"}], "dataSetIds": [{"externalId": "data_set"}]},
+                    ),
+                    (
+                        ["hierarchy"],
+                        [""],
+                        {"assetSubtreeIds": [{"externalId": "hierarchy"}], "dataSetIds": [{"externalId": ""}]},
+                    ),
+                    ([], ["data_set", ""], {"dataSetIds": [{"externalId": "data_set"}, {"externalId": ""}]}),
                 ],
             )
         ],

--- a/tests/test_unit/test_cdf_tk/test_utils/test_aggregators.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_aggregators.py
@@ -1,6 +1,9 @@
 from itertools import product
+from typing import ClassVar
+from unittest.mock import MagicMock, patch
 
 import pytest
+from _pytest.mark import ParameterSet
 
 from cognite_toolkit._cdf_tk.utils.aggregators import (
     AssetAggregator,
@@ -10,6 +13,9 @@ from cognite_toolkit._cdf_tk.utils.aggregators import (
     SequenceAggregator,
     TimeSeriesAggregator,
 )
+from cognite_toolkit._cdf_tk.utils.cdf import label_count, metadata_key_counts
+from tests.test_unit.approval_client import ApprovalToolkitClient
+from tests.test_unit.approval_client.client import LookUpAPIMock
 
 
 class TestAggregators:
@@ -69,4 +75,68 @@ class TestAggregators:
         actual_filter = aggregator_class.create_filter(hierarchy, data_set_external_id)
         assert (actual_filter is None and expected_filter is None) or actual_filter.dump() == expected_filter, (
             f"Failed with {hierarchy}, {data_set_external_id} -> {actual_filter.dump()} != {expected_filter}"
+        )
+
+    hierarchy_dataset_combinations: ClassVar[list[ParameterSet]] = [
+        pytest.param(None, None, None, None, id="No hierarchy and no data sets"),
+        pytest.param("hierarchy", None, [LookUpAPIMock.create_id("hierarchy")], None, id="Hierarchy only"),
+        pytest.param(None, "data_set", None, [LookUpAPIMock.create_id("data_set")], id="Data set only"),
+        pytest.param(
+            "hierarchy",
+            "data_set",
+            [LookUpAPIMock.create_id("hierarchy")],
+            [LookUpAPIMock.create_id("data_set")],
+            id="Hierarchy and data set",
+        ),
+        pytest.param(
+            ["hierarchy1", "hierarchy2"],
+            ["data_set1", "data_set2"],
+            sorted([LookUpAPIMock.create_id("hierarchy1"), LookUpAPIMock.create_id("hierarchy2")]),
+            sorted([LookUpAPIMock.create_id("data_set1"), LookUpAPIMock.create_id("data_set2")]),
+            id="Multiple hierarchies and data sets",
+        ),
+    ]
+
+    @pytest.mark.parametrize("hierarchy, data_sets, hierarchy_ids, data_set_ids", hierarchy_dataset_combinations)
+    def test_metadata_keys_count(
+        self,
+        hierarchy: str | list[str] | None,
+        data_sets: str | list[str] | None,
+        hierarchy_ids: list[int] | None,
+        data_set_ids: list[int] | None,
+        toolkit_client_approval: ApprovalToolkitClient,
+    ) -> None:
+        aggregator = AssetAggregator(toolkit_client_approval.mock_client)
+
+        metadata_key_counts_mock = MagicMock(spec=metadata_key_counts)
+        metadata_key_counts_mock.return_value = [("key1", 10), ("key2", 5), ("key3", 15)]
+
+        with patch(f"{AssetAggregator.__module__}.metadata_key_counts", metadata_key_counts_mock):
+            result = aggregator.metadata_key_count(hierarchy, data_sets)
+
+        assert result == 3
+        metadata_key_counts_mock.assert_called_once_with(
+            toolkit_client_approval.mock_client, "assets", hierarchies=hierarchy_ids, data_sets=data_set_ids
+        )
+
+    @pytest.mark.parametrize("hierarchy, data_sets, hierarchy_ids, data_set_ids", hierarchy_dataset_combinations)
+    def test_label_count(
+        self,
+        hierarchy: str | list[str] | None,
+        data_sets: str | list[str] | None,
+        hierarchy_ids: list[int] | None,
+        data_set_ids: list[int] | None,
+        toolkit_client_approval: ApprovalToolkitClient,
+    ) -> None:
+        aggregator = AssetAggregator(toolkit_client_approval.mock_client)
+
+        label_count_mock = MagicMock(spec=label_count)
+        label_count_mock.return_value = [("label1", 42), ("label2", 10)]
+
+        with patch(f"{AssetAggregator.__module__}.label_count", label_count_mock):
+            result = aggregator.label_count(hierarchy, data_sets)
+
+        assert result == 2
+        label_count_mock.assert_called_once_with(
+            toolkit_client_approval.mock_client, "assets", hierarchies=hierarchy_ids, data_sets=data_set_ids
         )

--- a/tests/test_unit/test_cdf_tk/test_utils/test_aggregators.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_aggregators.py
@@ -67,4 +67,6 @@ class TestAggregators:
         expected_filter: dict[str, object] | None,
     ) -> None:
         actual_filter = aggregator_class.create_filter(hierarchy, data_set_external_id)
-        assert (actual_filter is None and expected_filter is None) or actual_filter.dump() == expected_filter
+        assert (actual_filter is None and expected_filter is None) or actual_filter.dump() == expected_filter, (
+            f"Failed with {hierarchy}, {data_set_external_id} -> {actual_filter.dump()} != {expected_filter}"
+        )

--- a/tests/test_unit/test_cdf_tk/test_utils/test_interactive_select.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_interactive_select.py
@@ -59,15 +59,15 @@ class TestInteractiveSelect:
         assert selected_dataset == ["dataset3"]
 
     def test_interactive_select_filemetadata(self, monkeypatch) -> None:
-        def select_data_set(choices: list[Choice]) -> list[str]:
+        def select_data_set(choices: list[Choice]) -> str:
             assert len(choices) == 3
-            return [choices[2].value]
+            return choices[2].value
 
         def select_hierarchy(choices: list[Choice]) -> list[str]:
-            assert len(choices) == 2
-            return [choices[1].value]
+            assert len(choices) == 2 + 1  # +1 for "All Hierarchies" option
+            return [choices[2].value]
 
-        answers = ["Data Set", select_data_set, "Hierarchy", select_hierarchy, "Done"]
+        answers = ["Data Set", select_data_set, select_hierarchy]
         with (
             monkeypatch_toolkit_client() as client,
             MockQuestionary(FileMetadataInteractiveSelect.__module__, monkeypatch, answers),
@@ -89,15 +89,15 @@ class TestInteractiveSelect:
         assert selected_dataset == ["dataset3"]
 
     def test_interactive_select_filemetadata_empty_cdf(self, monkeypatch) -> None:
-        def select_data_set(choices: list[Choice]) -> list[str]:
+        def select_data_set(choices: list[Choice]) -> None:
             assert len(choices) == 0
-            return []
+            return None
 
         def select_hierarchy(choices: list[Choice]) -> list[str]:
             assert len(choices) == 0
             return []
 
-        answers = ["Data Set", select_data_set, "Hierarchy", select_hierarchy, "Done"]
+        answers = ["Data Set", select_data_set, select_hierarchy]
         with (
             monkeypatch_toolkit_client() as client,
             MockQuestionary(FileMetadataInteractiveSelect.__module__, monkeypatch, answers),
@@ -106,21 +106,21 @@ class TestInteractiveSelect:
             client.assets.list.return_value = []
             client.files.aggregate.return_value = [CountAggregate(100)]
             selector = FileMetadataInteractiveSelect(client, "test_operation")
-            selected_hierarchy, selected_dataset = selector.select_hierarchies_and_data_sets()
+            with pytest.raises(ToolkitValueError) as exc_info:
+                _ = selector.select_hierarchies_and_data_sets()
 
-        assert selected_hierarchy == []
-        assert selected_dataset == []
+        assert str(exc_info.value) == "No data Set available to select."
 
     def test_interactive_select_timeseries(self, monkeypatch) -> None:
-        def select_data_set(choices: list[Choice]) -> list[str]:
+        def select_data_set(choices: list[Choice]) -> str:
             assert len(choices) == 3
-            return [choices[2].value]
+            return choices[2].value
 
         def select_hierarchy(choices: list[Choice]) -> list[str]:
-            assert len(choices) == 2
-            return [choices[1].value]
+            assert len(choices) == 2 + 1  # +1 for "All Hierarchies" option
+            return [choices[2].value]
 
-        answers = ["Data Set", select_data_set, "Hierarchy", select_hierarchy, "Done"]
+        answers = ["Data Set", select_data_set, select_hierarchy]
         with (
             monkeypatch_toolkit_client() as client,
             MockQuestionary(TimeSeriesInteractiveSelect.__module__, monkeypatch, answers),
@@ -142,15 +142,15 @@ class TestInteractiveSelect:
         assert selected_dataset == ["dataset3"]
 
     def test_interactive_select_events(self, monkeypatch) -> None:
-        def select_data_set(choices: list[Choice]) -> list[str]:
+        def select_data_set(choices: list[Choice]) -> str:
             assert len(choices) == 3
-            return [choices[2].value]
+            return choices[2].value
 
         def select_hierarchy(choices: list[Choice]) -> list[str]:
-            assert len(choices) == 2
-            return [choices[1].value]
+            assert len(choices) == 2 + 1  # +1 for "All Hierarchies" option
+            return [choices[2].value]
 
-        answers = ["Data Set", select_data_set, "Hierarchy", select_hierarchy, "Done"]
+        answers = ["Data Set", select_data_set, select_hierarchy]
         with (
             monkeypatch_toolkit_client() as client,
             MockQuestionary(EventInteractiveSelect.__module__, monkeypatch, answers),

--- a/tests/test_unit/test_cdf_tk/test_utils/test_interactive_select.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_interactive_select.py
@@ -171,6 +171,150 @@ class TestInteractiveSelect:
         assert selected_hierarchy == ["Root2"]
         assert selected_dataset == ["dataset3"]
 
+    def test_select_data_set(self, monkeypatch):
+        def select_data_set(choices) -> str:
+            assert len(choices) == 2
+            selection = choices[1].value
+            assert isinstance(selection, str)
+            return selection
+
+        answers = [select_data_set]
+        with (
+            monkeypatch_toolkit_client() as client,
+            MockQuestionary(AssetInteractiveSelect.__module__, monkeypatch, answers),
+        ):
+            selector = AssetInteractiveSelect(client, "test")
+            aggregator = MagicMock(spec=AssetCentricAggregator)
+            aggregator.count.return_value = 1000
+            selector._aggregator = aggregator
+
+            client.data_sets.list.return_value = [
+                DataSet(id=1, external_id="ds1", name="DataSet 1"),
+                DataSet(id=2, external_id="ds2", name="DataSet 2"),
+            ]
+            result = selector.select_data_set()
+        assert result == "ds2"
+
+    def test_select_data_sets_allow_empty(self, monkeypatch) -> None:
+        def select_data_sets(choices) -> str | None:
+            assert len(choices) == 2 + 1  # +1 for "All Data Sets" option
+            assert choices[0].title.startswith("All")
+            return choices[0].value
+
+        answers = [select_data_sets]
+        with (
+            monkeypatch_toolkit_client() as client,
+            MockQuestionary(AssetInteractiveSelect.__module__, monkeypatch, answers),
+        ):
+            selector = AssetInteractiveSelect(client, "test")
+            aggregator = MagicMock(spec=AssetCentricAggregator)
+            aggregator.count.return_value = 1000
+            selector._aggregator = aggregator
+
+            client.data_sets.list.return_value = [
+                DataSet(id=1, external_id="ds1", name="DataSet 1"),
+                DataSet(id=2, external_id="ds2", name="DataSet 2"),
+            ]
+
+            result = selector.select_data_set(allow_empty=True)
+        assert result is None
+
+    def test_select_data_sets(self, monkeypatch):
+        def select_data_sets(choices) -> str:
+            assert len(choices) == 2
+            selection = choices[0].value
+            assert isinstance(selection, str)
+            return selection
+
+        answers = [select_data_sets]
+        with (
+            monkeypatch_toolkit_client() as client,
+            MockQuestionary(AssetInteractiveSelect.__module__, monkeypatch, answers),
+        ):
+            selector = AssetInteractiveSelect(client, "test")
+            aggregator = MagicMock(spec=AssetCentricAggregator)
+            aggregator.count.return_value = 1000
+            selector._aggregator = aggregator
+
+            client.data_sets.list.return_value = [
+                DataSet(id=1, external_id="ds1", name="DataSet 1"),
+                DataSet(id=2, external_id="ds2", name="DataSet 2"),
+            ]
+
+            result = selector.select_data_sets()
+        assert result == "ds1"
+
+    def test_select_hierarchy(self, monkeypatch):
+        def select_hierarchy(choices) -> str:
+            assert len(choices) == 2
+            selection = choices[0].value
+            assert isinstance(selection, str)
+            return selection
+
+        answers = [select_hierarchy]
+        with (
+            monkeypatch_toolkit_client() as client,
+            MockQuestionary(AssetInteractiveSelect.__module__, monkeypatch, answers),
+        ):
+            selector = AssetInteractiveSelect(client, "test")
+            aggregator = MagicMock(spec=AssetCentricAggregator)
+            aggregator.count.return_value = 1000
+            selector._aggregator = aggregator
+
+            client.assets.list.return_value = [
+                Asset(id=1, external_id="root1", name="Root 1"),
+                Asset(id=2, external_id="root2", name="Root 2"),
+            ]
+
+            result = selector.select_hierarchy()
+        assert result == "root1"
+
+    def test_select_hierarchy_allow_empty(self, monkeypatch) -> None:
+        def select_hierarchy(choices) -> str | None:
+            assert len(choices) == 2 + 1
+            # +1 for "All Hierarchies" option
+            assert choices[0].title.startswith("All")
+            return choices[0].value
+
+        answers = [select_hierarchy]
+        with (
+            monkeypatch_toolkit_client() as client,
+            MockQuestionary(AssetInteractiveSelect.__module__, monkeypatch, answers),
+        ):
+            selector = AssetInteractiveSelect(client, "test")
+            aggregator = MagicMock(spec=AssetCentricAggregator)
+            aggregator.count.return_value = 1000
+            selector._aggregator = aggregator
+
+            client.assets.list.return_value = [
+                Asset(id=1, external_id="root1", name="Root 1"),
+                Asset(id=2, external_id="root2", name="Root 2"),
+            ]
+
+            result = selector.select_hierarchy(allow_empty=True)
+        assert result is None
+
+    def test_select_hierarchies(self, monkeypatch):
+        def select_hierarchies(choices) -> list[str]:
+            assert len(choices) == 2
+            return [choices[1].value]
+
+        answers = [select_hierarchies]
+        with (
+            monkeypatch_toolkit_client() as client,
+            MockQuestionary(AssetInteractiveSelect.__module__, monkeypatch, answers),
+        ):
+            selector = AssetInteractiveSelect(client, "test")
+            aggregator = MagicMock(spec=AssetCentricAggregator)
+            aggregator.count.return_value = 1000
+            selector._aggregator = aggregator
+            client.assets.list.return_value = [
+                Asset(id=1, external_id="root1", name="Root 1"),
+                Asset(id=2, external_id="root2", name="Root 2"),
+            ]
+            result = selector.select_hierarchies()
+        assert result == ["root2"]
+
 
 class TestInteractiveCanvasSelect:
     @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Stacked on #1744 #1745, #1746, #1748, #1749

Implements option for selection of asset hierarchy when profiling.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- [alpha] Add support for running `cdf profile asset-centric` for  a single hierarchy.

## templates

No changes.
