### PR TITLE
[prep CDF-25549] 👷 Prepare asset download

### DIFF
--- a/cognite_toolkit/_cdf_tk/storageio/__init__.py
+++ b/cognite_toolkit/_cdf_tk/storageio/__init__.py
@@ -1,5 +1,15 @@
 from ._asset_centric import AssetIO
 from ._base import StorageIO, TableStorageIO
 from ._raw import RawIO
+from ._selectors import AssetCentricFileSelector, AssetCentricSelector, AssetSubtreeSelector, DataSetSelector
 
-__all__ = ["AssetIO", "RawIO", "StorageIO", "TableStorageIO"]
+__all__ = [
+    "AssetCentricFileSelector",
+    "AssetCentricSelector",
+    "AssetIO",
+    "AssetSubtreeSelector",
+    "DataSetSelector",
+    "RawIO",
+    "StorageIO",
+    "TableStorageIO",
+]

--- a/cognite_toolkit/_cdf_tk/storageio/_asset_centric.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_asset_centric.py
@@ -20,7 +20,7 @@ from cognite_toolkit._cdf_tk.utils.fileio import SchemaColumn
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 
 from ._base import StorageIOConfig, TableStorageIO
-from ._selectors import AssetCentricSelector
+from ._selectors import AssetCentricFileSelector, AssetCentricSelector, AssetSubtreeSelector, DataSetSelector
 
 
 class AssetIO(TableStorageIO[AssetCentricSelector, AssetWriteList, AssetList]):
@@ -40,15 +40,18 @@ class AssetIO(TableStorageIO[AssetCentricSelector, AssetWriteList, AssetList]):
 
     def get_schema(self, selector: AssetCentricSelector) -> list[SchemaColumn]:
         data_set_ids: list[int] = []
-        if selector.data_set_external_id:
+        if isinstance(selector, DataSetSelector):
             data_set_ids.append(self.client.lookup.data_sets.id(selector.data_set_external_id))
         hierarchy: list[int] = []
-        if selector.hierarchy:
+        if isinstance(selector, AssetSubtreeSelector):
             hierarchy.append(self.client.lookup.assets.id(selector.hierarchy))
 
-        metadata_keys = metadata_key_counts(
-            self.client, "assets", data_sets=data_set_ids or None, hierarchies=hierarchy or None
-        )
+        if hierarchy or data_set_ids:
+            metadata_keys = metadata_key_counts(
+                self.client, "assets", data_sets=data_set_ids or None, hierarchies=hierarchy or None
+            )
+        else:
+            metadata_keys = []
         metadata_schema: list[SchemaColumn] = []
         if metadata_keys:
             metadata_schema.extend(
@@ -66,13 +69,28 @@ class AssetIO(TableStorageIO[AssetCentricSelector, AssetWriteList, AssetList]):
         ]
         return asset_schema + metadata_schema
 
-    def count(self, selector: AssetCentricSelector) -> int:
-        return AssetAggregator(self.client).count(
-            hierarchy=selector.hierarchy, data_set_external_id=selector.data_set_external_id
-        )
+    def count(self, selector: AssetCentricSelector) -> int | None:
+        aggregator = AssetAggregator(self.client)
+        if isinstance(selector, DataSetSelector):
+            return aggregator.count(data_set_external_id=selector.data_set_external_id)
+        elif isinstance(selector, AssetSubtreeSelector):
+            return aggregator.count(hierarchy=selector.hierarchy)
+        return None
 
     def download_iterable(self, selector: AssetCentricSelector, limit: int | None = None) -> Iterable[AssetList]:
-        for asset_list in self.client.assets(chunk_size=self.chunk_size, limit=limit, **selector.as_filter()):
+        asset_subtree_external_ids: list[str] | None = None
+        data_set_external_ids: list[str] | None = None
+        if isinstance(selector, DataSetSelector):
+            data_set_external_ids = [selector.data_set_external_id]
+        elif isinstance(selector, AssetSubtreeSelector):
+            asset_subtree_external_ids = [selector.hierarchy]
+
+        for asset_list in self.client.assets(
+            chunk_size=self.chunk_size,
+            limit=limit,
+            asset_subtree_external_ids=asset_subtree_external_ids,
+            data_set_external_ids=data_set_external_ids,
+        ):
             for asset in asset_list:
                 if asset.data_set_id:
                     self._downloaded_data_sets_by_selector[selector].add(asset.data_set_id)
@@ -125,13 +143,13 @@ class AssetIO(TableStorageIO[AssetCentricSelector, AssetWriteList, AssetList]):
         )
 
     def load_selector(self, datafile: Path) -> AssetCentricSelector:
-        return AssetCentricSelector(datafile=datafile)
+        return AssetCentricFileSelector(datafile=datafile)
 
     def ensure_configurations(self, selector: AssetCentricSelector, console: Console | None = None) -> None:
         """Ensures that all data sets and labels referenced by the asset selection exist in CDF."""
-        datafile = selector.datafile
-        if not datafile:
+        if not isinstance(selector, AssetCentricFileSelector):
             return None
+        datafile = selector.datafile
         filepaths = find_files_with_suffix_and_prefix(
             datafile.parent.parent / DataSetsLoader.folder_name, datafile.name, suffix=f".{DataSetsLoader.kind}.yaml"
         )

--- a/cognite_toolkit/_cdf_tk/storageio/_selectors.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_selectors.py
@@ -1,28 +1,39 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+
+from cognite_toolkit._cdf_tk.utils.file import to_directory_compatible
 
 
 @dataclass(frozen=True)
