### PR TITLE
[CDF-25199] 🐛Unchanged workflow version redeploys

### DIFF
--- a/tests/test_integration/test_loaders/test_resource_loaders.py
+++ b/tests/test_integration/test_loaders/test_resource_loaders.py
@@ -714,6 +714,11 @@ workflowDefinition:
     parameters:
       function:
         externalId: fn_first_function
+  - externalId: myTask2
+    type: transformation
+    parameters:
+      transformation:
+        externalId: some_transformation
 """
         loader = WorkflowVersionLoader.create_loader(toolkit_client)
 


### PR DESCRIPTION
# Description

See below

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- When running `cdf deployd` workflow versions with a transformation tasks without defaults defined is no longer redeployed.

## templates

No changes.
