### PR TITLE
[CDF-25393] 😅 GraphQL parser error

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils/graphql_parser.py
+++ b/cognite_toolkit/_cdf_tk/utils/graphql_parser.py
@@ -196,7 +196,7 @@ class _Directive:
                 continue
             elif current == "\n":
                 standardized.append(",")
-            elif current in ")}]" and next_ != "\n)}]":
+            elif current in ")}]" and next_ not in "\n)}]":
                 # If we are at the end of a parenthesis, we need to add a comma
                 # to separate the next item
                 standardized.append(current + ",")

--- a/cognite_toolkit/_cdf_tk/utils/graphql_parser.py
+++ b/cognite_toolkit/_cdf_tk/utils/graphql_parser.py
@@ -196,7 +196,7 @@ class _Directive:
                 continue
             elif current == "\n":
                 standardized.append(",")
-            elif current in ")}]" and next_ != "\n":
+            elif current in ")}]" and next_ != "\n)}]":
                 # If we are at the end of a parenthesis, we need to add a comma
                 # to separate the next item
                 standardized.append(current + ",")

--- a/cognite_toolkit/_cdf_tk/utils/graphql_parser.py
+++ b/cognite_toolkit/_cdf_tk/utils/graphql_parser.py
@@ -196,7 +196,7 @@ class _Directive:
                 continue
             elif current == "\n":
                 standardized.append(",")
-            elif current in ")}]" and next_ not in "\n)}]":
+            elif current in ")}]" and next_ not in "\n)}],":
                 # If we are at the end of a parenthesis, we need to add a comma
                 # to separate the next item
                 standardized.append(current + ",")

--- a/cognite_toolkit/_cdf_tk/utils/graphql_parser.py
+++ b/cognite_toolkit/_cdf_tk/utils/graphql_parser.py
@@ -196,6 +196,10 @@ class _Directive:
                 continue
             elif current == "\n":
                 standardized.append(",")
+            elif current in ")}]" and next_ != "\n":
+                # If we are at the end of a parenthesis, we need to add a comma
+                # to separate the next item
+                standardized.append(current + ",")
             else:
                 standardized.append(current)
         return "".join(standardized)

--- a/tests/test_unit/test_cdf_tk/test_utils/test_graphql_parser.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_graphql_parser.py
@@ -10,6 +10,122 @@ SPACE = "sp_my_space"
 DATA_MODEL = DataModelId(SPACE, "MyDataModel", "v1")
 GraphQLTestCases = [
     pytest.param(
+        '''"Log File"
+type LogFile
+  @view(
+    rawFilter: {
+      hasData: [
+        {
+          type: "container"
+          space: "onse_logfile"
+          externalId: "LogFile"
+        }
+      ]
+    }  version: "1"
+  ) {
+  """
+  Name of the CSV which delivers result/logs from ONSE
+  @name CSV LogFile Name
+  """
+  csv_logfile_name: String
+  """
+  CDF address of the posted CSV log file from ONSE
+  @name CSV LogFile Unique ID
+  """
+  csv_logfile_uniqueId: Float
+  """
+  General result from ONSE such as Success or Partial or Failure (Status)
+  @name Status
+  """
+  status: String
+  """
+  Cryptic id from IX representing the Transmittal/transaction (key)
+  @name Transaction id
+  """
+  transaction_id: String
+  """
+  Transmittal Number (Referemce/Identifier)
+  @name Transmittal Number
+  """
+  transmittalNumber: String
+  """
+  Date and time when xml LogFile has been posted to CDF
+  @name Uploaded to CDF  Time
+  """
+  uploaded_to_cdf: String
+  """
+  Name of the XML which delivers result/logs from ONSE
+  @name XML LogFile Name
+  """
+  xml_logfile_name: String
+  """
+  CDF address of the posted XML log file from ONSE
+  @name XML LogFile Unique ID
+  """
+  xml_logfile_uniqueId: Float
+}
+
+"Log File From ONSE"
+type LogFile_DryRun
+  @view(
+    rawFilter: {
+      hasData: [
+        {
+          type: "container"
+          space: "onse_logfile"
+          externalId: "LogFile_DryRun"
+        }
+      ]
+    }  version: "1"
+  ) {
+  """
+  Name of the CSV which delivers result/logs from ONSE
+  @name CSV LogFile Name
+  """
+  csv_logfile_name: String
+  """
+  CDF address of the posted CSV log file from ONSE
+  @name CSV LogFile Unique ID
+  """
+  csv_logfile_uniqueId: Float
+  """
+  General result from ONSE
+  @name Status
+  """
+  status: String
+  """
+  Cryptic id from IX
+  @name Transaction id
+  """
+  transaction_id: String
+  """
+  Transmittal Number (Referemce/Identifier)
+  @name Transmittal Number
+  """
+  transmittalNumber: String
+  """
+  Date and time when xml LogFile has been posted to CDF
+  @name Uploaded to CDF  Time
+  """
+  uploaded_to_cdf: String
+  """
+  Name of the XML which delivers result/logs from ONSE
+  @name XML LogFile Name
+  """
+  xml_logfile_name: String
+  """
+  CDF address of the posted XML log file from ONSE
+  @name XML LogFile Unique ID
+  """
+  xml_logfile_uniqueId: Float
+}
+''',
+        DATA_MODEL,
+        {ViewId(SPACE, "LogFile", "1"), ViewId(SPACE, "LogFile_DryRun", "1")},
+        set(),
+        id="Simple type with view and raw filter",
+    ),
+    pytest.param(
         """interface Creatable @view(space: "cdf_apps_shared", version: "v1") @import {
   visibility: String
   createdBy: CDF_User
@@ -258,6 +374,22 @@ type TagBeta @view (version: "7#") {
 ]
 
 DirectiveTestCases = [
+    pytest.param(
+        """view(
+    rawFilter: {
+      hasData: [
+        {
+          type: "container"
+          space: "onse_logfile"
+          externalId: "LogFile"
+        }
+      ]
+    }
+    version: "1"
+  )""",
+        _ViewDirective(version="1"),
+        id="View directive with raw filter and version",
+    ),
     pytest.param(
         """view(
     space: "cdf_cdm"


### PR DESCRIPTION
# Description

The GraphQL parser fails for directives that looks like this

```graphql
view(
    rawFilter: {
      hasData: [
        {
          type: "container"
          space: "onse_logfile"
          externalId: "LogFile"
        }
      ]
    }   version: "1"
  )
```
due to the `version: "1"` is expected to be on a new line.

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- [alpha] When deploying a GraphQL model, the Cognite Toolkit no longer fails for `.graphql` schema that uses directives with multiple components without line separation. 

## templates

No changes.
