### PR TITLE
[CDF-24664] 🐛 Modules pull failing

### DIFF
--- a/cognite_toolkit/_cdf_tk/data_classes/_built_modules.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_built_modules.py
@@ -100,7 +100,7 @@ class BuiltModuleList(list, MutableSequence[BuiltModule]):
             resources = (
                 resource
                 for resource in resources
-                if (resource.source.path == selected or resource.source.path.is_relative_to(selected.absolute()))
+                if (resource.source.path == selected or self._are_relative(resource.source.path, selected))
             )
         if is_supported_file:
             # This is necessary as the destination file can be created from a source file that is not supported.
@@ -115,3 +115,13 @@ class BuiltModuleList(list, MutableSequence[BuiltModule]):
             for resource_dir, resources in module.resources.items():
                 resources_by_folder.setdefault(resource_dir, BuiltResourceList()).extend(resources)
         return resources_by_folder
+
+    @staticmethod
+    def _are_relative(filepath: Path, select_path: Path) -> bool:
+        if filepath.is_absolute() and not select_path.is_absolute():
+            return filepath.is_relative_to(select_path.absolute())
+        elif not filepath.is_absolute() and select_path.is_absolute():
+            return filepath.absolute().is_relative_to(select_path)
+        else:
+            # Either both are absolute or both are relative
+            return filepath.is_relative_to(select_path)

--- a/tests/test_unit/test_cdf_tk/test_data_classes/test_built_modules.py
+++ b/tests/test_unit/test_cdf_tk/test_data_classes/test_built_modules.py
@@ -1,0 +1,85 @@
+from itertools import groupby
+from pathlib import Path
+
+import pytest
+
+from cognite_toolkit._cdf_tk.data_classes import (
+    BuildVariables,
+    BuiltModule,
+    BuiltModuleList,
+    BuiltResource,
+    BuiltResourceList,
+    SourceLocationEager,
+)
+from cognite_toolkit._cdf_tk.loaders import ResourceTypes
+
+
+class TestBuiltModuleList:
+    @pytest.mark.parametrize(
+        "module,resource_dir,kind,selected,expected",
+        [
+            pytest.param(
+                {
+                    Path("/module1"): [
+                        Path("/module1/transformations/my.Transformation.yaml"),
+                        Path("/module1/transformations/my.Schedule.yaml"),
+                    ]
+                },
+                "transformations",
+                "Transformation",
+                "module1",
+                [Path("/module1/transformations/my.Transformation.yaml")],
+                id="Select by module name",
+            )
+        ],
+    )
+    def test_get_resources_selected(
+        self,
+        module: dict[Path, list[Path]],
+        resource_dir: ResourceTypes,
+        kind: str,
+        selected: str | Path | None,
+        expected: list[Path],
+    ) -> None:
+        module_list = self._create_built_resource_list(module)
+        result = module_list.get_resources(
+            id_type=None,
+            resource_dir=resource_dir,
+            kind=kind,
+            selected=selected,
+        )
+        actual = [item.source.path for item in result]
+        assert actual == expected
+
+    @staticmethod
+    def _create_built_resource_list(module: dict[Path, list[Path]]) -> BuiltModuleList:
+        modules: list[BuiltModule] = [
+            BuiltModule(
+                name=module_path.name,
+                location=SourceLocationEager(module_path, "hash1234"),
+                build_variables=BuildVariables([]),
+                resources={
+                    resource_dir: BuiltResourceList(
+                        [
+                            BuiltResource(
+                                identifier=f"resource_{i}",
+                                source=SourceLocationEager(resource_path, "hash5678"),
+                                kind=resource_path.stem.split(".")[-1],
+                                destination=None,
+                                extra_sources=None,
+                            )
+                            for i, resource_path in enumerate(resource_paths)
+                        ]
+                    )
+                    for resource_dir, resource_paths in groupby(
+                        sorted(resource_paths, key=lambda p: p.parent.name), key=lambda p: p.parent.name
+                    )
+                },
+                warning_count=0,
+                status="success",
+                iteration=1,
+            )
+            for module_path, resource_paths in module.items()
+        ]
+        module_list = BuiltModuleList(modules)
+        return module_list

--- a/tests/test_unit/test_cdf_tk/test_data_classes/test_built_modules.py
+++ b/tests/test_unit/test_cdf_tk/test_data_classes/test_built_modules.py
@@ -24,7 +24,7 @@ class GetResourcesArgs:
 
 class TestBuiltModuleList:
     # Anchor for absolute paths in tests
-    anchor = Path.home().anchor
+    anchor = f"{Path.cwd()}/"
 
     @pytest.mark.parametrize(
         "module,args,expected",
@@ -46,7 +46,7 @@ class TestBuiltModuleList:
             ),
             pytest.param(
                 {
-                    Path(f"{anchor}module1"): [
+                    Path(f"{anchor}modules/module1"): [
                         Path(f"{anchor}modules/module1/transformations/my.Transformation.yaml"),
                         Path(f"{anchor}modules/module1/transformations/my.Schedule.yaml"),
                     ]
@@ -54,10 +54,25 @@ class TestBuiltModuleList:
                 GetResourcesArgs(
                     resource_dir="transformations",
                     kind="Transformation",
-                    selected=Path("module1"),
+                    selected=Path("modules/module1"),
                 ),
                 [Path(f"{anchor}modules/module1/transformations/my.Transformation.yaml")],
                 id="Select with relative with module in absolute",
+            ),
+            pytest.param(
+                {
+                    Path("modules/module1"): [
+                        Path("modules/module1/transformations/my.Transformation.yaml"),
+                        Path("modules/module1/transformations/my.Schedule.yaml"),
+                    ]
+                },
+                GetResourcesArgs(
+                    resource_dir="transformations",
+                    kind="Transformation",
+                    selected=Path(f"{anchor}modules/module1"),
+                ),
+                [Path("modules/module1/transformations/my.Transformation.yaml")],
+                id="Select with absolute with module in relative",
             ),
             pytest.param(
                 {


### PR DESCRIPTION
# Description

**Context**: The pull command allows the user to pull down configuration from the fusion UI to local YAML configurations. This is useful when a governed resource, for example, a transformation is updated in the UI and you want the updated version in your local configuration while maintaining the location on disk and built variables.

This PR fixes a bug in which the selection of resources to pull fails when the Toolkit skips resources due to mix of relative and absolute filepaths. To fix this bug, I introduces a test battery for the selection logic and the fixed the bug.

## Changelog

- [x] Patch
- [ ] Skip

## cdf

### Fixed

- The command `cdf modules pull` now correctly selecting resources given as both relative and absolute paths.

## templates

No changes.
