### PR TITLE
[CDF-25385] 😁 Use upsert instead of delete - create 

### DIFF
--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/workflow_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/workflow_loaders.py
@@ -592,12 +592,15 @@ class WorkflowTriggerLoader(
         )
 
     def create(self, items: WorkflowTriggerUpsertList) -> WorkflowTriggerList:
+        return self._upsert(items)
+
+    def _upsert(self, items: WorkflowTriggerUpsertList) -> WorkflowTriggerList:
         created = WorkflowTriggerList([])
         for item in items:
-            created.append(self._create_item(item))
+            created.append(self._upsert_item(item))
         return created
 
-    def _create_item(self, item: WorkflowTriggerUpsert) -> WorkflowTrigger:
+    def _upsert_item(self, item: WorkflowTriggerUpsert) -> WorkflowTrigger:
         credentials = self._authentication_by_id.get(item.external_id)
         try:
             return self.client.workflows.triggers.upsert(item, credentials)
@@ -612,16 +615,7 @@ class WorkflowTriggerLoader(
         return WorkflowTriggerList([trigger for trigger in all_triggers if trigger.external_id in lookup])
 
     def update(self, items: WorkflowTriggerUpsertList) -> WorkflowTriggerList:
-        exising = self.client.workflows.triggers.list(limit=-1)
-        existing_lookup = {trigger.external_id: trigger for trigger in exising}
-        updated = WorkflowTriggerList([])
-        for item in items:
-            if item.external_id in existing_lookup:
-                self.client.workflows.triggers.delete(external_id=item.external_id)
-
-            created = self._create_item(item)
-            updated.append(created)
-        return updated
+        return self._upsert(items)
 
     def delete(self, ids: SequenceNotStr[str]) -> int:
         successes = 0


### PR DESCRIPTION
# Description

**Context**; Cognite Toolkit has standardized classes for all CDF resources for all CRUD operations called loaders. This PR updates the loader for WorkflowTrigger resources.

We added support for the CRUD operations for WorkflowTrigger resources in Toolkit before there was an upsert endpoint. As a workaround, we used list + delete + create. This PR takes advantage of the new upsert endpoint instead of the workaround. 

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- When deploying a workflow trigger, Toolkit no longer deletes and recreates it. Instead, the trigger is updated.

## templates

No changes.
