### PR TITLE
[CDF-25800] 🤖 AgentYAML class

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_classes/agent.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/agent.py
@@ -1,0 +1,57 @@
+from typing import Literal
+
+from pydantic import Field
+
+from .agent_tools import AgentTool
+from .base import ToolkitResource
+
+Model = Literal[
+    "azure/o3",
+    "azure/o4-mini",
+    "azure/gpt-4o",
+    "azure/gpt-4o-mini",
+    "azure/gpt-4.1",
+    "azure/gpt-4.1-nano",
+    "azure/gpt-4.1-mini",
+    "azure/gpt-5",
+    "azure/gpt-5-mini",
+    "azure/gpt-5-nano",
+    "gcp/gemini-2.5-pro",
+    "gcp/gemini-2.5-flash",
+    "aws/claude-4-sonnet",
+    "aws/claude-4-opus",
+    "aws/claude-4.1-opus",
+    "aws/claude-3.5-sonnet",
+]
+
+
+class AgentYAML(ToolkitResource):
+    """Atlas AI Agent"""
+
+    external_id: str = Field(
+        description="An external ID that uniquely identifies the agent.",
+        min_length=1,
+        max_length=128,
+        pattern=r"^[^\x00]{1,128}$",
+    )
+    name: str = Field(
+        description="A descriptive name intended for use in user interfaces.",
+        min_length=1,
+        max_length=255,
+    )
+    description: str | None = Field(
+        default=None,
+        description="A human-readable description of what the agent does, used for documentation only. "
+        "This description is not used by the language model.",
+        max_length=1024,
+    )
+    instructions: str | None = Field(
+        default=None,
+        description="The instructions for the agent prompt the language model to understand "
+        "the agent's goals and how to achieve them.",
+        max_length=32000,
+    )
+    model: Model = Field(
+        "azure/gpt-4o-mini", description="The name of the model to use. Defaults to your CDF project's default model."
+    )
+    tools: list[AgentTool] = Field(description="A list of tools available to the agent.", max_length=20)

--- a/cognite_toolkit/_cdf_tk/resource_classes/agent_tools.py
+++ b/cognite_toolkit/_cdf_tk/resource_classes/agent_tools.py
@@ -1,0 +1,101 @@
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from cognite_toolkit._cdf_tk.constants import DM_EXTERNAL_ID_PATTERN, DM_VERSION_PATTERN, SPACE_FORMAT_PATTERN
+
+from .base import BaseModelResource
+
+
+class AgentToolDefinition(BaseModelResource):
+    type: str
+    name: str = Field(
+        description="A name for the tool, unique within the agent.",
+        min_length=1,
+        max_length=64,
+        pattern=r"^[^\x00]{1,64}$",
+    )
+    description: str = Field(
+        description="A description of how the tool helps the language model understand when and how to use the tool.",
+        min_length=10,
+        max_length=1024,
+    )
+
+
+class AskDocument(AgentToolDefinition):
+    type: Literal["askDocument"] = "askDocument"
+
+
+class AgentDataModel(BaseModelResource):
+    space: str = Field(
+        description="The space the data model is in.",
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
+    )
+    external_id: str = Field(
+        description="The space the data model is in.",
+        min_length=1,
+        max_length=255,
+        pattern=DM_EXTERNAL_ID_PATTERN,
+    )
+    version: str = Field(
+        description="The version of the data model.",
+        max_length=43,
+        pattern=DM_VERSION_PATTERN,
+    )
+    view_external_ids: list[str] = Field(description="The views of the data model.", min_length=1, max_length=10)
+
+
+class AgentInstanceSpacesDefinition(BaseModelResource):
+    type: str
+
+
+class AllInstanceSpaces(AgentInstanceSpacesDefinition):
+    type: Literal["all"] = "all"
+
+
+class ManualInstanceSpaces(AgentInstanceSpacesDefinition):
+    type: Literal["manual"] = "manual"
+    spaces: list[str]
+
+
+AgentInstanceSpaces = Annotated[
+    AllInstanceSpaces | ManualInstanceSpaces,
+    Field(discriminator="type"),
+]
+
+
+class QueryKnowledgeGraphConfig(BaseModelResource):
+    data_models: list[AgentDataModel] = Field(
+        description="List of relevant data models.",
+        min_length=1,
+        max_length=80,
+    )
+    instance_spaces: AgentInstanceSpaces
+    version: Literal["v1", "v2"] = Field(
+        "v1",
+        description="The version of the query generation strategy to use. "
+        "A higher number does not necessarily mean a better query.",
+    )
+
+
+class QueryKnowledgeGraph(AgentToolDefinition):
+    type: Literal["queryKnowledgeGraph"] = "queryKnowledgeGraph"
+    configuration: QueryKnowledgeGraphConfig = Field(
+        description="Configuration for the Query Knowledge Graph tool.",
+    )
+
+
+class QueryTimeSeriesDatapoints(AgentToolDefinition):
+    type: Literal["queryTimeSeriesDatapoints"] = "queryTimeSeriesDatapoints"
+
+
+class SummarizeDocument(AgentToolDefinition):
+    type: Literal["summarizeDocument"] = "summarizeDocument"
+
+
+AgentTool = Annotated[
+    AskDocument | QueryKnowledgeGraph | QueryTimeSeriesDatapoints | SummarizeDocument,
+    Field(discriminator="type"),
+]


### PR DESCRIPTION
# Description

We are in the progress of adding pydantic classes to match the YAML format Toolkit expects for configurations. The goal is to give better error message to the user on syntax errors.

This PR introduces the `AgentYAML` to validate agents configurations. Note this is not yet exposed, so no change to the end user. 

## Changelog

- [ ] Patch
- [x] Skip

