### PR TITLE
Extraction pipeline bug fix

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_classes/extraction_pipeline.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/extraction_pipeline.py
@@ -18,7 +18,7 @@ class Contact(BaseModelResource):
 
 
 class NotificationConfig(BaseModelResource):
-    allow_not_seen_range_in_minutes: int | None = Field(
+    allowed_not_seen_range_in_minutes: int | None = Field(
         None,
         ge=0,
         description="Notifications configuration value. Time in minutes to pass without any Run. Null if extraction pipeline is not checked.",

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline.py
@@ -54,6 +54,7 @@ class TestExtractionPipelineYAML:
                 "name": "Pipeline 6",
                 "dataSetExternalId": "ds6",
                 "contacts": [{"name": "John Doe", "role": "Owner", "sendNotification": True}],
+                "notificationConfig": {"allowedNotSeenRangeInMinutes": 10},
             },
         ],
     )


### PR DESCRIPTION
# Description

Small bug in the YAML spec for extraction pipelines. [API Spec](https://api-docs.cognite.com/20230101/tag/Extraction-Pipelines/operation/createExtPipes#!path=items/notificationConfig/allowedNotSeenRangeInMinutes&t=request)

## Changelog

- [x] Patch
- [ ] Skip

## cdf

### Fixed

- When running `cdf build` Toolkit no longer give warnings on extraction pipelines for unused field allowedNotSeenRangeInMinutes. For example:  `In notificationConfig unused field: 
'allowedNotSeenRangeInMinutes'`

## templates

No changes.
