### PR TITLE
[CDF-25907] 🐛 Iterate instances

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils/cdf.py
+++ b/cognite_toolkit/_cdf_tk/utils/cdf.py
@@ -104,9 +104,13 @@ def iterate_instances(
     # WHERE deleted_at IS NULL. In other words, avoiding soft deleted instances.
     body["sort"] = [
         {
+            "property": [instance_type, "space"],
+            "direction": "ascending",
+        },
+        {
             "property": [instance_type, "externalId"],
             "direction": "ascending",
-        }
+        },
     ]
     url = f"/api/{client._API_VERSION}/projects/{client.config.project}/models/instances/list"
     if space:


### PR DESCRIPTION
# Description

We have a small bug when iterating over all instances. The builtin index is on space + externalId and not just `externalId`.

## Changelog

- [x] Patch
- [ ] Skip

## cdf

### Improved

- Faster downloading of instances when you run `cdf purge space`. 

## templates

No changes.
