### PR TITLE
[CDF-27633, CDF-26477] 👷‍♂️Improved Download/Upload Files

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -19,7 +19,6 @@ from cognite_toolkit._cdf_tk.storageio import (
     DatapointsIO,
     DataSelector,
     EventDataIO,
-    FileContentIO,
     FileMetadataDataIO,
     HierarchyIO,
     InstanceIO,
@@ -36,7 +35,6 @@ from cognite_toolkit._cdf_tk.storageio.selectors import (
     ChartSelector,
     DataPointsDataSetSelector,
     DataSetSelector,
-    FileIdentifierSelector,
     InstanceSelector,
     InstanceSpaceSelector,
     InstanceViewSelector,
@@ -44,7 +42,6 @@ from cognite_toolkit._cdf_tk.storageio.selectors import (
     SelectedTable,
     SelectedView,
 )
-from cognite_toolkit._cdf_tk.storageio.selectors._file_content import FileInternalID
 from cognite_toolkit._cdf_tk.storageio.selectors._records import (
     RecordContainerSelector,
     SelectedContainer,
@@ -551,7 +548,7 @@ class DownloadApp(typer.Typer):
                 "--include-file-contents",
                 "-c",
                 help="Whether to include file contents when downloading assets. Note if you enable this option, you can"
-                "only download 1000 files at a time.",
+                "only download 100 files at a time.",
                 hidden=not Flags.EXTEND_DOWNLOAD.is_enabled(),
             ),
         ] = False,
@@ -610,42 +607,23 @@ class DownloadApp(typer.Typer):
                 ).unsafe_ask()
             else:
                 include_file_contents = False
-
-            available_formats = FileContentFormats if include_file_contents else AssetCentricFormats
-            file_format = FileContentFormats.ndjson if include_file_contents else file_format  # type: ignore[assignment]
-            data_sets, file_format, compression, output_dir, limit = self._asset_centric_interactive(
-                FileMetadataInteractiveSelect(client, "download"),
-                file_format,
-                compression,
-                output_dir,
-                limit if not include_file_contents else 1000,
-                "file metadata",
-                max_limit=1000 if include_file_contents else None,
-                available_formats=available_formats,
-            )
-
+            if not include_file_contents:
+                # Continue with regular interactive selection
+                data_sets, file_format, compression, output_dir, limit = self._asset_centric_interactive(
+                    FileMetadataInteractiveSelect(client, "download"),
+                    file_format,
+                    compression,
+                    output_dir,
+                    limit if not include_file_contents else 1000,
+                    "file metadata",
+                    max_limit=1000 if include_file_contents else None,
+                    available_formats=AssetCentricFormats,
+                )
         io: StorageIO
         selectors: list[DataSelector]
         if include_file_contents:
