### PR TITLE
[prep CDF-25251] 🧑‍🎓Standardize Search client API

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
+++ b/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
@@ -15,7 +15,6 @@ from .api.lookup import LookUpGroup
 from .api.migration import MigrationAPI
 from .api.robotics import RoboticsAPI
 from .api.search import SearchAPI
-from .api.search_config import SearchConfigurationsAPI
 from .api.token import TokenAPI
 from .api.verify import VerifyAPI
 
@@ -81,7 +80,6 @@ class ToolkitClient(CogniteClient):
         super().__init__(config=config)
         self.search = SearchAPI(self._config, self._API_VERSION, self)
         self.location_filters = LocationFiltersAPI(self._config, self._API_VERSION, self)
-        self.search_configurations = SearchConfigurationsAPI(self._config, self._API_VERSION, self)
         self.robotics = RoboticsAPI(self._config, self._API_VERSION, self)
         self.dml = DMLAPI(self._config, self._API_VERSION, self)
         self.verify = VerifyAPI(self._config, self._API_VERSION, self)

--- a/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
+++ b/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
@@ -14,6 +14,7 @@ from .api.location_filters import LocationFiltersAPI
 from .api.lookup import LookUpGroup
 from .api.migration import MigrationAPI
 from .api.robotics import RoboticsAPI
+from .api.search import SearchAPI
 from .api.search_config import SearchConfigurationsAPI
 from .api.token import TokenAPI
 from .api.verify import VerifyAPI
@@ -78,6 +79,7 @@ class ToolkitClientConfig(ClientConfig):
 class ToolkitClient(CogniteClient):
     def __init__(self, config: ToolkitClientConfig | None = None, enable_set_pending_ids: bool = False) -> None:
         super().__init__(config=config)
+        self.search = SearchAPI(self._config, self._API_VERSION, self)
         self.location_filters = LocationFiltersAPI(self._config, self._API_VERSION, self)
         self.search_configurations = SearchConfigurationsAPI(self._config, self._API_VERSION, self)
         self.robotics = RoboticsAPI(self._config, self._API_VERSION, self)

--- a/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
+++ b/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
@@ -10,7 +10,6 @@ from .api.extended_data_modeling import ExtendedDataModelingAPI
 from .api.extended_files import ExtendedFileMetadataAPI
 from .api.extended_raw import ExtendedRawAPI
 from .api.extended_timeseries import ExtendedTimeSeriesAPI
-from .api.location_filters import LocationFiltersAPI
 from .api.lookup import LookUpGroup
 from .api.migration import MigrationAPI
 from .api.robotics import RoboticsAPI
@@ -79,7 +78,6 @@ class ToolkitClient(CogniteClient):
     def __init__(self, config: ToolkitClientConfig | None = None, enable_set_pending_ids: bool = False) -> None:
         super().__init__(config=config)
         self.search = SearchAPI(self._config, self._API_VERSION, self)
-        self.location_filters = LocationFiltersAPI(self._config, self._API_VERSION, self)
         self.robotics = RoboticsAPI(self._config, self._API_VERSION, self)
         self.dml = DMLAPI(self._config, self._API_VERSION, self)
         self.verify = VerifyAPI(self._config, self._API_VERSION, self)

--- a/cognite_toolkit/_cdf_tk/client/api/lookup.py
+++ b/cognite_toolkit/_cdf_tk/client/api/lookup.py
@@ -301,7 +301,7 @@ class SecurityCategoriesLookUpAPI(AllLookUpAPI):
 
 class LocationFiltersLookUpAPI(AllLookUpAPI):
     def _lookup(self) -> None:
-        for location in self._toolkit_client.location_filters.list():
+        for location in self._toolkit_client.search.locations.list():
             if location.external_id and location.id:
                 self._cache[location.external_id] = location.id
                 self._reverse_cache[location.id] = location.external_id

--- a/cognite_toolkit/_cdf_tk/client/api/search.py
+++ b/cognite_toolkit/_cdf_tk/client/api/search.py
@@ -1,0 +1,13 @@
+from cognite.client import CogniteClient
+from cognite.client._api_client import APIClient
+from cognite.client.config import ClientConfig
+
+from .location_filters import LocationFiltersAPI
+from .search_config import SearchConfigurationsAPI
+
+
+class SearchAPI(APIClient):
+    def __init__(self, config: ClientConfig, api_version: str | None, cognite_client: CogniteClient) -> None:
+        super().__init__(config, api_version, cognite_client)
+        self.locations = LocationFiltersAPI(config, api_version, cognite_client)
+        self.configurations = SearchConfigurationsAPI(config, api_version, cognite_client)

