### PR TITLE
[CDF-25285] 🦿Convert asset-centric properties to container properties Part 2

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils/dtype_conversion.py
+++ b/cognite_toolkit/_cdf_tk/utils/dtype_conversion.py
@@ -39,8 +39,34 @@ def convert_to_primary_property(
     else:
         raise TypeError(f"Unsupported property type {dtype}")
     if isinstance(type_, ListablePropertyType) and type_.is_list:
-        raise NotImplementedError(f"Listable property type {dtype} is not supported")
-    return converter(type_, nullable).convert(value)
+        values = _as_list(value)
+        output: list = []
+        for item in values:
+            converted = converter(type_, nullable).convert(item)
+            if converted is not None:
+                output.append(converted)
+        return output
+    else:
+        return converter(type_, nullable).convert(value)
+
+
+def _as_list(value: str | int | float | bool | dict | list | None) -> list:
+    """Convert a value to a list, ensuring that it is iterable."""
+    if value is None:
+        return []
+    elif isinstance(value, list):
+        return value
+    elif isinstance(value, str) and value.strip() == "":
+        return []
+    elif isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return [value]
+    elif isinstance(value, int | float | bool | dict):
+        return [value]
+    else:
+        raise TypeError(f"Cannot convert {value} of type {type(value)} to a list.")
 
 
 class _Converter(ABC):
@@ -63,7 +89,7 @@ class _ValueConverter(_Converter, ABC):
         elif value is None:
             return None
         elif isinstance(value, list):
-            raise ToolkitNotSupported("List values are not supported for this property type.")
+            raise ValueError(f"Cannot covert a list directly to {self.type_str}.")
         return self._convert(value)
 
     @abstractmethod

--- a/cognite_toolkit/_cdf_tk/utils/dtype_conversion.py
+++ b/cognite_toolkit/_cdf_tk/utils/dtype_conversion.py
@@ -89,7 +89,7 @@ class _ValueConverter(_Converter, ABC):
         elif value is None:
             return None
         elif isinstance(value, list):
-            raise ValueError(f"Cannot covert a list directly to {self.type_str}.")
+            raise ValueError(f"Expected a single value for {self.type_str}, but got a list.")
         return self._convert(value)
 
     @abstractmethod

--- a/tests/test_unit/test_cdf_tk/test_utils/test_dtype_conversion.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_dtype_conversion.py
@@ -345,6 +345,13 @@ class TestConvertToContainerProperty:
                 "Value -9223372036854775809 is out of range for int64.",
                 id="Int64 underflow (too small)",
             ),
+            pytest.param(
+                [123, 456],
+                Int64(is_list=False),
+                True,
+                "Expected a single value for int64, but got a list.",
+                id="List to Int64 (invalid, not a list type)",
+            ),
         ],
     )
     def test_invalid_conversion(

--- a/tests/test_unit/test_cdf_tk/test_utils/test_dtype_conversion.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_dtype_conversion.py
@@ -165,6 +165,55 @@ class TestConvertToContainerProperty:
                 datetime(2025, 7, 22, 14, 14, 56, 789000, tzinfo=timezone.utc),
                 id="Epoch float with milliseconds to Timestamp",
             ),
+            pytest.param(
+                [1, 2, 3],
+                Int32(is_list=True),
+                True,
+                [1, 2, 3],
+                id="List of int32 to Int32 list property",
+            ),
+            pytest.param(
+                ["2025-07-22T12:34:56Z", "2025-01-01T00:00:00Z"],
+                Timestamp(is_list=True),
+                True,
+                [
+                    datetime(2025, 7, 22, 12, 34, 56, tzinfo=timezone.utc),
+                    datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                ],
+                id="List of ISO timestamps to Timestamp list property",
+            ),
+            # List property type valid cases (additional)
+            pytest.param(
+                "[1, 2, 3]",
+                Int32(is_list=True),
+                True,
+                [1, 2, 3],
+                id="JSON string list to Int32 list property",
+            ),
+            pytest.param(
+                '["2025-07-22T12:34:56Z", "2025-01-01T00:00:00Z"]',
+                Timestamp(is_list=True),
+                True,
+                [
+                    datetime(2025, 7, 22, 12, 34, 56, tzinfo=timezone.utc),
+                    datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                ],
+                id="JSON string list to Timestamp list property",
+            ),
+            pytest.param(
+                42,
+                Int32(is_list=True),
+                True,
+                [42],
+                id="Single int to Int32 list property",
+            ),
+            pytest.param(
+                "2025-07-22T12:34:56Z",
+                Timestamp(is_list=True),
+                True,
+                [datetime(2025, 7, 22, 12, 34, 56, tzinfo=timezone.utc)],
+                id="Single ISO timestamp to Timestamp list property",
+            ),
         ],
     )
     def test_valid_conversion(


### PR DESCRIPTION
# Description

**Context**: This is part of the `alpha` migration tooling in Toolkit, for overview [see here](https://cognitedata.atlassian.net/wiki/spaces/~170890702/pages/5455773697/Migration+Tooling+in+Toolkit). This is step 3 of that process. 

This method will be used to convert the asset-centric properties/metadata to the appropriate container property. 

This is part 1 of likely 3 parts. I am splitting this up to try to limit the size. Current plan:
* Part 1: Conversion of non-list values.
* Part 2 (this PR): Conversion of list-values
* Part 3 Special cases from asset-centric to data modeling. For example, going from timeseries to `CogniteTimeSeries` the property `isString` must convert from a boolean to an enum.
## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip

