### PR TITLE
External library loading bugfix 

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -427,7 +427,7 @@ default_organization_dir = "{organization_dir.name}"''',
         choices = sorted(
             [
                 questionary.Choice(
-                    title=module.title,
+                    title=module.title if module.title else module.name,
                     value=module,
                     checked=module.name in dependencies or module.is_selected_by_default,
                     disabled="required" if module.name in dependencies else None,

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -834,12 +834,18 @@ default_organization_dir = "{organization_dir.name}"''',
                 for chunk in iter(lambda: f.read(chunk_size), b""):
                     sha256_hash.update(chunk)
             calculated = sha256_hash.hexdigest()
-            if calculated != checksum:
-                raise ToolkitError(f"Checksum mismatch. Expected {checksum}, got {calculated}.")
-            else:
-                print("Checksum verified")
-        except Exception as e:
+        except OSError as e:
             raise ToolkitError(f"Failed to calculate checksum for {file_path}: {e}") from e
+        except Exception as e:
+            raise ToolkitError(f"Unexpected error during checksum calculation for {file_path}: {e}") from e
+
+        if calculated != checksum:
+            raise ToolkitError(
+                f"Provided checksum sha256:{checksum} does not match downloaded file hash sha256:{calculated}.\n"
+                "Please verify the checksum with the source and update cdf.toml if needed."
+            )
+        else:
+            print("Checksum verified")
 
     def _unpack(self, file_path: Path) -> None:
         """

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -94,7 +94,7 @@ class ModulesCommand(ToolkitCommand):
     def __init__(self, print_warning: bool = True, skip_tracking: bool = False, silent: bool = False):
         super().__init__(print_warning, skip_tracking, silent)
         self._builtin_modules_path = Path(resources.files(cognite_toolkit.__name__)) / BUILTIN_MODULES  # type: ignore [arg-type]
-        self._temp_download_dir = Path(tempfile.gettempdir()) / "modules"
+        self._temp_download_dir = Path(tempfile.gettempdir()) / MODULES
         if not self._temp_download_dir.exists():
             self._temp_download_dir.mkdir(parents=True, exist_ok=True)
 

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -729,8 +729,15 @@ default_organization_dir = "{organization_dir.name}"''',
         if Flags.EXTERNAL_LIBRARIES.is_enabled() and cdf_toml.libraries:
             for library_name, library in cdf_toml.libraries.items():
                 try:
-                    print(f"[green]Adding library {library_name}[/]")
-                    file_path = self._temp_download_dir / f"{library_name}.zip"
+                    print(f"[green]Adding library {library_name} from {library.url}[/]")
+                    # Extract filename from URL, fallback to library_name.zip if no filename found
+                    from urllib.parse import urlparse
+
+                    url_path = urlparse(library.url).path
+                    filename = (
+                        url_path.split("/")[-1] if url_path and url_path.split("/")[-1] else f"{library_name}.zip"
+                    )
+                    file_path = self._temp_download_dir / filename
                     self._download(library.url, file_path)
                     self._validate_checksum(library.checksum, file_path)
                     self._unpack(file_path)
@@ -841,11 +848,11 @@ default_organization_dir = "{organization_dir.name}"''',
 
         if calculated != checksum:
             raise ToolkitError(
-                f"Provided checksum sha256:{checksum} does not match downloaded file hash sha256:{calculated}.\n"
+                f"[red]✗[/red] The provided checksum sha256:{checksum} does not match downloaded file hash sha256:{calculated}.\n"
                 "Please verify the checksum with the source and update cdf.toml if needed."
             )
         else:
-            print("Checksum verified")
+            print("[green]✓ Checksum verified[/green]")
 
     def _unpack(self, file_path: Path) -> None:
         """

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -427,7 +427,7 @@ default_organization_dir = "{organization_dir.name}"''',
         choices = sorted(
             [
                 questionary.Choice(
-                    title=module.title if module.title else module.name,
+                    title=module.title or module.name,
                     value=module,
                     checked=module.name in dependencies or module.is_selected_by_default,
                     disabled="required" if module.name in dependencies else None,

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -94,7 +94,7 @@ class ModulesCommand(ToolkitCommand):
     def __init__(self, print_warning: bool = True, skip_tracking: bool = False, silent: bool = False):
         super().__init__(print_warning, skip_tracking, silent)
         self._builtin_modules_path = Path(resources.files(cognite_toolkit.__name__)) / BUILTIN_MODULES  # type: ignore [arg-type]
-        self._temp_download_dir = Path(tempfile.gettempdir()) / "library_downloads"
+        self._temp_download_dir = Path(tempfile.gettempdir()) / "modules"
         if not self._temp_download_dir.exists():
             self._temp_download_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
# Description

Fixed a bug that caused loading of external libraries to fail due to wrong directory name

## Changelog

- [ ] Patch
- [x] Minor
- [ ] Skip

## cdf

### Fixed

- Fixed a bug that caused loading of external libraries to fail due to wrong directory name

## templates

No changes.
