### PR TITLE
[CDF-25612] 🐛Unit conversion

### DIFF
--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -157,3 +157,4 @@ COGNITE_MIGRATION_SPACE = "cognite_migration"
 
 COGNITE_TIME_SERIES_CONTAINER = ContainerId("cdf_cdm", "CogniteTimeSeries")
 COGNITE_FILE_CONTAINER = ContainerId("cdf_cdm", "CogniteFile")
+CDF_UNIT_SPACE = "cdf_cdm_units"

--- a/cognite_toolkit/_cdf_tk/utils/dtype_conversion.py
+++ b/cognite_toolkit/_cdf_tk/utils/dtype_conversion.py
@@ -254,7 +254,7 @@ class _TimeSeriesUnitConverter(_SpecialCaseConverter):
             return None
         if isinstance(value, str):
             return {"space": CDF_UNIT_SPACE, "externalId": value}
-        raise ValueError(f"Cannot convert {value!r} to TimeSeries unit. Expected a string or None.")
+        raise ValueError(f"Cannot convert {value!r} to TimeSeries unit. Expected a string representing the externalId.")
 
 
 class _LabelConverter(_SpecialCaseConverter, ABC):

--- a/cognite_toolkit/_cdf_tk/utils/dtype_conversion.py
+++ b/cognite_toolkit/_cdf_tk/utils/dtype_conversion.py
@@ -12,6 +12,7 @@ from cognite.client.data_classes.data_modeling.instances import PropertyValueWri
 from cognite.client.utils import ms_to_datetime
 from dateutil import parser
 
+from cognite_toolkit._cdf_tk.constants import CDF_UNIT_SPACE
 from cognite_toolkit._cdf_tk.exceptions import ToolkitNotSupported
 from cognite_toolkit._cdf_tk.utils._auxiliary import get_concrete_subclasses
 from cognite_toolkit._cdf_tk.utils.useful_types import AssetCentric, DataType, JsonVal, PythonTypes
@@ -242,6 +243,18 @@ class _TimeSeriesTypeConverter(_SpecialCaseConverter):
         if isinstance(value, bool):
             return "string" if value else "numeric"
         raise ValueError(f"Cannot convert {value} to TimeSeries type. Expected a boolean value.")
+
+
+class _TimeSeriesUnitConverter(_SpecialCaseConverter):
+    source_property = ("timeseries", "unitExternalId")
+    destination_container_property = (ContainerId("cdf_cdm", "CogniteTimeSeries"), "unit")
+
+    def convert(self, value: str | int | float | bool | dict | list | None) -> dict[str, str] | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return {"space": CDF_UNIT_SPACE, "externalId": value}
+        raise ValueError(f"Cannot convert {value!r} to TimeSeries unit. Expected a string or None.")
 
 
 class _LabelConverter(_SpecialCaseConverter, ABC):

--- a/tests/test_unit/test_cdf_tk/test_utils/test_dtype_conversion.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_dtype_conversion.py
@@ -6,6 +6,7 @@ from cognite.client.data_classes import Label, LabelDefinition
 from cognite.client.data_classes.data_modeling import ContainerId
 from cognite.client.data_classes.data_modeling.data_types import (
     Boolean,
+    DirectRelation,
     Enum,
     EnumValue,
     Float32,
@@ -435,6 +436,14 @@ class TestConvertToContainerProperty:
                 ("timeseries", "isString"),
                 False,
                 id="Non-asset-centric boolean to primary property conversion",
+            ),
+            pytest.param(
+                "acceleration:m-per-sec2",
+                DirectRelation(),
+                (ContainerId("cdf_cdm", "CogniteTimeSeries"), "unit"),
+                ("timeseries", "unitExternalId"),
+                {"space": "cdf_cdm_units", "externalId": "acceleration:m-per-sec2"},
+                id="TimeSeries unitExternalId to DirectRelation conversion",
             ),
         ],
     )

--- a/tests/test_unit/test_cdf_tk/test_utils/test_dtype_conversion.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_dtype_conversion.py
@@ -445,6 +445,14 @@ class TestConvertToContainerProperty:
                 {"space": "cdf_cdm_units", "externalId": "acceleration:m-per-sec2"},
                 id="TimeSeries unitExternalId to DirectRelation conversion",
             ),
+            pytest.param(
+                None,
+                DirectRelation(),
+                (ContainerId("cdf_cdm", "CogniteTimeSeries"), "unit"),
+                ("timeseries", "unitExternalId"),
+                None,
+                id="TimeSeries unitExternalId to DirectRelation conversion with None value (nullable)",
+            ),
         ],
     )
     def test_asset_centric_conversion(

--- a/tests/test_unit/test_cdf_tk/test_utils/test_dtype_conversion.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_dtype_conversion.py
@@ -480,6 +480,14 @@ class TestConvertToContainerProperty:
                 "Cannot convert not_a_list to labels. Expected a list of Labels, objects, or LabelDefinitions.",
                 id="List to Text conversion error",
             ),
+            pytest.param(
+                True,
+                DirectRelation(),
+                (ContainerId("cdf_cdm", "CogniteTimeSeries"), "unit"),
+                ("timeseries", "unitExternalId"),
+                "Cannot convert True to TimeSeries unit. Expected a string representing the externalId.",
+                id="TimeSeries unitExternalId to DirectRelation conversion error",
+            ),
         ],
     )
     def test_asset_centric_failed_conversion(


### PR DESCRIPTION
# Description

**Context**: This is part of the `alpha` migration tooling in Toolkit, for overview [see here](https://cognitedata.atlassian.net/wiki/spaces/~170890702/pages/5455773697/Migration+Tooling+in+Toolkit). 

This PR fixes the data type conversion from TimeSeries to CogniteTimeSeries. Note this functionality has not yet been released thus we do not need to release a new version of Toolkit.

## Changelog

- [ ] Patch
- [x] Skip

