### PR TITLE
[CDF-27549] Dune App resource (Files API + zip, alpha flag)

### DIFF
--- a/cognite_toolkit/_cdf_tk/builders/__init__.py
+++ b/cognite_toolkit/_cdf_tk/builders/__init__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from cognite_toolkit._cdf_tk.tk_warnings import ToolkitWarning
 
+from ._app import AppBuilder
 from ._base import Builder, DefaultBuilder, get_resource_crud
 from ._datamodels import DataModelBuilder
 from ._file import FileBuilder
@@ -27,6 +28,7 @@ def create_builder(
 
 _BUILDER_BY_RESOURCE_FOLDER = {_builder._resource_folder: _builder for _builder in Builder.__subclasses__()}
 __all__ = [
+    "AppBuilder",
     "Builder",
     "DataModelBuilder",
     "DefaultBuilder",

--- a/cognite_toolkit/_cdf_tk/builders/_app.py
+++ b/cognite_toolkit/_cdf_tk/builders/_app.py
@@ -2,6 +2,8 @@ import shutil
 from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
 
+from pydantic import ValidationError
+
 from cognite_toolkit._cdf_tk.builders._base import Builder
 from cognite_toolkit._cdf_tk.cruds import AppCRUD
 from cognite_toolkit._cdf_tk.data_classes import (
@@ -18,6 +20,7 @@ from cognite_toolkit._cdf_tk.tk_warnings import (
     ToolkitWarning,
     WarningList,
 )
+from cognite_toolkit._cdf_tk.yaml_classes import AppsYAML
 
 
 class AppBuilder(Builder):
@@ -93,33 +96,27 @@ class AppBuilder(Builder):
         raw_apps = raw_content if isinstance(raw_content, list) else [raw_content]
         warnings = WarningList[FileReadWarning]()
         for raw_app in raw_apps:
-            app_external_id = raw_app.get("appExternalId")
-            if not app_external_id:
+            try:
+                app_config = AppsYAML.model_validate(raw_app)
+            except ValidationError as e:
                 warnings.append(
                     HighSeverityWarning(
-                        f"App in {source_file.source.path.as_posix()!r} has no appExternalId defined. "
-                        f"This is used to match the app to the app directory.",
+                        f"App in {source_file.source.path.as_posix()!r} has invalid configuration: {e}",
                     ),
                 )
                 continue
-            if not raw_app.get("version"):
-                warnings.append(
-                    HighSeverityWarning(
-                        f"App {app_external_id} in {source_file.source.path.as_posix()!r} has no version defined.",
-                    ),
-                )
 
-            app_directory = source_file.source.path.with_name(app_external_id)
+            app_directory = source_file.source.path.with_name(app_config.app_external_id)
 
             if not app_directory.is_dir():
                 raise ToolkitNotADirectoryError(
-                    f"App directory not found for appExternalId {app_external_id} defined in {source_file.source.path.as_posix()!r}.",
+                    f"App directory not found for appExternalId {app_config.app_external_id} defined in {source_file.source.path.as_posix()!r}.",
                 )
 
-            destination = self.build_dir / self.resource_folder / app_external_id
+            destination = self.build_dir / self.resource_folder / app_config.app_external_id
             if destination.exists():
                 raise ToolkitFileExistsError(
-                    f"App {app_external_id!r} is duplicated. If this is unexpected, ensure you have a clean build directory.",
+                    f"App {app_config.app_external_id!r} is duplicated. If this is unexpected, ensure you have a clean build directory.",
                 )
             shutil.copytree(app_directory, destination, ignore=shutil.ignore_patterns("__pycache__"))
 

--- a/cognite_toolkit/_cdf_tk/builders/_app.py
+++ b/cognite_toolkit/_cdf_tk/builders/_app.py
@@ -1,0 +1,126 @@
+import shutil
+from collections.abc import Callable, Iterable, Sequence
+from pathlib import Path
+
+from cognite_toolkit._cdf_tk.builders._base import Builder
+from cognite_toolkit._cdf_tk.cruds import AppCRUD
+from cognite_toolkit._cdf_tk.data_classes import (
+    BuildDestinationFile,
+    BuildSourceFile,
+    BuiltResourceList,
+    ModuleLocation,
+)
+from cognite_toolkit._cdf_tk.exceptions import ToolkitFileExistsError, ToolkitNotADirectoryError, ToolkitValueError
+from cognite_toolkit._cdf_tk.tk_warnings import (
+    FileReadWarning,
+    HighSeverityWarning,
+    LowSeverityWarning,
+    ToolkitWarning,
+    WarningList,
+)
+
+
+class AppBuilder(Builder):
+    _resource_folder = AppCRUD.folder_name
+
+    def __init__(self, build_dir: Path, warn: Callable[[ToolkitWarning], None]) -> None:
+        super().__init__(build_dir, warn=warn)
+
+    def build(
+        self,
+        source_files: list[BuildSourceFile],
+        module: ModuleLocation,
+        console: Callable[[str], None] | None = None,
+    ) -> Iterable[BuildDestinationFile | Sequence[ToolkitWarning]]:
+        for source_file in source_files:
+            if source_file.loaded is None:
+                continue
+            if source_file.source.path.parent.parent != module.dir:
+                continue
+
+            loader, warning = self._get_loader(source_file.source.path)
+            if loader is None:
+                if warning is not None:
+                    yield [warning]
+                continue
+
+            warnings = WarningList[FileReadWarning]()
+            if loader is AppCRUD:
+                warnings = self.copy_app_directory_to_build(source_file)
+
+            destination_path = self._create_destination_path(source_file.source.path, loader.kind)
+
+            yield BuildDestinationFile(
+                path=destination_path,
+                loaded=source_file.loaded,
+                loader=loader,
+                source=source_file.source,
+                extra_sources=None,
+                warnings=warnings,
+            )
+
+    def validate_directory(
+        self,
+        built_resources: BuiltResourceList,
+        module: ModuleLocation,
+    ) -> WarningList[ToolkitWarning]:
+        warnings = WarningList[ToolkitWarning]()
+        has_config_files = any(resource.kind == AppCRUD.kind for resource in built_resources)
+        if has_config_files:
+            return warnings
+        config_files_misplaced = [
+            file
+            for file in module.source_paths_by_resource_folder[AppCRUD.folder_name]
+            if AppCRUD.is_supported_file(file)
+        ]
+        if config_files_misplaced:
+            for yaml_source_path in config_files_misplaced:
+                required_location = module.dir / AppCRUD.folder_name / yaml_source_path.name
+                warning = LowSeverityWarning(
+                    f"The required App resource configuration file "
+                    f"was not found in {required_location.as_posix()!r}. "
+                    f"The file {yaml_source_path.as_posix()!r} is currently "
+                    f"considered part of the App's artifacts and "
+                    f"will not be processed by the Toolkit.",
+                )
+                warnings.append(warning)
+        return warnings
+
+    def copy_app_directory_to_build(self, source_file: BuildSourceFile) -> WarningList[FileReadWarning]:
+        raw_content = source_file.loaded
+        if raw_content is None:
+            raise ToolkitValueError("App source file should be a YAML file.")
+        raw_apps = raw_content if isinstance(raw_content, list) else [raw_content]
+        warnings = WarningList[FileReadWarning]()
+        for raw_app in raw_apps:
+            app_external_id = raw_app.get("appExternalId")
+            if not app_external_id:
+                warnings.append(
+                    HighSeverityWarning(
+                        f"App in {source_file.source.path.as_posix()!r} has no appExternalId defined. "
+                        f"This is used to match the app to the app directory.",
+                    ),
+                )
+                continue
+            if not raw_app.get("version"):
+                warnings.append(
+                    HighSeverityWarning(
+                        f"App {app_external_id} in {source_file.source.path.as_posix()!r} has no version defined.",
+                    ),
+                )
+
+            app_directory = source_file.source.path.with_name(app_external_id)
+
+            if not app_directory.is_dir():
+                raise ToolkitNotADirectoryError(
+                    f"App directory not found for appExternalId {app_external_id} defined in {source_file.source.path.as_posix()!r}.",
+                )
+
+            destination = self.build_dir / self.resource_folder / app_external_id
+            if destination.exists():
+                raise ToolkitFileExistsError(
+                    f"App {app_external_id!r} is duplicated. If this is unexpected, ensure you have a clean build directory.",
+                )
+            shutil.copytree(app_directory, destination, ignore=shutil.ignore_patterns("__pycache__"))
+
+        return warnings

--- a/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
+++ b/cognite_toolkit/_cdf_tk/client/_toolkit_client.py
@@ -9,6 +9,7 @@ from cognite_toolkit._cdf_tk.client.http_client import HTTPClient
 
 from .api.agents import AgentsAPI
 from .api.annotations import AnnotationsAPI
+from .api.apps import AppsAPI
 from .api.assets import AssetsAPI
 from .api.canvas import IndustrialCanvasAPI
 from .api.cognite_files import CogniteFilesAPI
@@ -61,6 +62,7 @@ class ToolAPI:
     def __init__(self, http_client: HTTPClient, console: Console) -> None:
         self.http_client = http_client
         self.agents = AgentsAPI(http_client)
+        self.apps = AppsAPI(http_client)
         self.annotations = AnnotationsAPI(http_client)
         self.assets = AssetsAPI(http_client)
         self.cognite_files = CogniteFilesAPI(http_client)

--- a/cognite_toolkit/_cdf_tk/client/api/apps.py
+++ b/cognite_toolkit/_cdf_tk/client/api/apps.py
@@ -1,0 +1,96 @@
+"""Apps API: Dune apps as classic files under /dune-apps/ (same pattern as Streamlit + /files)."""
+
+from collections.abc import Iterable, Sequence
+from typing import Literal
+
+from cognite_toolkit._cdf_tk.client.cdf_client import CDFResourceAPI, PagedResponse, ResponseItems
+from cognite_toolkit._cdf_tk.client.cdf_client.api import Endpoint
+from cognite_toolkit._cdf_tk.client.http_client import (
+    HTTPClient,
+    ItemsSuccessResponse,
+    RequestMessage,
+    SuccessResponse,
+)
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.client.request_classes.filters import DuneAppFilter
+from cognite_toolkit._cdf_tk.client.resource_classes.app import AppRequest, AppResponse
+
+
+class AppsAPI(CDFResourceAPI[AppResponse]):
+    """Dune apps are file metadata objects under ``/dune-apps/`` with a zip uploaded to ``uploadUrl``."""
+
+    def __init__(self, http_client: HTTPClient) -> None:
+        super().__init__(
+            http_client=http_client,
+            method_endpoint_map={
+                "create": Endpoint(method="POST", path="/files", item_limit=1, concurrency_max_workers=1),
+                "retrieve": Endpoint(method="POST", path="/files/byids", item_limit=1000, concurrency_max_workers=1),
+                "update": Endpoint(method="POST", path="/files/update", item_limit=1000, concurrency_max_workers=1),
+                "delete": Endpoint(method="POST", path="/files/delete", item_limit=1000, concurrency_max_workers=1),
+                "list": Endpoint(method="POST", path="/files/list", item_limit=1000),
+            },
+        )
+
+    def _validate_page_response(self, response: SuccessResponse | ItemsSuccessResponse) -> PagedResponse[AppResponse]:
+        return PagedResponse[AppResponse].model_validate_json(response.body)
+
+    def _reference_response(self, response: SuccessResponse) -> ResponseItems[ExternalId]:
+        return ResponseItems[ExternalId].model_validate_json(response.body)
+
+    def create(self, items: Sequence[AppRequest], overwrite: bool = False) -> list[AppResponse]:
+        endpoint = self._method_endpoint_map["create"]
+        results: list[AppResponse] = []
+        for item in items:
+            request = RequestMessage(
+                endpoint_url=self._make_url(endpoint.path),
+                method=endpoint.method,
+                body_content=item.dump(),
+                parameters={"overwrite": overwrite},
+            )
+            response = self._http_client.request_single_retries(request)
+            result = response.get_success_or_raise(request)
+            results.append(AppResponse.model_validate_json(result.body))
+        return results
+
+    def retrieve(self, items: Sequence[ExternalId], ignore_unknown_ids: bool = False) -> list[AppResponse]:
+        return self._request_item_response(
+            items, method="retrieve", extra_body={"ignoreUnknownIds": ignore_unknown_ids}
+        )
+
+    def update(self, items: Sequence[AppRequest], mode: Literal["patch", "replace"] = "replace") -> list[AppResponse]:
+        return self._update(items, mode=mode)
+
+    def delete(self, items: Sequence[ExternalId], ignore_unknown_ids: bool = False) -> None:
+        self._request_no_response(items, "delete", extra_body={"ignoreUnknownIds": ignore_unknown_ids})
+
+    def paginate(
+        self,
+        filter: DuneAppFilter | None = None,
+        limit: int = 100,
+        cursor: str | None = None,
+    ) -> PagedResponse[AppResponse]:
+        return self._paginate(
+            cursor=cursor,
+            limit=limit,
+            body={"filter": (filter or DuneAppFilter()).dump()},
+        )
+
+    def iterate(
+        self,
+        filter: DuneAppFilter | None = None,
+        limit: int | None = 100,
+    ) -> Iterable[list[AppResponse]]:
+        return self._iterate(
+            limit=limit,
+            body={"filter": (filter or DuneAppFilter()).dump()},
+        )
+
+    def list(
+        self,
+        filter: DuneAppFilter | None = None,
+        limit: int | None = 100,
+    ) -> list[AppResponse]:
+        return self._list(
+            limit=limit,
+            body={"filter": (filter or DuneAppFilter()).dump()},
+        )

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -8,7 +8,6 @@ from cognite_toolkit._cdf_tk.client.cdf_client import CDFResourceAPI, PagedRespo
 from cognite_toolkit._cdf_tk.client.cdf_client.api import Endpoint
 from cognite_toolkit._cdf_tk.client.http_client import (
     HTTPClient,
-    HTTPResult,
     ItemsSuccessResponse,
     RequestMessage,
     SuccessResponse,
@@ -203,22 +202,16 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
                 _ = response.get_success_or_raise(request)
         return results
 
-    def upload_content(self, data_content: bytes, upload_url: str, mime_type: str | None = None) -> HTTPResult:
-        """Uploads file content to CDF.
-
-        Args:
-            data_content: Content to be uploaded.
-            upload_url: Upload URL.
-            mime_type: MIME type to upload. None for no MIME type.
-        """
-        return self._http_client.request_single_retries(
-            RequestMessage(
-                endpoint_url=upload_url,
-                method="PUT",
-                content_type=mime_type or "application/octet-stream",
-                data_content=data_content,
-            )
+    def upload_content(self, data_content: bytes, upload_url: str, mime_type: str | None = None) -> None:
+        """Uploads file content to the signed upload URL (same flow as ``upload_file`` for in-memory bytes)."""
+        request = RequestMessage(
+            endpoint_url=upload_url,
+            method="PUT",
+            content_type=mime_type or "application/octet-stream",
+            data_content=data_content,
         )
+        upload_response = self._http_client.request_single_retries(request)
+        upload_response.get_success_or_raise(request)
 
     def set_pending_ids(self, items: Sequence[PendingInstanceId]) -> builtins.list[FileMetadataResponse]:
         """Set pending instance IDs for one or more file metadata entries.

--- a/cognite_toolkit/_cdf_tk/client/request_classes/filters.py
+++ b/cognite_toolkit/_cdf_tk/client/request_classes/filters.py
@@ -5,6 +5,7 @@ from pydantic import ConfigDict, Field, JsonValue, field_validator
 from pydantic_core.core_schema import ValidationInfo
 
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, InternalId, ViewId
+from cognite_toolkit._cdf_tk.client.resource_classes import app as app_resources
 from cognite_toolkit._cdf_tk.client.resource_classes import streamlit_
 from cognite_toolkit._cdf_tk.client.resource_classes.annotation import AnnotationStatus, AnnotationType
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import NodeId
@@ -53,6 +54,15 @@ class StreamlitFilter(ClassicFilter):
         if self.creator is not None:
             body["metadata"] = {"creator": self.creator}
         body["directoryPrefix"] = streamlit_.STREAMLIT_DIRECTORY
+        return body
+
+
+class DuneAppFilter(ClassicFilter):
+    """List filter for Dune app zips stored under ``/dune-apps/``."""
+
+    def dump(self, camel_case: bool = True) -> dict[str, Any]:
+        body = self.model_dump(mode="json", by_alias=camel_case, exclude_unset=True)
+        body["directoryPrefix"] = app_resources.DUNE_APPS_DIRECTORY
         return body
 
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/app.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/app.py
@@ -1,0 +1,106 @@
+from typing import Any, Literal
+
+from pydantic import Field, model_validator
+
+from cognite_toolkit._cdf_tk.client._resource_base import (
+    BaseModelObject,
+    ResponseResource,
+    UpdatableRequestResource,
+)
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+
+DUNE_APPS_DIRECTORY = "/dune-apps/"
+
+
+class AppShared(BaseModelObject):
+    """Fields shared between app write/read models (under /dune-apps/)."""
+
+    app_external_id: str = Field(description="Logical app id; directory name in the module.")
+    version: str
+    name: str
+    description: str | None = None
+    published: bool | None = True
+    data_set_id: int | None = None
+    cognite_toolkit_app_hash: str | None = Field(None, alias="cdf-toolkit-app-hash")
+
+
+class AppRequest(AppShared, UpdatableRequestResource):
+    """Create/update body for Files API init; zip is uploaded separately to uploadUrl."""
+
+    @property
+    def external_id(self) -> str:
+        return f"{self.app_external_id}-{self.version}"
+
+    def as_id(self) -> ExternalId:
+        return ExternalId(external_id=self.external_id)
+
+    def dump(
+        self, camel_case: bool = True, exclude_extra: bool = False, context: Literal["api", "toolkit"] = "api"
+    ) -> dict[str, Any]:
+        if context == "toolkit":
+            dumped = super().dump(camel_case=camel_case, exclude_extra=exclude_extra)
+            dumped.pop("externalId", None)
+            dumped.pop("external_id", None)
+            return dumped
+        feid = self.external_id
+        return {
+            "externalId" if camel_case else "external_id": feid,
+            "name": f"{feid}.zip",
+            "dataSetId" if camel_case else "data_set_id": self.data_set_id,
+            "directory": DUNE_APPS_DIRECTORY,
+            "metadata": self._as_metadata(),
+        }
+
+    def _as_metadata(self) -> dict[str, str]:
+        metadata: dict[str, str] = {
+            "published": str(bool(self.published)).lower(),
+            "name": self.name,
+            "description": self.description or "",
+            "externalId": self.external_id,
+            "version": self.version,
+            "appExternalId": self.app_external_id,
+        }
+        if self.cognite_toolkit_app_hash:
+            metadata["cdf-toolkit-app-hash"] = self.cognite_toolkit_app_hash
+        return metadata
+
+    def as_update(self, mode: Literal["patch", "replace"]) -> dict[str, Any]:
+        update_data: dict[str, Any] = {
+            "metadata": {"set": self._as_metadata()},
+            "directory": {"set": DUNE_APPS_DIRECTORY},
+        }
+        if self.data_set_id is not None:
+            update_data["dataSetId"] = {"set": self.data_set_id}
+        elif mode == "replace":
+            update_data["dataSetId"] = {"setNull": True}
+
+        return {
+            "externalId": self.external_id,
+            "update": update_data,
+        }
+
+
+class AppResponse(AppShared, ResponseResource[AppRequest]):
+    """File metadata for a Dune app after create/retrieve (metadata merged to top level)."""
+
+    external_id: str
+    id: int
+    created_time: int
+    last_updated_time: int
+    uploaded_time: int | None = None
+    uploaded: bool
+    upload_url: str | None = None
+
+    @classmethod
+    def request_cls(cls) -> type[AppRequest]:
+        return AppRequest
+
+    @model_validator(mode="before")
+    @classmethod
+    def move_metadata(cls, values: dict[str, Any]) -> dict[str, Any]:
+        if "metadata" not in values:
+            return values
+        values_copy = values.copy()
+        metadata = values_copy.pop("metadata")
+        values_copy.update(metadata)
+        return values_copy

--- a/cognite_toolkit/_cdf_tk/client/testing.py
+++ b/cognite_toolkit/_cdf_tk/client/testing.py
@@ -32,6 +32,7 @@ from cognite_toolkit._cdf_tk.client.api.views import ViewsAPI
 
 from ._toolkit_client import ToolAPI
 from .api.agents import AgentsAPI
+from .api.apps import AppsAPI
 from .api.assets import AssetsAPI
 from .api.data_product_versions import DataProductVersionsAPI
 from .api.data_products import DataProductsAPI
@@ -152,6 +153,7 @@ class ToolkitClientMock(CogniteClientMock):
 
         self.tool = MagicMock(spec=ToolAPI)
         self.tool.agents = MagicMock(spec=AgentsAPI)
+        self.tool.apps = MagicMock(spec=AppsAPI)
         self.tool.datapoint_subscriptions = MagicMock(spec=DatapointSubscriptionsAPI)
         self.tool.three_d = MagicMock(spec=ThreeDAPI)
         self.tool.three_d.models_classic = MagicMock(spec_set=ThreeDClassicModelsAPI)

--- a/cognite_toolkit/_cdf_tk/cruds/__init__.py
+++ b/cognite_toolkit/_cdf_tk/cruds/__init__.py
@@ -21,6 +21,7 @@ from ._base_cruds import DataCRUD, Loader, ResourceContainerCRUD, ResourceCRUD
 from ._data_cruds import DatapointsCRUD, FileCRUD, RawFileCRUD
 from ._resource_cruds import (
     AgentCRUD,
+    AppCRUD,
     AssetCRUD,
     CogniteFileCRUD,
     ContainerCRUD,
@@ -110,6 +111,8 @@ if not FeatureFlag.is_enabled(Flags.DATA_PRODUCTS):
     _EXCLUDED_CRUDS.add(DataProductVersionCRUD)
     _EXCLUDED_CRUDS.add(RuleSetCRUD)
     _EXCLUDED_CRUDS.add(RuleSetVersionCRUD)
+if not FeatureFlag.is_enabled(Flags.APPS):
+    _EXCLUDED_CRUDS.add(AppCRUD)
 
 CRUDS_BY_FOLDER_NAME_INCLUDE_ALPHA: defaultdict[str, list[type[Loader]]] = defaultdict(list)
 CRUDS_BY_FOLDER_NAME: defaultdict[str, list[type[Loader]]] = defaultdict(list)
@@ -173,6 +176,7 @@ ResourceTypes: TypeAlias = Literal[
     "timeseries",
     "extraction_pipelines",
     "functions",
+    "apps",
     "raw",
     "robotics",
     "rulesets",
@@ -206,6 +210,7 @@ __all__ = [
     "RESOURCE_DATA_CRUD_LIST",
     "_EXCLUDED_CRUDS",
     "AgentCRUD",
+    "AppCRUD",
     "AssetCRUD",
     "CogniteFileCRUD",
     "ContainerCRUD",

--- a/cognite_toolkit/_cdf_tk/cruds/_resource_cruds/__init__.py
+++ b/cognite_toolkit/_cdf_tk/cruds/_resource_cruds/__init__.py
@@ -1,4 +1,5 @@
 from .agent import AgentCRUD
+from .app import AppCRUD
 from .auth import GroupAllScopedCRUD, GroupCRUD, SecurityCategoryCRUD
 from .classic import AssetCRUD, EventCRUD, SequenceCRUD, SequenceRowCRUD
 from .configuration import SearchConfigCRUD
@@ -54,6 +55,7 @@ from .workflow import WorkflowCRUD, WorkflowTriggerCRUD, WorkflowVersionCRUD
 
 __all__ = [
     "AgentCRUD",
+    "AppCRUD",
     "AssetCRUD",
     "CogniteFileCRUD",
     "ContainerCRUD",

--- a/cognite_toolkit/_cdf_tk/cruds/_resource_cruds/app.py
+++ b/cognite_toolkit/_cdf_tk/cruds/_resource_cruds/app.py
@@ -1,0 +1,212 @@
+from collections.abc import Hashable, Iterable, Sequence
+from pathlib import Path
+from typing import Any, Literal, final
+
+from rich.console import Console
+
+from cognite_toolkit._cdf_tk.client import ToolkitClient
+from cognite_toolkit._cdf_tk.client._resource_base import Identifier
+from cognite_toolkit._cdf_tk.client.http_client import RequestMessage
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.client.request_classes.filters import DuneAppFilter
+from cognite_toolkit._cdf_tk.client.resource_classes.app import AppRequest, AppResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.group import (
+    AclType,
+    AllScope,
+    DataSetScope,
+    FilesAcl,
+    ScopeDefinition,
+)
+from cognite_toolkit._cdf_tk.cruds._base_cruds import ResourceCRUD
+from cognite_toolkit._cdf_tk.exceptions import ToolkitRequiredValueError
+from cognite_toolkit._cdf_tk.utils import calculate_directory_hash, calculate_hash
+from cognite_toolkit._cdf_tk.utils.acl_helper import dataset_scoped_resource
+from cognite_toolkit._cdf_tk.utils.file import create_temporary_zip
+from cognite_toolkit._cdf_tk.yaml_classes import AppsYAML
+
+from .auth import GroupAllScopedCRUD
+from .data_organization import DataSetsCRUD
+
+
+@final
+class AppCRUD(ResourceCRUD[ExternalId, AppRequest, AppResponse]):
+    support_drop = True
+    folder_name = "apps"
+    resource_cls = AppResponse
+    resource_write_cls = AppRequest
+    kind = "App"
+    yaml_cls = AppsYAML
+    dependencies = frozenset({DataSetsCRUD, GroupAllScopedCRUD})
+    _doc_url = "Files/operation/initFileUpload"
+    metadata_value_limit = 512
+    support_update = True
+    _toolkit_hash_key = "cdf-toolkit-app-hash"
+
+    def __init__(self, client: ToolkitClient, build_path: Path | None, console: Console | None):
+        super().__init__(client, build_path, console)
+        self.data_set_id_by_file_external_id: dict[str, int] = {}
+        self.app_dir_by_file_external_id: dict[str, Path] = {}
+
+    @property
+    def display_name(self) -> str:
+        return "apps"
+
+    @classmethod
+    def get_minimum_scope(cls, items: Sequence[AppRequest]) -> ScopeDefinition:
+        return dataset_scoped_resource(items)
+
+    @classmethod
+    def create_acl(cls, actions: set[Literal["READ", "WRITE"]], scope: ScopeDefinition) -> Iterable[AclType]:
+        if isinstance(scope, AllScope | DataSetScope):
+            yield FilesAcl(actions=sorted(actions), scope=scope)
+
+    @classmethod
+    def get_id(cls, item: AppResponse | AppRequest | dict) -> ExternalId:
+        if isinstance(item, dict):
+            if "appExternalId" in item and "version" in item:
+                return ExternalId(external_id=f"{item['appExternalId']}-{item['version']}")
+            ext = item.get("externalId")
+            if ext is None:
+                raise ToolkitRequiredValueError("App must have appExternalId and version, or externalId set.")
+            return ExternalId(external_id=ext)
+        if isinstance(item, AppRequest):
+            return item.as_id()
+        if item.external_id is None:
+            raise ToolkitRequiredValueError("App must have external_id set.")
+        return ExternalId(external_id=item.external_id)
+
+    @classmethod
+    def dump_id(cls, id: ExternalId) -> dict[str, Any]:
+        return id.dump()
+
+    @classmethod
+    def as_str(cls, id: ExternalId) -> str:
+        return id.external_id
+
+    @classmethod
+    def get_dependent_items(cls, item: dict) -> Iterable[tuple[type[ResourceCRUD], Hashable]]:
+        if "dataSetExternalId" in item:
+            yield DataSetsCRUD, ExternalId(external_id=item["dataSetExternalId"])
+
+    @classmethod
+    def get_dependencies(cls, resource: AppsYAML) -> Iterable[tuple[type[ResourceCRUD], Identifier]]:
+        if resource.data_set_external_id:
+            yield DataSetsCRUD, ExternalId(external_id=resource.data_set_external_id)
+
+    def load_resource_file(
+        self, filepath: Path, environment_variables: dict[str, str | None] | None = None
+    ) -> list[dict[str, Any]]:
+        if filepath.parent.name != self.folder_name:
+            return []
+        if self.resource_build_path is None:
+            raise ValueError("build_path must be set to compare apps as app code must be compared.")
+
+        raw_list = super().load_resource_file(filepath, environment_variables)
+        for item in raw_list:
+            if "appExternalId" not in item or "version" not in item:
+                raise ToolkitRequiredValueError(
+                    "App YAML must define appExternalId and version (file external id is '<appExternalId>-<version>')."
+                )
+            file_external_id = f"{item['appExternalId']}-{item['version']}"
+            app_rootdir = Path(self.resource_build_path / item["appExternalId"])
+            self.app_dir_by_file_external_id[file_external_id] = app_rootdir
+            item[self._toolkit_hash_key] = self._create_hash_values(app_rootdir)
+
+        return raw_list
+
+    @classmethod
+    def _create_hash_values(cls, app_rootdir: Path) -> str:
+        root_hash = calculate_directory_hash(
+            app_rootdir, exclude_prefixes={".DS_Store"}, ignore_files={".pyc"}, shorten=True
+        )
+        hash_value = f"/={root_hash}"
+        to_search = [app_rootdir]
+        while to_search:
+            search_dir = to_search.pop()
+            for file in sorted(search_dir.glob("*"), key=lambda x: x.relative_to(app_rootdir).as_posix()):
+                if file.is_dir():
+                    to_search.append(file)
+                    continue
+                elif file.is_file() and file.suffix == ".pyc":
+                    continue
+                elif file.is_file() and file.name == ".DS_Store":
+                    continue
+                file_hash = calculate_hash(file, shorten=True)
+                new_entry = f"{file.relative_to(app_rootdir).as_posix()}={file_hash}"
+                if len(hash_value) + len(new_entry) > (cls.metadata_value_limit - 1):
+                    break
+                hash_value += f";{new_entry}"
+        return hash_value
+
+    def load_resource(self, resource: dict[str, Any], is_dry_run: bool = False) -> AppRequest:
+        item_id = self.get_id(resource)
+        file_external_id = item_id.external_id
+        if ds_external_id := resource.pop("dataSetExternalId", None):
+            data_set_id = self.client.lookup.data_sets.id(ds_external_id, is_dry_run)
+            self.data_set_id_by_file_external_id[file_external_id] = data_set_id
+            resource["dataSetId"] = data_set_id
+        resource.pop("metadata", None)
+        return AppRequest.model_validate(resource)
+
+    def dump_resource(self, resource: AppResponse, local: dict[str, Any] | None = None) -> dict[str, Any]:
+        dumped = resource.as_request_resource().dump(context="toolkit")
+        local = local or {}
+        if data_set_id := dumped.pop("dataSetId", None):
+            dumped["dataSetExternalId"] = self.client.lookup.data_sets.external_id(data_set_id)
+        return dumped
+
+    def _upload_zip(self, upload_url: str, content: bytes) -> None:
+        request = RequestMessage(
+            endpoint_url=upload_url,
+            method="PUT",
+            content_type="application/zip",
+            data_content=content,
+        )
+        result = self.client.http_client.request_single_retries(request)
+        result.get_success_or_raise(request)
+
+    def _deploy_zip(self, item: AppRequest, *, overwrite: bool) -> AppResponse:
+        feid = item.external_id
+        app_rootdir = self.app_dir_by_file_external_id[feid]
+        with create_temporary_zip(app_rootdir, "app.zip") as zip_path:
+            zip_bytes = zip_path.read_bytes()
+            responses = self.client.tool.apps.create([item], overwrite=overwrite)
+            if not responses:
+                raise ToolkitRequiredValueError(f"No response when creating app file metadata for {feid!r}.")
+            response = responses[0]
+            if not response.upload_url:
+                raise ToolkitRequiredValueError("Files init response missing upload_url for zip upload.")
+            self._upload_zip(response.upload_url, zip_bytes)
+            return response
+
+    def create(self, items: Sequence[AppRequest]) -> list[AppResponse]:
+        if self.resource_build_path is None:
+            raise ValueError("build_path must be set to deploy apps (zip is built from the app directory).")
+        return [self._deploy_zip(item, overwrite=False) for item in items]
+
+    def update(self, items: Sequence[AppRequest]) -> list[AppResponse]:
+        if self.resource_build_path is None:
+            raise ValueError("build_path must be set to update apps (zip is built from the app directory).")
+        return [self._deploy_zip(item, overwrite=True) for item in items]
+
+    def retrieve(self, ids: Sequence[ExternalId]) -> list[AppResponse]:
+        return self.client.tool.apps.retrieve(list(ids), ignore_unknown_ids=True)
+
+    def delete(self, ids: Sequence[ExternalId]) -> int:
+        if not ids:
+            return 0
+        self.client.tool.apps.delete(list(ids), ignore_unknown_ids=True)
+        return len(ids)
+
+    def _iterate(
+        self,
+        data_set_external_id: str | None = None,
+        space: str | None = None,
+        parent_ids: Sequence[Hashable] | None = None,
+    ) -> Iterable[AppResponse]:
+        ds_filter: DuneAppFilter | None = None
+        if data_set_external_id is not None:
+            ds_id = self.client.lookup.data_sets.id(data_set_external_id)
+            ds_filter = DuneAppFilter.from_asset_subtree_and_data_sets(data_set_id=ds_id)
+        for page in self.client.tool.apps.iterate(filter=ds_filter, limit=None):
+            yield from page

--- a/cognite_toolkit/_cdf_tk/cruds/_resource_cruds/app.py
+++ b/cognite_toolkit/_cdf_tk/cruds/_resource_cruds/app.py
@@ -6,7 +6,6 @@ from rich.console import Console
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client._resource_base import Identifier
-from cognite_toolkit._cdf_tk.client.http_client import RequestMessage
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.client.request_classes.filters import DuneAppFilter
 from cognite_toolkit._cdf_tk.client.resource_classes.app import AppRequest, AppResponse
@@ -40,7 +39,7 @@ class AppCRUD(ResourceCRUD[ExternalId, AppRequest, AppResponse]):
     _doc_url = "Files/operation/initFileUpload"
     metadata_value_limit = 512
     support_update = True
-    _toolkit_hash_key = "cdf-toolkit-app-hash"
+    _TOOLKIT_HASH_KEY = "cdf-toolkit-app-hash"
 
     def __init__(self, client: ToolkitClient, build_path: Path | None, console: Console | None):
         super().__init__(client, build_path, console)
@@ -110,7 +109,7 @@ class AppCRUD(ResourceCRUD[ExternalId, AppRequest, AppResponse]):
             file_external_id = f"{item['appExternalId']}-{item['version']}"
             app_rootdir = Path(self.resource_build_path / item["appExternalId"])
             self.app_dir_by_file_external_id[file_external_id] = app_rootdir
-            item[self._toolkit_hash_key] = self._create_hash_values(app_rootdir)
+            item[self._TOOLKIT_HASH_KEY] = self._create_hash_values(app_rootdir)
 
         return raw_list
 
@@ -155,16 +154,6 @@ class AppCRUD(ResourceCRUD[ExternalId, AppRequest, AppResponse]):
             dumped["dataSetExternalId"] = self.client.lookup.data_sets.external_id(data_set_id)
         return dumped
 
-    def _upload_zip(self, upload_url: str, content: bytes) -> None:
-        request = RequestMessage(
-            endpoint_url=upload_url,
-            method="PUT",
-            content_type="application/zip",
-            data_content=content,
-        )
-        result = self.client.http_client.request_single_retries(request)
-        result.get_success_or_raise(request)
-
     def _deploy_zip(self, item: AppRequest, *, overwrite: bool) -> AppResponse:
         feid = item.external_id
         app_rootdir = self.app_dir_by_file_external_id[feid]
@@ -176,7 +165,7 @@ class AppCRUD(ResourceCRUD[ExternalId, AppRequest, AppResponse]):
             response = responses[0]
             if not response.upload_url:
                 raise ToolkitRequiredValueError("Files init response missing upload_url for zip upload.")
-            self._upload_zip(response.upload_url, zip_bytes)
+            self.client.tool.filemetadata.upload_content(zip_bytes, response.upload_url, "application/zip")
             return response
 
     def create(self, items: Sequence[AppRequest]) -> list[AppResponse]:

--- a/cognite_toolkit/_cdf_tk/feature_flags.py
+++ b/cognite_toolkit/_cdf_tk/feature_flags.py
@@ -106,6 +106,10 @@ class Flags(Enum):
         visible=True,
         description="Enables support for the deployment pack in modules add command",
     )
+    APPS = FlagMetadata(
+        visible=False,
+        description="Enables support for App resources (file-backed, functions-style deployment)",
+    )
 
     def is_enabled(self) -> bool:
         return FeatureFlag.is_enabled(self)

--- a/cognite_toolkit/_cdf_tk/yaml_classes/__init__.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/__init__.py
@@ -8,6 +8,7 @@ This is means that we have three set of resource classes we use in Toolkit:
 """
 
 from .agent import AgentYAML
+from .apps import AppsYAML
 from .asset import AssetYAML
 from .base import BaseModelResource, ToolkitResource
 from .cognitefile import CogniteFileYAML
@@ -65,6 +66,7 @@ from .workflow_version import WorkflowVersionYAML
 
 __all__ = [
     "AgentYAML",
+    "AppsYAML",
     "AssetYAML",
     "BaseModelResource",
     "CogniteFileYAML",

--- a/cognite_toolkit/_cdf_tk/yaml_classes/apps.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/apps.py
@@ -1,0 +1,30 @@
+from pydantic import Field
+
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+
+from .base import ToolkitResource
+
+
+class AppsYAML(ToolkitResource):
+    """Dune app: zipped folder uploaded as a classic file under ``/dune-apps/``."""
+
+    app_external_id: str = Field(
+        description="Logical app id; must match the sibling directory name containing app sources.",
+        max_length=255,
+    )
+    version: str = Field(description="Version tag; combined with app id for the file external id.", max_length=255)
+    name: str = Field(description="Display name stored in file metadata.", max_length=140)
+    description: str | None = Field(
+        default=None,
+        description="Description stored in file metadata.",
+        max_length=500,
+    )
+    published: bool = Field(default=True, description="Published flag stored in file metadata.")
+    data_set_external_id: str | None = Field(
+        default=None,
+        description="Dataset for the uploaded zip file.",
+        max_length=255,
+    )
+
+    def as_id(self) -> ExternalId:
+        return ExternalId(external_id=f"{self.app_external_id}-{self.version}")

--- a/tests/test_integration/test_commands/test_deploy.py
+++ b/tests/test_integration/test_commands/test_deploy.py
@@ -15,6 +15,7 @@ from cognite_toolkit._cdf_tk.commands import BuildCommand, DeployCommand, PullCo
 from cognite_toolkit._cdf_tk.cruds import (
     CRUDS_BY_FOLDER_NAME,
     RESOURCE_CRUD_LIST,
+    AppCRUD,
     FunctionCRUD,
     FunctionScheduleCRUD,
     GraphQLCRUD,
@@ -169,7 +170,7 @@ def get_changed_source_files(
             # Authentication that causes the diff to fail
             loader_cls in {HostedExtractorSourceCRUD, HostedExtractorDestinationCRUD}
             # External files that cannot (or not yet supported) be pulled
-            or loader_cls in {GraphQLCRUD, FunctionCRUD, StreamlitCRUD}
+            or loader_cls in {GraphQLCRUD, FunctionCRUD, AppCRUD, StreamlitCRUD}
             # Have authentication hashes that is different for each environment
             or loader_cls in {TransformationCRUD, FunctionScheduleCRUD, WorkflowTriggerCRUD}
             # LocationFilterLoader needs to split the file into multiple files, so we cannot compare them

--- a/tests/test_unit/approval_client/config.py
+++ b/tests/test_unit/approval_client/config.py
@@ -116,6 +116,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.apm_config_v1 import (
     APMConfigRequest,
     APMConfigResponse,
 )
+from cognite_toolkit._cdf_tk.client.resource_classes.app import AppRequest, AppResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.asset import AssetRequest, AssetResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.cognite_file import (
     CogniteFileRequest,
@@ -1289,6 +1290,17 @@ API_RESOURCES = [
         api_name="tool.functions",
         resource_cls=FunctionResponse,
         _write_cls=FunctionRequest,
+        methods={
+            "create": [Method(api_class_method="create", mock_class_method="create")],
+            "retrieve": [
+                Method(api_class_method="retrieve", mock_class_method="retrieve"),
+            ],
+        },
+    ),
+    APIResource(
+        api_name="tool.apps",
+        resource_cls=AppResponse,
+        _write_cls=AppRequest,
         methods={
             "create": [Method(api_class_method="create", mock_class_method="create")],
             "retrieve": [

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_base.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_base.py
@@ -22,6 +22,7 @@ from pytest import MonkeyPatch
 from pytest_regressions.data_regression import DataRegressionFixture
 
 from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
+from cognite_toolkit._cdf_tk.client.resource_classes.app import AppResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.graphql_data_model import GraphQLDataModelResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.streamlit_ import StreamlitResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.transformation import TransformationResponse
@@ -140,7 +141,13 @@ class TestFormatConsistency:
     ) -> None:
         loader = Loader.create_loader(env_vars_with_client.get_client(), tmp_path)
 
-        if loader.resource_cls in [TransformationResponse, FileMetadata, GraphQLDataModelResponse, StreamlitResponse]:
+        if loader.resource_cls in [
+            TransformationResponse,
+            FileMetadata,
+            GraphQLDataModelResponse,
+            StreamlitResponse,
+            AppResponse,
+        ]:
             pytest.skip("Skipped loaders that require secondary files")
         elif loader.resource_cls in [Edge, Node, Destination]:
             pytest.skip(f"Skipping {loader.resource_cls} because it has special properties")
@@ -177,7 +184,13 @@ class TestFormatConsistency:
     ) -> None:
         loader = Loader.create_loader(env_vars_with_client.get_client(), tmp_path)
 
-        if loader.resource_cls in [TransformationResponse, FileMetadata, GraphQLDataModelResponse, StreamlitResponse]:
+        if loader.resource_cls in [
+            TransformationResponse,
+            FileMetadata,
+            GraphQLDataModelResponse,
+            StreamlitResponse,
+            AppResponse,
+        ]:
             pytest.skip("Skipped loaders that require secondary files")
         elif loader.resource_cls in [Edge, Node, Destination]:
             pytest.skip(f"Skipping {loader.resource_cls} because it has special properties")
@@ -239,6 +252,8 @@ def test_resource_types_is_up_to_date() -> None:
     if not FeatureFlag.is_enabled(Flags.DATA_PRODUCTS):
         extra.discard("data_products")
         extra.discard("rulesets")
+    if not FeatureFlag.is_enabled(Flags.APPS):
+        extra.discard("apps")
     if not FeatureFlag.is_enabled(Flags.SIGNALS):
         extra.discard("signals")
     assert not missing, f"Missing {missing=}"


### PR DESCRIPTION
# Description

Adds a Toolkit resource for Dune apps: folder `apps/`, kind `App`, behind the hidden alpha flag `apps` in `cdf.toml`.

Deployment mirrors **Streamlit** (Files API: `POST /files` with directory `/dune-apps/`, then `PUT` to `uploadUrl`) while packaging sources as a **zip** from the app directory (same zipping idea as **functions**). File external id is `<appExternalId>-<version>`; metadata matches the Dune upload shape (`published`, `name`, `description`, `externalId`, `version`, plus `appExternalId` for round-trip).

## Bump

- [ ] Patch
- [x] Skip

## Changelog

### Added

- `AppCRUD`, `AppBuilder`, `AppsYAML`, `AppsAPI` (`tool.apps`), `DuneAppFilter`, and `Flags.APPS` (hidden).