### PR TITLE
Reactivate tests

### DIFF
--- a/tests/test_integration/test_commands/test_migrate_files.py
+++ b/tests/test_integration/test_commands/test_migrate_files.py
@@ -46,9 +46,6 @@ def three_files_with_content(
     client.files.delete(external_id=created.as_external_ids(), ignore_unknown_ids=True)
 
 
-@pytest.mark.skip(
-    "This is not yet enabled in the staging cluster that Toolkit uses for testing. Only runs a dev cluster."
-)
 class TestMigrateFilesCommand:
     # This tests uses instances.apply_fast() which uses up to 4 workers for writing instances,
     # when this is used in parallel with other tests that uses instances.apply() then we get 5 workers in total,


### PR DESCRIPTION
# Description

After changing the migration model in #1987, we had to skip a few tests. This reactivates the tests again as the new migration model can be deployed to our test project.

## Changelog

- [ ] Patch
- [x] Skip

