### PR TITLE
[CDF-25666] 🗺 Data mapper interface

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1,4 +1,29 @@
-from abc import ABC
+from abc import ABC, abstractmethod
+from typing import Generic
+
+from cognite_toolkit._cdf_tk.storageio._base import T_CogniteResourceList, T_Selector, T_WritableCogniteResourceList
 
 
-class DataMapper(ABC): ...
+class DataMapper(Generic[T_Selector, T_WritableCogniteResourceList, T_CogniteResourceList], ABC):
+    def prepare(self, source_selector: T_Selector) -> None:
+        """Prepare the data mapper with the given source selector.
+
+        Args:
+            source_selector: The selector for the source data.
+
+        """
+        # Override in subclass if needed.
+        pass
+
+    @abstractmethod
+    def map_chunk(self, source: T_WritableCogniteResourceList) -> T_CogniteResourceList:
+        """Map a chunk of source data to the target format.
+
+        Args:
+            source: The source data chunk to be mapped.
+
+        Returns:
+            The mapped data chunk in the target format.
+
+        """
+        raise NotImplementedError("Subclasses must implement this method.")

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1,0 +1,4 @@
+from abc import ABC
+
+
+class DataMapper(ABC): ...

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1,7 +1,11 @@
 from abc import ABC, abstractmethod
 from typing import Generic
 
-from cognite_toolkit._cdf_tk.storageio._base import T_CogniteResourceList, T_Selector, T_WritableCogniteResourceList
+from cognite.client.data_classes._base import (
+    T_CogniteResourceList,
+)
+
+from cognite_toolkit._cdf_tk.storageio._base import T_Selector, T_WritableCogniteResourceList
 
 
 class DataMapper(Generic[T_Selector, T_WritableCogniteResourceList, T_CogniteResourceList], ABC):


### PR DESCRIPTION
# Description

**Context**: This is part of the `alpha` migration tooling in Toolkit, for overview [see here](https://cognitedata.atlassian.net/wiki/spaces/~170890702/pages/5455773697/Migration+Tooling+in+Toolkit). This is step 3 and 4 of that process. 

This introduces a generalized interface that we will use to go from asset-centric assets/event/timeseries/files/annotations -> to DM equivalent. It will also be used for charts/canvas were the mapping operation is to update the asset-centric references to data modeling references. 

## Changelog

- [ ] Patch
- [x] Skip

