### PR TITLE
[CDF-25523] 🎱Batching in datapoints subscriptions. 

### DIFF
--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/timeseries_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/timeseries_loaders.py
@@ -1,12 +1,14 @@
 import json
 from collections.abc import Hashable, Iterable, Sequence
 from functools import lru_cache
+from itertools import zip_longest
 from typing import Any, cast, final
 
 from cognite.client.data_classes import (
     DatapointsList,
     DatapointSubscription,
     DatapointSubscriptionList,
+    DataPointSubscriptionUpdate,
     DataPointSubscriptionWrite,
     DatapointSubscriptionWriteList,
     TimeSeries,
@@ -30,6 +32,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
 from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceContainerLoader, ResourceLoader
 from cognite_toolkit._cdf_tk.resource_classes import TimeSeriesYAML
 from cognite_toolkit._cdf_tk.utils import calculate_hash
+from cognite_toolkit._cdf_tk.utils.collection import chunker
 from cognite_toolkit._cdf_tk.utils.diff_list import diff_list_hashable, diff_list_identifiable, dm_identifier
 from cognite_toolkit._cdf_tk.utils.text import suffix_description
 
@@ -291,11 +294,16 @@ class DatapointSubscriptionLoader(
         )
 
     def create(self, items: DatapointSubscriptionWriteList) -> DatapointSubscriptionList:
-        created = DatapointSubscriptionList([])
+        created_list = DatapointSubscriptionList([])
         for item in items:
             self._hash_timeseries_ids(item)
-            created.append(self.client.time_series.subscriptions.create(item))
-        return created
+            to_create, batches = self._split_timeseries_ids(item)
+            created = self.client.time_series.subscriptions.create(to_create)
+            for batch_item in batches:
+                self.client.time_series.subscriptions.update(batch_item)
+            created_list.append(created)
+
+        return created_list
 
     def retrieve(self, ids: SequenceNotStr[str]) -> DatapointSubscriptionList:
         items = DatapointSubscriptionList([])
@@ -309,10 +317,13 @@ class DatapointSubscriptionLoader(
         updated = DatapointSubscriptionList([])
         for item in items:
             self._hash_timeseries_ids(item)
+            to_update, batches = self._split_timeseries_ids(item)
             # There are two versions of a TimeSeries Subscription, one selects timeseries based filter
             # and the other selects timeseries based on timeSeriesIds. If we use mode='replace', we try
             # to set timeSeriesIds to an empty list, while the filter is set. This will result in an error.
-            update = self.client.time_series.subscriptions.update(item, mode="replace_ignore_null")
+            update = self.client.time_series.subscriptions.update(to_update, mode="replace_ignore_null")
+            for batch_item in batches:
+                self.client.time_series.subscriptions.update(batch_item)
             updated.append(update)
 
         return updated
@@ -394,3 +405,36 @@ class DatapointSubscriptionLoader(
             self.display_name,
             self.console,
         )
+
+    def _split_timeseries_ids(
+        self, subscription: DataPointSubscriptionWrite
+    ) -> tuple[DataPointSubscriptionWrite, list[DataPointSubscriptionUpdate]]:
+        """Split the time series IDs into batches of 100.
+        This is needed because the API only supports 100 time series IDs per request.
+        """
+        if len(subscription.time_series_ids or []) <= self._timeseries_id_request_limit and (
+            len(subscription.instance_ids or []) <= self._timeseries_id_request_limit
+        ):
+            return subscription, []
+
+        # Serialization to create a copy of the subscription
+        # to avoid mutating the original subscription
+        to_create = DataPointSubscriptionWrite.load(subscription.dump())
+
+        timeseries_ids = to_create.time_series_ids or []
+        instance_ids = to_create.instance_ids or []
+        to_create.time_series_ids = timeseries_ids[: self._timeseries_id_request_limit] or None
+        to_create.instance_ids = instance_ids[: self._timeseries_id_request_limit] or None
+
+        batches: list[DataPointSubscriptionUpdate] = []
+        for timeseries_ids_chunk, instance_ids_chunk in zip_longest(
+            chunker(timeseries_ids[self._timeseries_id_request_limit :], self._timeseries_id_request_limit),
+            chunker(instance_ids[self._timeseries_id_request_limit :], self._timeseries_id_request_limit),
+        ):
+            update = DataPointSubscriptionUpdate(external_id=subscription.external_id)
+            if timeseries_ids_chunk:
+                update.time_series_ids.add(timeseries_ids_chunk)
+            if instance_ids_chunk:
+                update.instance_ids.add(instance_ids_chunk)
+            batches.append(update)
+        return to_create, batches

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/timeseries_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/timeseries_loaders.py
@@ -222,6 +222,10 @@ class DatapointSubscriptionLoader(
 
     _hash_key = "cdf-hash"
     _description_character_limit = 1000
+    # A datapoint subscription can hold 10,000 timeseries, but the API
+    # only supports 100 timeseries per request. Thus, if a subscription
+    # has more than 100 timeseries, we need to split it into multiple requests.
+    _timeseries_id_request_limit = 100
 
     @property
     def display_name(self) -> str:


### PR DESCRIPTION
# Description

The datapoint subscription supports up to 10,000 timeseries in one subscription. However, you cannot include this in a single request when you create it. Thus, you have to done one create request and up to 99 update requests. This PR does that split when creating datapoints subscriptions. 

Note there is a bug in the `cognite-sdk`, the `description` parameter is not updated. This have to go in first: https://github.com/cognitedata/cognite-sdk-python/pull/2255

## Changelog

- [x] Patch
- [ ] Skip

## cdf

### Fixed

- When deploying datapoints subscriptions, Toolkit now supports more than 100 timeseries IDs. It will correctly split into batches and support up to 10,000 timeseries per subscription. 

## templates

No changes.
