### PR TITLE
👷Fix test

### DIFF
--- a/tests/test_integration/test_commands/test_profile.py
+++ b/tests/test_integration/test_commands/test_profile.py
@@ -47,6 +47,11 @@ class TestProfileAssetCommand:
         results = ProfileAssetCommand().assets(
             toolkit_client, aggregator_root_asset.external_id, profile_row_limit=profile_row_limit
         )
+        for row in results:
+            for cell in row.values():
+                if "CogniteAPIError" in str(cell):
+                    pytest.skip("Skipping test due to intermediate CogniteAPI error.")
+
         columns = ProfileAssetCommand.Columns
         assert (
             results

--- a/tests/test_integration/test_utils/test_aggregators.py
+++ b/tests/test_integration/test_utils/test_aggregators.py
@@ -66,7 +66,7 @@ class TestAggregators:
             transformation_count = aggregator.transformation_count()
             used_transformations = aggregator.used_transformations(used_data_sets)
         except CogniteAPIError as e:
-            if e.code == 500 and "Internal Server Error" in e.message:
+            if e.code == 500 and "Internal server error" in e.message:
                 pytest.skip("Skipping test due to intermittent CDF 500 error.")
             raise e
 

--- a/tests/test_integration/test_utils/test_aggregators.py
+++ b/tests/test_integration/test_utils/test_aggregators.py
@@ -60,14 +60,12 @@ class TestAggregators:
         aggregator = aggregator_class(toolkit_client)
 
         actual_count = aggregator.count(root)
-        assert actual_count == expected_count
-
         used_data_sets = aggregator.used_data_sets(root)
-        assert used_data_sets == [expected_dataset_external_id]
-
         transformation_count = aggregator.transformation_count()
-        assert transformation_count >= 1  # We know at least one transformation is writing to the resource type.
         used_transformations = aggregator.used_transformations(used_data_sets)
 
+        assert actual_count == expected_count
+        assert used_data_sets == [expected_dataset_external_id]
+        assert transformation_count >= 1  # We know at least one transformation is writing to the resource type.
         assert len(used_transformations) == 1
         assert used_transformations[0].external_id == expected_transformation_external_id


### PR DESCRIPTION
# Description

These integration tests fails frequently due to the instability of the transformations service. Skipping the tests if we get CogniteAPIErrors

<img width="2282" height="649" alt="image" src="https://github.com/user-attachments/assets/c1a9dd25-7e9d-4a53-ba0d-ace1f7b4e8e0" />


## Changelog

- [ ] Patch
- [x] Skip
