### PR TITLE
[CDF-24802] 🥟 Added ExtractionPipelineYAML

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_classes/extraction_pipeline.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/extraction_pipeline.py
@@ -1,0 +1,55 @@
+from typing import Literal
+
+from pydantic import Field
+
+from .base import BaseModelResource, ToolkitResource
+
+
+class RawTable(BaseModelResource):
+    db_name: str = Field(description="Database name", min_length=1)
+    table_name: str = Field(description="Table name", min_length=1)
+
+
+class Contact(BaseModelResource):
+    name: str | None = Field(None, description="Contact name")
+    email: str | None = Field(None, description="Contact email", min_length=1, max_length=254)
+    role: str | None = Field(None, description="Contact role")
+    send_notifications: bool | None = Field(None, description="True, if contact receives email notifications")
+
+
+class NotificationConfig(BaseModelResource):
+    allow_not_seen_range_in_minutes: int | None = Field(
+        None,
+        ge=0,
+        description="Notifications configuration value. Time in minutes to pass without any Run. Null if extraction pipeline is not checked.",
+    )
+
+
+class ExtractionPipelineYAML(ToolkitResource):
+    external_id: str = Field(
+        description="External Id provided by client. Should be unique within the project.", max_length=255
+    )
+    name: str = Field(description="Name of the extraction pipeline.", max_length=140)
+    description: str | None = Field(None, description="Description of the extraction pipeline.", max_length=500)
+    data_set_external_id: str = Field(description="The external id of the dataset this extraction pipeline belongs to.")
+    raw_tables: list[RawTable] | None = Field(None, description="Raw tables")
+    config: dict = Field(description="Configuration of the extraction pipeline.")
+    schedule: Literal["On trigger", "Continuous"] | str | None = Field(
+        None,
+        description="Possible values: “On trigger”, “Continuous” or cron expression. If empty then null.",
+    )
+    contacts: list[Contact] | None = Field(None, description="Contacts list.")
+    metadata: dict[str, str] | None = Field(
+        None,
+        description="Custom, application specific metadata. String key -> String value. Limits: Key are at most 128 bytes. Values are at most 10240 bytes. Up to 256 key-value pairs. Total size is at most 10240.",
+    )
+    source: str | None = Field(None, description="Source for Extraction Pipeline", max_length=255)
+    documentation: str | None = Field(
+        None, description="Documentation text field, supports Markdown for text formatting.", max_length=10000
+    )
+    notification_config: NotificationConfig | None = Field(
+        None, description="Notification configuration for the extraction pipeline."
+    )
+    created_by: str | None = Field(
+        None, description="Extraction Pipeline creator. Usually user email is expected here."
+    )

--- a/cognite_toolkit/_cdf_tk/resource_classes/extraction_pipeline.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/extraction_pipeline.py
@@ -27,9 +27,9 @@ class NotificationConfig(BaseModelResource):
 
 class ExtractionPipelineYAML(ToolkitResource):
     external_id: str = Field(
-        description="External Id provided by client. Should be unique within the project.", max_length=255
+        description="External Id provided by client. Should be unique within the project.", min_length=1, max_length=255
     )
-    name: str = Field(description="Name of the extraction pipeline.", max_length=140)
+    name: str = Field(description="Name of the extraction pipeline.", min_length=1, max_length=140)
     description: str | None = Field(None, description="Description of the extraction pipeline.", max_length=500)
     data_set_external_id: str = Field(description="The external id of the dataset this extraction pipeline belongs to.")
     raw_tables: list[RawTable] | None = Field(None, description="Raw tables")

--- a/cognite_toolkit/_cdf_tk/resource_classes/extraction_pipeline.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/extraction_pipeline.py
@@ -33,7 +33,6 @@ class ExtractionPipelineYAML(ToolkitResource):
     description: str | None = Field(None, description="Description of the extraction pipeline.", max_length=500)
     data_set_external_id: str = Field(description="The external id of the dataset this extraction pipeline belongs to.")
     raw_tables: list[RawTable] | None = Field(None, description="Raw tables")