-class AssetCentricData:
-    """Data class for asset-centric data selection.
+class AssetCentricSelector:
+    """Data class for asset-centric data selection."""
 
-    This class is used to filter asset-centric data based on a data set external ID and a hierarchy.
 
-    Args:
-        data_set_external_id (str | None): The external ID of the data set to filter by. (Used for download)
-        hierarchy (str | None): The hierarchy to filter by, typically an asset subtree external ID. (Used for download)
-        datafile (Path | None): The path to the data file associated with this selection. (Used for upload)
+@dataclass(frozen=True)
+class DataSetSelector(AssetCentricSelector):
+    """Select data associated with a specific data set."""
 
-    """
+    data_set_external_id: str
 
-    data_set_external_id: str | None = None
-    hierarchy: str | None = None
-    datafile: Path | None = None
+    def __str__(self) -> str:
+        return f"DataSet={to_directory_compatible(self.data_set_external_id)}"
 
-    def as_filter(self) -> dict[str, Any]:
-        """Convert the AssetCentricData to a filter dictionary."""
-        return dict(
-            data_set_external_ids=[self.data_set_external_id] if self.data_set_external_id else None,
-            asset_subtree_external_ids=[self.hierarchy] if self.hierarchy else None,
-        )
+
+@dataclass(frozen=True)
+class AssetSubtreeSelector(AssetCentricSelector):
+    """Select data associated with an asset and its subtree."""
+
+    hierarchy: str
+
+    def __str__(self) -> str:
+        return f"AssetSubtree={to_directory_compatible(self.hierarchy)}"
+
+
+@dataclass(frozen=True)
+class AssetCentricFileSelector(AssetCentricSelector):
+    """Select data from a specific file."""
+
+    datafile: Path
+
+    def __str__(self) -> str:
+        return f"File={self.datafile.name}"

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_asset_centric.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_asset_centric.py
@@ -14,7 +14,7 @@ from cognite.client.data_classes import (
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.commands import DownloadCommand, UploadCommand
 from cognite_toolkit._cdf_tk.storageio import AssetIO
-from cognite_toolkit._cdf_tk.storageio._selectors import AssetCentricData
+from cognite_toolkit._cdf_tk.storageio._selectors import AssetCentricSelector
 from cognite_toolkit._cdf_tk.utils.collection import chunker
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 
@@ -40,7 +40,7 @@ def some_asset_data() -> AssetList:
 
 class TestAssetIO:
     def test_download_upload(self, some_asset_data: AssetList) -> None:
-        selector = AssetCentricData(data_set_external_id=None, hierarchy="test_hierarchy")
+        selector = AssetCentricSelector(data_set_external_id=None, hierarchy="test_hierarchy")
         with monkeypatch_toolkit_client() as client:
             client.assets.return_value = chunker(some_asset_data, 10)
             client.assets.aggregate_count.return_value = 100
@@ -75,7 +75,7 @@ class TestAssetIO:
             assert uploaded_assets.dump() == some_asset_data.as_write().dump()
 
     def test_download_upload_command(self, some_asset_data: AssetList, tmp_path: Path) -> None:
-        selector = AssetCentricData(data_set_external_id=None, hierarchy="test_hierarchy")
+        selector = AssetCentricSelector(data_set_external_id=None, hierarchy="test_hierarchy")
         with monkeypatch_toolkit_client() as client:
             client.assets.return_value = [some_asset_data]
             client.assets.aggregate_count.return_value = 100

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_asset_centric.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_asset_centric.py
@@ -14,7 +14,7 @@ from cognite.client.data_classes import (
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.commands import DownloadCommand, UploadCommand
 from cognite_toolkit._cdf_tk.storageio import AssetIO
-from cognite_toolkit._cdf_tk.storageio._selectors import AssetCentricSelector
+from cognite_toolkit._cdf_tk.storageio._selectors import AssetSubtreeSelector
 from cognite_toolkit._cdf_tk.utils.collection import chunker
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 
@@ -40,7 +40,7 @@ def some_asset_data() -> AssetList:
 
 class TestAssetIO:
     def test_download_upload(self, some_asset_data: AssetList) -> None:
-        selector = AssetCentricSelector(data_set_external_id=None, hierarchy="test_hierarchy")
+        selector = AssetSubtreeSelector(hierarchy="test_hierarchy")
         with monkeypatch_toolkit_client() as client:
             client.assets.return_value = chunker(some_asset_data, 10)
             client.assets.aggregate_count.return_value = 100
@@ -75,7 +75,7 @@ class TestAssetIO:
             assert uploaded_assets.dump() == some_asset_data.as_write().dump()
 
     def test_download_upload_command(self, some_asset_data: AssetList, tmp_path: Path) -> None:
-        selector = AssetCentricSelector(data_set_external_id=None, hierarchy="test_hierarchy")
+        selector = AssetSubtreeSelector(hierarchy="test_hierarchy")
         with monkeypatch_toolkit_client() as client:
             client.assets.return_value = [some_asset_data]
             client.assets.aggregate_count.return_value = 100


### PR DESCRIPTION
# Description

This is preparation for introducing a download/upload/migrate asset command. 

We have an interface in Toolkit for downloading/uploading data. `StorageIO`. To select data we use a selector. In this PR, I change the selector for asset-centric data to one of three subtypes. This makes for a cleaner implementation. 



## Changelog

- [ ] Patch
- [x] Skip

