### PR TITLE
[CDF-25405] Fix support dumping multiple groups

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -265,10 +265,10 @@ class DumpConfigApp(typer.Typer):
     def dump_group(
         ctx: typer.Context,
         group_name: Annotated[
-            str | None,
+            list[str] | None,
             typer.Argument(
-                help="Group name to dump. Format: name. Example: 'my_group'. "
-                "If nothing is provided, an interactive prompt will be shown to select the group.",
+                help="Group name(s) to dump. Format: name. Example: 'my_group'. "
+                "If nothing is provided, an interactive prompt will be shown to select the group(s).",
             ),
         ] = None,
         output_dir: Annotated[
@@ -303,7 +303,7 @@ class DumpConfigApp(typer.Typer):
         cmd = DumpResourceCommand()
         cmd.run(
             lambda: cmd.dump_to_yamls(
-                GroupFinder(client, group_name),
+                GroupFinder(client, tuple(group_name) if group_name else None),
                 output_dir=output_dir,
                 clean=clean,
                 verbose=verbose,

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -327,7 +327,7 @@ class GroupFinder(ResourceFinder[tuple[str, ...]]):
                 for group_name, groups in groups_by_name.items()
             ],
         ).ask()
-        if selected_groups is None:
+        if not selected_groups:
             raise ToolkitValueError("No group selected for dumping. Aborting...")
         self.groups = [group for group_list in selected_groups for group in group_list]
         return tuple(group_list[0].name for group_list in selected_groups)

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -324,7 +324,7 @@ class GroupFinder(ResourceFinder[tuple[str, ...]]):
             "Which group(s) would you like to dump?",
             choices=[
                 Choice(f"{group_name} ({len(groups)} group{'s' if len(groups) > 1 else ''})", value=groups)
-                for group_name, groups in groups_by_name.items()
+                for group_name, groups in sorted(groups_by_name.items())
             ],
         ).ask()
         if not selected_groups:

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -323,8 +323,8 @@ class GroupFinder(ResourceFinder[tuple[str, ...]]):
         selected_groups: list[list[Group]] | None = questionary.checkbox(
             "Which group(s) would you like to dump?",
             choices=[
-                Choice(f"{group_name} ({len(groups)} group{'s' if len(groups) > 1 else ''})", value=groups)
-                for group_name, groups in sorted(groups_by_name.items())
+                Choice(f"{group_name} ({len(group_list)} group{'s' if len(group_list) > 1 else ''})", value=group_list)
+                for group_name, group_list in sorted(groups_by_name.items())
             ],
         ).ask()
         if not selected_groups:

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -311,7 +311,7 @@ class TransformationFinder(ResourceFinder[tuple[str, ...]]):
 class GroupFinder(ResourceFinder[tuple[str, ...]]):
     def __init__(self, client: ToolkitClient, identifier: tuple[str, ...] | None = None):
         super().__init__(client, identifier)
-        self.groups: GroupList | None = None
+        self.groups: list[Group] | None = None
 
     def _interactive_select(self) -> tuple[str, ...]:
         groups = self.client.iam.groups.list(all=True)

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
@@ -376,5 +376,6 @@ class TestDumpGroups:
 
         filepaths = list(loader.find_files(tmp_path))
         assert len(filepaths) == 2
-        items = [read_yaml_file(filepath) for filepath in filepaths]
-        assert items == [loader.dump_resource(group) for group in three_groups[1:]]
+        items = sorted([read_yaml_file(filepath) for filepath in filepaths], key=lambda d: d.get("name"))
+        expected = sorted([loader.dump_resource(group) for group in three_groups[1:]], key=lambda d: d.get("name"))
+        assert items == expected

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
@@ -343,7 +343,7 @@ def three_groups() -> GroupList:
 
 class TestGroupFinder:
     def test_select_groups(self, three_groups: GroupList, monkeypatch: MonkeyPatch) -> None:
-        def select_groups(choices: list[Choice]) -> list[str]:
+        def select_groups(choices: list[Choice]) -> list[list[Group]]:
             assert len(choices) == len(three_groups)
             return [choices[1].value, choices[2].value]
 


### PR DESCRIPTION
# Description

Fixes the `cdf dump group` command such that the user can select multiple groups and not just one at a time. **Note** This command did not have any tests so I introduced tests for it. 

<img width="1153" height="503" alt="image" src="https://github.com/user-attachments/assets/0c21addc-775e-449c-a71f-8acdd0713ede" />

## Changelog

- [x] Patch
- [ ] Minor
- [ ] Skip

## cdf

### Fixed

- When running command `cdf dump group` you can now select multiple groups.

## templates

No changes.
