### PR TITLE
[CDF-24815] Pydantic class for sequence row

### DIFF
--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_sequence.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_sequence.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from cognite_toolkit._cdf_tk.resource_classes.sequence import SequenceYAML
+from cognite_toolkit._cdf_tk.resource_classes.sequence import SequenceRowYAML, SequenceYAML
 from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
 from cognite_toolkit._cdf_tk.validation import validate_resource_yaml_pydantic
 from tests.test_unit.utils import find_resources
@@ -129,6 +129,127 @@ class TestSequenceYAML:
     def test_invalid_sequence_error_messages(self, data: dict | list, expected_errors: set[str]) -> None:
         """Test that invalid sequences are properly rejected with appropriate error messages."""
         warning_list = validate_resource_yaml_pydantic(data, SequenceYAML, Path("some_file.yaml"))
+        assert len(warning_list) == 1
+        format_warning = warning_list[0]
+        assert isinstance(format_warning, ResourceFormatWarning)
+        assert set(format_warning.errors) == expected_errors
+
+
+def invalid_sequence_row_test_cases() -> Iterable:
+    yield pytest.param(
+        {"externalId": "seq_row_1"},
+        {"Missing required field: 'columns'", "Missing required field: 'rows'"},
+        id="missing-required-fields",
+    )
+    yield pytest.param(
+        {"externalId": "seq_row_1", "columns": [], "rows": []},
+        {
+            "In field columns list should have at least 1 item after validation, not 0",
+            "In field rows list should have at least 1 item after validation, not 0",
+        },
+        id="empty-lists-validation-errors",
+    )
+    yield pytest.param(
+        {
+            "externalId": "seq_row_1",
+            "columns": ["col1"],
+            "rows": [{"values": [1, 2, 3]}],
+        },
+        {"In rows[1] missing required field: 'rowNumber'"},
+        id="missing-rowNumber-in-row",
+    )
+    yield pytest.param(
+        {
+            "externalId": "seq_row_1",
+            "columns": ["col1"],
+            "rows": [{"rowNumber": -1, "values": [1, 2, 3]}],
+        },
+        {"In rows[1].rowNumber input should be greater than or equal to 0"},
+        id="negative-rowNumber",
+    )
+    yield pytest.param(
+        {
+            "externalId": "seq_row_1",
+            "columns": ["col1"],
+            "rows": [{"rowNumber": 0, "values": []}],
+        },
+        {"In rows[1].values list should have at least 1 item after validation, not 0"},
+        id="empty-values-in-row",
+    )
+    yield pytest.param(
+        {
+            "externalId": "seq_row_1",
+            "columns": ["col1", "col2"],
+            "rows": [{"rowNumber": 0, "values": [1]}],
+        },
+        {
+            "Row number 0 has 1 value(s). Each row must have exactly 2 value(s) which is the same as the number of column(s)."
+        },
+        id="values-columns-count-mismatch",
+    )
+    yield pytest.param(
+        {
+            "externalId": "seq_row_1",
+            "columns": ["col1"],
+            "rows": [{"rowNumber": 0, "values": [1, 2, 3]}],
+        },
+        {
+            "Row number 0 has 3 value(s). Each row must have exactly 1 value(s) which is the same as the number of column(s)."
+        },
+        id="too-many-values-for-columns",
+    )
+    yield pytest.param(
+        {
+            "externalId": "seq_row_1",
+            "columns": ["col1"],
+            "rows": [{"rowNumber": 0, "values": [1]}],
+            "unknownField": "value",
+        },
+        {"Unused field: 'unknownField'"},
+        id="unknown-field-present",
+    )
+
+
+def valid_sequence_row_test_cases() -> Iterable:
+    yield pytest.param(
+        {
+            "externalId": "minimal_sequence_row",
+            "columns": ["col1"],
+            "rows": [{"rowNumber": 0, "values": [1]}],
+        },
+        id="minimal-valid-sequence-row",
+    )
+    yield pytest.param(
+        {
+            "externalId": "full_sequence_row",
+            "columns": ["string_col", "double_col", "long_col"],
+            "rows": [
+                {"rowNumber": 0, "values": ["text1", 1.5, 100]},
+                {"rowNumber": 2, "values": [None, None, None]},
+                {"rowNumber": 3, "values": ["text3", 3.14, 300]},
+            ],
+        },
+        id="full-sequence-row-with-multiple-rows-and-types",
+    )
+
+
+class TestSequenceRowYAML:
+    @pytest.mark.parametrize("data", list(find_resources("SequenceRow")))
+    def test_load_valid_sequence_row_file(self, data: dict[str, object]) -> None:
+        """Test loading valid sequence rows from resource files."""
+        loaded = SequenceRowYAML.model_validate(data)
+        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    @pytest.mark.parametrize("data", list(valid_sequence_row_test_cases()))
+    def test_valid_sequence_rows(self, data: dict[str, object]) -> None:
+        """Test various valid sequence row configurations."""
+        loaded = SequenceRowYAML.model_validate(data)
+        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    @pytest.mark.parametrize("data, expected_errors", list(invalid_sequence_row_test_cases()))
+    def test_invalid_sequence_row(self, data: dict | list, expected_errors: set[str]) -> None:
+        """Test that invalid sequence rows are properly rejected with appropriate error messages."""
+        warning_list = validate_resource_yaml_pydantic(data, SequenceRowYAML, Path("some_file.yaml"))
         assert len(warning_list) == 1
         format_warning = warning_list[0]
         assert isinstance(format_warning, ResourceFormatWarning)


### PR DESCRIPTION
# Description

Stacked on #1951 

We are in the progress of adding pydantic classes to match the YAML format Toolkit expects for configurations. The goal is to give better error message to the user on syntax errors.

This PR introduces the `SequenceRowYAML` class to validate sequence row resource.

## Changelog

- [ ] Patch
- [x] Skip

## cdf

### Added

- `SequenceRowYAML` class for sequence row resource validation.

## templates

No changes.