--- a/cognite_toolkit/_cdf_tk/client/data_classes/search_config.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/search_config.py
@@ -105,6 +105,19 @@ class SearchConfigCore(WriteableCogniteResource["SearchConfigWrite"], ABC):
 
 
 class SearchConfigWrite(SearchConfigCore):
+    """
+    SearchConfig write/requst format.
+
+    Args:
+        view: The configuration for one specific view.
+        id: A server-generated ID for the object.
+        use_as_name: The name of property to use for the name column in the UI.
+        use_as_description: The name of property to use for the description column in the UI.
+        column_layout: Array of column configurations per property.
+        filter_layout: Array of filter configurations per property.
+        properties_layout: Array of property configurations per property.
+    """
+
     @classmethod
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         return cls(

--- a/cognite_toolkit/_cdf_tk/client/testing.py
+++ b/cognite_toolkit/_cdf_tk/client/testing.py
@@ -26,6 +26,8 @@ from .api.robotics.data_postprocessing import DataPostProcessingAPI
 from .api.robotics.frames import FramesAPI
 from .api.robotics.locations import LocationsAPI as RoboticsLocationsAPI
 from .api.robotics.maps import MapsAPI
+from .api.search import SearchAPI
+from .api.search_config import SearchConfigurationsAPI
 from .api.statistics import StatisticsAPI
 from .api.token import TokenAPI
 from .api.verify import VerifyAPI
@@ -48,6 +50,9 @@ class ToolkitClientMock(CogniteClientMock):
         #   - Add spacing above and below
         #   - Use `spec=MyAPI` only for "top level"
         #   - Use `spec_set=MyNestedAPI` for all nested APIs
+        self.search = MagicMock(spec=SearchAPI)
+        self.search.locations = MagicMock(spec_set=LocationFiltersAPI)
+        self.search.configurations = MagicMock(spec_set=SearchConfigurationsAPI)
         self.canvas = MagicMock(spec_set=CanvasAPI)
         self.dml = MagicMock(spec_set=DMLAPI)
         self.location_filters = MagicMock(spec_set=LocationFiltersAPI)

--- a/cognite_toolkit/_cdf_tk/client/testing.py
+++ b/cognite_toolkit/_cdf_tk/client/testing.py
@@ -55,7 +55,6 @@ class ToolkitClientMock(CogniteClientMock):
         self.search.configurations = MagicMock(spec_set=SearchConfigurationsAPI)
         self.canvas = MagicMock(spec_set=CanvasAPI)
         self.dml = MagicMock(spec_set=DMLAPI)
-        self.location_filters = MagicMock(spec_set=LocationFiltersAPI)
         self.lookup = MagicMock(spec=LookUpGroup)
         self.lookup.data_sets = MagicMock(spec_set=DataSetLookUpAPI)
         self.lookup.assets = MagicMock(spec_set=AssetLookUpAPI)

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -374,7 +374,7 @@ class NodeFinder(ResourceFinder[dm.ViewId]):
 class LocationFilterFinder(ResourceFinder[tuple[str, ...]]):
     @cached_property
     def all_filters(self) -> LocationFilterList:
-        return self.client.location_filters.list()
+        return self.client.search.locations.list()
 
     def _interactive_select(self) -> tuple[str, ...]:
         filters = self.all_filters

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/location_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/location_loaders.py
@@ -197,11 +197,11 @@ class LocationFilterLoader(
             # These are set if lookup has been deferred
             if item._parent_external_id and item.parent_id == -1:
                 item.parent_id = self.client.lookup.location_filters.id(item._parent_external_id)
-            created.append(self.client.location_filters.create(item))
+            created.append(self.client.search.locations.create(item))
         return LocationFilterList(created)
 
     def retrieve(self, external_ids: SequenceNotStr[str]) -> LocationFilterList:
-        all_locations = self.client.location_filters.list()
+        all_locations = self.client.search.locations.list()
         found_locations: LocationFilterList = LocationFilterList([])
 
         # locationfilter list returns a tree structure, so we need to traverse it
@@ -222,13 +222,13 @@ class LocationFilterLoader(
         updated = []
         ids = {item.external_id: item.id for item in self.retrieve([item.external_id for item in items])}
         for update in items:
-            updated.append(self.client.location_filters.update(ids[update.external_id], update))
+            updated.append(self.client.search.locations.update(ids[update.external_id], update))
         return LocationFilterList(updated)
 
     def delete(self, external_ids: SequenceNotStr[str]) -> int:
         count = 0
         for id in [loc.id for loc in self.retrieve(external_ids)]:
-            self.client.location_filters.delete(id)
+            self.client.search.locations.delete(id)
             count += 1
         return count
 
@@ -238,7 +238,7 @@ class LocationFilterLoader(
         space: str | None = None,
         parent_ids: list[Hashable] | None = None,
     ) -> Iterable[LocationFilter]:
-        return iter(self.client.location_filters)
+        return iter(self.client.search.locations)
 
     @classmethod
     @lru_cache(maxsize=1)

--- a/tests/test_integration/test_toolkit_client/test_locations.py
+++ b/tests/test_integration/test_toolkit_client/test_locations.py
@@ -18,9 +18,9 @@ def cleanup_before_session(toolkit_client: ToolkitClient) -> None:
     # Cleanup previously created locationfilters
 
     try:
-        for location_filter in toolkit_client.location_filters.list():
+        for location_filter in toolkit_client.search.locations.list():
             if location_filter.external_id.startswith("loc_ext_id_"):
-                toolkit_client.location_filters.delete(location_filter.id)
+                toolkit_client.search.locations.delete(location_filter.id)
     except CogniteAPIError:
         pass
 
@@ -34,10 +34,10 @@ def existing_location_filter(toolkit_client: ToolkitClient) -> LocationFilter:
         external_id=SESSION_EXTERNAL_ID,
     )
     try:
-        retrieved = toolkit_client.location_filters.retrieve(RUN_UNIQUE_ID)
+        retrieved = toolkit_client.search.locations.retrieve(RUN_UNIQUE_ID)
         return retrieved
     except CogniteAPIError:
-        created = toolkit_client.location_filters.create(location_filter)
+        created = toolkit_client.search.locations.create(location_filter)
         return created
 
 
@@ -64,37 +64,37 @@ class TestLocationFilterAPI:
         )
         created: LocationFilter | None = None
         try:
-            created = toolkit_client.location_filters.create(location_filter)
+            created = toolkit_client.search.locations.create(location_filter)
             assert isinstance(created, LocationFilter)
             assert created.as_write().dump() == location_filter.dump()
             assert created.data_modeling_type is not None
 
-            retrieved = toolkit_client.location_filters.retrieve(created.id)
+            retrieved = toolkit_client.search.locations.retrieve(created.id)
             assert isinstance(retrieved, LocationFilter)
             assert retrieved.as_write().dump() == location_filter.dump()
 
-            toolkit_client.location_filters.delete(created.id)
+            toolkit_client.search.locations.delete(created.id)
 
             with pytest.raises(CogniteAPIError):
-                toolkit_client.location_filters.retrieve(created.id)
+                toolkit_client.search.locations.retrieve(created.id)
         finally:
             if created:
                 try:
-                    toolkit_client.location_filters.delete(created.id)
+                    toolkit_client.search.locations.delete(created.id)
                 except CogniteAPIError:
                     pass
 
     def test_list_location_filters(
         self, toolkit_client: ToolkitClient, existing_location_filter: LocationFilter
     ) -> None:
-        location_filters = toolkit_client.location_filters.list()
+        location_filters = toolkit_client.search.locations.list()
         assert isinstance(location_filters, LocationFilterList)
         assert len(location_filters) > 0
 
     def test_iterate_location_filters(
         self, toolkit_client: ToolkitClient, existing_location_filter: LocationFilter
     ) -> None:
-        for location_filters in toolkit_client.location_filters:
+        for location_filters in toolkit_client.search.locations:
             assert isinstance(location_filters, LocationFilter)
             break
         else:
@@ -105,5 +105,5 @@ class TestLocationFilterAPI:
     ) -> None:
         update = existing_location_filter
         update.description = "New description"
