### PR TITLE
🐛Upload coverage report

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,34 @@ env:
   PYTHON_VERSION: '3.11'
 
 jobs:
+  upload_coverage:
+    name: Upload coverage report
+    runs-on: ubuntu-latest
+    environment: dev
+    env:
+      CDF_CLUSTER: ${{ secrets.CDF_CLUSTER }}
+      CDF_PROJECT: ${{ secrets.CDF_PROJECT }}
+      IDP_CLIENT_ID: ${{ secrets.IDP_CLIENT_ID }}
+      IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
+      IDP_TOKEN_URL: ${{ secrets.IDP_TOKEN_URL }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: 3.11
+      - name: Install dependencies
+        run: |
+          pip install uv
+          uv sync --all-extras
+      - name: Create test coverage report
+        env:
+          IS_GITHUB_ACTIONS: "true"
+        run: uv run pytest --cov=cognite_toolkit/ --cov-config=pyproject.toml --cov-report=xml:coverage.xml tests/ -n8
+      - uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: cognitedata/toolkit
+
   release-pypi-docker-hub:
     runs-on: ubuntu-latest
     environment: CD

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ jobs:
     name: Upload coverage report
     runs-on: ubuntu-latest
     environment: dev
+    permissions: read-all
     env:
       CDF_CLUSTER: ${{ secrets.CDF_CLUSTER }}
       CDF_PROJECT: ${{ secrets.CDF_PROJECT }}


### PR DESCRIPTION
# Description

We need to run coverage on merge to main to upload a report such that codecov can compare

<img width="1009" height="408" alt="image" src="https://github.com/user-attachments/assets/f566c0af-1c3c-4d9a-8a0c-9f59c941f57b" />


## Changelog

- [ ] Patch
- [x] Skip

