### PR TITLE
[CDF-25826] Dump proper error message on no selection

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -300,8 +300,10 @@ class TransformationFinder(ResourceFinder[tuple[str, ...]]):
             "Which transformation(s) would you like to dump?",
             choices=choices,
         ).ask()
-        if selected_transformation_ids is None:
-            raise ToolkitValueError("No transformations selected for dumping.")
+        if not selected_transformation_ids:
+            raise ToolkitValueError(
+                "No transformations selected for dumping. Use arrow keys to navigate and space key to select. Press enter to confirm."
+            )
         return tuple(selected_transformation_ids)
 
     def __iter__(self) -> Iterator[tuple[list[Hashable], CogniteResourceList | None, ResourceCRUD, None | str]]:
@@ -346,7 +348,9 @@ class GroupFinder(ResourceFinder[tuple[str, ...]]):
             ],
         ).ask()
         if not selected_groups:
-            raise ToolkitValueError("No group selected for dumping. Aborting...")
+            raise ToolkitValueError(
+                "No group selected for dumping. Use arrow keys to navigate and space key to select. Press enter to confirm."
+            )
         self.groups = [group for group_list in selected_groups for group in group_list]
         return tuple(group_list[0].name for group_list in selected_groups)
 
@@ -378,8 +382,10 @@ class AgentFinder(ResourceFinder[tuple[str, ...]]):
             "Which agent(s) would you like to dump?",
             choices=choices,
         ).ask()
-        if selected_agent_ids is None:
-            raise ToolkitValueError("No agents selected for dumping.")
+        if not selected_agent_ids:
+            raise ToolkitValueError(
+                "No agents selected for dumping. Use arrow keys to navigate and space key to select. Press enter to confirm."
+            )
         return tuple(selected_agent_ids)
 
     def __iter__(self) -> Iterator[tuple[list[Hashable], CogniteResourceList | None, ResourceCRUD, None | str]]:
@@ -450,12 +456,15 @@ class LocationFilterFinder(ResourceFinder[tuple[str, ...]]):
         if not filters:
             raise ToolkitMissingResourceError("No filters found")
         id_by_display_name = {f"{filter.name} ({filter.external_id})": filter.external_id for filter in filters}
-        return tuple(
-            questionary.checkbox(
-                "Which filters would you like to dump?",
-                choices=[Choice(name, value=id_) for name, id_ in id_by_display_name.items()],
-            ).ask()
-        )
+        selected_filter_ids: tuple[str, ...] | None = questionary.checkbox(
+            "Which filters would you like to dump?",
+            choices=[Choice(name, value=id_) for name, id_ in id_by_display_name.items()],
+        ).ask()
+        if not selected_filter_ids:
+            raise ToolkitValueError(
+                "No filters selected for dumping. Use arrow keys to navigate and space key to select. Press enter to confirm."
+            )
+        return tuple(selected_filter_ids)
 
     def _get_filters(self, identifiers: tuple[str, ...]) -> LocationFilterList:
         if not identifiers:
@@ -489,8 +498,10 @@ class ExtractionPipelineFinder(ResourceFinder[tuple[str, ...]]):
             "Which extraction pipeline(s) would you like to dump?",
             choices=choices,
         ).ask()
-        if selected_pipeline_ids is None:
-            raise ToolkitValueError("No extraction pipelines selected for dumping.")
+        if not selected_pipeline_ids:
+            raise ToolkitValueError(
+                "No extraction pipelines selected for dumping. Use arrow keys to navigate and space key to select. Press enter to confirm."
+            )
         return tuple(selected_pipeline_ids)
 
     def __iter__(self) -> Iterator[tuple[list[Hashable], CogniteResourceList | None, ResourceCRUD, None | str]]:
@@ -528,8 +539,10 @@ class DataSetFinder(ResourceFinder[tuple[str, ...]]):
             "Which dataset(s) would you like to dump?",
             choices=choices,
         ).ask()
-        if selected_dataset_ids is None:
-            raise ToolkitValueError("No datasets selected for dumping.")
+        if not selected_dataset_ids:
+            raise ToolkitValueError(
+                "No datasets selected for dumping. Use arrow keys to navigate and space key to select. Press enter to confirm."
+            )
         return tuple(selected_dataset_ids)
 
     def __iter__(self) -> Iterator[tuple[list[Hashable], CogniteResourceList | None, ResourceCRUD, None | str]]:
@@ -564,8 +577,10 @@ class FunctionFinder(ResourceFinder[tuple[str, ...]]):
             "Which function(s) would you like to dump?",
             choices=choices,
         ).ask()
-        if selected_function_ids is None:
-            raise ToolkitValueError("No functions selected for dumping.")
+        if not selected_function_ids:
+            raise ToolkitValueError(
+                "No functions selected for dumping. Use arrow keys to navigate and space key to select. Press enter to confirm."
+            )
         return tuple(selected_function_ids)
 
     def __iter__(self) -> Iterator[tuple[list[Hashable], CogniteResourceList | None, ResourceCRUD, None | str]]:
@@ -644,7 +659,9 @@ class StreamlitFinder(ResourceFinder[tuple[str, ...]]):
             ],
         ).ask()
         if not selected_ids:
-            raise ToolkitValueError("No Streamlit app selected for dumping. Aborting...")
+            raise ToolkitValueError(
+                "No Streamlit app selected for dumping. Use arrow keys to navigate and space key to select. Press enter to confirm."
+            )
         return tuple(selected_ids)
 
     def __iter__(self) -> Iterator[tuple[list[Hashable], CogniteResourceList | None, ResourceCRUD, None | str]]:


### PR DESCRIPTION
# Description

User encountered an error while dumping transformations.
*Before* 
In case of multi-select, user need to press `space` key to do the selection. But if user directly presses the `enter` key, it shows a success message with no dumped file.

<img width="956" height="183" alt="Screenshot 2025-09-24 at 3 47 06 PM" src="https://github.com/user-attachments/assets/d0cf7349-3fba-4bd2-a79a-b9875888f418" />

<img width="658" height="81" alt="Screenshot 2025-09-24 at 3 45 45 PM" src="https://github.com/user-attachments/assets/71622ef6-9ad8-4558-b0f1-ff7972d76cd0" />

*After*
Now if user directly presses the `enter` key, it will fail with error message along with navigation and selection helper.

<img width="1126" height="57" alt="Screenshot 2025-09-24 at 3 51 45 PM" src="https://github.com/user-attachments/assets/ec9b2731-02dd-4fad-873c-bbb528380008" />

This PR also contains similar check for other resources as well.

## Changelog

- [x] Patch
- [ ] Skip

## cdf

### Improved

- Improved handling and error message on `cdf dump transformation` (other resources as well) incase of no selection.

## templates

No changes.
