### PR TITLE
[CDF-25742] α Support setting alpha flag

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils/http_client/_client.py
+++ b/cognite_toolkit/_cdf_tk/utils/http_client/_client.py
@@ -143,7 +143,7 @@ class HTTPClient:
         session.mount("https://", adapter)
         return session
 
-    def _create_headers(self) -> MutableMapping[str, str]:
+    def _create_headers(self, api_version: str | None = None) -> MutableMapping[str, str]:
         headers: MutableMapping[str, str] = CaseInsensitiveDict()
         headers.update(requests.utils.default_headers())
         auth_name, auth_value = self._config.credentials.authorization_header()
@@ -152,7 +152,7 @@ class HTTPClient:
         headers["accept"] = "application/json"
         headers["x-cdp-sdk"] = f"CogniteToolkit:{get_current_toolkit_version()}"
         headers["x-cdp-app"] = self._config.client_name
-        headers["cdf-version"] = self._config.api_subversion
+        headers["cdf-version"] = api_version or self._config.api_subversion
         if "User-Agent" in headers:
             headers["User-Agent"] += f" {get_user_agent()}"
         else:
@@ -184,7 +184,7 @@ class HTTPClient:
         return data
 
     def _make_request(self, item: RequestMessage) -> requests.Response:
-        headers = self._create_headers()
+        headers = self._create_headers(item.api_version)
         params: dict[str, str] | None = None
         if isinstance(item, ParamRequest):
             params = item.parameters

--- a/cognite_toolkit/_cdf_tk/utils/http_client/_data_classes.py
+++ b/cognite_toolkit/_cdf_tk/utils/http_client/_data_classes.py
@@ -46,6 +46,7 @@ class RequestMessage(HTTPMessage):
     connect_attempt: int = 0
     read_attempt: int = 0
     status_attempt: int = 0
+    api_version: str | None = None
 
     @property
     def total_attempts(self) -> int:

--- a/tests/test_unit/test_cdf_tk/test_utils/test_http_client.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_http_client.py
@@ -204,6 +204,22 @@ class TestHTTPClient:
         assert response.status_code == 401
         assert response.error == '{"message": "plain_text"}'
 
+    def test_request_alpha(self, http_client: HTTPClient, rsps: responses.RequestsMock) -> None:
+        rsps.get("https://example.com/api/alpha/endpoint", json={"key": "value"}, status=200)
+        results = http_client.request(
+            ParamRequest(
+                endpoint_url="https://example.com/api/alpha/endpoint",
+                method="GET",
+                parameters={"query": "test"},
+                api_version="alpha",
+            )
+        )
+        assert len(results) == 1
+        response = results[0]
+        assert isinstance(response, SuccessResponse)
+        assert response.status_code == 200
+        assert rsps.calls[-1].request.headers["cdf-version"] == "alpha"
+
 
 @pytest.mark.usefixtures("disable_pypi_check")
 class TestHTTPClientItemRequests:


### PR DESCRIPTION
# Description

In the HTTPCLient in Toolkit, we need to be able to do calls against the alpha version of the CDF API.  I will need to use this  in the migration, were I need it to set-pending-instance-ids on files and timeseries for example. 

## Changelog

- [ ] Patch
- [x] Skip
