### PR TITLE
[CDF-25357] ☠ Add kill switch

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils/producer_worker.py
+++ b/cognite_toolkit/_cdf_tk/utils/producer_worker.py
@@ -120,7 +120,7 @@ class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
             for t in [download_thread, process_thread, write_thread]:
                 t.join()
 
-            self._stop_event.set()  # Ensure all threads stop if any thread finishes
+            self._stop_event.set()
 
     def _download_worker(self, progress: Progress, download_task: TaskID) -> None:
         """Worker thread for downloading data."""

--- a/cognite_toolkit/_cdf_tk/utils/producer_worker.py
+++ b/cognite_toolkit/_cdf_tk/utils/producer_worker.py
@@ -118,7 +118,13 @@ class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
             input_thread.start()
 
             for t in [download_thread, process_thread, write_thread]:
-                t.join()
+                try:
+                    t.join()
+                except KeyboardInterrupt:
+                    self.console.print("[red]Execution interrupted by user.[/red]")
+                    self.stopped_by_user = True
+                    self._stop_event.set()
+                    break
 
             self._stop_event.set()
 


### PR DESCRIPTION
# Description

We use the `WorkerProducerExecutor` to download large amounts of data. This PR introduces a kill-switch to enable the user to abort this operation. 

<img width="727" height="157" alt="image" src="https://github.com/user-attachments/assets/1d2949a9-9611-4d6c-8996-27c586c68267" />



## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Added

- [alpha] In the `cdf dump data` methods, the user can now stop the downloading of data.

## templates

No changes.