-        updated = toolkit_client.location_filters.update(update.id, update.as_write())
+        updated = toolkit_client.search.locations.update(update.id, update.as_write())
         assert updated.description == update.description

--- a/tests/test_integration/test_toolkit_client/test_search_config.py
+++ b/tests/test_integration/test_toolkit_client/test_search_config.py
@@ -20,7 +20,7 @@ def existing_search_config(toolkit_client: ToolkitClient) -> SearchConfig:
     configs = toolkit_client.search.configurations.list()
     if configs:
         for config in configs:
-            if config.use_as_name == SEARCH_CONFIG_NAME:
+            if config.view == view:
                 return config
 
     created = toolkit_client.search.configurations.upsert(search_config)
@@ -33,12 +33,12 @@ class TestSearchConfigAPI:
     ) -> None:
         view = existing_search_config.view
         test_description = f"Test description Update {randint(1000, 9999)}"
-        test_nanme = SEARCH_CONFIG_NAME
+        test_name = SEARCH_CONFIG_NAME
         search_config = SearchConfigWrite(
             id=existing_search_config.id,
             view=view,
             use_as_description=test_description,
-            use_as_name=test_nanme,
+            use_as_name=test_name,
         )
 
         updated = toolkit_client.search.configurations.upsert(search_config)

