### PR TITLE
👮Build skip CLI entrypoints in coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,12 @@ package = true
 
 [tool.coverage.report]
 show_missing = true
+omit = [
+    # The apps module only holds CLI entrypoints, so we skip it in coverage reports'
+    "/cognite_toolkit/_cdf_tk/apps/*",
+    # Exclude CLI entrypoints
+    "/cognite_toolkit/_cdf.py",
+    ]
 
 [tool.pytest.ini_options]
 minversion = "8.0"


### PR DESCRIPTION
# Description

We do not expects the CLI entrypoints to be tested, formalizing this by omitting it in the coverage report.

## Changelog

- [ ] Patch
- [x] Skip

