### PR TITLE
[CDF-25880] 🍉Simplify StorageIO Adapter

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -13,7 +13,7 @@ from cognite_toolkit._cdf_tk.commands import (
 from cognite_toolkit._cdf_tk.commands._migrate import MigrationCommand
 from cognite_toolkit._cdf_tk.commands._migrate.adapter import AssetCentricMigrationIOAdapter, MigrationCSVFileSelector
 from cognite_toolkit._cdf_tk.commands._migrate.data_mapper import AssetCentricMapper
-from cognite_toolkit._cdf_tk.storageio import AssetIO, InstanceIO
+from cognite_toolkit._cdf_tk.storageio import AssetIO
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 
 TODAY = date.today()
@@ -117,7 +117,7 @@ class MigrateApp(typer.Typer):
         cmd.run(
             lambda: cmd.migrate(
                 selected=MigrationCSVFileSelector(mapping_file, resource_type="asset"),
-                data=AssetCentricMigrationIOAdapter(client, AssetIO(client), InstanceIO(client)),
+                data=AssetCentricMigrationIOAdapter(client, AssetIO(client)),
                 mapper=AssetCentricMapper(client),
                 log_dir=log_dir,
                 dry_run=dry_run,

--- a/cognite_toolkit/_cdf_tk/commands/_download.py
+++ b/cognite_toolkit/_cdf_tk/commands/_download.py
@@ -7,7 +7,7 @@ from cognite.client.data_classes._base import T_CogniteResourceList
 from rich.console import Console
 
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
-from cognite_toolkit._cdf_tk.storageio import StorageIO, TableStorageIO
+from cognite_toolkit._cdf_tk.storageio import ConfigurableStorageIO, StorageIO, TableStorageIO
 from cognite_toolkit._cdf_tk.utils.file import safe_write, sanitize_filename, yaml_safe_dump
 from cognite_toolkit._cdf_tk.utils.fileio import TABLE_WRITE_CLS_BY_FORMAT, Compression, FileWriter, SchemaColumn
 from cognite_toolkit._cdf_tk.utils.producer_worker import ProducerWorkerExecutor
@@ -81,10 +81,11 @@ class DownloadCommand(ToolkitCommand):
                 executor.raise_on_error()
                 file_count = writer.file_count
 
-            for config in io.configurations(selector):
-                config_file = output_dir / config.folder_name / f"{filestem}.{config.kind}.yaml"
-                config_file.parent.mkdir(parents=True, exist_ok=True)
-                safe_write(config_file, yaml_safe_dump(config.value))
+            if isinstance(io, ConfigurableStorageIO):
+                for config in io.configurations(selector):
+                    config_file = output_dir / config.folder_name / f"{filestem}.{config.kind}.yaml"
+                    config_file.parent.mkdir(parents=True, exist_ok=True)
+                    safe_write(config_file, yaml_safe_dump(config.value))
 
             console.print(f"Downloaded {selector!s} to {file_count} file(s) in {target_directory.as_posix()!r}.")
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/adapter.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/adapter.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
@@ -23,7 +23,6 @@ from cognite.client.data_classes._base import (
 )
 from cognite.client.data_classes.data_modeling import EdgeApply, EdgeId, InstanceApply, NodeApply, NodeId
 from cognite.client.utils._identifier import InstanceId
-from rich.console import Console
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.data_classes.instances import InstanceApplyList
@@ -38,7 +37,7 @@ from cognite_toolkit._cdf_tk.storageio import (
     InstanceSelector,
     StorageIO,
 )
-from cognite_toolkit._cdf_tk.storageio._base import StorageIOConfig, T_WritableCogniteResourceList
+from cognite_toolkit._cdf_tk.storageio._base import T_WritableCogniteResourceList
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 from cognite_toolkit._cdf_tk.utils.http_client import HTTPClient, HTTPMessage, ItemsRequest, SuccessItem
 from cognite_toolkit._cdf_tk.utils.thread_safe_dict import ThreadSafeDict
@@ -194,15 +193,6 @@ class AssetCentricMigrationIOAdapter(
 
     def json_chunk_to_data(self, data_chunk: list[dict[str, JsonVal]]) -> InstanceApplyList:
         raise NotImplementedError()
-
-    def load_selector(self, datafile: Path) -> MigrationSelector:
-        raise ToolkitNotImplementedError("load_selector is not implemented for AssetCentricMigrationIOAdapter")
-
-    def configurations(self, selector: MigrationSelector) -> Iterable[StorageIOConfig]:
-        raise ToolkitNotImplementedError("configurations is not implemented for AssetCentricMigrationIOAdapter")
-
-    def ensure_configurations(self, selector: MigrationSelector, console: Console | None = None) -> None:
-        raise ToolkitNotImplementedError("ensure_configurations is not implemented for AssetCentricMappingList")
 
 
 class FileMetaAdapter(

--- a/cognite_toolkit/_cdf_tk/commands/_upload.py
+++ b/cognite_toolkit/_cdf_tk/commands/_upload.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from cognite.client.data_classes._base import T_CogniteResourceList
 from rich.console import Console
 
-from cognite_toolkit._cdf_tk.storageio import StorageIO
+from cognite_toolkit._cdf_tk.storageio import ConfigurableStorageIO, StorageIO
 from cognite_toolkit._cdf_tk.utils.collection import chunker
 from cognite_toolkit._cdf_tk.utils.fileio import FileReader
 from cognite_toolkit._cdf_tk.utils.http_client import HTTPClient, ItemIDMessage, SuccessItem
@@ -67,9 +67,10 @@ class UploadCommand(ToolkitCommand):
                 if verbose:
                     console.print(f"{action} {io.DISPLAY_NAME} from {file_display.as_posix()!r}")
 
-                selector = io.load_selector(file)
-                if ensure_configurations and not dry_run:
-                    io.ensure_configurations(selector, console)
+                if isinstance(io, ConfigurableStorageIO):
+                    selector = io.load_selector(file)
+                    if ensure_configurations and not dry_run:
+                        io.ensure_configurations(selector, console)
 
                 reader = FileReader.from_filepath(file)
                 tracker = ProgressTracker[T_ID]([self._UPLOAD])

--- a/cognite_toolkit/_cdf_tk/storageio/__init__.py
+++ b/cognite_toolkit/_cdf_tk/storageio/__init__.py
@@ -1,6 +1,6 @@
 from ._applications import ChartIO
 from ._asset_centric import AssetIO, BaseAssetCentricIO, FileMetadataIO
-from ._base import StorageIO, TableStorageIO
+from ._base import ConfigurableStorageIO, StorageIO, StorageIOConfig, TableStorageIO
 from ._data_classes import InstanceIdCSVList, InstanceIdRow, ModelList
 from ._instances import InstanceIO
 from ._raw import RawIO
@@ -29,6 +29,7 @@ __all__ = [
     "ChartIO",
     "ChartOwnerSelector",
     "ChartSelector",
+    "ConfigurableStorageIO",
     "DataSetSelector",
     "FileMetadataIO",
     "InstanceFileSelector",
@@ -40,5 +41,6 @@ __all__ = [
     "ModelList",
     "RawIO",
     "StorageIO",
+    "StorageIOConfig",
     "TableStorageIO",
 ]

--- a/cognite_toolkit/_cdf_tk/storageio/_applications.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_applications.py
@@ -1,14 +1,11 @@
 from collections.abc import Iterable
-from pathlib import Path
-
-from rich.console import Console
 
 from cognite_toolkit._cdf_tk.client.data_classes.charts import Chart, ChartList, ChartWrite, ChartWriteList
 from cognite_toolkit._cdf_tk.exceptions import ToolkitNotImplementedError
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
-from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal, T_Selector
+from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 
-from ._base import StorageIO, StorageIOConfig
+from ._base import StorageIO
 from ._selectors import AllChartSelector, ChartOwnerSelector, ChartSelector
 
 
@@ -69,14 +66,3 @@ class ChartIO(StorageIO[str, ChartSelector, ChartWriteList, ChartList]):
 
     def json_chunk_to_data(self, data_chunk: list[dict[str, JsonVal]]) -> ChartWriteList:
         return ChartWriteList._load(data_chunk)
-
-    def configurations(self, selector: ChartSelector) -> Iterable[StorageIOConfig]:
-        # Charts does not have any configurations for its data.
-        return []
-
-    def load_selector(self, datafile: Path) -> ChartSelector:
-        raise ToolkitNotImplementedError("Loading charts is not implemented yet.")
-
-    def ensure_configurations(self, selector: T_Selector, console: Console | None = None) -> None:
-        # Charts do not have any configurations to ensure.
-        return None

--- a/cognite_toolkit/_cdf_tk/storageio/_asset_centric.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_asset_centric.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Iterable, MutableSequence, Sequence
 from pathlib import Path
-from typing import Generic
+from typing import ClassVar, Generic
 
 from cognite.client.data_classes import (
     Asset,
@@ -33,7 +33,7 @@ from cognite_toolkit._cdf_tk.utils.cdf import metadata_key_counts
 from cognite_toolkit._cdf_tk.utils.file import find_files_with_suffix_and_prefix
 from cognite_toolkit._cdf_tk.utils.fileio import SchemaColumn
 from cognite_toolkit._cdf_tk.utils.http_client import HTTPClient, HTTPMessage, SimpleBodyRequest
-from cognite_toolkit._cdf_tk.utils.useful_types import T_ID, JsonVal, T_WritableCogniteResourceList
+from cognite_toolkit._cdf_tk.utils.useful_types import T_ID, AssetCentric, JsonVal, T_WritableCogniteResourceList
 
 from ._base import StorageIOConfig, TableStorageIO
 from ._selectors import AssetCentricFileSelector, AssetCentricSelector, AssetSubtreeSelector, DataSetSelector
@@ -44,6 +44,7 @@ class BaseAssetCentricIO(
     TableStorageIO[int, AssetCentricSelector, T_CogniteResourceList, T_WritableCogniteResourceList],
     ABC,
 ):
+    RESOURCE_TYPE: ClassVar[AssetCentric]
     CHUNK_SIZE = 1000
 
     def __init__(self, client: ToolkitClient) -> None:
@@ -170,6 +171,7 @@ class AssetIO(BaseAssetCentricIO[str, AssetWrite, Asset, AssetWriteList, AssetLi
     FOLDER_NAME = "classic"
     KIND = "Assets"
     DISPLAY_NAME = "Assets"
+    RESOURCE_TYPE = "asset"
     SUPPORTED_DOWNLOAD_FORMATS = frozenset({".parquet", ".csv", ".ndjson"})
     SUPPORTED_COMPRESSIONS = frozenset({".gz"})
     SUPPORTED_READ_FORMATS = frozenset({".parquet", ".csv", ".ndjson", ".yaml", ".yml"})
@@ -247,6 +249,7 @@ class FileMetadataIO(BaseAssetCentricIO[str, FileMetadataWrite, FileMetadata, Fi
     FOLDER_NAME = FileMetadataCRUD.folder_name
     KIND = "FileMetadata"
     DISPLAY_NAME = "file metadata"
+    RESOURCE_TYPE = "file"
     SUPPORTED_DOWNLOAD_FORMATS = frozenset({".parquet", ".csv", ".ndjson"})
     SUPPORTED_COMPRESSIONS = frozenset({".gz"})
     SUPPORTED_READ_FORMATS = frozenset({".parquet", ".csv", ".ndjson"})

--- a/cognite_toolkit/_cdf_tk/storageio/_base.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_base.py
@@ -143,6 +143,8 @@ class StorageIO(ABC, Generic[T_ID, T_Selector, T_CogniteResourceList, T_Writable
         """
         raise NotImplementedError()
 
+
+class ConfigurableStorageIO(StorageIO[T_ID, T_Selector, T_CogniteResourceList, T_WritableCogniteResourceList], ABC):
     @abstractmethod
     def configurations(self, selector: T_Selector) -> Iterable[StorageIOConfig]:
         """Return configurations for the storage item."""
@@ -170,7 +172,9 @@ class StorageIO(ABC, Generic[T_ID, T_Selector, T_CogniteResourceList, T_Writable
         raise NotImplementedError()
 
 
-class TableStorageIO(StorageIO[T_ID, T_Selector, T_CogniteResourceList, T_WritableCogniteResourceList], ABC):
+class TableStorageIO(
+    ConfigurableStorageIO[T_ID, T_Selector, T_CogniteResourceList, T_WritableCogniteResourceList], ABC
+):
     @abstractmethod
     def get_schema(self, selector: T_Selector) -> list[SchemaColumn]:
         """Get the schema of the table associated with the given selector.

--- a/cognite_toolkit/_cdf_tk/storageio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_instances.py
@@ -1,24 +1,21 @@
 from collections.abc import Iterable, Mapping
-from pathlib import Path
 from types import MappingProxyType
 from typing import ClassVar
 
 from cognite.client.data_classes.aggregations import Count
 from cognite.client.data_classes.data_modeling import Edge, EdgeApply, Node, NodeApply
 from cognite.client.utils._identifier import InstanceId
-from rich.console import Console
 
 from cognite_toolkit._cdf_tk.client.data_classes.instances import InstanceApplyList, InstanceList
 from cognite_toolkit._cdf_tk.utils.cdf import iterate_instances
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
-from cognite_toolkit._cdf_tk.utils.fileio import SchemaColumn
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 
-from ._base import StorageIOConfig, TableStorageIO
+from ._base import StorageIO
 from ._selectors import InstanceFileSelector, InstanceSelector, InstanceViewSelector
 
 
-class InstanceIO(TableStorageIO[InstanceId, InstanceSelector, InstanceApplyList, InstanceList]):
+class InstanceIO(StorageIO[InstanceId, InstanceSelector, InstanceApplyList, InstanceList]):
     FOLDER_NAME = "instances"
     KIND = "Instances"
     DISPLAY_NAME = "Instances"
@@ -92,16 +89,4 @@ class InstanceIO(TableStorageIO[InstanceId, InstanceSelector, InstanceApplyList,
         raise NotImplementedError()
 
     def json_chunk_to_data(self, data_chunk: list[dict[str, JsonVal]]) -> InstanceApplyList:
-        raise NotImplementedError()
-
-    def configurations(self, selector: InstanceSelector) -> Iterable[StorageIOConfig]:
-        raise NotImplementedError()
-
-    def load_selector(self, datafile: Path) -> InstanceSelector:
-        raise NotImplementedError()
-
-    def ensure_configurations(self, selector: InstanceSelector, console: Console | None = None) -> None:
-        raise NotImplementedError()
-
-    def get_schema(self, selector: InstanceSelector) -> list[SchemaColumn]:
         raise NotImplementedError()

--- a/cognite_toolkit/_cdf_tk/storageio/_raw.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_raw.py
@@ -11,10 +11,10 @@ from cognite_toolkit._cdf_tk.utils.file import find_adjacent_files, read_yaml_fi
 from cognite_toolkit._cdf_tk.utils.http_client import HTTPClient, HTTPMessage, ItemsRequest
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 
-from ._base import StorageIO, StorageIOConfig
+from ._base import ConfigurableStorageIO, StorageIOConfig
 
 
-class RawIO(StorageIO[str, RawTable, RowWriteList, RowList]):
+class RawIO(ConfigurableStorageIO[str, RawTable, RowWriteList, RowList]):
     FOLDER_NAME = "raw"
     KIND = "RawRows"
     DISPLAY_NAME = "Raw Rows"

--- a/tests/test_integration/test_commands/test_migrate_assets.py
+++ b/tests/test_integration/test_commands/test_migrate_assets.py
@@ -11,7 +11,7 @@ from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.commands._migrate.adapter import AssetCentricMigrationIOAdapter, MigrationCSVFileSelector
 from cognite_toolkit._cdf_tk.commands._migrate.command import MigrationCommand
 from cognite_toolkit._cdf_tk.commands._migrate.data_mapper import AssetCentricMapper
-from cognite_toolkit._cdf_tk.storageio import AssetIO, InstanceIO
+from cognite_toolkit._cdf_tk.storageio import AssetIO
 from tests.test_integration.constants import RUN_UNIQUE_ID
 
 
@@ -68,7 +68,7 @@ class TestMigrateAssetsCommand:
         cmd = MigrationCommand(skip_tracking=True, silent=True)
         cmd.migrate(
             selected=MigrationCSVFileSelector(input_file, resource_type="asset"),
-            data=AssetCentricMigrationIOAdapter(client, AssetIO(client), InstanceIO(client)),
+            data=AssetCentricMigrationIOAdapter(client, AssetIO(client)),
             mapper=AssetCentricMapper(client),
             log_dir=tmp_path / "logs",
             dry_run=False,

--- a/tests/test_integration/test_commands/test_migrate_files.py
+++ b/tests/test_integration/test_commands/test_migrate_files.py
@@ -10,6 +10,7 @@ from cognite.client.exceptions import CogniteAPIError
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.data_classes.extended_timeseries import ExtendedTimeSeriesList
+from cognite_toolkit._cdf_tk.client.data_classes.migration import AssetCentricId
 from cognite_toolkit._cdf_tk.commands import MigrateFilesCommand
 from cognite_toolkit._cdf_tk.commands._migrate.adapter import (
     FileMetaAdapter,
@@ -18,7 +19,6 @@ from cognite_toolkit._cdf_tk.commands._migrate.adapter import (
 from cognite_toolkit._cdf_tk.commands._migrate.command import MigrationCommand
 from cognite_toolkit._cdf_tk.commands._migrate.data_mapper import AssetCentricMapper
 from cognite_toolkit._cdf_tk.commands._migrate.default_mappings import _FILE_METADATA_ID
-from cognite_toolkit._cdf_tk.storageio import InstanceIO
 
 
 @pytest.fixture()
@@ -125,13 +125,13 @@ class TestMigrateFilesCommand:
         cmd = MigrationCommand(skip_tracking=True, silent=True)
         results = cmd.migrate(
             selected=MigrationCSVFileSelector(input_file, resource_type="file"),
-            data=FileMetaAdapter(client, InstanceIO(client)),
+            data=FileMetaAdapter(client),
             mapper=AssetCentricMapper(client),
             log_dir=tmp_path / "logs",
             dry_run=False,
             verbose=False,
         )
-        actual_results = [results.get_progress(item.id) for item in three_files_with_content]
+        actual_results = [results.get_progress(AssetCentricId("file", item.id)) for item in three_files_with_content]
         expected_results = [
             {
                 cmd.Steps.DOWNLOAD: "success",

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_adapter.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_adapter.py
@@ -4,7 +4,7 @@ import responses
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
 from cognite_toolkit._cdf_tk.commands._migrate.adapter import AssetCentricMigrationIOAdapter, MigrationCSVFileSelector
-from cognite_toolkit._cdf_tk.storageio import AssetIO, InstanceIO
+from cognite_toolkit._cdf_tk.storageio import AssetIO
 
 
 class TestAssetCentricMigrationIOAdapter:
@@ -19,11 +19,7 @@ class TestAssetCentricMigrationIOAdapter:
         csv_file = tmp_path / "files.csv"
         csv_file.write_text("id,space,externalId\n" + "\n".join(f"{i},mySpace,asset_{i}" for i in range(N)))
         selector = MigrationCSVFileSelector(datafile=csv_file, resource_type="asset")
-        adapter = AssetCentricMigrationIOAdapter(
-            client,
-            AssetIO(client),
-            InstanceIO(client),
-        )
+        adapter = AssetCentricMigrationIOAdapter(client, AssetIO(client))
         downloaded = list(adapter.stream_data(selector))
         assert len(downloaded) == 2
         assert sum(len(chunk) for chunk in downloaded) == N

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -35,7 +35,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.data_model import (
 )
 from cognite_toolkit._cdf_tk.commands._migrate.default_mappings import _ASSET_ID, create_default_mappings
 from cognite_toolkit._cdf_tk.exceptions import ToolkitMigrationError, ToolkitValueError
-from cognite_toolkit._cdf_tk.storageio import AssetIO, InstanceIO
+from cognite_toolkit._cdf_tk.storageio import AssetIO
 from cognite_toolkit._cdf_tk.utils.fileio import CSVReader
 
 
@@ -176,7 +176,7 @@ class TestMigrationCommand:
 
         result = command.migrate(
             selected=MigrationCSVFileSelector(csv_file, resource_type="asset"),
-            data=AssetCentricMigrationIOAdapter(client, AssetIO(client), InstanceIO(client)),
+            data=AssetCentricMigrationIOAdapter(client, AssetIO(client)),
             mapper=AssetCentricMapper(client),
             log_dir=tmp_path / "logs",
             dry_run=False,

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -23,6 +23,7 @@ from cognite.client.data_classes.data_modeling import (
 from cognite.client.data_classes.data_modeling.statistics import InstanceStatistics, ProjectStatistics
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
+from cognite_toolkit._cdf_tk.client.data_classes.migration import AssetCentricId
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.commands._migrate.adapter import AssetCentricMigrationIOAdapter, MigrationCSVFileSelector
 from cognite_toolkit._cdf_tk.commands._migrate.command import MigrationCommand
@@ -214,14 +215,15 @@ class TestMigrationCommand:
             for asset in assets
         ]
         assert actual_instances == expected_instance
-        actual_results = [result.get_progress(asset.id) for asset in assets]
+        actual_results = [result.get_progress(AssetCentricId("asset", asset.id)) for asset in assets]
         expected_results = [{"download": "success", "convert": "success", "upload": "success"} for _ in assets]
         assert actual_results == expected_results
         csv_file = next((tmp_path / "logs").glob("*.csv"), None)
         assert csv_file is not None, "Expected a CSV log file to be created"
         csv_results = list(CSVReader(csv_file).read_chunks_unprocessed())
         assert csv_results == [
-            {"ID": str(asset.id), "download": "success", "convert": "success", "upload": "success"} for asset in assets
+            {"ID": f"asset(id={asset.id})", "download": "success", "convert": "success", "upload": "success"}
+            for asset in assets
         ]
 
     def test_validate_migration_model_available(self) -> None:

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_applications.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_applications.py
@@ -103,13 +103,6 @@ class TestChartIO:
             assert second.data.time_series_collection[0].ts_external_id == "ts_4"
             assert second.data.time_series_collection[1].ts_external_id == "ts_3"
 
-    def test_no_configurations(self) -> None:
-        with monkeypatch_toolkit_client() as client:
-            io = ChartIO(client)
-            selector = AllChartSelector()
-            assert list(io.configurations(selector)) == []
-            assert io.ensure_configurations(selector, None) is None
-
     @pytest.mark.parametrize(
         "limit,selector,expected_external_ids",
         [


### PR DESCRIPTION
# Description

This is a small quality-of-life improvemnt to the StorageIO (used to download/upload/migrate data)

* Moved out the `ConfigurableStorageIO` from `StorageIO` as multiple of the implementations did not support these methods.
* Removed unused part of `AssetCentricMigrationIOAdapter`.
* Switched the id type of `AssetCentricMigrationIOAdapter`  from int to `AssetCentricId`. This is preparation for having a `cdf migrate hierarchy` command that migrate assets, events, timeseries, and files in the same command. Then, we need the IDs to include the resource type.

## Changelog

- [ ] Patch
- [x] Skip

