### PR TITLE
[CDF-24818] 🍨 Datapoint subscription YAML class

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_classes/datapoint_subscription.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/datapoint_subscription.py
@@ -1,0 +1,71 @@
+import sys
+
+from pydantic import Field, JsonValue, model_validator
+
+from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
+
+from .base import BaseModelResource, ToolkitResource
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+_SUBSCRIPTION_MAX_TOTAL_TIMESERIES = 10_000
+
+
+class InstanceId(BaseModelResource):
+    space: str = Field(
+        description="The Space identifier (id).",
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
+    )
+    external_id: str = Field(
+        description="The external ID of the instance.",
+        max_length=255,
+    )
+
+
+class DatapointSubscriptionYAML(ToolkitResource):
+    external_id: str = Field(
+        description="Externally provided ID for the subscription. Must be unique.",
+        max_length=255,
+    )
+    name: str | None = Field(
+        default=None,
+        description="Human readable name of the subscription.",
+    )
+    description: str | None = Field(default=None, description="A description of the subscription.")
+    data_set_external_id: str | None = Field(
+        default=None,
+        description="The dataSet Id for the item.",
+    )
+    partition_count: int | None = Field(
+        default=None,
+        ge=1,
+        le=100,
+        description="The maximum effective parallelism of this subscription (the number of clients that can read from it concurrently) will be limited to this number, but a higher partition count will cause a higher time overhead.",
+    )
+    time_series_ids: list[str] | None = Field(
+        None,
+        description="List of (external) ids of time series that this subscription will listen to. Not compatible with filter.",
+    )
+    instance_ids: list[InstanceId] | None = Field(
+        None,
+        description="List of instance ids of time series that this subscription will listen to. Not compatible with filter.",
+    )
+
+    filter: dict[str, JsonValue] | None = Field(
+        default=None,
+        description="A filter Domain Specific Language (DSL) used to create advanced filter queries. Not compatible with time_series_ids or instance_ids.",
+    )
+
+    @model_validator(mode="after")
+    def check_total_instances(self) -> Self:
+        total = len(self.time_series_ids or []) + len(self.instance_ids or [])
+        if total > _SUBSCRIPTION_MAX_TOTAL_TIMESERIES:
+            raise ValueError(
+                f"The total number of time_series_ids and instance_ids cannot exceed {_SUBSCRIPTION_MAX_TOTAL_TIMESERIES}."
+            )
+        return self

--- a/cognite_toolkit/_cdf_tk/resource_classes/datapoint_subscription.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/datapoint_subscription.py
@@ -62,16 +62,16 @@ class DatapointSubscriptionYAML(ToolkitResource):
     )
 
     @model_validator(mode="after")
-    def check_total_instances(self) -> Self:
-        total = len(self.time_series_ids or []) + len(self.instance_ids or [])
+    def check_subscription_targets(self) -> Self:
+        time_series_ids = self.time_series_ids or []
+        instance_ids = self.instance_ids or []
+
+        total = len(time_series_ids) + len(instance_ids)
         if total > _SUBSCRIPTION_MAX_TOTAL_TIMESERIES:
             raise ValueError(
                 f"The total number of time_series_ids and instance_ids cannot exceed {_SUBSCRIPTION_MAX_TOTAL_TIMESERIES}."
             )
-        return self
 
-    @model_validator(mode="after")
-    def check_filter_and_ids_mutual_exclusivity(self) -> Self:
-        if self.filter is not None and (self.time_series_ids or self.instance_ids):
+        if self.filter is not None and total > 0:
             raise ValueError("Cannot set both filter and time_series_ids/instance_ids.")
         return self

--- a/cognite_toolkit/_cdf_tk/resource_classes/datapoint_subscription.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/datapoint_subscription.py
@@ -69,3 +69,9 @@ class DatapointSubscriptionYAML(ToolkitResource):
                 f"The total number of time_series_ids and instance_ids cannot exceed {_SUBSCRIPTION_MAX_TOTAL_TIMESERIES}."
             )
         return self
