### PR TITLE
[CDF-24817] 🎏 StreamlitYAML

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_classes/streamlit_.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/streamlit_.py
@@ -1,0 +1,26 @@
+from typing import Literal
+
+from pydantic import Field
+
+from .base import ToolkitResource
+
+
+class StreamlitYAML(ToolkitResource):
+    external_id: str = Field(
+        max_length=255,
+        description="The external ID of the Streamlit app.",
+    )
+    name: str = Field(
+        description="The name of the Streamlit app.",
+        min_length=1,
+        max_length=255,
+    )
+    creator: str = Field(description="The creator of the Streamlit app.")
+    entrypoint: str | None = Field(None, description="Path to the entrypoint file of the Streamlit app.")
+    description: str | None = Field(None, description="The description of the Streamlit app.")
+    published: bool = Field(False, description="Whether the Streamlit app is published or not.")
+    theme: Literal["Light", "Dark"] = Field("Light", description="The theme of the Streamlit app.")
+    thumbnail: str | None = Field(None, description="URL to the thumbnail image of the Streamlit app.")
+    data_set_external_id: str | None = Field(
+        None, description="The external ID of the data set to associate with the app."
+    )

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_streamlit.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_streamlit.py
@@ -1,0 +1,39 @@
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+from cognite_toolkit._cdf_tk.resource_classes.streamlit_ import StreamlitYAML
+from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
+from cognite_toolkit._cdf_tk.validation import validate_resource_yaml_pydantic
+from tests.test_unit.utils import find_resources
+
+
+def invalid_streamlit_test_cases() -> Iterable:
+    yield pytest.param(
+        {"externalId": "MyApp", "name": "MyApp"},
+        {"Missing required field: 'creator'"},
+        id="Missing required field: creator",
+    )
+    yield pytest.param(
+        {"externalId": "MyApp", "creator": "doctrino", "name": "MyApp", "published": "yes", "draft": "no"},
+        {"In field published input should be a valid boolean. Got 'yes' of type str.", "Unused field: 'draft'"},
+        id="Invalid boolean and unused field",
+    )
+
+
+class TestStreamlitYAML:
+    @pytest.mark.parametrize("data", list(find_resources("Streamlit")))
+    def test_load_valid_space(self, data: dict[str, object]) -> None:
+        loaded = StreamlitYAML.model_validate(data)
+
+        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    @pytest.mark.parametrize("data, expected_errors", list(invalid_streamlit_test_cases()))
+    def test_invalid_asset_error_messages(self, data: dict | list, expected_errors: set[str]) -> None:
+        warning_list = validate_resource_yaml_pydantic(data, StreamlitYAML, Path("some_file.yaml"))
+        assert len(warning_list) == 1
+        format_warning = warning_list[0]
+        assert isinstance(format_warning, ResourceFormatWarning)
+
+        assert set(format_warning.errors) == expected_errors


### PR DESCRIPTION
# Description

We are in the progress of adding pydantic classes to match the YAML
format Toolkit expects for configurations. The goal is to give better
error message to the user on syntax errors.

This PR introduces the StreamlitYAML class to validate streamlit applications. Note this is not yet exposed, so no change
to the end user.

## Changelog

- [ ] Patch
- [x] Skip