-            if limit == -1 or limit > 1000:
-                limit = 1000
-                print(
-                    "[yellow]When including file contents, the maximum number of files that can be downloaded at a time is 1000. "
-                )
-            if file_format == AssetCentricFormats.csv or file_format == AssetCentricFormats.parquet:
-                print(
-                    "[red]When including file contents, the only supported format is ndjson. Overriding the format to ndjson.[/]"
-                )
-                file_format = AssetCentricFormats.ndjson
-            files = client.files.list(data_set_external_ids=data_sets, limit=limit)
-            download_dir_name = "asset-centric-files"
-            selector = FileIdentifierSelector(
-                identifiers=tuple([FileInternalID(internal_id=file.id) for file in files]),
-                download_dir_name=download_dir_name,
-            )
-            selectors = [selector]
-            io = FileContentIO(client, output_dir / download_dir_name)
-        else:
+            raise NotImplementedError()
+        elif data_sets is not None:
             selectors = [
                 DataSetSelector(
                     kind="FileMetadata", data_set_external_id=data_set, download_dir_name="asset-centric-files"
@@ -653,6 +631,8 @@ class DownloadApp(typer.Typer):
                 for data_set in data_sets
             ]
             io = FileMetadataDataIO(client)
+        else:
+            raise NotImplementedError("Bug in Toolkit. Unexpected execution path.")
 
         cmd = DownloadCommand(client=client)
         cmd.run(

--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -627,13 +627,21 @@ class DownloadApp(typer.Typer):
         selectors: list[DataSelector]
         if include_file_contents:
             selector = DocumentsInteractiveSelect(client, max_selected=100)
+            file_format = AssetCentricFormats.ndjson
+            download_dir_name = "asset_centric-files-with-content"
+            output_dir = Path(
+                questionary.path(
+                    "Where to download the file metadata and contents:", default=str(output_dir), only_directories=True
+                ).unsafe_ask()
+            )
             documents = selector.select_documents()
-            io = FileMetadataContentIO(client)
+            io = FileMetadataContentIO(client, target_dir=output_dir / download_dir_name / "files")
             selectors = [
                 FileMetadataFilesSelectorV2(
                     ids=tuple(
                         InternalWithNameId(id=document.id, name=document.source_file.name) for document in documents
-                    )
+                    ),
+                    download_dir_name=download_dir_name,
                 )
             ]
         elif data_sets is not None:

--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -19,6 +19,7 @@ from cognite_toolkit._cdf_tk.storageio import (
     DatapointsIO,
     DataSelector,
     EventDataIO,
+    FileMetadataContentIO,
     FileMetadataDataIO,
     HierarchyIO,
     InstanceIO,
@@ -35,9 +36,11 @@ from cognite_toolkit._cdf_tk.storageio.selectors import (
     ChartSelector,
     DataPointsDataSetSelector,
     DataSetSelector,
+    FileMetadataFilesSelectorV2,
     InstanceSelector,
     InstanceSpaceSelector,
     InstanceViewSelector,
+    InternalWithNameId,
     RawTableSelector,
     SelectedTable,
     SelectedView,
@@ -53,6 +56,7 @@ from cognite_toolkit._cdf_tk.utils.interactive_select import (
     AssetCentricInteractiveSelect,
     AssetInteractiveSelect,
     DataModelingSelect,
+    DocumentsInteractiveSelect,
     EventInteractiveSelect,
     FileMetadataInteractiveSelect,
     InteractiveCanvasSelect,
@@ -622,7 +626,16 @@ class DownloadApp(typer.Typer):
         io: StorageIO
         selectors: list[DataSelector]
         if include_file_contents:
-            raise NotImplementedError()
+            selector = DocumentsInteractiveSelect(client, max_selected=100)
+            documents = selector.select_documents()
+            io = FileMetadataContentIO(client)
+            selectors = [
+                FileMetadataFilesSelectorV2(
+                    ids=tuple(
+                        InternalWithNameId(id=document.id, name=document.source_file.name) for document in documents
+                    )
+                )
+            ]
         elif data_sets is not None:
             selectors = [
                 DataSetSelector(

--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -635,7 +635,11 @@ class DownloadApp(typer.Typer):
                 ).unsafe_ask()
             )
             documents = selector.select_documents()
-            io = FileMetadataContentIO(client, target_dir=output_dir / download_dir_name / "files")
+            io = FileMetadataContentIO(
+                client,
+                config_directory=output_dir / download_dir_name,
+                file_directory=output_dir / download_dir_name / "files",
+            )
             selectors = [
                 FileMetadataFilesSelectorV2(
                     ids=tuple(

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -283,8 +283,7 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             data_content=filepath.read_bytes(),
         )
         upload_response = self._http_client.request_single_retries(fileupoad)
-        success = upload_response.get_success_or_raise(fileupoad)
-        return success
+        return upload_response.get_success_or_raise(fileupoad)
 
     def get_upload_url(self, items: Sequence[ExternalId | InstanceId]) -> builtins.list[FileMetadataResponse]:
         """Get a URL to upload a file to CDF for one or more file metadata entries."""

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -4,6 +4,8 @@ from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import Any, Literal
 
+import httpx
+
 from cognite_toolkit._cdf_tk.client.cdf_client import CDFResourceAPI, PagedResponse, ResponseItems
 from cognite_toolkit._cdf_tk.client.cdf_client.api import Endpoint
 from cognite_toolkit._cdf_tk.client.http_client import (
@@ -12,11 +14,17 @@ from cognite_toolkit._cdf_tk.client.http_client import (
     ItemsSuccessResponse,
     RequestMessage,
     SuccessResponse,
+    ToolkitAPIError,
 )
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, InstanceId, InternalId, InternalOrExternalId
 from cognite_toolkit._cdf_tk.client.request_classes.filters import ClassicFilter
-from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataRequest, FileMetadataResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import (
+    DownloadResponse,
+    FileMetadataRequest,
+    FileMetadataResponse,
+)
 from cognite_toolkit._cdf_tk.client.resource_classes.pending_instance_id import PendingInstanceId
+from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 
 
 class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
@@ -32,6 +40,7 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             },
             api_version="alpha",
         )
+        self._download_link = Endpoint(method="POST", path="/files/downloadlink", item_limit=10)
 
     def _validate_page_response(
         self, response: SuccessResponse | ItemsSuccessResponse
@@ -299,3 +308,45 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             responses_with_url = ResponseItems[FileMetadataResponse].model_validate_json(url_response.body).items
             results.extend(responses_with_url)
         return results
+
+    def get_download_url(
+        self, items: Sequence[InternalId], extended_expiration: bool = False
+    ) -> builtins.list[DownloadResponse]:
+        """Get a URL to download a file to CDF for one or more file metadata entries.
+
+        Args:
+            items: Sequence of InternalId identifying the files to download.
+            extended_expiration: If True, the expiration will be 1 hour instead of 30 seconds for the
+                the download URL.
+
+        Returns:
+                List of DownloadResponse objects containing the download URLs.
+        """
+        results: list[DownloadResponse] = []
+        for chunk in chunker_sequence(items, self._download_link.item_limit):
+            request = RequestMessage(
+                endpoint_url=self._http_client.config.create_api_url(self._download_link.path),
+                method=self._download_link.method,
+                body_content={"items": [item.dump() for item in chunk]},
+                parameters={"extendedExpiration": extended_expiration},
+            )
+            success = self._http_client.request_single_retries(request).get_success_or_raise(request)
+            results.extend(ResponseItems[DownloadResponse].model_validate_json(success.body).items)
+        return results
+
+    def dowonload_file(self, download_url: str, destination: Path) -> None:
+        """Download a file from CDF using a download URL.
+
+        Args:
+            download_url: The URL to download the file from.
+            destination: The local path to save the downloaded file to.
+        """
+        with httpx.stream("GET", download_url) as response:
+            if response.status_code != 200:
+                raise ToolkitAPIError(
+                    message=f"Download failed with status code {response.status_code}: {response.text}",
+                    code=response.status_code,
+                )
+            with destination.open(mode="wb") as file_stream:
+                for chunk in response.iter_bytes(chunk_size=8192):
+                    file_stream.write(chunk)

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -274,7 +274,8 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             sleep_time *= 2
         return to_check, elapsed_time
 
-    def upload_file(self, filepath: Path, upload_url: str, mime_type: str | None = None) -> None:
+    def upload_file(self, filepath: Path, upload_url: str, mime_type: str | None = None) -> SuccessResponse:
+        # Todo: If file size is above 5000 MB - 5,000,000,000 bytes, do a multipart file upload.
         fileupoad = RequestMessage(
             endpoint_url=upload_url,
             method="PUT",
@@ -282,7 +283,8 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             data_content=filepath.read_bytes(),
         )
         upload_response = self._http_client.request_single_retries(fileupoad)
-        upload_response.get_success_or_raise(fileupoad)
+        success = upload_response.get_success_or_raise(fileupoad)
+        return success
 
     def get_upload_url(self, items: Sequence[ExternalId | InstanceId]) -> builtins.list[FileMetadataResponse]:
         """Get a URL to upload a file to CDF for one or more file metadata entries."""

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -334,7 +334,7 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             results.extend(ResponseItems[DownloadResponse].model_validate_json(success.body).items)
         return results
 
-    def dowonload_file(self, download_url: str, destination: Path) -> None:
+    def download_file(self, download_url: str, destination: Path) -> None:
         """Download a file from CDF using a download URL.
 
         Args:

--- a/cognite_toolkit/_cdf_tk/client/http_client/_data_classes.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_data_classes.py
@@ -31,6 +31,7 @@ class HTTPResult(HTTPBaseModel):
                 duplicated=self.error.duplicated,  # type: ignore[arg-type]
                 code=self.error.code,
                 request=request,
+                response=self,
             )
         elif isinstance(self, FailedRequest):
             raise ToolkitAPIError(f"Request failed with error: {self.error}", request=request)

--- a/cognite_toolkit/_cdf_tk/client/http_client/_exception.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_exception.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from cognite_toolkit._cdf_tk.client.http_client._data_classes import RequestMessage
+    from cognite_toolkit._cdf_tk.client.http_client._data_classes import FailedResponse, RequestMessage
 
 
 class ToolkitAPIError(Exception):
@@ -15,6 +15,7 @@ class ToolkitAPIError(Exception):
         code: int | None = None,
         is_auto_retryable: bool | None = None,
         request: "RequestMessage | None " = None,
+        response: "FailedResponse | None " = None,
     ) -> None:
         super().__init__(message)
         self.message = message
@@ -23,6 +24,7 @@ class ToolkitAPIError(Exception):
         self.code = code
         self.is_auto_retryable = is_auto_retryable
         self.request = request
+        self.response = response
 
     def as_debug_dict(self) -> dict[str, Any]:
         debug_info: dict[str, Any] = {}

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/filemetadata.py
@@ -19,7 +19,7 @@ class FileMetadata(BaseModelObject):
     metadata: Metadata | None = None
     asset_ids: list[int] | None = None
     data_set_id: int | None = None
-    labels: list[dict[Literal["externalId"], str]] | None = None
+    labels: list[ExternalId] | None = None
     geo_location: JsonValue | None = None
     source_created_time: int | None = None
     source_modified_time: int | None = None

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/filemetadata.py
@@ -65,3 +65,8 @@ class FileMetadataResponse(FileMetadata, ResponseResource[FileMetadataRequest]):
 
     def as_internal_id(self) -> InternalId:
         return InternalId(id=self.id)
+
+
+class DownloadResponse(BaseModelObject):
+    id: int
+    download_url: str | None = None

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/filemetadata.py
@@ -5,7 +5,7 @@ from pydantic import Field, JsonValue
 
 from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject, ResponseResource, UpdatableRequestResource
 from cognite_toolkit._cdf_tk.client._types import Metadata
-from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, NodeUntypedId
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, InternalId, NodeUntypedId
 
 FILEPATH = "$FILEPATH"
 
@@ -62,3 +62,6 @@ class FileMetadataResponse(FileMetadata, ResponseResource[FileMetadataRequest]):
     @classmethod
     def request_cls(cls) -> type[FileMetadataRequest]:
         return FileMetadataRequest
+
+    def as_internal_id(self) -> InternalId:
+        return InternalId(id=self.id)

--- a/cognite_toolkit/_cdf_tk/commands/_upload.py
+++ b/cognite_toolkit/_cdf_tk/commands/_upload.py
@@ -22,6 +22,7 @@ from cognite_toolkit._cdf_tk.resource_ios import ViewIO
 from cognite_toolkit._cdf_tk.storageio import (
     ChartIO,
     FileContentIO,
+    FileMetadataContentIO,
     T_Selector,
     UploadableStorageIO,
     get_upload_io,
@@ -294,6 +295,8 @@ class UploadCommand(ToolkitCommand):
             return None
         if issubclass(io_cls, ChartIO):
             return ChartIO(client, skip_strict_mode=skip_strict_mode)
+        elif issubclass(io_cls, FileMetadataContentIO):
+            return FileMetadataContentIO(client, config_directory=data_file.parent)
         else:
             return io_cls(client)
 

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/file.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/file.py
@@ -191,7 +191,7 @@ class FileMetadataCRUD(ResourceContainerIO[ExternalId, FileMetadataRequest, File
         if asset_external_ids := resource.pop("assetExternalIds", None):
             resource["assetIds"] = self.client.lookup.assets.id(asset_external_ids, is_dry_run)
         request = FileMetadataRequest.model_validate(resource)
-        if request.external_id:
+        if request.external_id and not request.filepath:
             request.filepath = self._filepath_by_external_id.get(request.external_id, None)
         return request
 

--- a/cognite_toolkit/_cdf_tk/storageio/__init__.py
+++ b/cognite_toolkit/_cdf_tk/storageio/__init__.py
@@ -26,6 +26,7 @@ from ._base import (
 from ._data_classes import InstanceIdCSVList, InstanceIdRow, ModelList
 from ._datapoints import DatapointsIO
 from ._file_content import FileContentIO
+from ._file_contentv2 import FileMetadataContentIO
 from ._instances import InstanceIO
 from ._raw import RawIO
 from ._records import RecordIO
@@ -56,6 +57,7 @@ __all__ = [
     "DatapointsIO",
     "EventDataIO",
     "FileContentIO",
+    "FileMetadataContentIO",
     "FileMetadataDataIO",
     "HierarchyIO",
     "InstanceIO",

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -13,24 +13,27 @@ from cognite_toolkit._cdf_tk.client.http_client._item_classes import (
     ItemsResultList,
     ItemsResultMessage,
 )
-from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, InternalId
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import (
     FILEPATH,
     FileMetadataRequest,
     FileMetadataResponse,
 )
 from cognite_toolkit._cdf_tk.resource_ios import FileMetadataCRUD
+from cognite_toolkit._cdf_tk.utils import sanitize_filename
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 from cognite_toolkit._cdf_tk.utils.fileio import MultiFileReader
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 
 from . import StorageIOConfig
 from ._base import Bookmark, ConfigurableStorageIO, DataItem, Page, TableUploadableStorageIO
+from .logger import LogEntryV2, Severity
 from .selectors import (
     FILENAME_VARIABLE,
     FileMetadataContentSelectorV2,
     FileMetadataFilesSelectorV2,
     FileMetadataTemplateSelectorV2,
+    InternalIdWithName,
 )
 
 
@@ -40,16 +43,17 @@ class FileMetadataContentIO(
 ):
     CHUNK_SIZE = 10
 
-    def __init__(self, client: ToolkitClient, overwrite: bool = False) -> None:
+    def __init__(self, client: ToolkitClient, overwrite: bool = False, target_dir: Path = Path.cwd()) -> None:
         super().__init__(client)
         self.overwrite = overwrite
+        self._target_dir = target_dir
         self._crud = FileMetadataCRUD(client, None, None, support_upload=False)
         self._downloaded_data_sets_by_selector: dict[FileMetadataContentSelectorV2 | None, set[int]] = defaultdict(set)
         self._downloaded_labels_by_selector: dict[FileMetadataContentSelectorV2 | None, set[ExternalId]] = defaultdict(
             set
         )
 
-    def _verify_download_selector(self, selector: FileMetadataContentSelectorV2) -> tuple[InternalId, ...]:
+    def _verify_download_selector(self, selector: FileMetadataContentSelectorV2) -> tuple[InternalIdWithName, ...]:
         if isinstance(selector, FileMetadataFilesSelectorV2) and selector.ids:
             return selector.ids
         raise NotImplementedError(f"{selector.type} does not support download")
@@ -58,29 +62,61 @@ class FileMetadataContentIO(
         self, selector: FileMetadataContentSelectorV2, limit: int | None = None, bookmark: Bookmark | None = None
     ) -> Iterable[Page[FileMetadataResponse]]:
         file_ids = self._verify_download_selector(selector)
+        self._target_dir.mkdir(exist_ok=True, parents=True)
         for chunk in chunker_sequence(file_ids, self.CHUNK_SIZE):
+            self.logger.register([item.display_name for item in chunk])
             file_metadata = self.client.tool.filemetadata.retrieve(list(chunk), ignore_unknown_ids=True)
-            if len(file_metadata) != len(chunk) and (
-                missing_file_ids := ({file.as_internal_id() for file in file_metadata} - set(chunk))
-            ):
-                raise NotImplementedError(
-                    f"The following file ids were not found and cannot be downloaded: {', '.join(str(id) for id in missing_file_ids)}"
-                )
+            retrieved_by_id = {file.id: file for file in file_metadata}
+            data_items: list[DataItem[FileMetadataResponse]] = []
+            for item in chunk:
+                if item.id not in retrieved_by_id:
+                    self.logger.log(
+                        LogEntryV2(
+                            id=item.display_name,
+                            severity=Severity.skipped,
+                            label="Missing in CDF",
+                            message=f"File {item.display_name} not found in CDF, skipping.",
+                        )
+                    )
+                    continue
+                file = retrieved_by_id[item.id]
+                if not file.uploaded:
+                    self.logger.log(
+                        LogEntryV2(
+                            id=item.display_name,
+                            severity=Severity.warning,
+                            label="Missing file content",
+                            message=f"File {item.display_name} metadata found in CDF, but file content is not uploaded.",
+                        )
+                    )
+                else:
+                    filepath = self._target_dir / sanitize_filename(file.name)
+                    has_downloaded = self._try_download_content(file, filepath, item.display_name)
+                    if has_downloaded:
+                        file.filepath = filepath
+                data_items.append(DataItem(tracking_id=item.display_name, item=file))
 
-            for file in file_metadata:
-                filepath = self._download_content(file)
-                file.filepath = filepath
-
-            yield Page(
-                worker_id="main",
-                items=[DataItem(tracking_id=str(file.id), item=file) for file in file_metadata],
-            )
+            yield Page(worker_id="main", items=data_items)
 
     def count(self, selector: FileMetadataContentSelectorV2) -> int | None:
         return len(self._verify_download_selector(selector))
 
-    def _download_content(self, file_metadata: FileMetadataResponse) -> Path:
-        raise NotImplementedError()
+    def _try_download_content(self, file_metadata: FileMetadataResponse, destination: Path, tracking_id: str) -> bool:
+        """Tries to download the file content to the destination returns whether it was successful."""
+        try:
+            result = self.client.tool.filemetadata.get_download_url([file_metadata.as_internal_id()])[0]
+            if result.download_url:
+                self.client.tool.filemetadata.dowonload_file(download_url=result.download_url, destination=destination)
+                return True
+            message = f"File content download URL not found for {tracking_id}."
+        except ToolkitAPIError as err:
+            message = f"File content not download for {tracking_id} failed with error: {err.message}."
+        except IndexError:
+            message = f"File content not downloaded for {tracking_id}. CDF did not return a download URL."
+        self.logger.log(
+            LogEntryV2(id=tracking_id, label="File content download failed", severity=Severity.warning, message=message)
+        )
+        return False
 
     def row_to_resource(
         self, source_id: str, row: dict[str, JsonVal], selector: FileMetadataContentSelectorV2 | None = None

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -181,6 +181,11 @@ class FileMetadataContentIO(
                 security_ids.update(item.security_categories)
             if item.labels:
                 label_ids.update(item.labels)
+
+        self.client.lookup.assets.external_id(list(asset_ids))
+        self.client.lookup.data_sets.external_id(list(data_set_ids))
+        self.client.lookup.security_categories.external_id(list(security_ids))
+
         self._downloaded_data_sets_by_selector[selector].update(data_set_ids)
         self._downloaded_labels_by_selector[selector].update(label_ids)
         self._downloaded_security_categories_by_selector[selector].update(security_ids)

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -1,6 +1,9 @@
 from abc import ABC
 from collections.abc import Iterable
-from typing import Literal
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import ConfigDict, DirectoryPath, field_validator, json
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.http_client import (
@@ -9,14 +12,55 @@ from cognite_toolkit._cdf_tk.client.http_client import (
 from cognite_toolkit._cdf_tk.client.http_client._item_classes import ItemsResultList
 from cognite_toolkit._cdf_tk.client.resource_classes.cognite_file import CogniteFileRequest, CogniteFileResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataRequest, FileMetadataResponse
+from cognite_toolkit._cdf_tk.cruds import FileMetadataCRUD
+from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
+from cognite_toolkit._cdf_tk.utils.fileio import MultiFileReader
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 
 from . import DataSelector, StorageIOConfig, T_DataResponse, T_Selector
-from ._base import Bookmark, ConfigurableStorageIO, Page, TableUploadableStorageIO
+from ._base import Bookmark, ConfigurableStorageIO, DataItem, Page, TableUploadableStorageIO
+from .selectors._base import SelectorObject
+
+FILENAME_VARIABLE = "$FILENAME"
+FILEPATH = "$FILEPATH"
+
+
+class FileMetadataTemplate(SelectorObject):
+    model_config = ConfigDict(extra="allow")
+    name: str
+    external_id: str
+
+    def create_instance(self, filepath: Path) -> dict[str, Any]:
+        json_str = self.model_dump_json(by_alias=True)
+        output = json.loads(json_str.replace(FILENAME_VARIABLE, filepath.name))
+        output[FILEPATH] = filepath
+        return output
+
+    @field_validator("name", "external_id")
+    @classmethod
+    def _validate_filename_in_fields(cls, v: str) -> str:
+        if FILENAME_VARIABLE not in v:
+            raise ValueError(
+                f"{FILENAME_VARIABLE!s} must be present in 'name' and 'external_id' fields. "
+                f"This allows for dynamic substitution based on the file name."
+            )
+        return v
 
 
 class FileMetadataContentSelector(DataSelector, ABC):
     kind: Literal["FileMetadataContent"] = "FileMetadataContent"
+
+
+class FileMetadataTemplateSelector(FileMetadataContentSelector):
+    type: Literal["FileMetadataTemplateSelector"] = "FileMetadataTemplateSelector"
+    template: FileMetadataTemplate
+    file_directory: DirectoryPath
+
+
+class FileMetadataUploadSelector(DataSelector, ABC):
+    """Upload all in a given csv/parquest file"""
+
+    kind: Literal["FileMetadataUploadSelector"] = "FileMetadataUploadSelector"
 
 
 class CogniteFileContentSelector(DataSelector, ABC):
@@ -30,6 +74,7 @@ class FileMetadataContentIO(
     def __init__(self, client: ToolkitClient, overwrite: bool = False) -> None:
         super().__init__(client)
         self.overwrite = overwrite
+        self._crud = FileMetadataCRUD(client, None, None, support_upload=False)
 
     def stream_data(
         self, selector: FileMetadataContentSelector, limit: int | None = None, bookmark: Bookmark | None = None
@@ -42,10 +87,20 @@ class FileMetadataContentIO(
     def row_to_resource(
         self, source_id: str, row: dict[str, JsonVal], selector: FileMetadataContentSelector | None = None
     ) -> FileMetadataRequest:
-        raise NotImplementedError()
+        metadata: dict[str, JsonVal] = {}
+        cleaned_row: dict[str, JsonVal] = {}
+        for key, value in row.items():
+            if key.startswith("metadata."):
+                metadata_key = key[len("metadata.") :]
+                metadata[metadata_key] = value
+            else:
+                cleaned_row[key] = value
+        if metadata:
+            cleaned_row["metadata"] = metadata
+        return self._crud.load_resource(cleaned_row)
 
     def json_to_resource(self, item_json: dict[str, JsonVal]) -> FileMetadataRequest:
-        raise NotImplementedError()
+        return self._crud.load_resource(item_json)
 
     def data_to_json_chunk(
         self, data_chunk: Page[FileMetadataResponse], selector: FileMetadataContentSelector | None = None
@@ -62,6 +117,26 @@ class FileMetadataContentIO(
         selector: T_Selector | None = None,
     ) -> ItemsResultList:
         raise NotImplementedError()
+
+    @classmethod
+    def read_chunks(
+        cls, reader: MultiFileReader, selector: FileMetadataContentSelector
+    ) -> Iterable[Page[dict[str, JsonVal]]]:
+        if not isinstance(selector, FileMetadataTemplateSelector):
+            yield from super().read_chunks(reader, selector)
+            return
+        template = selector.template
+        for chunk in chunker_sequence(reader.input_files, cls.CHUNK_SIZE):
+            yield Page(
+                worker_id="main",
+                items=[DataItem(tracking_id=item.as_posix(), item=template.create_instance(item)) for item in chunk],
+            )
+
+    @classmethod
+    def count_items(cls, reader: MultiFileReader, selector: FileMetadataContentSelector | None = None) -> int:
+        if not isinstance(selector, FileMetadataTemplateSelector):
+            return super().count_items(reader, selector)
+        return len(reader.input_files)
 
 
 class CogniteFileContentIO(

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import ConfigDict, DirectoryPath, field_validator
+from pydantic import ConfigDict, DirectoryPath, Field, field_validator
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.http_client import (
@@ -17,6 +17,7 @@ from cognite_toolkit._cdf_tk.client.http_client._item_classes import (
     ItemsResultList,
     ItemsResultMessage,
 )
+from cognite_toolkit._cdf_tk.client.identifiers import InternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.cognite_file import CogniteFileRequest, CogniteFileResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataRequest, FileMetadataResponse
 from cognite_toolkit._cdf_tk.cruds import FileMetadataCRUD
@@ -74,10 +75,16 @@ class FileMetadataTemplateSelector(FileMetadataContentSelector):
         return [file for file in self.file_directory.iterdir() if file.is_file()]
 
 
-class FileMetadataUploadSelector(FileMetadataContentSelector, ABC):
-    """Upload all in a given csv/parquest file"""
+class FileMetadataFilesSelector(FileMetadataContentSelector, ABC):
+    """Download/upload individual files.
 
-    type: Literal["FileMetadataUpload"] = "FileMetadataUpload"
+    For download, the ids field must be set.
+    For upload, all files in a csv/parquest file are uploaded.
+
+    """
+
+    type: Literal["FileMetadataFiles"] = "FileMetadataFiles"
+    ids: tuple[InternalId, ...] | None = Field(None, exclude=True, description="(Only used for download)")
 
     def __str__(self) -> str:
         return self.type
@@ -98,13 +105,30 @@ class FileMetadataContentIO(
         self.overwrite = overwrite
         self._crud = FileMetadataCRUD(client, None, None, support_upload=False)
 
+    def _verify_selector(self, selector: FileMetadataContentSelector) -> tuple[InternalId, ...]:
+        if isinstance(selector, FileMetadataFilesSelector) and selector.ids:
+            return selector.ids
+        raise NotImplementedError(f"{selector.type} does not support download")
+
     def stream_data(
         self, selector: FileMetadataContentSelector, limit: int | None = None, bookmark: Bookmark | None = None
     ) -> Iterable[Page[FileMetadataResponse]]:
-        raise NotImplementedError()
+        file_ids = self._verify_selector(selector)
+        for chunk in chunker_sequence(file_ids, self.CHUNK_SIZE):
+            file_metadata = self.client.tool.filemetadata.retrieve(list(chunk), ignore_unknown_ids=True)
+            if len(file_metadata) != len(chunk) and (
+                missing_file_ids := {file.as_internal_id() for file in file_metadata} - set(chunk)
+            ):
+                for file_id in missing_file_ids:
+                    self.logger.tracker.add_issue(str(file_id.id), "Missing in CDF")
+                    self.logger.tracker.finalize_item(str(file_id.id), "failure")
+            yield Page(
+                worker_id="main",
+                items=[DataItem(tracking_id=str(file.id), item=file) for file in file_metadata],
+            )
 
     def count(self, selector: FileMetadataContentSelector) -> int | None:
-        raise NotImplementedError()
+        return len(self._verify_selector(selector))
 
     def row_to_resource(
         self, source_id: str, row: dict[str, JsonVal], selector: FileMetadataContentSelector | None = None
@@ -138,9 +162,7 @@ class FileMetadataContentIO(
         http_client: HTTPClient,
         selector: FileMetadataContentSelector | None = None,
     ) -> ItemsResultList:
-        return ItemsResultList(
-            [self._upload_single_item(item) for item in data_chunk],
-        )
+        return ItemsResultList([self._upload_single_item(item) for item in data_chunk])
 
     def _upload_single_item(self, item: DataItem[FileMetadataRequest]) -> ItemsFailedRequest | Any:
         request = item.item

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -1,9 +1,11 @@
+import json
+import mimetypes
 from abc import ABC
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import ConfigDict, DirectoryPath, field_validator, json
+from pydantic import ConfigDict, DirectoryPath, field_validator
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.http_client import (
@@ -34,10 +36,13 @@ class FileMetadataTemplate(SelectorObject):
     name: str
     external_id: str
 
-    def create_instance(self, filepath: Path) -> dict[str, Any]:
+    def create_instance(self, filepath: Path, guess_mime_type: bool) -> dict[str, Any]:
         json_str = self.model_dump_json(by_alias=True)
         output = json.loads(json_str.replace(FILENAME_VARIABLE, filepath.name))
         output[FILEPATH] = filepath
+        if "mimeType" not in output and guess_mime_type:
+            me_type, _ = mimetypes.guess_type(filepath)
+            output["mimeType"] = me_type
         return output
 
     @field_validator("name", "external_id")
@@ -59,6 +64,7 @@ class FileMetadataTemplateSelector(FileMetadataContentSelector):
     type: Literal["FileMetadataTemplate"] = "FileMetadataTemplate"
     template: FileMetadataTemplate
     file_directory: DirectoryPath
+    guess_mime_type: bool
 
     def __str__(self) -> str:
         return self.type
@@ -188,7 +194,10 @@ class FileMetadataContentIO(
         for chunk in chunker_sequence(reader.input_files, cls.CHUNK_SIZE):
             yield Page(
                 worker_id="main",
-                items=[DataItem(tracking_id=item.as_posix(), item=template.create_instance(item)) for item in chunk],
+                items=[
+                    DataItem(tracking_id=item.as_posix(), item=template.create_instance(item, selector.guess_mime_type))
+                    for item in chunk
+                ],
             )
 
     @classmethod

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -15,6 +15,7 @@ from cognite_toolkit._cdf_tk.client.http_client import (
 from cognite_toolkit._cdf_tk.client.http_client._item_classes import (
     ItemsFailedRequest,
     ItemsResultList,
+    ItemsResultMessage,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.cognite_file import CogniteFileRequest, CogniteFileResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataRequest, FileMetadataResponse
@@ -134,54 +135,55 @@ class FileMetadataContentIO(
         http_client: HTTPClient,
         selector: FileMetadataContentSelector | None = None,
     ) -> ItemsResultList:
-        results = ItemsResultList()
-        for item in data_chunk.items:
-            request = item.item
-            if request.filepath is None:
-                results.append(
-                    ItemsFailedRequest(
-                        ids=[item.tracking_id],
-                        error_message=f"Failed to create upload {item.tracking_id}. Not file path provided ({FILENAME_VARIABLE} is missing).",
-                    )
-                )
-                continue
+        return ItemsResultList(
+            [self._upload_single_item(item) for item in data_chunk],
+        )
 
-            try:
-                created = self.client.tool.filemetadata.create([request], self.overwrite)[0]
-            except ToolkitAPIError as error:
-                if error.response is not None:
-                    results.append(error.response.as_item_response(item.tracking_id))
-                    continue
-                raise error
-            except IndexError:
-                results.append(
-                    ItemsFailedRequest(
-                        ids=[item.tracking_id],
-                        error_message=f"No response returned from CDF for item {item.tracking_id}.",
-                    )
-                )
-                continue
-            if created.upload_url is None:
-                results.append(
-                    ItemsFailedRequest(
-                        ids=[item.tracking_id],
-                        error_message=f"Failed to retrieve upload URL for item {item.tracking_id}.",
-                    )
-                )
-                continue
-            try:
-                response = self.client.tool.filemetadata.upload_file(
-                    request.filepath, created.upload_url, request.mime_type
-                )
-            except ToolkitAPIError as error:
-                if error.response is not None:
-                    results.append(error.response.as_item_response(item.tracking_id))
-                    continue
-                raise error
-            else:
-                results.append(response.as_item_response(item.tracking_id))
+    def _upload_single_item(self, item: DataItem[FileMetadataRequest]) -> ItemsFailedRequest | Any:
+        request = item.item
+        if request.filepath is None:
+            return ItemsFailedRequest(
+                ids=[item.tracking_id],
+                error_message=f"Failed to create {item.tracking_id}. Not file path provided ({FILENAME_VARIABLE} is missing).",
+            )
 
-        return results
+        created = self._create_file_metadata(item, request)
+        if not isinstance(created, FileMetadataResponse):
+            return created
+
+        if created.upload_url is None:
+            return ItemsFailedRequest(
+                ids=[item.tracking_id],
+                error_message=f"Failed to retrieve upload URL for item {item.tracking_id}.",
+            )
+
+        return self._upload_file_content(item, request.filepath, request.mime_type, created.upload_url)
+
+    def _create_file_metadata(
+        self, item: DataItem[FileMetadataRequest], request: FileMetadataRequest
+    ) -> FileMetadataResponse | ItemsResultMessage:
+        try:
+            return self.client.tool.filemetadata.create([request], self.overwrite)[0]
+        except ToolkitAPIError as error:
+            if error.response is not None:
+                return error.response.as_item_response(item.tracking_id)
+            raise
+        except IndexError:
+            return ItemsFailedRequest(
+                ids=[item.tracking_id],
+                error_message=f"No response returned from CDF for item {item.tracking_id}.",
+            )
+
+    def _upload_file_content(
+        self, item: DataItem[FileMetadataRequest], filepath: Path, mime_type: str | None, upload_url: str
+    ) -> Any:
+        try:
+            response = self.client.tool.filemetadata.upload_file(filepath, upload_url, mime_type)
+        except ToolkitAPIError as error:
+            if error.response is not None:
+                return error.response.as_item_response(item.tracking_id)
+            raise
+        return response.as_item_response(item.tracking_id)
 
     @classmethod
     def read_chunks(

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -1,3 +1,4 @@
+import mimetypes
 from collections import defaultdict
 from collections.abc import Hashable, Iterable, Sequence
 from pathlib import Path
@@ -93,6 +94,13 @@ class FileMetadataContentIO(
                     )
                 else:
                     filepath = self._target_dir / sanitize_filename(file.name)
+                    if (
+                        filepath.suffix == ""
+                        and file.mime_type
+                        and (guessed_extension := mimetypes.guess_extension(file.mime_type))
+                    ):
+                        # Recover file extension if missing.
+                        filepath = filepath.with_suffix(guessed_extension)
                     has_downloaded = self._try_download_content(file, filepath, item.display_name)
                     if has_downloaded:
                         file.filepath = filepath
@@ -167,7 +175,11 @@ class FileMetadataContentIO(
         for item in data_chunk.items:
             dumped_item = self._crud.dump_resource(item.item)
             # Preserve filepath
-            dumped_item[FILEPATH] = item.item.filepath
+            if item.item.filepath:
+                dumped_filepath = item.item.filepath
+                if dumped_filepath.is_relative_to(self._target_dir):
+                    dumped_filepath = dumped_filepath.relative_to(self._target_dir)
+                dumped_item[FILEPATH] = dumped_filepath.as_posix()
             dumped.append(DataItem(tracking_id=item.tracking_id, item=dumped_item))
         return data_chunk.create_from(dumped)
 

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -42,6 +42,8 @@ class FileMetadataContentIO(
     ConfigurableStorageIO[FileMetadataContentSelectorV2, FileMetadataResponse],
 ):
     CHUNK_SIZE = 10
+    KIND = "FileMetadataContent"
+    BASE_SELECTOR = FileMetadataContentSelectorV2
 
     def __init__(self, client: ToolkitClient, overwrite: bool = False, target_dir: Path = Path.cwd()) -> None:
         super().__init__(client)

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -2,7 +2,6 @@ import mimetypes
 from collections import defaultdict
 from collections.abc import Hashable, Iterable, Sequence
 from pathlib import Path
-from typing import Any
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.http_client import (
@@ -221,7 +220,7 @@ class FileMetadataContentIO(
     ) -> ItemsResultList:
         return ItemsResultList([self._upload_single_item(item) for item in data_chunk])
 
-    def _upload_single_item(self, item: DataItem[FileMetadataRequest]) -> ItemsFailedRequest | Any:
+    def _upload_single_item(self, item: DataItem[FileMetadataRequest]) -> ItemsResultMessage:
         request = item.item
         if request.filepath is None:
             return ItemsFailedRequest(
@@ -256,7 +255,9 @@ class FileMetadataContentIO(
                 error_message=f"No response returned from CDF for item {item.tracking_id}.",
             )
 
-    def _upload_file_content(self, filepath: Path, upload_url: str, mime_type: str | None, tracking_id: str) -> Any:
+    def _upload_file_content(
+        self, filepath: Path, upload_url: str, mime_type: str | None, tracking_id: str
+    ) -> ItemsResultMessage:
         try:
             response = self.client.tool.filemetadata.upload_file(filepath, upload_url, mime_type)
         except ToolkitAPIError as error:

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -1,12 +1,7 @@
-import json
-import mimetypes
-from abc import ABC
 from collections import defaultdict
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Literal
-
-from pydantic import ConfigDict, DirectoryPath, Field, field_validator
+from typing import Any
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.http_client import (
@@ -19,85 +14,29 @@ from cognite_toolkit._cdf_tk.client.http_client._item_classes import (
     ItemsResultMessage,
 )
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, InternalId
-from cognite_toolkit._cdf_tk.client.resource_classes.cognite_file import CogniteFileRequest, CogniteFileResponse
-from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataRequest, FileMetadataResponse
-from cognite_toolkit._cdf_tk.cruds import FileMetadataCRUD
+from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import (
+    FILEPATH,
+    FileMetadataRequest,
+    FileMetadataResponse,
+)
+from cognite_toolkit._cdf_tk.resource_ios import FileMetadataCRUD
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 from cognite_toolkit._cdf_tk.utils.fileio import MultiFileReader
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 
-from . import DataSelector, StorageIOConfig
+from . import StorageIOConfig
 from ._base import Bookmark, ConfigurableStorageIO, DataItem, Page, TableUploadableStorageIO
-from .selectors._base import SelectorObject
-
-FILENAME_VARIABLE = "$FILENAME"
-FILEPATH = "$FILEPATH"
-
-
-class FileMetadataTemplate(SelectorObject):
-    model_config = ConfigDict(extra="allow")
-    name: str
-    external_id: str
-
-    def create_instance(self, filepath: Path, guess_mime_type: bool) -> dict[str, Any]:
-        json_str = self.model_dump_json(by_alias=True)
-        output = json.loads(json_str.replace(FILENAME_VARIABLE, filepath.name))
-        output[FILEPATH] = filepath
-        if "mimeType" not in output and guess_mime_type:
-            me_type, _ = mimetypes.guess_type(filepath)
-            output["mimeType"] = me_type
-        return output
-
-    @field_validator("name", "external_id")
-    @classmethod
-    def _validate_filename_in_fields(cls, v: str) -> str:
-        if FILENAME_VARIABLE not in v:
-            raise ValueError(
-                f"{FILENAME_VARIABLE!s} must be present in 'name' and 'external_id' fields. "
-                f"This allows for dynamic substitution based on the file name."
-            )
-        return v
-
-
-class FileMetadataContentSelector(DataSelector, ABC):
-    kind: Literal["FileMetadataContent"] = "FileMetadataContent"
-
-
-class FileMetadataTemplateSelector(FileMetadataContentSelector):
-    type: Literal["FileMetadataTemplate"] = "FileMetadataTemplate"
-    template: FileMetadataTemplate
-    file_directory: DirectoryPath
-    guess_mime_type: bool
-
-    def __str__(self) -> str:
-        return self.type
-
-    def find_data_files(self, input_dir: Path, manifest_file: Path) -> list[Path]:
-        return [file for file in self.file_directory.iterdir() if file.is_file()]
-
-
-class FileMetadataFilesSelector(FileMetadataContentSelector, ABC):
-    """Download/upload individual files.
-
-    For download, the ids field must be set.
-    For upload, all files in a csv/parquest file are uploaded.
-
-    """
-
-    type: Literal["FileMetadataFiles"] = "FileMetadataFiles"
-    ids: tuple[InternalId, ...] | None = Field(None, exclude=True, description="(Only used for download)")
-
-    def __str__(self) -> str:
-        return self.type
-
-
-class CogniteFileContentSelector(DataSelector, ABC):
-    kind: Literal["CogniteFileContent"] = "CogniteFileContent"
+from .selectors import (
+    FILENAME_VARIABLE,
+    FileMetadataContentSelectorV2,
+    FileMetadataFilesSelectorV2,
+    FileMetadataTemplateSelectorV2,
+)
 
 
 class FileMetadataContentIO(
-    TableUploadableStorageIO[FileMetadataContentSelector, FileMetadataResponse, FileMetadataRequest],
-    ConfigurableStorageIO[FileMetadataContentSelector, FileMetadataResponse],
+    TableUploadableStorageIO[FileMetadataContentSelectorV2, FileMetadataResponse, FileMetadataRequest],
+    ConfigurableStorageIO[FileMetadataContentSelectorV2, FileMetadataResponse],
 ):
     CHUNK_SIZE = 10
 
@@ -105,29 +44,28 @@ class FileMetadataContentIO(
         super().__init__(client)
         self.overwrite = overwrite
         self._crud = FileMetadataCRUD(client, None, None, support_upload=False)
-        self._downloaded_data_sets_by_selector: dict[FileMetadataContentSelector | None, set[int]] = defaultdict(set)
-        self._downloaded_labels_by_selector: dict[FileMetadataContentSelector | None, set[ExternalId]] = defaultdict(
+        self._downloaded_data_sets_by_selector: dict[FileMetadataContentSelectorV2 | None, set[int]] = defaultdict(set)
+        self._downloaded_labels_by_selector: dict[FileMetadataContentSelectorV2 | None, set[ExternalId]] = defaultdict(
             set
         )
 
-    def _verify_download_selector(self, selector: FileMetadataContentSelector) -> tuple[InternalId, ...]:
-        if isinstance(selector, FileMetadataFilesSelector) and selector.ids:
+    def _verify_download_selector(self, selector: FileMetadataContentSelectorV2) -> tuple[InternalId, ...]:
+        if isinstance(selector, FileMetadataFilesSelectorV2) and selector.ids:
             return selector.ids
         raise NotImplementedError(f"{selector.type} does not support download")
 
     def stream_data(
-        self, selector: FileMetadataContentSelector, limit: int | None = None, bookmark: Bookmark | None = None
+        self, selector: FileMetadataContentSelectorV2, limit: int | None = None, bookmark: Bookmark | None = None
     ) -> Iterable[Page[FileMetadataResponse]]:
         file_ids = self._verify_download_selector(selector)
         for chunk in chunker_sequence(file_ids, self.CHUNK_SIZE):
             file_metadata = self.client.tool.filemetadata.retrieve(list(chunk), ignore_unknown_ids=True)
-
             if len(file_metadata) != len(chunk) and (
                 missing_file_ids := ({file.as_internal_id() for file in file_metadata} - set(chunk))
             ):
-                for file_id in missing_file_ids:
-                    self.logger.tracker.add_issue(str(file_id.id), "Missing in CDF")
-                    self.logger.tracker.finalize_item(str(file_id.id), "failure")
+                raise NotImplementedError(
+                    f"The following file ids were not found and cannot be downloaded: {', '.join(str(id) for id in missing_file_ids)}"
+                )
 
             for file in file_metadata:
                 filepath = self._download_content(file)
@@ -138,14 +76,14 @@ class FileMetadataContentIO(
                 items=[DataItem(tracking_id=str(file.id), item=file) for file in file_metadata],
             )
 
-    def count(self, selector: FileMetadataContentSelector) -> int | None:
+    def count(self, selector: FileMetadataContentSelectorV2) -> int | None:
         return len(self._verify_download_selector(selector))
 
     def _download_content(self, file_metadata: FileMetadataResponse) -> Path:
         raise NotImplementedError()
 
     def row_to_resource(
-        self, source_id: str, row: dict[str, JsonVal], selector: FileMetadataContentSelector | None = None
+        self, source_id: str, row: dict[str, JsonVal], selector: FileMetadataContentSelectorV2 | None = None
     ) -> FileMetadataRequest:
         metadata: dict[str, JsonVal] = {}
         cleaned_row: dict[str, JsonVal] = {}
@@ -163,7 +101,7 @@ class FileMetadataContentIO(
         return self._crud.load_resource(item_json)
 
     def _populate_id_cache(
-        self, items: Iterable[FileMetadataResponse], selector: FileMetadataContentSelector | None = None
+        self, items: Iterable[FileMetadataResponse], selector: FileMetadataContentSelectorV2 | None = None
     ) -> None:
         data_set_ids: set[int] = set()
         asset_ids: set[int] = set()
@@ -182,7 +120,7 @@ class FileMetadataContentIO(
         self._downloaded_labels_by_selector[selector].update(label_ids)
 
     def data_to_json_chunk(
-        self, data_chunk: Page[FileMetadataResponse], selector: FileMetadataContentSelector | None = None
+        self, data_chunk: Page[FileMetadataResponse], selector: FileMetadataContentSelectorV2 | None = None
     ) -> Page[dict[str, JsonVal]]:
         # Ensure data sets/assets/security-categories are looked up to populate cache.
         # This is to avoid looking up each data set id individually in the .dump_resource call
@@ -195,14 +133,14 @@ class FileMetadataContentIO(
             dumped.append(DataItem(tracking_id=item.tracking_id, item=dumped_item))
         return data_chunk.create_from(dumped)
 
-    def configurations(self, selector: FileMetadataContentSelector) -> Iterable[StorageIOConfig]:
+    def configurations(self, selector: FileMetadataContentSelectorV2) -> Iterable[StorageIOConfig]:
         raise NotImplementedError()
 
     def upload_items(
         self,
         data_chunk: Page[FileMetadataRequest],
         http_client: HTTPClient,
-        selector: FileMetadataContentSelector | None = None,
+        selector: FileMetadataContentSelectorV2 | None = None,
     ) -> ItemsResultList:
         return ItemsResultList([self._upload_single_item(item) for item in data_chunk])
 
@@ -252,9 +190,9 @@ class FileMetadataContentIO(
 
     @classmethod
     def read_chunks(
-        cls, reader: MultiFileReader, selector: FileMetadataContentSelector
+        cls, reader: MultiFileReader, selector: FileMetadataContentSelectorV2
     ) -> Iterable[Page[dict[str, JsonVal]]]:
-        if not isinstance(selector, FileMetadataTemplateSelector):
+        if not isinstance(selector, FileMetadataTemplateSelectorV2):
             yield from super().read_chunks(reader, selector)
             return
         template = selector.template
@@ -268,48 +206,7 @@ class FileMetadataContentIO(
             )
 
     @classmethod
-    def count_items(cls, reader: MultiFileReader, selector: FileMetadataContentSelector | None = None) -> int:
-        if not isinstance(selector, FileMetadataTemplateSelector):
+    def count_items(cls, reader: MultiFileReader, selector: FileMetadataContentSelectorV2 | None = None) -> int:
+        if not isinstance(selector, FileMetadataTemplateSelectorV2):
             return super().count_items(reader, selector)
         return len(reader.input_files)
-
-
-class CogniteFileContentIO(
-    TableUploadableStorageIO[CogniteFileContentSelector, CogniteFileResponse, CogniteFileRequest],
-    ConfigurableStorageIO[CogniteFileContentSelector, CogniteFileResponse],
-):
-    def __init__(self, client: ToolkitClient, overwrite: bool = False) -> None:
-        super().__init__(client)
-        self.overwrite = overwrite
-
-    def stream_data(
-        self, selector: CogniteFileContentSelector, limit: int | None = None, bookmark: Bookmark | None = None
-    ) -> Iterable[Page[CogniteFileResponse]]:
-        raise NotImplementedError()
-
-    def count(self, selector: CogniteFileContentSelector) -> int | None:
-        raise NotImplementedError()
-
-    def row_to_resource(
-        self, source_id: str, row: dict[str, JsonVal], selector: CogniteFileContentSelector | None = None
-    ) -> CogniteFileRequest:
-        raise NotImplementedError()
-
-    def json_to_resource(self, item_json: dict[str, JsonVal]) -> CogniteFileRequest:
-        raise NotImplementedError()
-
-    def data_to_json_chunk(
-        self, data_chunk: Page[CogniteFileResponse], selector: CogniteFileContentSelector | None = None
-    ) -> Page[dict[str, JsonVal]]:
-        raise NotImplementedError()
-
-    def configurations(self, selector: CogniteFileContentSelector) -> Iterable[StorageIOConfig]:
-        raise NotImplementedError()
-
-    def upload_items(
-        self,
-        data_chunk: Page[CogniteFileRequest],
-        http_client: HTTPClient,
-        selector: CogniteFileContentSelector | None = None,
-    ) -> ItemsResultList:
-        raise NotImplementedError()

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -41,14 +41,30 @@ class FileMetadataContentIO(
     TableUploadableStorageIO[FileMetadataContentSelectorV2, FileMetadataResponse, FileMetadataRequest],
     ConfigurableStorageIO[FileMetadataContentSelectorV2, FileMetadataResponse],
 ):
+    """FileMetadataContentIO
+
+    Args:
+        client: ToolkitClient
+        config_directory: The directory were the filemetadata and manifest files are stored.
+        file_directory: On download, location to store file content.
+        overwrite: On upload, whether to overwrite existing files.
+    """
+
     CHUNK_SIZE = 10
     KIND = "FileMetadataContent"
     BASE_SELECTOR = FileMetadataContentSelectorV2
 
-    def __init__(self, client: ToolkitClient, overwrite: bool = False, target_dir: Path = Path.cwd()) -> None:
+    def __init__(
+        self,
+        client: ToolkitClient,
+        config_directory: Path,
+        file_directory: Path,
+        overwrite: bool = False,
+    ) -> None:
         super().__init__(client)
         self.overwrite = overwrite
-        self._target_dir = target_dir
+        self._config_directory = config_directory
+        self._file_directory = file_directory
         self._crud = FileMetadataCRUD(client, None, None, support_upload=False)
         self._downloaded_data_sets_by_selector: dict[FileMetadataContentSelectorV2 | None, set[int]] = defaultdict(set)
         self._downloaded_labels_by_selector: dict[FileMetadataContentSelectorV2 | None, set[ExternalId]] = defaultdict(
@@ -64,7 +80,7 @@ class FileMetadataContentIO(
         self, selector: FileMetadataContentSelectorV2, limit: int | None = None, bookmark: Bookmark | None = None
     ) -> Iterable[Page[FileMetadataResponse]]:
         file_ids = self._verify_download_selector(selector)
-        self._target_dir.mkdir(exist_ok=True, parents=True)
+        self._file_directory.mkdir(exist_ok=True, parents=True)
         for chunk in chunker_sequence(file_ids, self.CHUNK_SIZE):
             self.logger.register([item.display_name for item in chunk])
             file_metadata = self.client.tool.filemetadata.retrieve(list(chunk), ignore_unknown_ids=True)
@@ -92,7 +108,7 @@ class FileMetadataContentIO(
                         )
                     )
                 else:
-                    filepath = self._target_dir / sanitize_filename(file.name)
+                    filepath = self._file_directory / sanitize_filename(file.name)
                     if (
                         filepath.suffix == ""
                         and file.mime_type
@@ -176,8 +192,8 @@ class FileMetadataContentIO(
             # Preserve filepath
             if item.item.filepath:
                 dumped_filepath = item.item.filepath
-                if dumped_filepath.is_relative_to(self._target_dir):
-                    dumped_filepath = dumped_filepath.relative_to(self._target_dir)
+                if dumped_filepath.is_relative_to(self._config_directory):
+                    dumped_filepath = dumped_filepath.relative_to(self._config_directory)
                 dumped_item[FILEPATH] = dumped_filepath.as_posix()
             dumped.append(DataItem(tracking_id=item.tracking_id, item=dumped_item))
         return data_chunk.create_from(dumped)

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -238,11 +238,21 @@ class FileMetadataContentIO(
 
     def _upload_single_item(self, item: DataItem[FileMetadataRequest]) -> ItemsResultMessage:
         request = item.item
-        if request.filepath is None:
+        filepath = request.filepath
+        if filepath is None:
             return ItemsFailedRequest(
                 ids=[item.tracking_id],
                 error_message=f"Failed to create {item.tracking_id}. Not file path provided ({FILENAME_VARIABLE} is missing).",
             )
+        if not filepath.is_file():
+            candidate = self._config_directory / filepath
+            if candidate.is_file():
+                filepath = candidate
+            else:
+                return ItemsFailedRequest(
+                    ids=[item.tracking_id],
+                    error_message=f"Failed to create {item.tracking_id}. File path {filepath.as_posix()} does not exist.",
+                )
 
         created = self._create_file_metadata(item, request)
         if not isinstance(created, FileMetadataResponse):
@@ -254,7 +264,7 @@ class FileMetadataContentIO(
                 error_message=f"Failed to retrieve upload URL for item {item.tracking_id}.",
             )
 
-        return self._upload_file_content(request.filepath, created.upload_url, request.mime_type, item.tracking_id)
+        return self._upload_file_content(filepath, created.upload_url, request.mime_type, item.tracking_id)
 
     def _create_file_metadata(
         self, item: DataItem[FileMetadataRequest], request: FileMetadataRequest

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -74,10 +74,13 @@ class FileMetadataTemplateSelector(FileMetadataContentSelector):
         return [file for file in self.file_directory.iterdir() if file.is_file()]
 
 
-class FileMetadataUploadSelector(DataSelector, ABC):
+class FileMetadataUploadSelector(FileMetadataContentSelector, ABC):
     """Upload all in a given csv/parquest file"""
 
-    kind: Literal["FileMetadataUploadSelector"] = "FileMetadataUploadSelector"
+    type: Literal["FileMetadataUpload"] = "FileMetadataUpload"
+
+    def __str__(self) -> str:
+        return self.type
 
 
 class CogniteFileContentSelector(DataSelector, ABC):

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -13,13 +13,13 @@ from cognite_toolkit._cdf_tk.client.http_client._item_classes import (
     ItemsResultList,
     ItemsResultMessage,
 )
-from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, NameId
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import (
     FILEPATH,
     FileMetadataRequest,
     FileMetadataResponse,
 )
-from cognite_toolkit._cdf_tk.resource_ios import DataSetsIO, FileMetadataCRUD, LabelIO
+from cognite_toolkit._cdf_tk.resource_ios import DataSetsIO, FileMetadataCRUD, LabelIO, SecurityCategoryIO
 from cognite_toolkit._cdf_tk.utils import sanitize_filename
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 from cognite_toolkit._cdf_tk.utils.fileio import MultiFileReader
@@ -29,7 +29,6 @@ from . import StorageIOConfig
 from ._base import Bookmark, ConfigurableStorageIO, DataItem, Page, TableUploadableStorageIO
 from .logger import LogEntryV2, Severity
 from .selectors import (
-    FILENAME_VARIABLE,
     FileMetadataContentSelectorV2,
     FileMetadataFilesSelectorV2,
     FileMetadataTemplateSelectorV2,
@@ -69,6 +68,9 @@ class FileMetadataContentIO(
         self._downloaded_data_sets_by_selector: dict[FileMetadataContentSelectorV2 | None, set[int]] = defaultdict(set)
         self._downloaded_labels_by_selector: dict[FileMetadataContentSelectorV2 | None, set[ExternalId]] = defaultdict(
             set
+        )
+        self._downloaded_security_categories_by_selector: dict[FileMetadataContentSelectorV2 | None, set[int]] = (
+            defaultdict(set)
         )
 
     def _verify_download_selector(self, selector: FileMetadataContentSelectorV2) -> tuple[InternalWithNameId, ...]:
@@ -137,7 +139,7 @@ class FileMetadataContentIO(
                 return True
             message = f"File content download URL not found for {tracking_id}."
         except ToolkitAPIError as err:
-            message = f"File content not download for {tracking_id} failed with error: {err.message}."
+            message = f"File content download failed for {tracking_id} with error: {err.message}."
         except IndexError:
             message = f"File content not downloaded for {tracking_id}. CDF did not return a download URL."
         self.logger.log(
@@ -181,6 +183,7 @@ class FileMetadataContentIO(
                 label_ids.update(item.labels)
         self._downloaded_data_sets_by_selector[selector].update(data_set_ids)
         self._downloaded_labels_by_selector[selector].update(label_ids)
+        self._downloaded_security_categories_by_selector[selector].update(security_ids)
 
     def data_to_json_chunk(
         self, data_chunk: Page[FileMetadataResponse], selector: FileMetadataContentSelectorV2 | None = None
@@ -212,12 +215,18 @@ class FileMetadataContentIO(
         labels = self._downloaded_labels_by_selector[selector]
         if labels:
             yield from self._configurations(list(labels), LabelIO.create_loader(self.client))
+        if security_categories := self._downloaded_security_categories_by_selector[selector]:
+            category_ids: list[NameId] = [
+                NameId(name=name)
+                for name in self.client.lookup.security_categories.external_id(list(security_categories))
+            ]
+            yield from self._configurations(category_ids, SecurityCategoryIO.create_loader(self.client))
 
     @classmethod
     def _configurations(
         cls,
         ids: Sequence[Hashable],
-        loader: DataSetsIO | LabelIO,
+        loader: DataSetsIO | LabelIO | SecurityCategoryIO,
     ) -> Iterable[StorageIOConfig]:
         if not ids:
             return
@@ -244,7 +253,7 @@ class FileMetadataContentIO(
         if filepath is None:
             return ItemsFailedRequest(
                 ids=[item.tracking_id],
-                error_message=f"Failed to create {item.tracking_id}. Not file path provided ({FILENAME_VARIABLE} is missing).",
+                error_message=f"Failed to create {item.tracking_id}. The {FILEPATH} has not been set.",
             )
         if not filepath.is_file():
             candidate = self._config_directory / filepath

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -24,7 +24,7 @@ from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 from cognite_toolkit._cdf_tk.utils.fileio import MultiFileReader
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 
-from . import DataSelector, StorageIOConfig, T_DataResponse, T_Selector
+from . import DataSelector, StorageIOConfig
 from ._base import Bookmark, ConfigurableStorageIO, DataItem, Page, TableUploadableStorageIO
 from .selectors._base import SelectorObject
 
@@ -100,7 +100,7 @@ class FileMetadataContentIO(
 
     def stream_data(
         self, selector: FileMetadataContentSelector, limit: int | None = None, bookmark: Bookmark | None = None
-    ) -> Iterable[Page[T_DataResponse]]:
+    ) -> Iterable[Page[FileMetadataResponse]]:
         raise NotImplementedError()
 
     def count(self, selector: FileMetadataContentSelector) -> int | None:
@@ -246,6 +246,6 @@ class CogniteFileContentIO(
         self,
         data_chunk: Page[CogniteFileRequest],
         http_client: HTTPClient,
-        selector: T_Selector | None = None,
+        selector: CogniteFileContentSelector | None = None,
     ) -> ItemsResultList:
         raise NotImplementedError()

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Hashable, Iterable, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -19,7 +19,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import (
     FileMetadataRequest,
     FileMetadataResponse,
 )
-from cognite_toolkit._cdf_tk.resource_ios import FileMetadataCRUD
+from cognite_toolkit._cdf_tk.resource_ios import DataSetsIO, FileMetadataCRUD, LabelIO
 from cognite_toolkit._cdf_tk.utils import sanitize_filename
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 from cognite_toolkit._cdf_tk.utils.fileio import MultiFileReader
@@ -172,7 +172,34 @@ class FileMetadataContentIO(
         return data_chunk.create_from(dumped)
 
     def configurations(self, selector: FileMetadataContentSelectorV2) -> Iterable[StorageIOConfig]:
-        raise NotImplementedError()
+        data_set_ids = self._downloaded_data_sets_by_selector[selector]
+        if data_set_ids:
+            data_set_external_ids = [
+                ExternalId(external_id=data_set_external_id)
+                for data_set_external_id in self.client.lookup.data_sets.external_id(list(data_set_ids))
+            ]
+            yield from self._configurations(data_set_external_ids, DataSetsIO.create_loader(self.client))
+
+        labels = self._downloaded_labels_by_selector[selector]
+        if labels:
+            yield from self._configurations(list(labels), LabelIO.create_loader(self.client))
+
+    @classmethod
+    def _configurations(
+        cls,
+        ids: Sequence[Hashable],
+        loader: DataSetsIO | LabelIO,
+    ) -> Iterable[StorageIOConfig]:
+        if not ids:
+            return
+
+        items = loader.retrieve(ids)  # type: ignore[arg-type]
+        yield StorageIOConfig(
+            kind=loader.kind,
+            folder_name=loader.folder_name,
+            # We know that the items will be labels for LabelLoader and data sets for DataSetsLoader
+            value=[loader.dump_resource(item) for item in items],  # type: ignore[arg-type]
+        )
 
     def upload_items(
         self,

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -33,7 +33,7 @@ from .selectors import (
     FileMetadataContentSelectorV2,
     FileMetadataFilesSelectorV2,
     FileMetadataTemplateSelectorV2,
-    InternalIdWithName,
+    InternalWithNameId,
 )
 
 
@@ -55,7 +55,7 @@ class FileMetadataContentIO(
             set
         )
 
-    def _verify_download_selector(self, selector: FileMetadataContentSelectorV2) -> tuple[InternalIdWithName, ...]:
+    def _verify_download_selector(self, selector: FileMetadataContentSelectorV2) -> tuple[InternalWithNameId, ...]:
         if isinstance(selector, FileMetadataFilesSelectorV2) and selector.ids:
             return selector.ids
         raise NotImplementedError(f"{selector.type} does not support download")

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -133,7 +133,7 @@ class FileMetadataContentIO(
         try:
             result = self.client.tool.filemetadata.get_download_url([file_metadata.as_internal_id()])[0]
             if result.download_url:
-                self.client.tool.filemetadata.dowonload_file(download_url=result.download_url, destination=destination)
+                self.client.tool.filemetadata.download_file(download_url=result.download_url, destination=destination)
                 return True
             message = f"File content download URL not found for {tracking_id}."
         except ToolkitAPIError as err:

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -1,6 +1,7 @@
 import json
 import mimetypes
 from abc import ABC
+from collections import defaultdict
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Literal
@@ -17,7 +18,7 @@ from cognite_toolkit._cdf_tk.client.http_client._item_classes import (
     ItemsResultList,
     ItemsResultMessage,
 )
-from cognite_toolkit._cdf_tk.client.identifiers import InternalId
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, InternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.cognite_file import CogniteFileRequest, CogniteFileResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataRequest, FileMetadataResponse
 from cognite_toolkit._cdf_tk.cruds import FileMetadataCRUD
@@ -104,8 +105,12 @@ class FileMetadataContentIO(
         super().__init__(client)
         self.overwrite = overwrite
         self._crud = FileMetadataCRUD(client, None, None, support_upload=False)
+        self._downloaded_data_sets_by_selector: dict[FileMetadataContentSelector | None, set[int]] = defaultdict(set)
+        self._downloaded_labels_by_selector: dict[FileMetadataContentSelector | None, set[ExternalId]] = defaultdict(
+            set
+        )
 
-    def _verify_selector(self, selector: FileMetadataContentSelector) -> tuple[InternalId, ...]:
+    def _verify_download_selector(self, selector: FileMetadataContentSelector) -> tuple[InternalId, ...]:
         if isinstance(selector, FileMetadataFilesSelector) and selector.ids:
             return selector.ids
         raise NotImplementedError(f"{selector.type} does not support download")
@@ -113,22 +118,31 @@ class FileMetadataContentIO(
     def stream_data(
         self, selector: FileMetadataContentSelector, limit: int | None = None, bookmark: Bookmark | None = None
     ) -> Iterable[Page[FileMetadataResponse]]:
-        file_ids = self._verify_selector(selector)
+        file_ids = self._verify_download_selector(selector)
         for chunk in chunker_sequence(file_ids, self.CHUNK_SIZE):
             file_metadata = self.client.tool.filemetadata.retrieve(list(chunk), ignore_unknown_ids=True)
+
             if len(file_metadata) != len(chunk) and (
-                missing_file_ids := {file.as_internal_id() for file in file_metadata} - set(chunk)
+                missing_file_ids := ({file.as_internal_id() for file in file_metadata} - set(chunk))
             ):
                 for file_id in missing_file_ids:
                     self.logger.tracker.add_issue(str(file_id.id), "Missing in CDF")
                     self.logger.tracker.finalize_item(str(file_id.id), "failure")
+
+            for file in file_metadata:
+                filepath = self._download_content(file)
+                file.filepath = filepath
+
             yield Page(
                 worker_id="main",
                 items=[DataItem(tracking_id=str(file.id), item=file) for file in file_metadata],
             )
 
     def count(self, selector: FileMetadataContentSelector) -> int | None:
-        return len(self._verify_selector(selector))
+        return len(self._verify_download_selector(selector))
+
+    def _download_content(self, file_metadata: FileMetadataResponse) -> Path:
+        raise NotImplementedError()
 
     def row_to_resource(
         self, source_id: str, row: dict[str, JsonVal], selector: FileMetadataContentSelector | None = None
@@ -148,10 +162,38 @@ class FileMetadataContentIO(
     def json_to_resource(self, item_json: dict[str, JsonVal]) -> FileMetadataRequest:
         return self._crud.load_resource(item_json)
 
+    def _populate_id_cache(
+        self, items: Iterable[FileMetadataResponse], selector: FileMetadataContentSelector | None = None
+    ) -> None:
+        data_set_ids: set[int] = set()
+        asset_ids: set[int] = set()
+        security_ids: set[int] = set()
+        label_ids: set[ExternalId] = set()
+        for item in items:
+            if item.data_set_id is not None:
+                data_set_ids.add(item.data_set_id)
+            if item.asset_ids is not None:
+                asset_ids.update(item.asset_ids)
+            if item.security_categories is not None:
+                security_ids.update(item.security_categories)
+            if item.labels:
+                label_ids.update(item.labels)
+        self._downloaded_data_sets_by_selector[selector].update(data_set_ids)
+        self._downloaded_labels_by_selector[selector].update(label_ids)
+
     def data_to_json_chunk(
         self, data_chunk: Page[FileMetadataResponse], selector: FileMetadataContentSelector | None = None
     ) -> Page[dict[str, JsonVal]]:
-        raise NotImplementedError()
+        # Ensure data sets/assets/security-categories are looked up to populate cache.
+        # This is to avoid looking up each data set id individually in the .dump_resource call
+        self._populate_id_cache(di.item for di in data_chunk.items)
+        dumped: list[DataItem[dict[str, JsonVal]]] = []
+        for item in data_chunk.items:
+            dumped_item = self._crud.dump_resource(item.item)
+            # Preserve filepath
+            dumped_item[FILEPATH] = item.item.filepath
+            dumped.append(DataItem(tracking_id=item.tracking_id, item=dumped_item))
+        return data_chunk.create_from(dumped)
 
     def configurations(self, selector: FileMetadataContentSelector) -> Iterable[StorageIOConfig]:
         raise NotImplementedError()

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -1,0 +1,105 @@
+from abc import ABC
+from collections.abc import Iterable
+from typing import Literal
+
+from cognite_toolkit._cdf_tk.client import ToolkitClient
+from cognite_toolkit._cdf_tk.client.http_client import (
+    HTTPClient,
+)
+from cognite_toolkit._cdf_tk.client.http_client._item_classes import ItemsResultList
+from cognite_toolkit._cdf_tk.client.resource_classes.cognite_file import CogniteFileRequest, CogniteFileResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataRequest, FileMetadataResponse
+from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
+
+from . import DataSelector, StorageIOConfig, T_DataResponse, T_Selector
+from ._base import Bookmark, ConfigurableStorageIO, Page, TableUploadableStorageIO
+
+
+class FileMetadataContentSelector(DataSelector, ABC):
+    kind: Literal["FileMetadataContent"] = "FileMetadataContent"
+
+
+class CogniteFileContentSelector(DataSelector, ABC):
+    kind: Literal["CogniteFileContent"] = "CogniteFileContent"
+
+
+class FileMetadataContentIO(
+    TableUploadableStorageIO[FileMetadataContentSelector, FileMetadataResponse, FileMetadataRequest],
+    ConfigurableStorageIO[FileMetadataContentSelector, FileMetadataResponse],
+):
+    def __init__(self, client: ToolkitClient, overwrite: bool = False) -> None:
+        super().__init__(client)
+        self.overwrite = overwrite
+
+    def stream_data(
+        self, selector: FileMetadataContentSelector, limit: int | None = None, bookmark: Bookmark | None = None
+    ) -> Iterable[Page[T_DataResponse]]:
+        raise NotImplementedError()
+
+    def count(self, selector: FileMetadataContentSelector) -> int | None:
+        raise NotImplementedError()
+
+    def row_to_resource(
+        self, source_id: str, row: dict[str, JsonVal], selector: FileMetadataContentSelector | None = None
+    ) -> FileMetadataRequest:
+        raise NotImplementedError()
+
+    def json_to_resource(self, item_json: dict[str, JsonVal]) -> FileMetadataRequest:
+        raise NotImplementedError()
+
+    def data_to_json_chunk(
+        self, data_chunk: Page[FileMetadataResponse], selector: FileMetadataContentSelector | None = None
+    ) -> Page[dict[str, JsonVal]]:
+        raise NotImplementedError()
+
+    def configurations(self, selector: FileMetadataContentSelector) -> Iterable[StorageIOConfig]:
+        raise NotImplementedError()
+
+    def upload_items(
+        self,
+        data_chunk: Page[FileMetadataRequest],
+        http_client: HTTPClient,
+        selector: T_Selector | None = None,
+    ) -> ItemsResultList:
+        raise NotImplementedError()
+
+
+class CogniteFileContentIO(
+    TableUploadableStorageIO[CogniteFileContentSelector, CogniteFileResponse, CogniteFileRequest],
+    ConfigurableStorageIO[CogniteFileContentSelector, CogniteFileResponse],
+):
+    def __init__(self, client: ToolkitClient, overwrite: bool = False) -> None:
+        super().__init__(client)
+        self.overwrite = overwrite
+
+    def stream_data(
+        self, selector: CogniteFileContentSelector, limit: int | None = None, bookmark: Bookmark | None = None
+    ) -> Iterable[Page[CogniteFileResponse]]:
+        raise NotImplementedError()
+
+    def count(self, selector: CogniteFileContentSelector) -> int | None:
+        raise NotImplementedError()
+
+    def row_to_resource(
+        self, source_id: str, row: dict[str, JsonVal], selector: CogniteFileContentSelector | None = None
+    ) -> CogniteFileRequest:
+        raise NotImplementedError()
+
+    def json_to_resource(self, item_json: dict[str, JsonVal]) -> CogniteFileRequest:
+        raise NotImplementedError()
+
+    def data_to_json_chunk(
+        self, data_chunk: Page[CogniteFileResponse], selector: CogniteFileContentSelector | None = None
+    ) -> Page[dict[str, JsonVal]]:
+        raise NotImplementedError()
+
+    def configurations(self, selector: CogniteFileContentSelector) -> Iterable[StorageIOConfig]:
+        raise NotImplementedError()
+
+    def upload_items(
+        self,
+        data_chunk: Page[CogniteFileRequest],
+        http_client: HTTPClient,
+        selector: T_Selector | None = None,
+    ) -> ItemsResultList:
+        raise NotImplementedError()

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -8,8 +8,12 @@ from pydantic import ConfigDict, DirectoryPath, field_validator, json
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.http_client import (
     HTTPClient,
+    ToolkitAPIError,
 )
-from cognite_toolkit._cdf_tk.client.http_client._item_classes import ItemsResultList
+from cognite_toolkit._cdf_tk.client.http_client._item_classes import (
+    ItemsFailedRequest,
+    ItemsResultList,
+)
 from cognite_toolkit._cdf_tk.client.resource_classes.cognite_file import CogniteFileRequest, CogniteFileResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataRequest, FileMetadataResponse
 from cognite_toolkit._cdf_tk.cruds import FileMetadataCRUD
@@ -114,9 +118,56 @@ class FileMetadataContentIO(
         self,
         data_chunk: Page[FileMetadataRequest],
         http_client: HTTPClient,
-        selector: T_Selector | None = None,
+        selector: FileMetadataContentSelector | None = None,
     ) -> ItemsResultList:
-        raise NotImplementedError()
+        results = ItemsResultList()
+        for item in data_chunk.items:
+            request = item.item
+            if request.filepath is None:
+                results.append(
+                    ItemsFailedRequest(
+                        ids=[item.tracking_id],
+                        error_message=f"Failed to create upload {item.tracking_id}. Not file path provided ({FILENAME_VARIABLE} is missing).",
+                    )
+                )
+                continue
+
+            try:
+                created = self.client.tool.filemetadata.create([request], self.overwrite)[0]
+            except ToolkitAPIError as error:
+                if error.response is not None:
+                    results.append(error.response.as_item_response(item.tracking_id))
+                    continue
+                raise error
+            except IndexError:
+                results.append(
+                    ItemsFailedRequest(
+                        ids=[item.tracking_id],
+                        error_message=f"No response returned from CDF for item {item.tracking_id}.",
+                    )
+                )
+                continue
+            if created.upload_url is None:
+                results.append(
+                    ItemsFailedRequest(
+                        ids=[item.tracking_id],
+                        error_message=f"Failed to retrieve upload URL for item {item.tracking_id}.",
+                    )
+                )
+                continue
+            try:
+                response = self.client.tool.filemetadata.upload_file(
+                    request.filepath, created.upload_url, request.mime_type
+                )
+            except ToolkitAPIError as error:
+                if error.response is not None:
+                    results.append(error.response.as_item_response(item.tracking_id))
+                    continue
+                raise error
+            else:
+                results.append(response.as_item_response(item.tracking_id))
+
+        return results
 
     @classmethod
     def read_chunks(

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -58,7 +58,7 @@ class FileMetadataContentIO(
         self,
         client: ToolkitClient,
         config_directory: Path,
-        file_directory: Path,
+        file_directory: Path | None = None,
         overwrite: bool = False,
     ) -> None:
         super().__init__(client)
@@ -80,6 +80,8 @@ class FileMetadataContentIO(
         self, selector: FileMetadataContentSelectorV2, limit: int | None = None, bookmark: Bookmark | None = None
     ) -> Iterable[Page[FileMetadataResponse]]:
         file_ids = self._verify_download_selector(selector)
+        if self._file_directory is None:
+            raise ValueError("Bug in Toolkit: File directory must be specified for downloading file content.")
         self._file_directory.mkdir(exist_ok=True, parents=True)
         for chunk in chunker_sequence(file_ids, self.CHUNK_SIZE):
             self.logger.register([item.display_name for item in chunk])

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -56,9 +56,15 @@ class FileMetadataContentSelector(DataSelector, ABC):
 
 
 class FileMetadataTemplateSelector(FileMetadataContentSelector):
-    type: Literal["FileMetadataTemplateSelector"] = "FileMetadataTemplateSelector"
+    type: Literal["FileMetadataTemplate"] = "FileMetadataTemplate"
     template: FileMetadataTemplate
     file_directory: DirectoryPath
+
+    def __str__(self) -> str:
+        return self.type
+
+    def find_data_files(self, input_dir: Path, manifest_file: Path) -> list[Path]:
+        return [file for file in self.file_directory.iterdir() if file.is_file()]
 
 
 class FileMetadataUploadSelector(DataSelector, ABC):
@@ -75,6 +81,8 @@ class FileMetadataContentIO(
     TableUploadableStorageIO[FileMetadataContentSelector, FileMetadataResponse, FileMetadataRequest],
     ConfigurableStorageIO[FileMetadataContentSelector, FileMetadataResponse],
 ):
+    CHUNK_SIZE = 10
+
     def __init__(self, client: ToolkitClient, overwrite: bool = False) -> None:
         super().__init__(client)
         self.overwrite = overwrite

--- a/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_contentv2.py
@@ -157,7 +157,7 @@ class FileMetadataContentIO(
                 error_message=f"Failed to retrieve upload URL for item {item.tracking_id}.",
             )
 
-        return self._upload_file_content(item, request.filepath, request.mime_type, created.upload_url)
+        return self._upload_file_content(request.filepath, created.upload_url, request.mime_type, item.tracking_id)
 
     def _create_file_metadata(
         self, item: DataItem[FileMetadataRequest], request: FileMetadataRequest
@@ -174,16 +174,14 @@ class FileMetadataContentIO(
                 error_message=f"No response returned from CDF for item {item.tracking_id}.",
             )
 
-    def _upload_file_content(
-        self, item: DataItem[FileMetadataRequest], filepath: Path, mime_type: str | None, upload_url: str
-    ) -> Any:
+    def _upload_file_content(self, filepath: Path, upload_url: str, mime_type: str | None, tracking_id: str) -> Any:
         try:
             response = self.client.tool.filemetadata.upload_file(filepath, upload_url, mime_type)
         except ToolkitAPIError as error:
             if error.response is not None:
-                return error.response.as_item_response(item.tracking_id)
+                return error.response.as_item_response(tracking_id)
             raise
-        return response.as_item_response(item.tracking_id)
+        return response.as_item_response(tracking_id)
 
     @classmethod
     def read_chunks(

--- a/cognite_toolkit/_cdf_tk/storageio/selectors/__init__.py
+++ b/cognite_toolkit/_cdf_tk/storageio/selectors/__init__.py
@@ -68,6 +68,8 @@ Selector = Annotated[
     | CanvasExternalIdSelector
     | FileMetadataTemplateSelector
     | FileDataModelingTemplateSelector
+    | FileMetadataTemplateSelectorV2
+    | FileMetadataFilesSelectorV2
     | FileIdentifierSelector
     | RecordContainerSelector
     | InstanceQuerySelector,

--- a/cognite_toolkit/_cdf_tk/storageio/selectors/__init__.py
+++ b/cognite_toolkit/_cdf_tk/storageio/selectors/__init__.py
@@ -36,6 +36,7 @@ from ._file_contentv2 import (
     FileMetadataFilesSelectorV2,
     FileMetadataTemplateSelectorV2,
     FileMetadataTemplateV2,
+    InternalIdWithName,
 )
 from ._instances import (
     InstanceFileSelector,
@@ -138,6 +139,7 @@ __all__ = [
     "InstanceSpaceSelector",
     "InstanceViewSelector",
     "InternalIdColumn",
+    "InternalIdWithName",
     "RawTableSelector",
     "RecordContainerSelector",
     "SelectedContainer",

--- a/cognite_toolkit/_cdf_tk/storageio/selectors/__init__.py
+++ b/cognite_toolkit/_cdf_tk/storageio/selectors/__init__.py
@@ -36,7 +36,7 @@ from ._file_contentv2 import (
     FileMetadataFilesSelectorV2,
     FileMetadataTemplateSelectorV2,
     FileMetadataTemplateV2,
-    InternalIdWithName,
+    InternalWithNameId,
 )
 from ._instances import (
     InstanceFileSelector,
@@ -141,7 +141,7 @@ __all__ = [
     "InstanceSpaceSelector",
     "InstanceViewSelector",
     "InternalIdColumn",
-    "InternalIdWithName",
+    "InternalWithNameId",
     "RawTableSelector",
     "RecordContainerSelector",
     "SelectedContainer",

--- a/cognite_toolkit/_cdf_tk/storageio/selectors/__init__.py
+++ b/cognite_toolkit/_cdf_tk/storageio/selectors/__init__.py
@@ -30,6 +30,13 @@ from ._file_content import (
     FileMetadataTemplate,
     FileMetadataTemplateSelector,
 )
+from ._file_contentv2 import (
+    FILENAME_VARIABLE,
+    FileMetadataContentSelectorV2,
+    FileMetadataFilesSelectorV2,
+    FileMetadataTemplateSelectorV2,
+    FileMetadataTemplateV2,
+)
 from ._instances import (
     InstanceFileSelector,
     InstanceQuerySelector,
@@ -98,6 +105,7 @@ def load_selector(manifest_file: Path) -> Selector | ToolkitWarning:
 
 
 __all__ = [
+    "FILENAME_VARIABLE",
     "AllChartsSelector",
     "AssetCentricFileSelector",
     "AssetCentricSelector",
@@ -117,8 +125,12 @@ __all__ = [
     "FileDataModelingTemplate",
     "FileDataModelingTemplateSelector",
     "FileIdentifierSelector",
+    "FileMetadataContentSelectorV2",
+    "FileMetadataFilesSelectorV2",
     "FileMetadataTemplate",
     "FileMetadataTemplateSelector",
+    "FileMetadataTemplateSelectorV2",
+    "FileMetadataTemplateV2",
     "InstanceColumn",
     "InstanceFileSelector",
     "InstanceQuerySelector",

--- a/cognite_toolkit/_cdf_tk/storageio/selectors/_base.py
+++ b/cognite_toolkit/_cdf_tk/storageio/selectors/_base.py
@@ -45,8 +45,11 @@ class DataSelector(SelectorObject, ABC):
     def dump(self) -> dict[str, JsonVal]:
         return self.model_dump(by_alias=True)
 
+    def as_filestem(self) -> str:
+        return sanitize_filename(str(self))
+
     def as_filename(self) -> str:
-        return f"{sanitize_filename(str(self))}{DATA_MANIFEST_SUFFIX}"
+        return f"{self.as_filestem()}{DATA_MANIFEST_SUFFIX}"
 
     def dump_to_file(self, directory: Path) -> Path:
         """Dumps the selector to a YAML file in the specified directory.

--- a/cognite_toolkit/_cdf_tk/storageio/selectors/_base.py
+++ b/cognite_toolkit/_cdf_tk/storageio/selectors/_base.py
@@ -45,6 +45,9 @@ class DataSelector(SelectorObject, ABC):
     def dump(self) -> dict[str, JsonVal]:
         return self.model_dump(by_alias=True)
 
+    def as_filename(self) -> str:
+        return f"{sanitize_filename(str(self))}{DATA_MANIFEST_SUFFIX}"
+
     def dump_to_file(self, directory: Path) -> Path:
         """Dumps the selector to a YAML file in the specified directory.
 
@@ -54,7 +57,7 @@ class DataSelector(SelectorObject, ABC):
             directory: The directory where the YAML file will be saved.
         """
 
-        filepath = directory / f"{sanitize_filename(str(self))}{DATA_MANIFEST_SUFFIX}"
+        filepath = directory / self.as_filename()
         filepath.parent.mkdir(parents=True, exist_ok=True)
         safe_write(file=filepath, content=yaml_safe_dump(self.model_dump(mode="json", by_alias=True)), encoding="utf-8")
         return filepath

--- a/cognite_toolkit/_cdf_tk/storageio/selectors/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/selectors/_file_contentv2.py
@@ -68,7 +68,7 @@ class FileMetadataFilesSelectorV2(FileMetadataContentSelectorV2):
     """Download/upload individual files.
 
     For download, the ids field must be set.
-    For upload, all files in a csv/parquest file are uploaded.
+    For upload, all files in a csv/parquet file are uploaded.
 
     """
 

--- a/cognite_toolkit/_cdf_tk/storageio/selectors/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/selectors/_file_contentv2.py
@@ -1,0 +1,79 @@
+import json
+import mimetypes
+from abc import ABC
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import ConfigDict, DirectoryPath, Field, field_validator
+
+from cognite_toolkit._cdf_tk.client.identifiers import InternalId
+from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FILEPATH
+
+from ._base import DataSelector, SelectorObject
+
+FILENAME_VARIABLE = "$FILENAME"
+
+
+class InternalIdWithName(InternalId):
+    name: str = Field(exclude=True, description="The name of the item.")
+
+    @property
+    def display_name(self) -> str:
+        return f"{self.name} (id={self.id})"
+
+
+class FileMetadataTemplateV2(SelectorObject):
+    model_config = ConfigDict(extra="allow")
+    name: str
+    external_id: str
+
+    def create_instance(self, filepath: Path, guess_mime_type: bool) -> dict[str, Any]:
+        json_str = self.model_dump_json(by_alias=True)
+        output = json.loads(json_str.replace(FILENAME_VARIABLE, filepath.name))
+        output[FILEPATH] = filepath
+        if "mimeType" not in output and guess_mime_type:
+            me_type, _ = mimetypes.guess_type(filepath)
+            output["mimeType"] = me_type
+        return output
+
+    @field_validator("name", "external_id")
+    @classmethod
+    def _validate_filename_in_fields(cls, v: str) -> str:
+        if FILENAME_VARIABLE not in v:
+            raise ValueError(
+                f"{FILENAME_VARIABLE!s} must be present in 'name' and 'external_id' fields. "
+                f"This allows for dynamic substitution based on the file name."
+            )
+        return v
+
+
+class FileMetadataContentSelectorV2(DataSelector, ABC):
+    kind: Literal["FileMetadataContent"] = "FileMetadataContent"
+
+
+class FileMetadataTemplateSelectorV2(FileMetadataContentSelectorV2):
+    type: Literal["FileMetadataTemplate"] = "FileMetadataTemplate"
+    template: FileMetadataTemplateV2
+    file_directory: DirectoryPath
+    guess_mime_type: bool
+
+    def __str__(self) -> str:
+        return self.type
+
+    def find_data_files(self, input_dir: Path, manifest_file: Path) -> list[Path]:
+        return [file for file in self.file_directory.iterdir() if file.is_file()]
+
+
+class FileMetadataFilesSelectorV2(FileMetadataContentSelectorV2, ABC):
+    """Download/upload individual files.
+
+    For download, the ids field must be set.
+    For upload, all files in a csv/parquest file are uploaded.
+
+    """
+
+    type: Literal["FileMetadataFiles"] = "FileMetadataFiles"
+    ids: tuple[InternalIdWithName, ...] | None = Field(None, exclude=True, description="Only used for download")
+
+    def __str__(self) -> str:
+        return self.type

--- a/cognite_toolkit/_cdf_tk/storageio/selectors/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/selectors/_file_contentv2.py
@@ -64,7 +64,7 @@ class FileMetadataTemplateSelectorV2(FileMetadataContentSelectorV2):
         return [file for file in self.file_directory.iterdir() if file.is_file()]
 
 
-class FileMetadataFilesSelectorV2(FileMetadataContentSelectorV2, ABC):
+class FileMetadataFilesSelectorV2(FileMetadataContentSelectorV2):
     """Download/upload individual files.
 
     For download, the ids field must be set.

--- a/cognite_toolkit/_cdf_tk/storageio/selectors/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/storageio/selectors/_file_contentv2.py
@@ -14,7 +14,7 @@ from ._base import DataSelector, SelectorObject
 FILENAME_VARIABLE = "$FILENAME"
 
 
-class InternalIdWithName(InternalId):
+class InternalWithNameId(InternalId):
     name: str = Field(exclude=True, description="The name of the item.")
 
     @property
@@ -73,7 +73,7 @@ class FileMetadataFilesSelectorV2(FileMetadataContentSelectorV2):
     """
 
     type: Literal["FileMetadataFiles"] = "FileMetadataFiles"
-    ids: tuple[InternalIdWithName, ...] | None = Field(None, exclude=True, description="Only used for download")
+    ids: tuple[InternalWithNameId, ...] | None = Field(None, exclude=True, description="Only used for download")
 
     def __str__(self) -> str:
         return self.type

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from cognite_toolkit._cdf_tk.client.http_client import HTTPClient
+from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
+from cognite_toolkit._cdf_tk.storageio._file_contentv2 import (
+    FILENAME_VARIABLE,
+    FileMetadataContentIO,
+    FileMetadataTemplate,
+    FileMetadataTemplateSelector,
+)
+from cognite_toolkit._cdf_tk.utils.fileio import MultiFileReader
+
+
+class TestFileMetadataContentIO:
+    def test_upload_template(self, tmp_path: Path):
+        file_directory = tmp_path / "target"
+        file_directory.mkdir()
+        (file_directory / "my_file.txt").write_text("This is a test file.")
+        (file_directory / "my_file.json").write_text('{"key": "value"}')
+
+        selector = FileMetadataTemplateSelector(
+            template=FileMetadataTemplate.model_validate(
+                dict(
+                    name=FILENAME_VARIABLE,
+                    external_id=f"my_id_{FILENAME_VARIABLE}",
+                    directory="/my_directory",
+                )
+            ),
+            file_directory=file_directory,
+        )
+        selector.dump_to_file(tmp_path)
+
+        with monkeypatch_toolkit_client() as client:
+            io = FileMetadataContentIO(client, overwrite=True)
+            files = selector.find_data_files(tmp_path, tmp_path / selector.as_filename())
+            assert len(files) == 2
+            reader = MultiFileReader(files)
+
+            chunks = io.read_chunks(reader, selector)
+            requests = (io.json_chunk_to_data(page) for page in chunks)
+            result = [io.upload_items(page, MagicMock(spec=HTTPClient), selector) for page in requests]
+
+            assert len(result) == len(files)

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
@@ -14,9 +14,9 @@ from cognite_toolkit._cdf_tk.storageio._file_contentv2 import (
     FILEPATH,
     FileMetadataContentIO,
     FileMetadataContentSelector,
+    FileMetadataFilesSelector,
     FileMetadataTemplate,
     FileMetadataTemplateSelector,
-    FileMetadataUploadSelector,
 )
 from cognite_toolkit._cdf_tk.utils.fileio import MultiFileReader
 
@@ -58,7 +58,7 @@ class TestFileMetadataContentIO:
         text_file.write_text("This is a test file.")
         json_file.write_text('{"key": "value"}')
 
-        selector = FileMetadataUploadSelector()
+        selector = FileMetadataFilesSelector()
         selector.dump_to_file(tmp_path)
         csv_file = f"""externalId,name,{FILEPATH}\n
 my_json_file,my_json_file.json,{json_file.relative_to(tmp_path)}\n

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
@@ -28,6 +28,7 @@ class TestFileMetadataContentIO:
                 )
             ),
             file_directory=file_directory,
+            guess_mime_type=True,
         )
         selector.dump_to_file(tmp_path)
 
@@ -39,6 +40,8 @@ class TestFileMetadataContentIO:
 
             chunks = io.read_chunks(reader, selector)
             requests = (io.json_chunk_to_data(page) for page in chunks)
-            result = [io.upload_items(page, MagicMock(spec=HTTPClient), selector) for page in requests]
+            result_pages = [io.upload_items(page, MagicMock(spec=HTTPClient), selector) for page in requests]
+            assert len(result_pages) == 1
+            results = result_pages[0]
 
-            assert len(result) == len(files)
+            assert len(results) == len(files)

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
@@ -1,8 +1,8 @@
-from collections import Counter
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from cognite_toolkit._cdf_tk.client.http_client import HTTPClient, ItemsSuccessResponse
+from cognite_toolkit._cdf_tk.client.http_client import HTTPClient, ItemsSuccessResponse, SuccessResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataResponse
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.storageio._file_contentv2 import (
     FILENAME_VARIABLE,
@@ -17,8 +17,10 @@ class TestFileMetadataContentIO:
     def test_upload_template(self, tmp_path: Path):
         file_directory = tmp_path / "target"
         file_directory.mkdir()
-        (file_directory / "my_file.txt").write_text("This is a test file.")
-        (file_directory / "my_file.json").write_text('{"key": "value"}')
+        text_file = file_directory / "my_file.txt"
+        json_file = file_directory / "my_file.json"
+        text_file.write_text("This is a test file.")
+        json_file.write_text('{"key": "value"}')
 
         selector = FileMetadataTemplateSelector(
             template=FileMetadataTemplate.model_validate(
@@ -34,16 +36,28 @@ class TestFileMetadataContentIO:
         selector.dump_to_file(tmp_path)
 
         with monkeypatch_toolkit_client() as client:
+            client.tool.filemetadata.create.return_value = [
+                FileMetadataResponse(
+                    name="dummy",
+                    created_time=1,
+                    last_updated_time=1,
+                    uploaded=False,
+                    upload_url="https://some.url",
+                    id=37,
+                )
+            ]
+            client.tool.filemetadata.upload_file.return_value = SuccessResponse(status_code=200, body="", content=b"")
+
             io = FileMetadataContentIO(client, overwrite=True)
             files = selector.find_data_files(tmp_path, tmp_path / selector.as_filename())
-            assert len(files) == 2
-            reader = MultiFileReader(files)
 
-            chunks = io.read_chunks(reader, selector)
+            chunks = io.read_chunks(MultiFileReader(files), selector)
             requests = (io.json_chunk_to_data(page) for page in chunks)
             result_pages = [io.upload_items(page, MagicMock(spec=HTTPClient), selector) for page in requests]
             assert len(result_pages) == 1
-            results = result_pages[0]
+            results = sorted(result_pages[0], key=lambda x: x.ids[0])
 
-            actual = dict(Counter([type(item).__name__ for item in results]))
-            assert actual == {ItemsSuccessResponse.__name__: len(files)}
+            assert results == [
+                ItemsSuccessResponse(ids=[json_file.as_posix()], status_code=200, body="", content=b""),
+                ItemsSuccessResponse(ids=[text_file.as_posix()], status_code=200, body="", content=b""),
+            ]

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
@@ -7,16 +7,17 @@ from cognite_toolkit._cdf_tk.client.http_client import (
     ItemsSuccessResponse,
     SuccessResponse,
 )
-from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FILEPATH, FileMetadataResponse
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.storageio._file_contentv2 import (
     FILENAME_VARIABLE,
-    FILEPATH,
     FileMetadataContentIO,
-    FileMetadataContentSelector,
-    FileMetadataFilesSelector,
-    FileMetadataTemplate,
-    FileMetadataTemplateSelector,
+)
+from cognite_toolkit._cdf_tk.storageio.selectors import (
+    FileMetadataContentSelectorV2,
+    FileMetadataFilesSelectorV2,
+    FileMetadataTemplateSelectorV2,
+    FileMetadataTemplateV2,
 )
 from cognite_toolkit._cdf_tk.utils.fileio import MultiFileReader
 
@@ -30,8 +31,8 @@ class TestFileMetadataContentIO:
         text_file.write_text("This is a test file.")
         json_file.write_text('{"key": "value"}')
 
-        selector = FileMetadataTemplateSelector(
-            template=FileMetadataTemplate.model_validate(
+        selector = FileMetadataTemplateSelectorV2(
+            template=FileMetadataTemplateV2.model_validate(
                 dict(
                     name=FILENAME_VARIABLE,
                     external_id=f"my_id_{FILENAME_VARIABLE}",
@@ -58,7 +59,7 @@ class TestFileMetadataContentIO:
         text_file.write_text("This is a test file.")
         json_file.write_text('{"key": "value"}')
 
-        selector = FileMetadataFilesSelector()
+        selector = FileMetadataFilesSelectorV2()
         selector.dump_to_file(tmp_path)
         csv_file = f"""externalId,name,{FILEPATH}\n
 my_json_file,my_json_file.json,{json_file.relative_to(tmp_path)}\n
@@ -73,7 +74,7 @@ my_text_file,my_text_file.txt,{text_file.relative_to(tmp_path)}\n
             ItemsSuccessResponse(ids=["row 2"], status_code=200, body="", content=b""),
         ]
 
-    def _upload_files(self, selector: FileMetadataContentSelector, tmp_path: Path) -> list[ItemsResultMessage]:
+    def _upload_files(self, selector: FileMetadataContentSelectorV2, tmp_path: Path) -> list[ItemsResultMessage]:
         with monkeypatch_toolkit_client() as client:
             client.tool.filemetadata.create.return_value = [
                 FileMetadataResponse(

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
@@ -10,10 +10,10 @@ from cognite_toolkit._cdf_tk.client.http_client import (
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FILEPATH, FileMetadataResponse
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.storageio._file_contentv2 import (
-    FILENAME_VARIABLE,
     FileMetadataContentIO,
 )
 from cognite_toolkit._cdf_tk.storageio.selectors import (
+    FILENAME_VARIABLE,
     FileMetadataContentSelectorV2,
     FileMetadataFilesSelectorV2,
     FileMetadataTemplateSelectorV2,

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
@@ -88,7 +88,7 @@ my_text_file,my_text_file.txt,{text_file.relative_to(tmp_path)}\n
             ]
             client.tool.filemetadata.upload_file.return_value = SuccessResponse(status_code=200, body="", content=b"")
 
-            io = FileMetadataContentIO(client, overwrite=True)
+            io = FileMetadataContentIO(client, overwrite=True, config_directory=tmp_path)
             files = selector.find_data_files(tmp_path, tmp_path / selector.as_filename())
 
             chunks = io.read_chunks(MultiFileReader(files), selector)

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
@@ -1,20 +1,28 @@
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from cognite_toolkit._cdf_tk.client.http_client import HTTPClient, ItemsSuccessResponse, SuccessResponse
+from cognite_toolkit._cdf_tk.client.http_client import (
+    HTTPClient,
+    ItemsResultMessage,
+    ItemsSuccessResponse,
+    SuccessResponse,
+)
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataResponse
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.storageio._file_contentv2 import (
     FILENAME_VARIABLE,
+    FILEPATH,
     FileMetadataContentIO,
+    FileMetadataContentSelector,
     FileMetadataTemplate,
     FileMetadataTemplateSelector,
+    FileMetadataUploadSelector,
 )
 from cognite_toolkit._cdf_tk.utils.fileio import MultiFileReader
 
 
 class TestFileMetadataContentIO:
-    def test_upload_template(self, tmp_path: Path):
+    def test_upload_using_template(self, tmp_path: Path) -> None:
         file_directory = tmp_path / "target"
         file_directory.mkdir()
         text_file = file_directory / "my_file.txt"
@@ -35,6 +43,37 @@ class TestFileMetadataContentIO:
         )
         selector.dump_to_file(tmp_path)
 
+        results = self._upload_files(selector, tmp_path)
+
+        assert results == [
+            ItemsSuccessResponse(ids=[json_file.as_posix()], status_code=200, body="", content=b""),
+            ItemsSuccessResponse(ids=[text_file.as_posix()], status_code=200, body="", content=b""),
+        ]
+
+    def test_upload_using_identifier(self, tmp_path: Path) -> None:
+        file_directory = tmp_path / "target"
+        file_directory.mkdir()
+        text_file = file_directory / "my_file.txt"
+        json_file = file_directory / "my_file.json"
+        text_file.write_text("This is a test file.")
+        json_file.write_text('{"key": "value"}')
+
+        selector = FileMetadataUploadSelector()
+        selector.dump_to_file(tmp_path)
+        csv_file = f"""externalId,name,{FILEPATH}\n
+my_json_file,my_json_file.json,{json_file.relative_to(tmp_path)}\n
+my_text_file,my_text_file.txt,{text_file.relative_to(tmp_path)}\n
+"""
+        (tmp_path / f"{selector.as_filestem()}.csv").write_text(csv_file)
+
+        results = self._upload_files(selector, tmp_path)
+
+        assert results == [
+            ItemsSuccessResponse(ids=["row 1"], status_code=200, body="", content=b""),
+            ItemsSuccessResponse(ids=["row 2"], status_code=200, body="", content=b""),
+        ]
+
+    def _upload_files(self, selector: FileMetadataContentSelector, tmp_path: Path) -> list[ItemsResultMessage]:
         with monkeypatch_toolkit_client() as client:
             client.tool.filemetadata.create.return_value = [
                 FileMetadataResponse(
@@ -56,8 +95,4 @@ class TestFileMetadataContentIO:
             result_pages = [io.upload_items(page, MagicMock(spec=HTTPClient), selector) for page in requests]
             assert len(result_pages) == 1
             results = sorted(result_pages[0], key=lambda x: x.ids[0])
-
-            assert results == [
-                ItemsSuccessResponse(ids=[json_file.as_posix()], status_code=200, body="", content=b""),
-                ItemsSuccessResponse(ids=[text_file.as_posix()], status_code=200, body="", content=b""),
-            ]
+        return results

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
@@ -1,7 +1,8 @@
+from collections import Counter
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from cognite_toolkit._cdf_tk.client.http_client import HTTPClient
+from cognite_toolkit._cdf_tk.client.http_client import HTTPClient, ItemsSuccessResponse
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.storageio._file_contentv2 import (
     FILENAME_VARIABLE,
@@ -44,4 +45,5 @@ class TestFileMetadataContentIO:
             assert len(result_pages) == 1
             results = result_pages[0]
 
-            assert len(results) == len(files)
+            actual = dict(Counter([type(item).__name__ for item in results]))
+            assert actual == {ItemsSuccessResponse.__name__: len(files)}

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_selectors.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_selectors.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, get_args
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FILEPATH
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import AssetCentricMigrationSelector
@@ -14,6 +15,7 @@ from cognite_toolkit._cdf_tk.storageio import (
     DatapointsIO,
     EventDataIO,
     FileContentIO,
+    FileMetadataContentIO,
     InstanceIO,
     RawIO,
     RecordIO,
@@ -34,7 +36,9 @@ from cognite_toolkit._cdf_tk.storageio.selectors import (
     DataSetSelector,
     FileDataModelingTemplateSelector,
     FileIdentifierSelector,
+    FileMetadataFilesSelectorV2,
     FileMetadataTemplateSelector,
+    FileMetadataTemplateSelectorV2,
     InstanceFileSelector,
     InstanceQuerySelector,
     InstanceSpaceSelector,
@@ -328,6 +332,33 @@ def example_selector_data() -> Iterable[tuple]:
         InstanceIO.KIND,
         id="InstanceQuerySelector",
     )
+    yield pytest.param(
+        {
+            "type": "FileMetadataTemplate",
+            "kind": "FileMetadataContent",
+            "fileDirectory": "path/to/files",
+            "guessMimeType": True,
+            "template": {
+                "name": "$FILENAME",
+                "externalId": "my$FILENAME",
+            },
+        },
+        FileMetadataTemplateSelectorV2,
+        FileMetadataContentIO,
+        FileMetadataContentIO.KIND,
+        id="FileMetadataTemplateSelectorV2",
+    )
+    yield pytest.param(
+        {
+            "kind": "FileMetadataContent",
+            "type": "FileMetadataFiles",
+            "ids": [{"id": 123, "name": "file1"}, {"id": 456, "name": "file2"}],
+        },
+        FileMetadataFilesSelectorV2,
+        FileMetadataContentIO,
+        FileMetadataContentIO.KIND,
+        id="FileMetadataFilesSelectorV2",
+    )
 
 
 @pytest.fixture(scope="module")
@@ -372,7 +403,12 @@ class TestDataSelectors:
         expected_io: type[StorageIO] | None,
         kind: str,
         tmp_path: Path,
+        monkeypatch: MonkeyPatch,
     ) -> None:
+        monkeypatch.chdir(tmp_path)
+        if expected_selector is FileMetadataTemplateSelectorV2:
+            (tmp_path / data["fileDirectory"]).mkdir(parents=True, exist_ok=True)
+
         instance = SelectorAdapter.validate_python(data)
 
         # Assert correct type


### PR DESCRIPTION
# Description

This is a complete reimplementation of the FileContentIO. The motivation for the reimplementation
1. We now have pydantic classes for FileMetadata requset and response objects that simplifies the implementation. 
2. We can use the ToolkitClient instead of the CogniteClient to work with the file API (`client.tool.filemeta`). This do not hide away the underlying API calls we need.
3. We have much better logging now, which is very useful as there is a lot that can go wrong with a download/upload of files with content which we should inform the user about.

Note the new implementation is much simpler going from ~500 to ~300 lines of code.

## Download all pdf files
<img width="1160" height="425" alt="image" src="https://github.com/user-attachments/assets/92ffe220-61d6-4f17-a63f-51573006ab9a" />

## Downloaded
<img width="1980" height="390" alt="image" src="https://github.com/user-attachments/assets/fb10553d-ee0a-4414-ba02-e1dda67d95b8" />

 The content of the Manifest is simplified to
 ```yaml
type: FileMetadataFiles
kind: FileMetadataContent
# No longer storing the file IDs, those are in the `.ndjson` file. Making
#  this manifest file much easier to make in manually. 
```

## Uploaded
<img width="798" height="171" alt="image" src="https://github.com/user-attachments/assets/227a4ed7-d7dd-4134-9c80-5515973c4d9f" />


## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Improved

- [alpha] When downloading files with content `cdf data download files`, Toolkit now supports wider filtering to select files. In addition, simplified the manifest file when uploading files with content. 

