### PR TITLE
😎 Use yaml classes

### DIFF
--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/datamodel_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/datamodel_loaders.py
@@ -90,7 +90,7 @@ from cognite_toolkit._cdf_tk.loaders._base_loaders import (
     ResourceContainerLoader,
     ResourceLoader,
 )
-from cognite_toolkit._cdf_tk.resource_classes import SpaceYAML
+from cognite_toolkit._cdf_tk.resource_classes import ContainerYAML, SpaceYAML, ViewYAML
 from cognite_toolkit._cdf_tk.tk_warnings import HighSeverityWarning, LowSeverityWarning, MediumSeverityWarning
 from cognite_toolkit._cdf_tk.utils import (
     GraphQLParser,
@@ -254,6 +254,7 @@ class ContainerLoader(
     list_write_cls = ContainerApplyList
     kind = "Container"
     dependencies = frozenset({SpaceLoader})
+    yaml_cls = ContainerYAML
     _doc_url = "Containers/operation/ApplyContainers"
 
     @property
@@ -493,6 +494,7 @@ class ViewLoader(ResourceLoader[ViewId, ViewApply, View, ViewApplyList, ViewList
     list_write_cls = ViewApplyList
     kind = "View"
     dependencies = frozenset({SpaceLoader, ContainerLoader})
+    yaml_cls = ViewYAML
     _doc_url = "Views/operation/ApplyViews"
 
     def __init__(

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/extraction_pipeline_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/extraction_pipeline_loaders.py
@@ -48,6 +48,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitRequiredValueError,
 )
 from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceLoader
+from cognite_toolkit._cdf_tk.resource_classes import ExtractionPipelineConfigYAML, ExtractionPipelineYAML
 from cognite_toolkit._cdf_tk.tk_warnings import (
     HighSeverityWarning,
 )
@@ -78,6 +79,7 @@ class ExtractionPipelineLoader(
     list_write_cls = ExtractionPipelineWriteList
     kind = "ExtractionPipeline"
     dependencies = frozenset({DataSetsLoader, RawDatabaseLoader, RawTableLoader, GroupAllScopedLoader})
+    yaml_cls = ExtractionPipelineYAML
     _doc_url = "Extraction-Pipelines/operation/createExtPipes"
 
     @property
@@ -250,6 +252,7 @@ class ExtractionPipelineConfigLoader(
     dependencies = frozenset({ExtractionPipelineLoader})
     _doc_url = "Extraction-Pipelines-Config/operation/createExtPipeConfig"
     parent_resource = frozenset({ExtractionPipelineLoader})
+    yaml_cls = ExtractionPipelineConfigYAML
 
     @property
     def display_name(self) -> str:

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/timeseries_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/timeseries_loaders.py
@@ -34,7 +34,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitValueError,
 )
 from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceContainerLoader, ResourceLoader
-from cognite_toolkit._cdf_tk.resource_classes import TimeSeriesYAML
+from cognite_toolkit._cdf_tk.resource_classes import DatapointSubscriptionYAML, TimeSeriesYAML
 from cognite_toolkit._cdf_tk.utils import calculate_hash
 from cognite_toolkit._cdf_tk.utils.collection import chunker
 from cognite_toolkit._cdf_tk.utils.diff_list import diff_list_hashable, diff_list_identifiable, dm_identifier
@@ -225,6 +225,7 @@ class DatapointSubscriptionLoader(
             GroupAllScopedLoader,
         }
     )
+    yaml_cls = DatapointSubscriptionYAML
 
     _hash_key = "cdf-hash"
     _description_character_limit = 1000

--- a/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/workflow_loaders.py
+++ b/cognite_toolkit/_cdf_tk/loaders/_resource_loaders/workflow_loaders.py
@@ -54,6 +54,8 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitRequiredValueError,
 )
 from cognite_toolkit._cdf_tk.loaders._base_loaders import ResourceLoader
+from cognite_toolkit._cdf_tk.resource_classes import WorkflowTriggerYAML, WorkflowVersionYAML
+from cognite_toolkit._cdf_tk.resource_classes.workflow import WorkflowYAML
 from cognite_toolkit._cdf_tk.tk_warnings import (
     LowSeverityWarning,
     MissingReferencedWarning,
@@ -92,6 +94,7 @@ class WorkflowLoader(ResourceLoader[str, WorkflowUpsert, Workflow, WorkflowUpser
             DataSetsLoader,
         }
     )
+    yaml_cls = WorkflowYAML
     _doc_base_url = "https://api-docs.cognite.com/20230101-beta/tag/"
     _doc_url = "Workflows/operation/CreateOrUpdateWorkflow"
 
@@ -229,6 +232,7 @@ class WorkflowVersionLoader(
     kind = "WorkflowVersion"
     dependencies = frozenset({WorkflowLoader})
     parent_resource = frozenset({WorkflowLoader})
+    yaml_cls = WorkflowVersionYAML
 
     _doc_base_url = "https://api-docs.cognite.com/20230101-beta/tag/"
     _doc_url = "Workflow-versions/operation/CreateOrUpdateWorkflowVersion"
@@ -543,6 +547,7 @@ class WorkflowTriggerLoader(
     kind = "WorkflowTrigger"
     dependencies = frozenset({WorkflowLoader, WorkflowVersionLoader, GroupResourceScopedLoader, GroupAllScopedLoader})
     parent_resource = frozenset({WorkflowLoader})
+    yaml_cls = WorkflowTriggerYAML
 
     _doc_url = "Workflow-triggers/operation/CreateOrUpdateTriggers"
 

--- a/cognite_toolkit/_cdf_tk/resource_classes/__init__.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/__init__.py
@@ -9,6 +9,7 @@ This is means that we have three set of resource classes we use in Toolkit:
 
 from .asset import AssetYAML
 from .base import BaseModelResource, ToolkitResource
+from .containers import ContainerYAML
 from .datapoint_subscription import DatapointSubscriptionYAML
 from .dataset import DataSetYAML
 from .event import EventYAML
@@ -28,12 +29,14 @@ from .threedmodels import ThreeDModelYAML
 from .timeseries import TimeSeriesYAML
 from .transformation_schedule import TransformationScheduleYAML
 from .transformations import TransformationYAML
+from .views import ViewYAML
 from .workflow_trigger import WorkflowTriggerYAML
 from .workflow_version import WorkflowVersionYAML
 
 __all__ = [
     "AssetYAML",
     "BaseModelResource",
+    "ContainerYAML",
     "DataSetYAML",
     "DatabaseYAML",
     "DatapointSubscriptionYAML",
@@ -55,6 +58,7 @@ __all__ = [
     "ToolkitResource",
     "TransformationScheduleYAML",
     "TransformationYAML",
+    "ViewYAML",
     "WorkflowTriggerYAML",
     "WorkflowVersionYAML",
 ]

--- a/cognite_toolkit/_cdf_tk/resource_classes/__init__.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/__init__.py
@@ -9,8 +9,11 @@ This is means that we have three set of resource classes we use in Toolkit:
 
 from .asset import AssetYAML
 from .base import BaseModelResource, ToolkitResource
+from .datapoint_subscription import DatapointSubscriptionYAML
 from .dataset import DataSetYAML
 from .event import EventYAML
+from .extraction_pipeline import ExtractionPipelineYAML
+from .extraction_pipeline_config import ExtractionPipelineConfigYAML
 from .filemetadata import FileMetadataYAML
 from .function_schedule import FunctionScheduleYAML
 from .functions import FunctionsYAML
@@ -25,13 +28,18 @@ from .threedmodels import ThreeDModelYAML
 from .timeseries import TimeSeriesYAML
 from .transformation_schedule import TransformationScheduleYAML
 from .transformations import TransformationYAML
+from .workflow_trigger import WorkflowTriggerYAML
+from .workflow_version import WorkflowVersionYAML
 
 __all__ = [
     "AssetYAML",
     "BaseModelResource",
     "DataSetYAML",
     "DatabaseYAML",
+    "DatapointSubscriptionYAML",
     "EventYAML",
+    "ExtractionPipelineConfigYAML",
+    "ExtractionPipelineYAML",
     "FileMetadataYAML",
     "FunctionScheduleYAML",
     "FunctionsYAML",
@@ -47,4 +55,6 @@ __all__ = [
     "ToolkitResource",
     "TransformationScheduleYAML",
     "TransformationYAML",
+    "WorkflowTriggerYAML",
+    "WorkflowVersionYAML",
 ]


### PR DESCRIPTION
# Description

These classes are already implemented and well tested. Setting the `yaml_cls` in the Loader (CRUD interface) will start using this in the build command. 

## Changelog

- [ ] Patch
- [ ] Skip

## cdf

### Improved

- Warning on syntax errors when running `cdf build` for resources types containers, views, extraction pipeline, extraction pipeline conig, workflow, workflow version, workflow trigger, and datapoint subscriptions.

## templates

No changes.
