### PR TITLE
Removed search config id from data class

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/api/search_config.py
+++ b/cognite_toolkit/_cdf_tk/client/api/search_config.py
@@ -22,19 +22,22 @@ class SearchConfigurationsAPI(APIClient):
             base_path = f"/apps/{self._api_version}/projects/{self._config.project}/storage/config/apps/search/views"
         return urljoin(self._config.base_url, base_path)
 
-    def upsert(self, configuration_update: SearchConfigWrite) -> SearchConfig:
+    def upsert(self, configuration_update: SearchConfigWrite, id: int | None = None) -> SearchConfig:
         """Update/Create a Configuration.
 
         Args:
             configuration_update: The content of the configuration to update
-
+            id: The id of the configuration to update (required for update)
         Returns:
             SearchConfig
 
         """
+        data: dict = configuration_update.dump()
+        if id:
+            data["id"] = id
         res = self._post(
             url_path="/upsert",
-            json=configuration_update.dump(),
+            json=data,
         )
         return SearchConfig._load(res.json(), cognite_client=self._cognite_client)
 

--- a/cognite_toolkit/_cdf_tk/client/data_classes/search_config.py
+++ b/cognite_toolkit/_cdf_tk/client/data_classes/search_config.py
@@ -48,7 +48,6 @@ class SearchConfigCore(WriteableCogniteResource["SearchConfigWrite"], ABC):
 
     Args:
         view: The configuration for one specific view.
-        id: A server-generated ID for the object.
         use_as_name: The name of property to use for the name column in the UI.
         use_as_description: The name of property to use for the description column in the UI.
         columns_layout: Array of column configurations per property.
@@ -59,7 +58,6 @@ class SearchConfigCore(WriteableCogniteResource["SearchConfigWrite"], ABC):
     def __init__(
         self,
         view: ViewId,
-        id: int | None = None,
         use_as_name: str | None = None,
         use_as_description: str | None = None,
         columns_layout: list[SearchConfigViewProperty] | None = None,
@@ -67,7 +65,6 @@ class SearchConfigCore(WriteableCogniteResource["SearchConfigWrite"], ABC):
         properties_layout: list[SearchConfigViewProperty] | None = None,
     ) -> None:
         self.view = view
-        self.id = id
         self.use_as_name = use_as_name
         self.use_as_description = use_as_description
         self.columns_layout = columns_layout
@@ -77,7 +74,6 @@ class SearchConfigCore(WriteableCogniteResource["SearchConfigWrite"], ABC):
     def as_write(self) -> "SearchConfigWrite":
         return SearchConfigWrite(
             view=self.view,
-            id=self.id,
             use_as_name=self.use_as_name,
             use_as_description=self.use_as_description,
             columns_layout=self.columns_layout,
@@ -110,7 +106,6 @@ class SearchConfigWrite(SearchConfigCore):
 
     Args:
         view: The configuration for one specific view.
-        id: A server-generated ID for the object.
         use_as_name: The name of property to use for the name column in the UI.
         use_as_description: The name of property to use for the description column in the UI.
         columns_layout: Array of column configurations per property.
@@ -121,7 +116,6 @@ class SearchConfigWrite(SearchConfigCore):
     @classmethod
     def _load(cls, resource: dict[str, Any], cognite_client: CogniteClient | None = None) -> Self:
         return cls(
-            id=resource.get("id"),
             view=ViewId.load(resource["view"]),
             use_as_name=resource.get("useAsName"),
             use_as_description=resource.get("useAsDescription"),
@@ -173,13 +167,13 @@ class SearchConfig(SearchConfigCore):
     ) -> None:
         super().__init__(
             view,
-            id,
             use_as_name,
             use_as_description,
             columns_layout,
             filter_layout,
             properties_layout,
         )
+        self.id = id
         self.created_time = created_time
         self.updated_time = updated_time
 

--- a/tests/test_integration/test_toolkit_client/test_search_config.py
+++ b/tests/test_integration/test_toolkit_client/test_search_config.py
@@ -35,13 +35,12 @@ class TestSearchConfigAPI:
         test_description = f"Test description Update {randint(1000, 9999)}"
         test_name = SEARCH_CONFIG_NAME
         search_config = SearchConfigWrite(
-            id=existing_search_config.id,
             view=view,
             use_as_description=test_description,
             use_as_name=test_name,
         )
 
-        updated = toolkit_client.search.configurations.upsert(search_config)
+        updated = toolkit_client.search.configurations.upsert(search_config, id=existing_search_config.id)
         assert isinstance(updated, SearchConfig)
         assert updated.id == existing_search_config.id
         assert updated.view.external_id == view.external_id

--- a/tests/test_unit/test_cdf_tk/test_client/test_search_config.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_search_config.py
@@ -60,7 +60,6 @@ class TestSearchConfigWrite:
 
         config = SearchConfigWrite(
             view=view,
-            id=123,
             use_as_name="name-prop",
             use_as_description="desc-prop",
             columns_layout=[property_1],
@@ -69,7 +68,6 @@ class TestSearchConfigWrite:
         )
 
         assert config.view == view
-        assert config.id == 123
         assert config.use_as_name == "name-prop"
         assert config.use_as_description == "desc-prop"
         assert config.columns_layout == [property_1]
@@ -78,7 +76,6 @@ class TestSearchConfigWrite:
 
     def test_load(self):
         data = {
-            "id": 123,
             "view": {"externalId": "test-view", "space": "test-space"},
             "useAsName": "name-prop",
             "useAsDescription": "desc-prop",
@@ -89,7 +86,6 @@ class TestSearchConfigWrite:
 
         config = SearchConfigWrite.load(data)
 
-        assert config.id == 123
         assert config.view.external_id == "test-view"
         assert config.view.space == "test-space"
         assert config.use_as_name == "name-prop"
@@ -108,14 +104,12 @@ class TestSearchConfigWrite:
 
         config = SearchConfigWrite(
             view=view,
-            id=123,
             use_as_name="name-prop",
             columns_layout=[property_1],
         )
 
         dumped = config.dump()
 
-        assert dumped["id"] == 123
         assert dumped["useAsName"] == "name-prop"
         assert dumped["view"] == {"externalId": "test-view", "space": "test-space"}
         assert dumped["columnsLayout"] == [{"property": "prop1", "selected": True}]
@@ -130,9 +124,11 @@ class TestSearchConfig:
         write_config = config.as_write()
 
         assert isinstance(write_config, SearchConfigWrite)
-        assert write_config.id == config.id
         assert write_config.view == config.view
         assert write_config.use_as_name == config.use_as_name
+        assert not hasattr(write_config, "id")
+        assert not hasattr(write_config, "created_time")
+        assert not hasattr(write_config, "updated_time")
 
     def test_load(self):
         data = {
@@ -166,5 +162,9 @@ class TestSearchConfigList:
         assert isinstance(write_list, SearchConfigWriteList)
         assert len(write_list) == 2
         assert all(isinstance(item, SearchConfigWrite) for item in write_list)
-        assert write_list[0].id == 1
-        assert write_list[1].id == 2
+        assert not hasattr(write_list[0], "id")
+        assert not hasattr(write_list[1], "id")
+        assert not hasattr(write_list[0], "created_time")
+        assert not hasattr(write_list[1], "created_time")
+        assert not hasattr(write_list[0], "updated_time")
+        assert not hasattr(write_list[1], "updated_time")


### PR DESCRIPTION
# Description

In search config resource `id` is only required when an update is required for a view's config. This PR contains changes which removes `id` field in write data classes. upsert API is also updated with a new parameter for `id`.

## Changelog

- [ ] Patch
- [x] Skip