+
+    @model_validator(mode="after")
+    def check_filter_and_ids_mutual_exclusivity(self) -> Self:
+        if self.filter is not None and (self.time_series_ids or self.instance_ids):
+            raise ValueError("Cannot set both filter and time_series_ids/instance_ids.")
+        return self

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_datapoint_subscription_yaml.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_datapoint_subscription_yaml.py
@@ -13,6 +13,18 @@ def invalid_datapoint_subscription_test_cases() -> Iterable:
     yield pytest.param(
         {"name": "Subscription 1"}, {"Missing required field: 'externalId'"}, id="Missing required field: externalId"
     )
+    # Test case: more than 10,000 time_series_ids
+    yield pytest.param(
+        {"externalId": "sub-overlimit", "timeSeriesIds": [f"ts_{i}" for i in range(10_001)]},
+        {"The total number of time_series_ids and instance_ids cannot exceed 10000."},
+        id="Too many time_series_ids",
+    )
+    # Test case: both filter and time_series_ids set
+    yield pytest.param(
+        {"externalId": "sub-filter-and-tsids", "timeSeriesIds": ["ts_1", "ts_2"], "filter": {"some": "filter"}},
+        {"Cannot set both filter and time_series_ids/instance_ids."},
+        id="Filter and time_series_ids set",
+    )
 
 
 class TestDatapointSubscription:
@@ -23,7 +35,7 @@ class TestDatapointSubscription:
         assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
 
     @pytest.mark.parametrize("data, expected_errors", list(invalid_datapoint_subscription_test_cases()))
-    def test_invalid_asset_error_messages(self, data: dict | list, expected_errors: set[str]) -> None:
+    def test_invalid_datapoint_subscription_error_messages(self, data: dict | list, expected_errors: set[str]) -> None:
         warning_list = validate_resource_yaml_pydantic(data, DatapointSubscriptionYAML, Path("some_file.yaml"))
         assert len(warning_list) == 1
         format_warning = warning_list[0]

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_datapoint_subscription_yaml.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_datapoint_subscription_yaml.py
@@ -1,0 +1,32 @@
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+from cognite_toolkit._cdf_tk.resource_classes.datapoint_subscription import DatapointSubscriptionYAML
+from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
+from cognite_toolkit._cdf_tk.validation import validate_resource_yaml_pydantic
+from tests.test_unit.utils import find_resources
+
+
+def invalid_datapoint_subscription_test_cases() -> Iterable:
+    yield pytest.param(
+        {"name": "Subscription 1"}, {"Missing required field: 'externalId'"}, id="Missing required field: externalId"
+    )
+
+
+class TestDatapointSubscription:
+    @pytest.mark.parametrize("data", list(find_resources("DatapointSubscription")))
+    def test_load_valid_dataset(self, data: dict[str, object]) -> None:
+        loaded = DatapointSubscriptionYAML.model_validate(data)
+
+        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    @pytest.mark.parametrize("data, expected_errors", list(invalid_datapoint_subscription_test_cases()))
+    def test_invalid_asset_error_messages(self, data: dict | list, expected_errors: set[str]) -> None:
+        warning_list = validate_resource_yaml_pydantic(data, DatapointSubscriptionYAML, Path("some_file.yaml"))
+        assert len(warning_list) == 1
+        format_warning = warning_list[0]
+        assert isinstance(format_warning, ResourceFormatWarning)
+
+        assert set(format_warning.errors) == expected_errors


### PR DESCRIPTION
# Description

We are in the progress of adding pydantic classes to match the YAML format Toolkit expects for configurations. The goal is to give better error message to the user on syntax errors.

This PR introduces the DatapointSubscription class to validate datapoint subsccriptions. Note this is not yet exposed, so no change to the end user.

## Changelog

- [ ] Patch
- [x] Skip
