### PR TITLE
🚨Warning message on purge

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -81,7 +81,13 @@ class PurgeCommand(ToolkitCommand):
                 ).ask()
                 if not confirm:
                     return
-
+                confirm = questionary.confirm(
+                    f"If any of the nodes in {selected_space!r} are TimeSeries or Files, this will delete the "
+                    "datapoints and file contents. If you want to unlink the nodes before deleting, please use the "
+                    "cdf purge instances command. Are you sure you want to continue?",
+                )
+                if not confirm:
+                    return
         loaders = self._get_dependencies(
             SpaceCRUD,
             exclude={

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -85,7 +85,8 @@ class PurgeCommand(ToolkitCommand):
                     f"If any of the nodes in {selected_space!r} are TimeSeries or Files, this will delete the "
                     "datapoints and file contents. If you want to unlink the nodes before deleting, please use the "
                     "cdf purge instances command. Are you sure you want to continue?",
-                )
+                    default=False,
+                ).ask()
                 if not confirm:
                     return
         loaders = self._get_dependencies(


### PR DESCRIPTION
# Description

We had a user purging the space instead of instances, leading to data loss. This is a stop-gap solution to try to avoid this happening again. Once #1977 and #1978 are merged, I will add a better solution for it in the reimplementation of this command.

## Changelog

- [x] Patch
- [ ] Skip

## cdf

### Improved

- When running the `cdf purge space` command, the user will now get an extra warning.

## templates

No changes.
