### PR TITLE
[CDF-25714] 😳 Generic fileselector

### DIFF
--- a/cognite_toolkit/_cdf_tk/storageio/_data_classes.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_data_classes.py
@@ -2,7 +2,10 @@ import sys
 from abc import ABC, abstractmethod
 from collections.abc import Collection, Iterator, Sequence
 from pathlib import Path
-from typing import Generic, SupportsIndex, TypeVar, overload
+from typing import Generic, Literal, SupportsIndex, TypeVar, overload
+
+from cognite.client.utils._text import to_camel_case
+from pydantic import BaseModel
 
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
@@ -78,3 +81,15 @@ class ModelList(Generic[T_BaseModel], list, Sequence[T_BaseModel], ABC):
 
 
 T_ModelList = TypeVar("T_ModelList", bound=ModelList)
+
+
+class InstanceCSV(BaseModel, alias_generator=to_camel_case):
+    space: str
+    external_id: str
+    instance_type: Literal["node", "edge"] = "node"
+
+
+class InstanceCSVList(ModelList[InstanceCSV]):
+    @classmethod
+    def _get_base_model_cls(cls) -> type[InstanceCSV]:
+        return InstanceCSV

--- a/cognite_toolkit/_cdf_tk/storageio/_data_classes.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_data_classes.py
@@ -2,7 +2,7 @@ import sys
 from abc import ABC, abstractmethod
 from collections.abc import Collection, Iterator, Sequence
 from pathlib import Path
-from typing import Generic, SupportsIndex, overload
+from typing import Generic, SupportsIndex, TypeVar, overload
 
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
@@ -75,3 +75,6 @@ class ModelList(Generic[T_BaseModel], list, Sequence[T_BaseModel], ABC):
         actual = {col.name for col in schema}
         if missing_columns := cls._required_header_names() - actual:
             raise ToolkitValueError(f"Missing required columns: {humanize_collection(missing_columns)}")
+
+
+T_ModelList = TypeVar("T_ModelList", bound=ModelList)

--- a/cognite_toolkit/_cdf_tk/storageio/_selectors.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_selectors.py
@@ -1,10 +1,31 @@
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from functools import cached_property
 from pathlib import Path
-from typing import Literal
+from typing import Generic, Literal
 
 from cognite.client.data_classes.data_modeling import ViewId
 
+from cognite_toolkit._cdf_tk.storageio._data_classes import T_ModelList
 from cognite_toolkit._cdf_tk.utils.file import to_directory_compatible
+
+
+@dataclass(frozen=True)
+class FileSelector(Generic[T_ModelList], ABC):
+    """Data class for file-based data selection."""
+
+    datafile: Path
+
+    @abstractmethod
+    def list_cls(self) -> type[T_ModelList]:
+        raise NotImplementedError()
+
+    @cached_property
+    def items(self) -> T_ModelList:
+        return self.list_cls().read_csv_file(self.datafile)
+
+    def __str__(self) -> str:
+        return f"{type(self).__name__}={self.datafile.name}"
 
 
 @dataclass(frozen=True)

--- a/cognite_toolkit/_cdf_tk/storageio/_selectors.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_selectors.py
@@ -6,7 +6,7 @@ from typing import Generic, Literal
 
 from cognite.client.data_classes.data_modeling import ViewId
 
-from cognite_toolkit._cdf_tk.storageio._data_classes import T_ModelList
+from cognite_toolkit._cdf_tk.storageio._data_classes import InstanceCSVList, T_ModelList
 from cognite_toolkit._cdf_tk.utils.file import to_directory_compatible
 
 
@@ -68,8 +68,9 @@ class InstanceSelector: ...
 
 
 @dataclass(frozen=True)
-class InstanceFileSelector(InstanceSelector):
-    datafile: Path
+class InstanceFileSelector(FileSelector[InstanceCSVList], InstanceSelector):
+    def list_cls(self) -> type[InstanceCSVList]:
+        return InstanceCSVList
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
# Description

An implementation of the ModelList for instanceId. We will use this to read csv files in the purge/migrate command. This is to enable the user granular control over exactly which instances/resources to purge/migrate.


## Changelog

- [ ] Patch
- [x] Skip
