### PR TITLE
[CDF-25748] Support search configuration dump

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -6,6 +6,7 @@ from cognite.client.data_classes import WorkflowVersionId
 from cognite.client.data_classes.data_modeling import DataModelId, ViewId
 from rich import print
 
+from cognite_toolkit._cdf_tk.client.data_classes.search_config import ViewId as SearchConfigViewId
 from cognite_toolkit._cdf_tk.commands import DumpDataCommand, DumpResourceCommand
 from cognite_toolkit._cdf_tk.commands.dump_data import (
     AssetFinder,
@@ -22,6 +23,7 @@ from cognite_toolkit._cdf_tk.commands.dump_resource import (
     GroupFinder,
     LocationFilterFinder,
     NodeFinder,
+    SearchConfigFinder,
     StreamlitFinder,
     TransformationFinder,
     WorkflowFinder,
@@ -62,8 +64,11 @@ class DumpApp(typer.Typer):
                 self.command("datasets")(DumpConfigApp.dump_datasets)
                 self.command("streamlit")(DumpConfigApp.dump_streamlit)
 
-            if Flags.AGENTS.is_enabled() and Flags.DUMP_EXTENDED.is_enabled():
-                self.command("agents")(DumpConfigApp.dump_agents)
+                if Flags.AGENTS.is_enabled():
+                    self.command("agents")(DumpConfigApp.dump_agents)
+
+                if Flags.SEARCH_CONFIG.is_enabled():
+                    self.command("search-config")(DumpConfigApp.dump_search_config)
 
     @staticmethod
     def dump_main(ctx: typer.Context) -> None:
@@ -89,8 +94,12 @@ class DumpConfigApp(typer.Typer):
             self.command("datasets")(DumpConfigApp.dump_datasets)
             self.command("functions")(self.dump_functions)
             self.command("streamlit")(DumpConfigApp.dump_streamlit)
-        if Flags.DUMP_EXTENDED.is_enabled() and Flags.AGENTS.is_enabled():
-            self.command("agents")(self.dump_agents)
+
+            if Flags.AGENTS.is_enabled():
+                self.command("agents")(self.dump_agents)
+
+            if Flags.SEARCH_CONFIG.is_enabled():
+                self.command("search-config")(self.dump_search_config)
 
     @staticmethod
     def dump_config_main(ctx: typer.Context) -> None:
@@ -661,6 +670,59 @@ class DumpConfigApp(typer.Typer):
         cmd.run(
             lambda: cmd.dump_to_yamls(
                 StreamlitFinder(client, tuple(external_id) if external_id else None),
+                output_dir=output_dir,
+                clean=clean,
+                verbose=verbose,
+            )
+        )
+
+    @staticmethod
+    def dump_search_config(
+        ctx: typer.Context,
+        view_id: Annotated[
+            list[str] | None,
+            typer.Argument(
+                help="The view for which you want to dump the search configuration. Format: externalId space. Example: 'my_external_id my_space'."
+                "If nothing is provided, an interactive prompt will be shown to select the view for which search configurations are available.",
+            ),
+        ] = None,
+        output_dir: Annotated[
+            Path,
+            typer.Option(
+                "--output-dir",
+                "-o",
+                help="Where to dump the search configuration files for the selected view.",
+                allow_dash=True,
+            ),
+        ] = Path("tmp"),
+        clean: Annotated[
+            bool,
+            typer.Option(
+                "--clean",
+                "-c",
+                help="Delete the output directory before dumping the search configuration for the selected view.",
+            ),
+        ] = False,
+        verbose: Annotated[
+            bool,
+            typer.Option(
+                "--verbose",
+                "-v",
+                help="Turn on to get more verbose output when running the command",
+            ),
+        ] = False,
+    ) -> None:
+        """This command will dump the selected view's search configuration as yaml to the folder specified, defaults to /tmp."""
+        client = EnvironmentVariables.create_from_environment().get_client()
+        selected_view_id: Union[None, SearchConfigViewId] = None
+        if view_id is not None:
+            if len(view_id) < 2:
+                raise ToolkitRequiredValueError("View ID must have externalId and space.")
+            selected_view_id = SearchConfigViewId(*view_id)
+        cmd = DumpResourceCommand()
+        cmd.run(
+            lambda: cmd.dump_to_yamls(
+                SearchConfigFinder(client, tuple([selected_view_id]) if selected_view_id else None),
                 output_dir=output_dir,
                 clean=clean,
                 verbose=verbose,

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -52,6 +52,8 @@ from rich.panel import Panel
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.data_classes.location_filters import LocationFilterList
+from cognite_toolkit._cdf_tk.client.data_classes.search_config import SearchConfigList
+from cognite_toolkit._cdf_tk.client.data_classes.search_config import ViewId as SearchConfigViewId
 from cognite_toolkit._cdf_tk.client.data_classes.streamlit_ import Streamlit, StreamlitList
 from cognite_toolkit._cdf_tk.cruds import (
     AgentCRUD,
@@ -66,6 +68,7 @@ from cognite_toolkit._cdf_tk.cruds import (
     LocationFilterCRUD,
     NodeCRUD,
     ResourceCRUD,
+    SearchConfigCRUD,
     SpaceCRUD,
     StreamlitCRUD,
     TransformationCRUD,
@@ -726,6 +729,36 @@ class StreamlitFinder(ResourceFinder[tuple[str, ...]]):
             ).print_warning(console=console)
 
 
+class SearchConfigFinder(ResourceFinder[tuple[SearchConfigViewId, ...]]):
+    def __init__(self, client: ToolkitClient, identifier: tuple[SearchConfigViewId, ...] | None = None):
+        super().__init__(client, identifier)
+        self.search_configs: SearchConfigList | None = None
+
+    def _interactive_select(self) -> tuple[SearchConfigViewId, ...]:
+        self.search_configs = self.client.search.configurations.list()
+        if not self.search_configs:
+            raise ToolkitMissingResourceError("No search configurations found!")
+        choices = [
+            Choice(f"{config.view.external_id} {config.view.space}", value=config.view)
+            for config in self.search_configs
+        ]
+        selected_view_ids: tuple[SearchConfigViewId, ...] | None = questionary.checkbox(
+            "For which view would you like to dump the search configuration?",
+            choices=choices,
+        ).ask()
+        if not selected_view_ids:
+            raise ToolkitValueError("No view selected for dumping the search configuration.")
+        return selected_view_ids
+
+    def __iter__(self) -> Iterator[tuple[list[Hashable], CogniteResourceList | None, ResourceCRUD, None | str]]:
+        self.identifier = self._selected()
+        loader = SearchConfigCRUD.create_loader(self.client)
+        if self.search_configs:
+            yield [], SearchConfigList([sc for sc in self.search_configs if sc.view in self.identifier]), loader, None
+        else:
+            yield list(self.identifier), None, loader, None
+
+
 class DumpResourceCommand(ToolkitCommand):
     def dump_to_yamls(
         self,
@@ -782,4 +815,15 @@ class DumpResourceCommand(ToolkitCommand):
                 if isinstance(finder, StreamlitFinder) and isinstance(resource, Streamlit):
                     finder.dump_code(resource, resource_folder)
                 dumped_ids.append(resource_id)
-        print(Panel(f"Dumped {humanize_collection(dumped_ids)}", title="Success", style="green", expand=False))
+
+        if isinstance(finder, SearchConfigFinder):
+            print(
+                Panel(
+                    f"Dumped search configurations for views {humanize_collection([f'({view.external_id}, {view.space})' for view in dumped_ids])}",  # type: ignore[attr-defined]
+                    title="Success",
+                    style="green",
+                    expand=False,
+                )
+            )
+        else:
+            print(Panel(f"Dumped {humanize_collection(dumped_ids)}", title="Success", style="green", expand=False))

--- a/cognite_toolkit/_cdf_tk/cruds/_resource_cruds/configuration.py
+++ b/cognite_toolkit/_cdf_tk/cruds/_resource_cruds/configuration.py
@@ -16,6 +16,7 @@ from cognite_toolkit._cdf_tk.client.data_classes.search_config import (
 )
 from cognite_toolkit._cdf_tk.cruds._base_cruds import ResourceCRUD
 from cognite_toolkit._cdf_tk.resource_classes import SearchConfigYAML
+from cognite_toolkit._cdf_tk.utils import to_directory_compatible
 from cognite_toolkit._cdf_tk.utils.diff_list import diff_list_identifiable, dm_identifier
 
 from .datamodel import ViewCRUD
@@ -69,11 +70,17 @@ class SearchConfigCRUD(ResourceCRUD[ViewId, SearchConfigWrite, SearchConfig, Sea
     def dump_id(cls, id: ViewId) -> dict[str, Any]:
         return {"view": id.dump()}
 
+    @classmethod
+    def as_str(cls, id: ViewId) -> str:
+        return to_directory_compatible(f"{id.external_id}_{id.space}")
+
     def dump_resource(self, resource: SearchConfig, local: dict[str, Any] | None = None) -> dict[str, Any]:
         dumped = resource.as_write().dump()
         local = local or {}
-        if "id" in dumped and "id" not in local:
-            dumped.pop("id", None)
+        excluded_keys = ["id", "createdTime", "lastUpdatedTime"]
+        for key in excluded_keys:
+            if key in dumped and key not in local:
+                dumped.pop(key, None)
         for key in ["columnsLayout", "filterLayout", "propertiesLayout"]:
             if not dumped.get(key) and key not in local:
                 dumped.pop(key, None)


### PR DESCRIPTION
# Description

Recently we added support for a new resource type `search configuration` for configuring the search application for a particular view. This adds support to dump the already existing `search configuration`.
<img width="1578" height="82" alt="Screenshot 2025-09-22 at 5 02 36 PM" src="https://github.com/user-attachments/assets/5b170164-ec7b-4e6e-92b1-369a7a96377c" />

## Changelog

- [x] Patch
- [ ] Skip

## cdf

### Added

- [alpha] Support dumping search configurations, `cdf dump search-config`.

## templates

No changes.
