### PR TITLE
Removing option to bump minor version

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,6 @@ Please describe the change you have made.
 ## Changelog
 
 - [ ] Patch
-- [ ] Minor
 - [ ] Skip
 
 ## cdf


### PR DESCRIPTION
# Description

Removing the option to bump Minor version, since it is too easy to do by mistake

## Changelog

- [ ] Patch
- [ ] Minor
- [x] Skip

## cdf

### Added/Changed/Improved/Removed/Fixed

- My change

## templates

No changes.