-    config: dict = Field(description="Configuration of the extraction pipeline.")
     schedule: Literal["On trigger", "Continuous"] | str | None = Field(
         None,
         description="Possible values: “On trigger”, “Continuous” or cron expression. If empty then null.",

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline.py
@@ -1,0 +1,34 @@
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+from cognite_toolkit._cdf_tk.resource_classes.extraction_pipeline import ExtractionPipelineYAML
+from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
+from cognite_toolkit._cdf_tk.validation import validate_resource_yaml_pydantic
+from tests.test_unit.utils import find_resources
+
+
+def invalid_extraction_pipeline_test_cases() -> Iterable:
+    yield pytest.param(
+        {"externalId": "myPipeline"},
+        {"Missing required field: 'name'", "Missing required field: 'dataSetExternalId'"},
+        id="Missing required fields",
+    )
+
+
+class TestEventYAML:
+    @pytest.mark.parametrize("data", list(find_resources("ExtractionPipeline")))
+    def test_load_valid_extraction_pipeline(self, data: dict[str, object]) -> None:
+        loaded = ExtractionPipelineYAML.model_validate(data)
+
+        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    @pytest.mark.parametrize("data, expected_errors", list(invalid_extraction_pipeline_test_cases()))
+    def test_invalid_extraction_pipeline_error_messages(self, data: dict | list, expected_errors: set[str]) -> None:
+        warning_list = validate_resource_yaml_pydantic(data, ExtractionPipelineYAML, Path("some_file.yaml"))
+        assert len(warning_list) == 1
+        format_warning = warning_list[0]
+        assert isinstance(format_warning, ResourceFormatWarning)
+
+        assert set(format_warning.errors) == expected_errors

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline.py
@@ -44,7 +44,7 @@ def invalid_extraction_pipeline_test_cases() -> Iterable:
     )
 
 
-class TestEventYAML:
+class TestExtractionPipelineYAML:
     @pytest.mark.parametrize("data", list(find_resources("ExtractionPipeline")))
     def test_load_valid_extraction_pipeline(self, data: dict[str, object]) -> None:
         loaded = ExtractionPipelineYAML.model_validate(data)

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline.py
@@ -15,6 +15,33 @@ def invalid_extraction_pipeline_test_cases() -> Iterable:
         {"Missing required field: 'name'", "Missing required field: 'dataSetExternalId'"},
         id="Missing required fields",
     )
+    # Missing externalId
+    yield pytest.param(
+        {"name": "Pipeline 2", "dataSetExternalId": "ds1"},
+        {"Missing required field: 'externalId'"},
+        id="Missing externalId",
+    )
+    # Empty name
+    yield pytest.param(
+        {"externalId": "pipeline3", "name": "", "dataSetExternalId": "ds2"},
+        {"In field name string should have at least 1 character"},
+        id="Empty name",
+    )
+    # Invalid dataSetExternalId type
+    yield pytest.param(
+        {"externalId": "pipeline4", "name": "Pipeline 4", "dataSetExternalId": 123},
+        {
+            "In field dataSetExternalId input should be a valid string. Got 123 of type "
+            "int. Hint: Use double quotes to force string."
+        },
+        id="Invalid dataSetExternalId type",
+    )
+    # All required fields present but with extra unknown field
+    yield pytest.param(
+        {"externalId": "pipeline5", "name": "Pipeline 5", "dataSetExternalId": "ds5", "unknownField": "value"},
+        {"Unused field: 'unknownField'"},
+        id="Unknown field present",
+    )
 
 
 class TestEventYAML:


### PR DESCRIPTION
# Description


We are in the progress of adding pydantic classes to match the YAML format Toolkit expects for configurations. The goal is to give better error message to the user on syntax errors.

This PR introduces the ExtractionPipelineYAML class to validate extraction pipeline. Note this is not yet exposed, so no change to the end user.


## Changelog

- [ ] Patch
- [x] Skip

