### PR TITLE
[CDF-25387] 🤖 Publish agents issue

### DIFF
--- a/cognite_toolkit/_builtin_modules/common/cdf_auth_readwrite_all/auth/admin.readonly.group.yaml
+++ b/cognite_toolkit/_builtin_modules/common/cdf_auth_readwrite_all/auth/admin.readonly.group.yaml
@@ -9,6 +9,11 @@ capabilities:
         - READ
       scope:
         all: {}
+  - agentsAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
   - analyticsAcl:
       actions:
       - READ

--- a/cognite_toolkit/_builtin_modules/common/cdf_auth_readwrite_all/auth/admin.readwrite.group.yaml
+++ b/cognite_toolkit/_builtin_modules/common/cdf_auth_readwrite_all/auth/admin.readwrite.group.yaml
@@ -10,6 +10,13 @@ capabilities:
         - UPDATE
       scope:
         all: {}
+  - agentsAcl:
+      actions:
+        - RUN
+        - READ
+        - WRITE
+      scope:
+        all: {}
   - analyticsAcl:
       actions:
       - READ

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
@@ -93,7 +93,7 @@ class AgentLoader(ResourceLoader[str, AgentUpsert, Agent, AgentUpsertList, Agent
         # not part of the official API. For example, as of 31.July 2025, `labels` is not part of the API, however,
         # this is necessary to ensure that the agents are shown as published in the UI, so we cannot ignore it.
         # The below logic ensures that we keep the unknown properties returned by the API, such that when we run
-        # cdf dump agents, we will not lose any properties that are not part of the official API.
+        # `cdf dump agents` we will not lose any properties that are not part of the official API.
         if hasattr(resource, "_unknown_properties") and resource._unknown_properties:
             dumped.update(resource._unknown_properties)
         if local is None:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
@@ -10,7 +10,7 @@ from cognite.client.utils.useful_types import SequenceNotStr
 from cognite_toolkit._cdf_tk._parameters.constants import ANY_INT, ANYTHING
 from cognite_toolkit._cdf_tk._parameters.data_classes import ParameterSpec, ParameterSpecSet
 from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceLoader
-from cognite_toolkit._cdf_tk.utils.diff_list import diff_list_identifiable
+from cognite_toolkit._cdf_tk.utils.diff_list import diff_list_hashable, diff_list_identifiable
 
 
 class AgentLoader(ResourceLoader[str, AgentUpsert, Agent, AgentUpsertList, AgentList]):
@@ -115,4 +115,8 @@ class AgentLoader(ResourceLoader[str, AgentUpsert, Agent, AgentUpsertList, Agent
             return diff_list_identifiable(
                 local, cdf, get_identifier=lambda t: (t.get("name", ""), t.get("description", ""))
             )
+        elif json_path == ("labels",):
+            return diff_list_hashable(local, cdf)
+        elif json_path == ("exampleQuestions",):
+            return diff_list_identifiable(local, cdf, get_identifier=lambda q: q.get("question", ""))
         return super().diff_list(local, cdf, json_path)

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
@@ -94,8 +94,8 @@ class AgentLoader(ResourceLoader[str, AgentUpsert, Agent, AgentUpsertList, Agent
         # this is necessary to ensure that the agents are shown as published in the UI, so we cannot ignore it.
         # The below logic ensures that we keep the unknown properties returned by the API, such that when we run
         # `cdf dump agents` we will not lose any properties that are not part of the official API.
-        if hasattr(resource, "_unknown_properties") and resource._unknown_properties:
-            dumped.update(resource._unknown_properties)
+        if (unknown_props := getattr(resource, "_unknown_properties", None)) and isinstance(unknown_props, dict):
+            dumped.update(unknown_props)
         if local is None:
             return dumped
         if resource.instructions == "" and "instructions" not in local:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
@@ -89,6 +89,13 @@ class AgentLoader(ResourceLoader[str, AgentUpsert, Agent, AgentUpsertList, Agent
 
     def dump_resource(self, resource: Agent, local: dict[str, Any] | None = None) -> dict[str, Any]:
         dumped = resource.as_write().dump()
+        # The atlas endpoints are not yet full implemented. There are properties being added and removed that are
+        # not part of the official API. For example, as of 31.July 2025, `labels` is not part of the API, however,
+        # this is necessary to ensure that the agents are shown as published in the UI, so we cannot ignore it.
+        # The below logic ensures that we keep the unknown properties returned by the API, such that when we run
+        # cdf dump agents, we will not lose any properties that are not part of the official API.
+        if hasattr(resource, "_unknown_properties") and resource._unknown_properties:
+            dumped.update(resource._unknown_properties)
         if local is None:
             return dumped
         if resource.instructions == "" and "instructions" not in local:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
@@ -123,5 +123,7 @@ class AgentLoader(ResourceLoader[str, AgentUpsert, Agent, AgentUpsertList, Agent
         elif json_path == ("labels",):
             return diff_list_hashable(local, cdf)
         elif json_path == ("exampleQuestions",):
-            return diff_list_identifiable(local, cdf, get_identifier=lambda q: q.get("question", ""))
+            return diff_list_identifiable(
+                local, cdf, get_identifier=lambda q: q.get("question", "") if isinstance(q, dict) else str(q)
+            )
         return super().diff_list(local, cdf, json_path)

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
@@ -102,6 +102,11 @@ class AgentLoader(ResourceLoader[str, AgentUpsert, Agent, AgentUpsertList, Agent
             # Instructions are optional, if not set the server set them to an empty string.
             # We remove them from the dumped resource to ensure it will be equal to the local resource.
             dumped.pop("instructions", None)
+        for key in ["labels", "exampleQuestions"]:
+            if key not in local and not dumped.get(key):
+                # If the local resource does not have the key and the server set Agent has it set to an empty list,
+                # we remove it from the dumped resource to ensure it will be equal to the local resource.
+                dumped.pop(key, None)
         return dumped
 
     def diff_list(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "python-dotenv >=1.0.0",
-    "cognite-sdk >=7.77.0, <8.0.0",
+    "cognite-sdk >=7.78.0, <8.0.0",
     "pandas >=1.5.3, <3.0.0",
     "pyyaml >=6.0.1",
     "typer >=0.12.0, <1.0.0",

--- a/tests/data/complete_org_alpha_flags/modules/my_example_module/agents/my.Agent.yaml
+++ b/tests/data/complete_org_alpha_flags/modules/my_example_module/agents/my.Agent.yaml
@@ -6,5 +6,3 @@ tools:
 - name: Operations on datapoints tool
   description: This tool allows you to perform operations on query time series datapoints.
   type: queryTimeSeriesDatapoints
-labels: []
-exampleQuestions: []

--- a/tests/data/complete_org_alpha_flags/modules/my_example_module/agents/my.Agent.yaml
+++ b/tests/data/complete_org_alpha_flags/modules/my_example_module/agents/my.Agent.yaml
@@ -6,3 +6,5 @@ tools:
 - name: Operations on datapoints tool
   description: This tool allows you to perform operations on query time series datapoints.
   type: queryTimeSeriesDatapoints
+labels: []
+exampleQuestions: []

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_auth_readwrite_all.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/cdf_auth_readwrite_all.yaml
@@ -7,6 +7,13 @@ Group:
       - UPDATE
       scope:
         all: {}
+  - agentsAcl:
+      actions:
+      - RUN
+      - READ
+      - WRITE
+      scope:
+        all: {}
   - analyticsAcl:
       actions:
       - READ
@@ -332,6 +339,11 @@ Group:
   - projectsAcl:
       actions:
       - LIST
+      - READ
+      scope:
+        all: {}
+  - agentsAcl:
+      actions:
       - READ
       scope:
         all: {}

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "cognite-sdk"
-version = "7.77.0"
+version = "7.78.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "msal" },
@@ -185,9 +185,9 @@ dependencies = [
     { name = "requests-oauthlib" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/7e/d62497f236bbb4f394acd6899297a88b36c54297bd84d5fd13130791bbe5/cognite_sdk-7.77.0.tar.gz", hash = "sha256:199efa1d58a66cfd5f55a13ea93f4bfa6e86c574a06d60b061ac88b8789c77f9", size = 511344, upload-time = "2025-07-23T09:02:42.731Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/af/093168e2714e7e3df345a0296f9751d769dc2a2bc3aeeefc59d3ab3c7323/cognite_sdk-7.78.0.tar.gz", hash = "sha256:52d33afc0e9f2e7a723de0e585170deaed3e3810f0dd6ab39cb69ba389a6e621", size = 512579, upload-time = "2025-07-30T13:24:06.912Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/ac/8f45ff582933e5ab72e224b7e5fbf98aa2b021647dfe52280255ead15d6f/cognite_sdk-7.77.0-py3-none-any.whl", hash = "sha256:99198b93cf2b62398c0584cc1a0812978666e3ca5123a55e47592602924e1d9d", size = 638431, upload-time = "2025-07-23T09:02:40.255Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b6/2168020ea9d83d655304bb4ee04fee8734f56fba20d91b27975ba43ae7c0/cognite_sdk-7.78.0-py3-none-any.whl", hash = "sha256:e2a9a454deedd20016ca727a98a8237f8bb2f53357d01e03804028676372833d", size = 639634, upload-time = "2025-07-30T13:24:04.849Z" },
 ]
 
 [[package]]
@@ -249,7 +249,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognite-sdk", specifier = ">=7.77.0,<8.0.0" },
+    { name = "cognite-sdk", specifier = ">=7.78.0,<8.0.0" },
     { name = "filelock", specifier = ">=3.18.0" },
     { name = "mixpanel", specifier = ">=4.10.1" },
     { name = "openpyxl", marker = "extra == 'table'", specifier = ">=3.1.5" },


### PR DESCRIPTION
# Description

Currently there are unofficial properties in the Agents API. These will likely be removed/changed, however, we cannot ignore them in a CICD setting as the unofficial property `labels` is used to determine whether an Agent is shown in the UI or not. 

This PR ensures that all unofficial properties are passed from the API to the YAML file in `cdf dump agents` and when reading the YAML file and deploying it with the `cdf deploy`. 

In addition, since we are updating the `cognite-sdk` to the version that includes the `AgentsAcl` we have to include this in the builtin modules read and read-write all. (We have a tests that ensure that these modules are up-to-date with all available ACLs.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- [alpha] Running `cdf dump agents` and `cdf deploy` with agents. Unofficial properties from the API are now included. 

## templates

No changes.