--- a/tests/test_integration/test_toolkit_client/test_search_config.py
+++ b/tests/test_integration/test_toolkit_client/test_search_config.py
@@ -17,13 +17,13 @@ def existing_search_config(toolkit_client: ToolkitClient) -> SearchConfig:
     view = SearchConfigView(external_id="CogniteTimeSeries", space="cdf_cdm")
     search_config = SearchConfigWrite(view=view, use_as_name=SEARCH_CONFIG_NAME)
 
-    configs = toolkit_client.search_configurations.list()
+    configs = toolkit_client.search.configurations.list()
     if configs:
         for config in configs:
             if config.use_as_name == SEARCH_CONFIG_NAME:
                 return config
 
-    created = toolkit_client.search_configurations.upsert(search_config)
+    created = toolkit_client.search.configurations.upsert(search_config)
     return created
 
 
@@ -41,7 +41,7 @@ class TestSearchConfigAPI:
             use_as_name=test_nanme,
         )
 
-        updated = toolkit_client.search_configurations.upsert(search_config)
+        updated = toolkit_client.search.configurations.upsert(search_config)
         assert isinstance(updated, SearchConfig)
         assert updated.id == existing_search_config.id
         assert updated.view.external_id == view.external_id
@@ -49,7 +49,7 @@ class TestSearchConfigAPI:
         assert updated.use_as_name == SEARCH_CONFIG_NAME
         assert updated.use_as_description == test_description
 
-        configs = toolkit_client.search_configurations.list()
+        configs = toolkit_client.search.configurations.list()
         found_config = next((c for c in configs if c.id == updated.id), None)
         assert found_config is not None
         assert found_config.use_as_name == SEARCH_CONFIG_NAME

--- a/tests/test_unit/approval_client/config.py
+++ b/tests/test_unit/approval_client/config.py
@@ -636,7 +636,7 @@ API_RESOURCES = [
         },
     ),
     APIResource(
-        api_name="location_filters",
+        api_name="search.locations",
         resource_cls=LocationFilter,
         list_cls=LocationFilterList,
         _write_cls=LocationFilterWrite,

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
@@ -140,7 +140,7 @@ class TestLocationFilterFinder:
             monkeypatch_toolkit_client() as client,
             MockQuestionary(LocationFilterFinder.__module__, monkeypatch, answers),
         ):
-            client.location_filters.list.return_value = three_location_filters
+            client.search.locations.list.return_value = three_location_filters
             finder = LocationFilterFinder(client, None)
             selected = finder._interactive_select()
 
@@ -150,7 +150,7 @@ class TestLocationFilterFinder:
 class TestDumpLocationFilter:
     def test_dump_location_filter(self, three_location_filters: LocationFilterList, tmp_path: Path) -> None:
         with monkeypatch_toolkit_client() as client:
-            client.location_filters.list.return_value = three_location_filters
+            client.search.locations.list.return_value = three_location_filters
             cmd = DumpResourceCommand(silent=True)
             cmd.dump_to_yamls(
                 LocationFilterFinder(client, ("filterB", "filterC")),


### PR DESCRIPTION
# Description

Small preparation for adding SearchConfiguration support into Toolkit.

Refactoring:
* Added docstring to SearchConfigurationWrite. Even though this is not used outside Toolkit developers, it is still helpful to have the docstring.
* Moved `search_configurations` and `location_filters` under `search`. So instead of `client.search_configurations.list()` and `client.location_filters.list()` it is now `client.search.configurations.list()` and `client.search.locations.list()`. 


## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip
