### PR TITLE
[CDF-25768] 😀 Writing migration output to csv

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -10,7 +10,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.data_mapper import DataMapper
 from cognite_toolkit._cdf_tk.exceptions import ToolkitFileExistsError
 from cognite_toolkit._cdf_tk.storageio import StorageIO
 from cognite_toolkit._cdf_tk.storageio._base import T_CogniteResourceList, T_Selector, T_WritableCogniteResourceList
-from cognite_toolkit._cdf_tk.utils.fileio import Chunk, NDJsonWriter, Uncompressed
+from cognite_toolkit._cdf_tk.utils.fileio import Chunk, CSVWriter, NDJsonWriter, SchemaColumn, Uncompressed
 from cognite_toolkit._cdf_tk.utils.http_client import HTTPClient, HTTPMessage, ItemIDMessage, SuccessItem
 from cognite_toolkit._cdf_tk.utils.producer_worker import ProducerWorkerExecutor
 from cognite_toolkit._cdf_tk.utils.progress_tracker import AVAILABLE_STATUS, ProgressTracker, Status
@@ -70,6 +70,7 @@ class MigrationCommand(ToolkitCommand):
             total = executor.total_items
 
         self._print_table(tracker.aggregate(), console)
+        self._print_csv(tracker, log_dir, f"{data.KIND}MigrationItems", console)
         executor.raise_on_error()
         action = "Would migrate" if dry_run else "Migrating"
         console.print(f"{action} {total:,} {data.DISPLAY_NAME} to instances.")
@@ -96,6 +97,25 @@ class MigrationCommand(ToolkitCommand):
             table.add_row(*row)
 
         console.print(table)
+
+    def _print_csv(self, tracker: ProgressTracker[T_ID], log_dir: Path, kind: str, console: Console) -> None:
+        with CSVWriter(log_dir, kind=kind, compression=Uncompressed, columns=self._csv_columns()) as csv_file:
+            batch: list[Chunk] = []
+            for item_id, progress in tracker.result().items():
+                batch.append({"ID": str(item_id), **{step: progress[step] for step in self.Steps.list()}})
+                if len(batch) >= 1000:
+                    csv_file.write_chunks(batch)
+                    batch = []
+            if batch:
+                csv_file.write_chunks(batch)
+        console.print(f"Migration items written to {log_dir}")
+
+    @classmethod
+    def _csv_columns(cls) -> list[SchemaColumn]:
+        return [
+            SchemaColumn(name="ID", type="string"),
+            *(SchemaColumn(name=step, type="string") for step in cls.Steps.list()),
+        ]
 
     def _download_iterable(
         self,


### PR DESCRIPTION
# Description

**Context**: This is part of the `alpha` migration tooling in Toolkit, for overview [see here](https://cognitedata.atlassian.net/wiki/spaces/~170890702/pages/5455773697/Migration+Tooling+in+Toolkit).

This command is used for migration and the PR introduces writing the results of a migration to file such that the user can see what happened to each migrated item.

## Changelog

- [ ] Patch
- [x] Skip

