### PR TITLE
🐛 API spec for extraction pipeline

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_classes/extraction_pipeline.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/extraction_pipeline.py
@@ -14,7 +14,7 @@ class Contact(BaseModelResource):
     name: str | None = Field(None, description="Contact name")
     email: str | None = Field(None, description="Contact email", min_length=1, max_length=254)
     role: str | None = Field(None, description="Contact role")
-    send_notifications: bool | None = Field(None, description="True, if contact receives email notifications")
+    send_notification: bool | None = Field(None, description="True, if contact receives email notifications")
 
 
 class NotificationConfig(BaseModelResource):

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline.py
@@ -45,7 +45,18 @@ def invalid_extraction_pipeline_test_cases() -> Iterable:
 
 
 class TestExtractionPipelineYAML:
-    @pytest.mark.parametrize("data", list(find_resources("ExtractionPipeline")))
+    @pytest.mark.parametrize(
+        "data",
+        [
+            *find_resources("ExtractionPipeline"),
+            {
+                "externalId": "pipeline6",
+                "name": "Pipeline 6",
+                "dataSetExternalId": "ds6",
+                "contacts": [{"name": "John Doe", "role": "Owner", "sendNotification": True}],
+            },
+        ],
+    )
     def test_load_valid_extraction_pipeline(self, data: dict[str, object]) -> None:
         loaded = ExtractionPipelineYAML.model_validate(data)
 


### PR DESCRIPTION
# Description

Small bug in the YAML spec for extraction pipelines

## Changelog

- [x] Patch
- [ ] Skip

## cdf

### Fixed

- When running `cdf build` Toolkit no longer give warnings on extraction pipelines for unused field sendNotification. For example: ` In contacts[1] unused field: 'sendNotification'`

## templates

No changes.
