### PR TITLE
[CDF-25251] Search configuration resource loader

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,4 +5,5 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "python.terminal.activateEnvironment": true,
+    "files.autoSave": "afterDelay"
 }

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/configuration_loader.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/configuration_loader.py
@@ -1,0 +1,129 @@
+from collections.abc import Hashable, Iterable, Sequence
+from pathlib import Path
+from typing import Any, final
+
+from cognite.client.data_classes.capabilities import AppConfigAcl, Capability
+from cognite.client.utils.useful_types import SequenceNotStr
+
+from cognite_toolkit._cdf_tk.client.data_classes.search_config import (
+    SearchConfig,
+    SearchConfigList,
+    SearchConfigWrite,
+    SearchConfigWriteList,
+)
+from cognite_toolkit._cdf_tk.constants import BUILD_FOLDER_ENCODING
+from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceLoader
+
+# TODO: Import SearchConfigYAML when it is implemented
+from cognite_toolkit._cdf_tk.utils import quote_int_value_by_key_in_yaml, safe_read
+from cognite_toolkit._cdf_tk.utils.diff_list import diff_list_identifiable, dm_identifier
+
+from .datamodel_loaders import ViewLoader
+
+
+@final
+class SearchConfigLoader(ResourceLoader[str, SearchConfigWrite, SearchConfig, SearchConfigWriteList, SearchConfigList]):
+    folder_name = "search_configs"
+    filename_pattern = r"^.*SearchConfig$"
+    resource_cls = SearchConfig
+    resource_write_cls = SearchConfigWrite
+    list_cls = SearchConfigList
+    list_write_cls = SearchConfigWriteList
+    # yaml_cls = searchConfigYAML
+    dependencies = frozenset({ViewLoader})
+    kind = "SearchConfig"
+    _doc_base_url = "https://api-docs.cogheim.net/redoc/#tag/"
+    _doc_url = "Search-Config/operation/upsertSearchConfigViews"
+
+    subfilter_names = ("assets", "events", "files", "timeseries", "sequences")
+
+    @property
+    def display_name(self) -> str:
+        return "search config"
+
+    @classmethod
+    def get_required_capability(
+        cls, items: Sequence[SearchConfigWrite] | None, read_only: bool
+    ) -> Capability | list[Capability]:
+        if not items and items is not None:
+            return []
+
+        actions = [AppConfigAcl.Action.Read] if read_only else [AppConfigAcl.Action.Read, AppConfigAcl.Action.Write]
+
+        return AppConfigAcl(
+            actions=actions,
+            scope=AppConfigAcl.Scope.All(),
+            allow_unknown=True,
+        )
+
+    @classmethod
+    def get_id(cls, item: SearchConfig | SearchConfigWrite | dict) -> str:
+        if isinstance(item, dict):
+            return str(item.get("id", ""))
+        if isinstance(item, SearchConfig) and not item.id:
+            raise KeyError("SearchConfig must have id")
+        return str(item.id) if item.id is not None else ""
+
+    @classmethod
+    def dump_id(cls, id: int | str) -> dict[str, Any]:
+        return {"id": id}
+
+    def safe_read(self, filepath: Path | str) -> str:
+        # Search config Id is int type
+        return quote_int_value_by_key_in_yaml(safe_read(filepath, encoding=BUILD_FOLDER_ENCODING), key="id")
+
+    def load_resource(self, resource: dict[str, Any], is_dry_run: bool = False) -> SearchConfigWrite:
+        if "id" in resource and isinstance(resource["id"], str) and resource["id"].isdigit():
+            resource["id"] = int(resource["id"])
+
+        return self.resource_write_cls._load(resource)
+
+    def diff_list(
+        self, local: list[Any], cdf: list[Any], json_path: tuple[str | int, ...]
+    ) -> tuple[dict[int, int], list[int]]:
+        if json_path in [("columnLayout",), ("filterLayout",), ("propertiesLayout",)]:
+            return diff_list_identifiable(local, cdf, get_identifier=lambda x: x.get("property"))
+        elif json_path == ("view",):
+            return diff_list_identifiable(local, cdf, get_identifier=dm_identifier)
+        return super().diff_list(local, cdf, json_path)
+
+    def create(self, items: SearchConfigWrite | SearchConfigWriteList) -> SearchConfigList:
+        """Create new search configurations using the upsert method"""
+        if isinstance(items, SearchConfigWrite):
+            items = SearchConfigWriteList([items])
+
+        created = []
+        for item in items:
+            created.append(self.client.search.configurations.upsert(item))
+        return SearchConfigList(created)
+
+    def retrieve(self, ids: SequenceNotStr[str]) -> SearchConfigList:
+        """Retrieve search configurations by their IDs"""
+        numeric_ids = [int(id_str) if id_str.isdigit() else id_str for id_str in ids]
+
+        all_configs = self.client.search.configurations.list()
+        return SearchConfigList([config for config in all_configs if config.id in numeric_ids])
+
+    def update(self, items: SearchConfigWrite | SearchConfigWriteList) -> SearchConfigList:
+        """Update search configurations using the upsert method"""
+        if isinstance(items, SearchConfigWrite):
+            items = SearchConfigWriteList([items])
+
+        if any([item for item in items if not item.id]):
+            raise KeyError("Search Configuaration Update Requires Id!")
+        return self.create(items)
+
+    def delete(self, ids: SequenceNotStr[str]) -> int:
+        """
+        Delete is not implemented in the API client
+        """
+        raise NotImplementedError("Delete operation is not supported for SearchConfig")
+
+    def _iterate(
+        self,
+        data_set_external_id: str | None = None,
+        space: str | None = None,
+        parent_ids: list[Hashable] | None = None,
+    ) -> Iterable[SearchConfig]:
+        """Iterate through all search configurations"""
+        return iter(self.client.search.configurations.list())

