### PR TITLE
[prep CDF-25015] 🕵  Added validation for asset access

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils/validate_access.py
+++ b/cognite_toolkit/_cdf_tk/utils/validate_access.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from typing import Literal
 
 from cognite.client.data_classes.capabilities import (
+    AssetsAcl,
     Capability,
     DataModelInstancesAcl,
     DataModelsAcl,
@@ -177,6 +178,43 @@ class ValidateAccess:
                 output["dataset"] = self.client.lookup.data_sets.external_id(scope.ids)
             else:
                 raise ValueError(f"Unexpected file scope type: {type(scope)}. Expected DataSet or All.")
+        return output
+
+    def assets(
+        self, action: Sequence[Literal["read", "write"]], dataset_id: int | None = None, operation: str | None = None
+    ) -> dict[str, list[str]] | None:
+        """Validate access to assets.
+        Args:
+            action (Sequence[Literal["read", "write"]]): The actions to validate access for
+            dataset_id (int | None): The dataset ID to check access for. If None, checks access for all datasets.
+            operation (str | None): The operation being performed, used for error messages.
+        Returns:
+            dict[str, list[str]] | None: Returns a dictionary with the key 'dataset'
+                if access is limited to a dataset scope, or None if access is granted to all assets.
+        Raises:
+            ValueError: If the client.token.get_scope() returns an unexpected asset scope type.
+            AuthorizationError: If the user does not have permission to perform the specified action on the given
+                dataset.
+        """
+        operation = operation or self.default_operation
+        asset_scopes, actions_str = self._set_up_read_write(
+            action, AssetsAcl.Action.Read, AssetsAcl.Action.Write, operation, "assets"
+        )
+        if isinstance(asset_scopes[0], AssetsAcl.Scope.All):
+            return None
+        if dataset_id is not None:
+            for scope in asset_scopes:
+                if isinstance(scope, AssetsAcl.Scope.DataSet) and dataset_id in scope.ids:
+                    return None
+            raise AuthorizationError(
+                f"You have no permission to {actions_str} assets in dataset {dataset_id}. This is required to {operation}."
+            )
+        output: dict[str, list[str]] = {}
+        for scope in asset_scopes:
+            if isinstance(scope, AssetsAcl.Scope.DataSet):
+                output["dataset"] = self.client.lookup.data_sets.external_id(scope.ids)
+            else:
+                raise ValueError(f"Unexpected asset scope type: {type(scope)}. Expected DataSet or All.")
         return output
 
     def _set_up_read_write(

--- a/cognite_toolkit/_cdf_tk/utils/validate_access.py
+++ b/cognite_toolkit/_cdf_tk/utils/validate_access.py
@@ -218,7 +218,7 @@ class ValidateAccess:
         output: dict[str, list[str]] = {}
         for scope in asset_scopes:
             if isinstance(scope, AssetsAcl.Scope.DataSet):
-                output["dataset"] = self.client.lookup.assets.external_id(scope.ids)
+                output["dataset"] = self.client.lookup.data_sets.external_id(scope.ids)
             else:
                 raise ValueError(f"Unexpected asset scope type: {type(scope)}. Expected DataSet or All.")
         return output

--- a/cognite_toolkit/_cdf_tk/utils/validate_access.py
+++ b/cognite_toolkit/_cdf_tk/utils/validate_access.py
@@ -218,7 +218,7 @@ class ValidateAccess:
         output: dict[str, list[str]] = {}
         for scope in asset_scopes:
             if isinstance(scope, AssetsAcl.Scope.DataSet):
-                output["dataset"] = self.client.lookup.data_sets.external_id(scope.ids)
+                output["dataset"] = self.client.lookup.assets.external_id(scope.ids)
             else:
                 raise ValueError(f"Unexpected asset scope type: {type(scope)}. Expected DataSet or All.")
         return output

--- a/tests/test_unit/test_cdf_tk/test_utils/test_validate_access.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_validate_access.py
@@ -345,7 +345,7 @@ class TestValidateAccess:
 
         with monkeypatch_toolkit_client() as client:
             client.iam.token.inspect.return_value = inspection
-            client.lookup.assets.external_id.side_effect = external_id_lookup
+            client.lookup.data_sets.external_id.side_effect = external_id_lookup
             validator = ValidateAccess(client, "test the operation")
             with pytest.raises(AuthorizationError) as exc:
                 validator.assets(["read"], dataset_ids=dataset_ids)

--- a/tests/test_unit/test_cdf_tk/test_utils/test_validate_access.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_validate_access.py
@@ -384,7 +384,7 @@ class TestValidateAccess:
 
         with monkeypatch_toolkit_client() as client:
             client.iam.token.inspect.return_value = inspection
-            client.lookup.assets.external_id.side_effect = external_id_lookup
+            client.lookup.data_sets.external_id.side_effect = external_id_lookup
             validator = ValidateAccess(client, "test the operation")
             result = validator.assets(["read"], dataset_ids=dataset_ids)
             assert result == expected_result

--- a/tests/test_unit/test_cdf_tk/test_utils/test_validate_access.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_validate_access.py
@@ -1,9 +1,10 @@
 import pytest
 from cognite.client.data_classes.capabilities import (
+    AssetsAcl,
     Capability,
     DataModelInstancesAcl,
     DataModelsAcl,
-    FilesAcl,  # Added import for FilesAcl
+    FilesAcl,
     ProjectCapability,
     ProjectCapabilityList,
     TimeSeriesAcl,
@@ -315,6 +316,77 @@ class TestValidateAccess:
             client.lookup.data_sets.external_id.side_effect = external_id_lookup
             validator = ValidateAccess(client, "test the operation")
             result = validator.files(["read"], dataset_id=dataset_id)
+            assert result == expected_result
+
+    @pytest.mark.parametrize(
+        "capabilities, dataset_ids, expected_error",
+        [
+            pytest.param(
+                [],
+                None,
+                "You have no permission to read assets. This is required to test the operation.",
+                id="No capabilities",
+            ),
+            pytest.param(
+                [AssetsAcl([AssetsAcl.Action.Read], AssetsAcl.Scope.DataSet([1]))],
+                {1, 2},
+                "You have no permission to read assets in dataset(s) 2. This is required to test the operation.",
+                id="Missing dataset",
+            ),
+        ],
+    )
+    def test_assets_access_raise(
+        self, capabilities: list[Capability], dataset_ids: set[int] | None, expected_error: str
+    ) -> None:
+        inspection = self._create_inspection_obj(capabilities)
+
+        def external_id_lookup(ids: list[int]) -> list[str]:
+            return [str(id_) for id_ in ids]
+
+        with monkeypatch_toolkit_client() as client:
+            client.iam.token.inspect.return_value = inspection
+            client.lookup.assets.external_id.side_effect = external_id_lookup
+            validator = ValidateAccess(client, "test the operation")
+            with pytest.raises(AuthorizationError) as exc:
+                validator.assets(["read"], dataset_ids=dataset_ids)
+            assert str(exc.value) == expected_error
+
+    @pytest.mark.parametrize(
+        "capabilities, dataset_ids, expected_result",
+        [
+            pytest.param(
+                [AssetsAcl([AssetsAcl.Action.Read], AssetsAcl.Scope.DataSet([1, 2]))],
+                {1},
+                None,
+                id="Dataset match",
+            ),
+            pytest.param(
+                [AssetsAcl([AssetsAcl.Action.Read], AssetsAcl.Scope.All())],
+                None,
+                None,
+                id="All scope",
+            ),
+            pytest.param(
+                [AssetsAcl([AssetsAcl.Action.Read], AssetsAcl.Scope.DataSet([1, 2]))],
+                None,
+                {"dataset": ["1", "2"]},
+                id="Limited list of datasets",
+            ),
+        ],
+    )
+    def test_assets_access(
+        self, capabilities: list[Capability], dataset_ids: set[int] | None, expected_result: dict | None
+    ) -> None:
+        inspection = self._create_inspection_obj(capabilities)
+
+        def external_id_lookup(ids: list[int]) -> list[str]:
+            return [str(id_) for id_ in ids]
+
+        with monkeypatch_toolkit_client() as client:
+            client.iam.token.inspect.return_value = inspection
+            client.lookup.assets.external_id.side_effect = external_id_lookup
+            validator = ValidateAccess(client, "test the operation")
+            result = validator.assets(["read"], dataset_ids=dataset_ids)
             assert result == expected_result
 
     @staticmethod


### PR DESCRIPTION
# Description

This adds a check for whether the user can access assets. We will use this before migrating/downloading/uploading asset to verify that the user has access to do the operation, and if not, they get an appropriate error message. 

## Changelog

- [ ] Patch
- [x] Skip