### PR TITLE
🐛 Fix: flaky test

### DIFF
--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/agent_loaders.py
@@ -22,7 +22,7 @@ class AgentLoader(ResourceLoader[str, AgentUpsert, Agent, AgentUpsertList, Agent
     list_write_cls = AgentUpsertList
     kind = "Agent"
     _doc_base_url = ""
-    _doc_url = "https://api-docs.cognite.com/20230101-alpha/tag/Agents/operation/main_api_v1_projects__projectName__ai_agents_post"
+    _doc_url = "https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/main_ai_agents_post/"
 
     @classmethod
     def get_id(cls, item: AgentUpsert | Agent | dict) -> str:

--- a/tests/test_integration/test_toolkit_client/test_extended_files.py
+++ b/tests/test_integration/test_toolkit_client/test_extended_files.py
@@ -78,7 +78,7 @@ class TestExtendedFilesAPI:
             created_dm = client.data_modeling.instances.apply(cognite_file).nodes
 
             retrieved_ts: FileMetadata | None = None
-            for _ in range(10):
+            for _ in range(30):  # Wait up to 30 seconds for the syncer to update the file metadata
                 retrieved_ts = client.files.retrieve(instance_id=cognite_file.as_id())
                 if retrieved_ts is not None:
                     break


### PR DESCRIPTION
# Description

The file syncer frequently takes more than 10 seconds, increasing to 30.

<img width="1274" height="189" alt="image" src="https://github.com/user-attachments/assets/ceb43ea2-a2b8-4ceb-80d2-b72dbbbab77d" />

## Changelog

- [ ] Patch
- [x] Skip