--- a/tests/data/load_data/search_configs/basic.SearchConfig.yaml
+++ b/tests/data/load_data/search_configs/basic.SearchConfig.yaml
@@ -1,0 +1,12 @@
+
+id: 1001
+view:
+  externalId: "test-view"
+  space: "test-space"
+useAsName: "name"
+useAsDescription: "description"
+columnLayout:
+  - property: "name"
+    selected: true
+  - property: "description"
+    selected: true

--- a/tests/data/load_data/search_configs/complex.SearchConfig.yaml
+++ b/tests/data/load_data/search_configs/complex.SearchConfig.yaml
@@ -1,0 +1,26 @@
+
+id: 1002
+view:
+  externalId: "complex-view"
+  space: "complex-space"
+useAsName: "title"
+useAsDescription: "summary"
+columnLayout:
+  - property: "title"
+    selected: true
+  - property: "summary"
+    selected: true
+  - property: "status"
+    selected: false
+filterLayout:
+  - property: "status"
+    disabled: false
+  - property: "category"
+    disabled: false
+propertiesLayout:
+  - property: "title"
+    hidden: false
+  - property: "summary"
+    hidden: false
+  - property: "description"
+    hidden: true

--- a/tests/test_unit/test_cdf_tk/test_loaders/test_search_config_loader.py
+++ b/tests/test_unit/test_cdf_tk/test_loaders/test_search_config_loader.py
@@ -1,0 +1,166 @@
+from unittest.mock import patch
+
+import pytest
+
+from cognite_toolkit._cdf_tk.client.data_classes.search_config import (
+    SearchConfig,
+    SearchConfigView,
+    SearchConfigWrite,
+)
+from cognite_toolkit._cdf_tk.loaders._resource_loaders.configuration_loader import SearchConfigLoader
+from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
+from tests.data import LOAD_DATA
+
+
+@pytest.fixture
+def basic_search_config(env_vars_with_client: EnvironmentVariables) -> SearchConfigWrite:
+    """Fixture to load a basic search configuration."""
+    loader = SearchConfigLoader.create_loader(env_vars_with_client.get_client())
+    raw_list = loader.load_resource_file(
+        LOAD_DATA / "search_configs" / "basic.SearchConfig.yaml", env_vars_with_client.dump()
+    )
+    loaded = loader.load_resource(raw_list[0], is_dry_run=False)
+    return loaded
+
+
+@pytest.fixture
+def complex_search_config(env_vars_with_client: EnvironmentVariables) -> SearchConfigWrite:
+    """Fixture to load a complex search configuration."""
+    loader = SearchConfigLoader.create_loader(env_vars_with_client.get_client())
+    raw_list = loader.load_resource_file(
+        LOAD_DATA / "search_configs" / "complex.SearchConfig.yaml", env_vars_with_client.dump()
+    )
+    loaded = loader.load_resource(raw_list[0], is_dry_run=False)
+    return loaded
+
+
+class TestSearchConfigLoader:
+    def test_load_basic_search_config(self, env_vars_with_client: EnvironmentVariables) -> None:
+        """Test loading a basic search configuration."""
+        loader = SearchConfigLoader.create_loader(env_vars_with_client.get_client())
+        raw_list = loader.load_resource_file(
+            LOAD_DATA / "search_configs" / "basic.SearchConfig.yaml", env_vars_with_client.dump()
+        )
+        loaded = loader.load_resource(raw_list[0], is_dry_run=False)
+
+        assert isinstance(loaded, SearchConfigWrite)
+        assert loaded.id == 1001
+        assert loaded.view.external_id == "test-view"
+        assert loaded.view.space == "test-space"
+        assert loaded.use_as_name == "name"
+        assert loaded.use_as_description == "description"
+        assert len(loaded.column_layout) == 2
+        assert loaded.column_layout[0].property == "name"
+        assert loaded.column_layout[0].selected is True
+
+    def test_load_complex_search_config(self, complex_search_config: SearchConfigWrite) -> None:
+        """Test loading a complex search configuration with all layout types."""
+        assert isinstance(complex_search_config, SearchConfigWrite)
+        assert complex_search_config.id == 1002
+        assert complex_search_config.view.external_id == "complex-view"
+        assert complex_search_config.view.space == "complex-space"
+
+    def test_create(self, env_vars_with_client: EnvironmentVariables) -> None:
+        """Test create method by mocking the API call."""
+        loader = SearchConfigLoader.create_loader(env_vars_with_client.get_client())
+        view = SearchConfigView(external_id="test-view", space="test-space")
+        config = SearchConfigWrite(view=view, id=1001)
+
+        with patch.object(loader.client.search.configurations, "upsert") as mock_upsert:
+            mock_upsert.return_value = SearchConfig(
+                view=config.view,
+                id=config.id,
+                created_time=1625097600000,
+                updated_time=1625097600000,
+                use_as_name=config.use_as_name,
+                use_as_description=config.use_as_description,
+                column_layout=config.column_layout,
+                filter_layout=config.filter_layout,
+                properties_layout=config.properties_layout,
+            )
+
+            result = loader.create(config)
+            mock_upsert.assert_called_once_with(config)
+            assert len(result) == 1
+            assert result[0].id == 1001
+            assert result[0].view.external_id == "test-view"
+
+    def test_retrieve(self, env_vars_with_client: EnvironmentVariables) -> None:
+        """Test retrieve method by mocking the API call."""
+        loader = SearchConfigLoader.create_loader(env_vars_with_client.get_client())
+
+        with patch.object(loader.client.search.configurations, "list") as mock_list:
+            mock_list.return_value = [
+                SearchConfig(
+                    view=SearchConfigView(external_id="view1", space="space1"),
+                    id=1001,
+                    created_time=1625097600000,
+                    updated_time=1625097600000,
+                ),
+                SearchConfig(
+                    view=SearchConfigView(external_id="view2", space="space2"),
+                    id=1002,
+                    created_time=1625097600000,
+                    updated_time=1625097600000,
+                ),
+            ]
+
+            result = loader.retrieve(["1001"])
+            mock_list.assert_called_once()
+            assert len(result) == 1
+            assert result[0].id == 1001
+
+    def test_update(self, env_vars_with_client: EnvironmentVariables) -> None:
+        """Test update method which uses upsert under the hood."""
+        loader = SearchConfigLoader.create_loader(env_vars_with_client.get_client())
+        view = SearchConfigView(external_id="test-view", space="test-space")
+        config = SearchConfigWrite(view=view, id=1001, use_as_name="updated_name")
+
+        with patch.object(loader.client.search.configurations, "upsert") as mock_upsert:
+            mock_upsert.return_value = SearchConfig(
+                view=config.view,
+                id=config.id,
+                created_time=1625097600000,
+                updated_time=1625097700000,
+                use_as_name=config.use_as_name,
+                use_as_description=config.use_as_description,
+                column_layout=config.column_layout,
+                filter_layout=config.filter_layout,
+                properties_layout=config.properties_layout,
+            )
+
+            result = loader.update(config)
+            mock_upsert.assert_called_once_with(config)
+            assert len(result) == 1
+            assert result[0].id == 1001
+            assert result[0].use_as_name == "updated_name"
+            assert result[0].updated_time == 1625097700000
+
+        # Test update with no ID
+        config_no_id = SearchConfigWrite(view=view)
+        with pytest.raises(KeyError, match="Search Configuaration Update Requires Id"):
+            loader.update(config_no_id)
+
+    def test_iterate(self, env_vars_with_client: EnvironmentVariables) -> None:
+        """Test the _iterate method."""
+        loader = SearchConfigLoader.create_loader(env_vars_with_client.get_client())
+        with patch.object(loader.client.search.configurations, "list") as mock_list:
+            mock_list.return_value = [
+                SearchConfig(
+                    view=SearchConfigView(external_id="view1", space="space1"),
+                    id=1001,
+                    created_time=1625097600000,
+                    updated_time=1625097600000,
+                ),
+                SearchConfig(
+                    view=SearchConfigView(external_id="view2", space="space2"),
+                    id=1002,
+                    created_time=1625097600000,
+                    updated_time=1625097600000,
+                ),
+            ]
+            result = list(loader._iterate())
+            mock_list.assert_called_once()
+            assert len(result) == 2
+            assert result[0].id == 1001
+            assert result[1].id == 1002


### PR DESCRIPTION
# Description

This PR introduces the resource loader for search configuration. Toolkit will now have the capability to read SearchConfig resource configuration with this resource loader. `setting.json` is updated to auto save the files in vscode and this has no relation with `SearchConfigLoader`.

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip

## cdf

### Added

- Added a sesrch configuration resource loader `SearchConfigLoader`.
