### PR TITLE
[CDF-25848] allow modules prefix in packages.toml

### DIFF
--- a/cognite_toolkit/_cdf_tk/data_classes/_packages.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_packages.py
@@ -90,10 +90,11 @@ class Packages(dict, MutableMapping[str, Package]):
                         module_path_obj = Path(module_path)
 
                         # Remove "modules/" prefix if present to normalize user input
-                        if module_path_obj.parts and module_path_obj.parts[0] == "modules":
-                            normalized_path = Path(*module_path_obj.parts[1:])
-                        else:
-                            normalized_path = module_path_obj
+                        normalized_path = (
+                            Path(*module_path_obj.parts[1:])
+                            if module_path_obj.parts and module_path_obj.parts[0] == "modules"
+                            else module_path_obj
+                        )
 
                         # Try to find module by normalized path, then by adding "modules/" prefix
                         if (module := module_by_relative_path.get(normalized_path)) is None:

--- a/cognite_toolkit/_cdf_tk/data_classes/_packages.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_packages.py
@@ -96,8 +96,7 @@ class Packages(dict, MutableMapping[str, Package]):
                             normalized_path = module_path_obj
 
                         # Try to find module by normalized path, then by adding "modules/" prefix
-                        module = module_by_relative_path.get(normalized_path)
-                        if module is None:
+                        if (module := module_by_relative_path.get(normalized_path)) is None:
                             module = module_by_relative_path.get(Path("modules") / normalized_path)
 
                         if module is None:

--- a/cognite_toolkit/_cdf_tk/data_classes/_packages.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_packages.py
@@ -89,18 +89,16 @@ class Packages(dict, MutableMapping[str, Package]):
                     for module_path in modules:
                         module_path_obj = Path(module_path)
 
-                        # Try to find the module by the exact path first
-                        module = module_by_relative_path.get(module_path_obj)
+                        # Remove "modules/" prefix if present to normalize user input
+                        if module_path_obj.parts and module_path_obj.parts[0] == "modules":
+                            normalized_path = Path(*module_path_obj.parts[1:])
+                        else:
+                            normalized_path = module_path_obj
 
-                        # If not found and the path starts with "modules/", try without the prefix
-                        if module is None and module_path_obj.parts and module_path_obj.parts[0] == "modules":
-                            module_path_without_prefix = Path(*module_path_obj.parts[1:])
-                            module = module_by_relative_path.get(module_path_without_prefix)
-
-                        # If still not found and the path doesn't start with "modules/", try with the prefix
-                        if module is None and (not module_path_obj.parts or module_path_obj.parts[0] != "modules"):
-                            module_path_with_prefix = Path("modules") / module_path_obj
-                            module = module_by_relative_path.get(module_path_with_prefix)
+                        # Try to find module by normalized path, then by adding "modules/" prefix
+                        module = module_by_relative_path.get(normalized_path)
+                        if module is None:
+                            module = module_by_relative_path.get(Path("modules") / normalized_path)
 
                         if module is None:
                             available = sorted(str(m.relative_path) for m in module_directories)

--- a/cognite_toolkit/_cdf_tk/utils/aggregators.py
+++ b/cognite_toolkit/_cdf_tk/utils/aggregators.py
@@ -180,7 +180,7 @@ class MetadataAggregator(AssetCentricAggregator, ABC, Generic[T_CogniteFilter]):
             data_set_ids = [{"externalId": item} for item in data_set_external_id]
 
         # MyPy fails to understand that filter_cls() produce a T_CogniteFilter
-        return cls.filter_cls(asset_subtree_ids=asset_subtree_ids, data_set_ids=data_set_ids)  # type: ignore[return-value]
+        return cls.filter_cls(asset_subtree_ids=asset_subtree_ids, data_set_ids=data_set_ids)
 
     @classmethod
     def _is_empty(cls, items: str | list[str] | tuple[str, ...] | None) -> bool:

--- a/tests/test_unit/test_cdf_tk/test_data_classes/test_packages.py
+++ b/tests/test_unit/test_cdf_tk/test_data_classes/test_packages.py
@@ -57,7 +57,7 @@ class TestPackages:
     def test_load_modules_with_and_without_prefix(self, tmp_path: Path) -> None:
         """Test that modules can be specified with or without 'modules/' prefix in packages.toml"""
 
-        # Create a simple module structure
+        # Create the modules directory (required by iterate_modules)
         modules_dir = tmp_path / "modules"
         modules_dir.mkdir()
 
@@ -131,7 +131,7 @@ modules = [
         assert packages["test_with_prefix"].module_names == expected_module_names
         assert packages["test_mixed"].module_names == expected_module_names
 
-        # Verify modules have correct relative paths
+        # Verify modules have correct relative paths (should have modules/ prefix since they're under modules/)
         for package in packages.values():
             for module in package.modules:
                 if module.name == "test_module":


### PR DESCRIPTION
# Description

Giving package authors some leeway if they add "modules/" to their package toml manifests because it can be confusing whether to include or not. 

allowed: 

[packages.quickstart]
title = "Quickstart"
description = "Get started with Cognite Data Fusion in minutes."
canCherryPick = false
modules = [
    "cdf_ingestion",
    "sourcesystem/cdf_pi",
    "sourcesystem/cdf_sap_assets",
    "sourcesystem/cdf_sap_events",
    "sourcesystem/cdf_sharepoint",
    "models/cdf_process_industry_extension",
    "contextualization/cdf_connection_sql",
    "contextualization/cdf_p_and_id_parser",
    "industrial_tools/cdf_search"
]

also allowed:

[packages.quickstart]
title = "Quickstart"
description = "Get started with Cognite Data Fusion in minutes."
canCherryPick = false
modules = [
    "modules/cdf_ingestion",
    "modules/sourcesystem/cdf_pi",
    "modules/sourcesystem/cdf_sap_assets",
    "modules/sourcesystem/cdf_sap_events",
    "modules/sourcesystem/cdf_sharepoint",
    "modules/models/cdf_process_industry_extension",
    "modules/contextualization/cdf_connection_sql",
    "modules/contextualization/cdf_p_and_id_parser",
    "modules/industrial_tools/cdf_search"
]



## Changelog

- [x] Patch
- [ ] Skip

## cdf

### Improved

- leading "modules/" segment is now optional in packages.toml

## templates

No changes.
