### PR TITLE
[CDF-27646] 🩸 Support upload raw table deploy v2

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_upload.py
+++ b/cognite_toolkit/_cdf_tk/commands/_upload.py
@@ -94,7 +94,7 @@ class UploadCommand(ToolkitCommand):
         self._deploy_resource_folder(input_dir / DATA_RESOURCE_DIR, deploy_resources, client, console, dry_run, verbose)
 
         data_files_by_selector = self._topological_sort_if_instance_selector(data_files_by_selector, client)
-        self._upload_data(data_files_by_selector, client, dry_run, input_dir, console, verbose)
+        self.upload_data(data_files_by_selector, client, dry_run, input_dir, console, verbose)
 
     def _topological_sort_if_instance_selector(
         self, data_files_by_selector: dict[Selector, list[Path]], client: ToolkitClient
@@ -200,7 +200,7 @@ class UploadCommand(ToolkitCommand):
                 )
             )
 
-    def _upload_data(
+    def upload_data(
         self,
         data_files_by_selector: dict[Selector, list[Path]],
         client: ToolkitClient,

--- a/cognite_toolkit/_cdf_tk/commands/_upload.py
+++ b/cognite_toolkit/_cdf_tk/commands/_upload.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from collections.abc import Mapping
 from functools import partial
 from pathlib import Path
 
@@ -94,7 +95,12 @@ class UploadCommand(ToolkitCommand):
         self._deploy_resource_folder(input_dir / DATA_RESOURCE_DIR, deploy_resources, client, console, dry_run, verbose)
 
         data_files_by_selector = self._topological_sort_if_instance_selector(data_files_by_selector, client)
-        self.upload_data(data_files_by_selector, client, dry_run, input_dir, console, verbose)
+
+        total_file_count = sum(len(files) for files in data_files_by_selector.values())
+        if verbose:
+            input_dir_display = self._path_as_display_name(input_dir)
+            console.print(f"Found {total_file_count} files to upload in {input_dir_display.as_posix()!r}.")
+        self.upload_data(data_files_by_selector, client, dry_run, console, verbose)
 
     def _topological_sort_if_instance_selector(
         self, data_files_by_selector: dict[Selector, list[Path]], client: ToolkitClient
@@ -200,24 +206,20 @@ class UploadCommand(ToolkitCommand):
                 )
             )
 
+    @classmethod
     def upload_data(
-        self,
-        data_files_by_selector: dict[Selector, list[Path]],
+        cls,
+        data_files_by_selector: Mapping[Selector, list[Path]],
         client: ToolkitClient,
         dry_run: bool,
-        input_dir: Path,
         console: Console,
         verbose: bool,
     ) -> None:
-        total_file_count = sum(len(files) for files in data_files_by_selector.values())
-        if verbose:
-            input_dir_display = self._path_as_display_name(input_dir)
-            console.print(f"Found {total_file_count} files to upload in {input_dir_display.as_posix()!r}.")
         action = "Would upload" if dry_run else "Uploading"
         with HTTPClient(config=client.config) as upload_client:
             file_count = 1
             for selector, datafiles in data_files_by_selector.items():
-                io = self._create_selected_io(selector, datafiles[0], client)
+                io = cls._create_selected_io(selector, datafiles[0], client)
                 if io is None:
                     continue
                 schema = io.get_schema(selector) if isinstance(io, TableStorageIO) else None
@@ -230,14 +232,14 @@ class UploadCommand(ToolkitCommand):
 
                 item_count = io.count_items(reader, selector)
 
-                tracker = ProgressTracker[str]([self._UPLOAD])
+                tracker = ProgressTracker[str]([cls._UPLOAD])
                 executor = ProducerWorkerExecutor[Page[dict[str, JsonVal]], Page](
                     download_iterable=io.read_chunks(reader, selector),
                     process=partial(io.rows_to_data, selector=selector)
                     if reader.is_table and isinstance(io, TableUploadableStorageIO)
                     else io.json_chunk_to_data,
                     write=partial(
-                        self._upload_items,
+                        cls._upload_items,
                         upload_client=upload_client,
                         io=io,
                         dry_run=dry_run,
@@ -247,7 +249,7 @@ class UploadCommand(ToolkitCommand):
                         verbose=verbose,
                     ),
                     total_item_count=item_count,
-                    max_queue_size=self._MAX_QUEUE_SIZE,
+                    max_queue_size=cls._MAX_QUEUE_SIZE,
                     download_description="Reading files",
                     process_description="Processing",
                     write_description=f"{action} {selector.display_name}",
@@ -259,8 +261,8 @@ class UploadCommand(ToolkitCommand):
                 final_action = "Uploaded" if not dry_run else "Would upload"
                 suffix = " successfully" if not dry_run else ""
                 results = tracker.aggregate()
-                success = results.get((self._UPLOAD, "success"), 0)
-                failed = results.get((self._UPLOAD, "failed"), 0)
+                success = results.get((cls._UPLOAD, "success"), 0)
+                failed = results.get((cls._UPLOAD, "failed"), 0)
                 if failed > 0:
                     suffix += f", {failed:,} failed"
                 console.print(
@@ -274,13 +276,16 @@ class UploadCommand(ToolkitCommand):
             display_name = input_path.relative_to(cwd)
         return display_name
 
+    @classmethod
     def _create_selected_io(
-        self, selector: Selector, data_file: Path, client: ToolkitClient
+        cls, selector: Selector, data_file: Path, client: ToolkitClient
     ) -> UploadableStorageIO | None:
         try:
             io_cls = get_upload_io(selector)
         except ValueError as e:
-            self.warn(HighSeverityWarning(f"Could not find StorageIO for selector {selector}: {e}"))
+            HighSeverityWarning(f"Could not find StorageIO for selector {selector}: {e}").print_warning(
+                console=client.console
+            )
             return None
         return io_cls(client)
 

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_lineage.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_lineage.py
@@ -58,6 +58,10 @@ class ResourceLineageItem(_BaseLineageModel):
         resource_type: ResourceType = info.data["type"]
         return resource_type.load_identifier(value)
 
+    @field_serializer("identifier", when_used="always")
+    def serialize_identifier(self, value: Identifier) -> dict[str, Any]:
+        return value.dump()
+
 
 class ModuleLineageItem(_BaseLineageModel):
     """Tracks a module through the build process."""

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_lineage.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_lineage.py
@@ -15,6 +15,7 @@ from pydantic import (
 )
 from pydantic.alias_generators import to_camel
 
+from cognite_toolkit._cdf_tk.client._resource_base import Identifier
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuildFolder, BuiltModule
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import (
     ConsistencyError,
@@ -42,6 +43,7 @@ class ResourceLineageItem(_BaseLineageModel):
     source_hash: str
     type: ResourceType
     built_file: AbsoluteFilePath
+    identifier: Identifier
 
 
 class ModuleLineageItem(_BaseLineageModel):
@@ -87,6 +89,7 @@ class ModuleLineageItem(_BaseLineageModel):
                     source_hash=resource.source_hash,
                     built_file=resource.build_path.resolve(),
                     type=resource.type,
+                    identifier=resource.identifier,
                 )
             )
         return cls(

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_lineage.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_lineage.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import yaml
 from pydantic import (
@@ -12,8 +12,10 @@ from pydantic import (
     ValidationError,
     computed_field,
     field_serializer,
+    field_validator,
 )
 from pydantic.alias_generators import to_camel
+from pydantic_core.core_schema import ValidationInfo
 
 from cognite_toolkit._cdf_tk.client._resource_base import Identifier
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuildFolder, BuiltModule
@@ -44,6 +46,17 @@ class ResourceLineageItem(_BaseLineageModel):
     type: ResourceType
     built_file: AbsoluteFilePath
     identifier: Identifier
+
+    @field_validator("identifier", mode="plain")
+    @classmethod
+    def load_identifier(cls, value: Any, info: ValidationInfo) -> Any:
+        """Load identifier from dict using ResourceType."""
+        if not isinstance(value, dict):
+            return value
+        if "type" not in info.data:
+            raise ValueError("Resource type must be provided to load identifier")
+        resource_type: ResourceType = info.data["type"]
+        return resource_type.load_identifier(value)
 
 
 class ModuleLineageItem(_BaseLineageModel):

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_module.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_module.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Generic, Literal, TypeAlias, get_args
+from typing import Any, Generic, Literal, TypeAlias, get_args
 
 from pydantic import BaseModel, ConfigDict, DirectoryPath, Field, JsonValue
 
@@ -173,6 +173,9 @@ class ResourceType(BaseModel):
         kind = self.kind
         folder_name = self.resource_folder
         return RESOURCE_CRUD_BY_FOLDER_NAME_BY_KIND[folder_name][kind]
+
+    def load_identifier(self, data: dict[str, Any]) -> Identifier:
+        return self.crud_cls.get_id(data)
 
     def __str__(self) -> str:
         return f"{self.kind} ({self.resource_folder})"

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -1,6 +1,6 @@
 import json
 from collections import Counter, defaultdict
-from collections.abc import Iterable, Sequence, Set
+from collections.abc import Iterable, Mapping, Sequence, Set
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -230,7 +230,7 @@ class DeployV2Command(ToolkitCommand):
 
         if build_lineage and (raw_files := self._find_raw_tables(build_lineage)):
             self._display_deprecation_warning(raw_files, client.console)
-            UploadCommand.upload_data(raw_files, client, client.console, options.dry_run, options.verbose)
+            UploadCommand.upload_data(raw_files, client, options.dry_run, client.console, options.verbose)  # type: ignore[arg-type]
 
         return results
 
@@ -896,11 +896,11 @@ class DeployV2Command(ToolkitCommand):
             console.print(Panel("\n".join(skipped_str), title="Skipped resources", expand=False))
 
     @classmethod
-    def _find_raw_tables(cls, build_lineage: BuildLineage) -> dict[RawTableSelector, list[Path]]:
+    def _find_raw_tables(cls, build_lineage: BuildLineage) -> Mapping[RawTableSelector, list[Path]]:
         raise NotImplementedError()
 
     @classmethod
-    def _display_deprecation_warning(cls, raw_files: dict[RawTableSelector, list[Path]], console: Console) -> None:
+    def _display_deprecation_warning(cls, raw_files: Mapping[RawTableSelector, list[Path]], console: Console) -> None:
         raw_table_count = len(raw_files)
         file_count = sum(len(files) for files in raw_files.values())
         console.print(

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -18,12 +18,14 @@ from yaml import YAMLError
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client._resource_base import T_Identifier, T_RequestResource, T_ResponseResource
 from cognite_toolkit._cdf_tk.client.http_client import ToolkitAPIError
+from cognite_toolkit._cdf_tk.client.identifiers import RawTableId
 from cognite_toolkit._cdf_tk.commands import UploadCommand
 from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import BuildLineage
 from cognite_toolkit._cdf_tk.constants import HINT_LEAD_TEXT
 from cognite_toolkit._cdf_tk.cruds import (
     RESOURCE_CRUD_BY_FOLDER_NAME_BY_KIND,
+    RawTableCRUD,
     ResourceContainerCRUD,
     ResourceCRUD,
 )
@@ -38,7 +40,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitWrongResourceError,
     ToolkitYAMLFormatError,
 )
-from cognite_toolkit._cdf_tk.storageio.selectors import RawTableSelector
+from cognite_toolkit._cdf_tk.storageio.selectors import RawTableSelector, SelectedTable
 from cognite_toolkit._cdf_tk.tk_warnings import (
     EnvironmentVariableMissingWarning,
     LowSeverityWarning,
@@ -897,7 +899,24 @@ class DeployV2Command(ToolkitCommand):
 
     @classmethod
     def _find_raw_tables(cls, build_lineage: BuildLineage) -> Mapping[RawTableSelector, list[Path]]:
-        raise NotImplementedError()
+        selections: dict[RawTableSelector, list[Path]] = defaultdict(list)
+        for module in build_lineage.module_lineage:
+            for resource in module.resource_lineage:
+                if (
+                    resource.type.resource_folder == RawTableCRUD.folder_name
+                    and resource.type.kind == RawTableCRUD.kind
+                    and isinstance(resource.identifier, RawTableId)
+                ):
+                    for file_type in ["csv", "parquet"]:
+                        if (data_file := resource.source_file.with_suffix(f".{file_type}")).is_file():
+                            selections[
+                                RawTableSelector(
+                                    table=SelectedTable(
+                                        db_name=resource.identifier.db_name, table_name=resource.identifier.name
+                                    )
+                                )
+                            ].append(data_file)
+        return selections
 
     @classmethod
     def _display_deprecation_warning(cls, raw_files: Mapping[RawTableSelector, list[Path]], console: Console) -> None:

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -18,6 +18,7 @@ from yaml import YAMLError
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client._resource_base import T_Identifier, T_RequestResource, T_ResponseResource
 from cognite_toolkit._cdf_tk.client.http_client import ToolkitAPIError
+from cognite_toolkit._cdf_tk.commands import UploadCommand
 from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import BuildLineage
 from cognite_toolkit._cdf_tk.constants import HINT_LEAD_TEXT
@@ -37,6 +38,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitWrongResourceError,
     ToolkitYAMLFormatError,
 )
+from cognite_toolkit._cdf_tk.storageio.selectors import RawTableSelector
 from cognite_toolkit._cdf_tk.tk_warnings import (
     EnvironmentVariableMissingWarning,
     LowSeverityWarning,
@@ -225,6 +227,10 @@ class DeployV2Command(ToolkitCommand):
 
         # Todo: Some mixpanel tracking??
         self._display_results(results, options.operation, options.operation_noun, client.console, options.verbose)
+
+        if build_lineage and (raw_files := self._find_raw_tables(build_lineage)):
+            self._display_deprecation_warning(raw_files, client.console)
+            UploadCommand.upload_data(raw_files, client, client.console, options.dry_run, options.verbose)
 
         return results
 
@@ -888,3 +894,23 @@ class DeployV2Command(ToolkitCommand):
                 for skip in total.skipped
             ]
             console.print(Panel("\n".join(skipped_str), title="Skipped resources", expand=False))
+
+    @classmethod
+    def _find_raw_tables(cls, build_lineage: BuildLineage) -> dict[RawTableSelector, list[Path]]:
+        raise NotImplementedError()
+
+    @classmethod
+    def _display_deprecation_warning(cls, raw_files: dict[RawTableSelector, list[Path]], console: Console) -> None:
+        raw_table_count = len(raw_files)
+        file_count = sum(len(files) for files in raw_files.values())
+        console.print(
+            Panel(
+                f"[yellow]Deprecation Warning[/]\n\n"
+                f"You are deploying {raw_table_count} raw table{'' if raw_table_count == 1 else 's'} based on {file_count} file{'' if file_count == 1 else 's'}.\n\n"
+                f"Support for deploying raw tables through the deploy command will be removed in a future release. "
+                f"Please migrate your raw tables to use the new data plugin. See the documentation for more details.",
+                title="Deprecation Warning",
+                border_style="yellow",
+                expand=False,
+            )
+        )

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -197,7 +197,8 @@ class DeployV2Command(ToolkitCommand):
         options: DeployOptions | None = None,
     ) -> Sequence[DeploymentResult]:
         options = options or DeployOptions(environment_variables=env_vars.dump())
-        build_dir = self.read_build_directory(user_build_dir, options.include)
+        build_lineage = self.read_build_lineage(user_build_dir)
+        build_dir = self.read_build_directory(user_build_dir, options.include, build_lineage)
 
         client = env_vars.get_client(is_strict_validation=build_dir.is_strict_validation)
 
@@ -228,7 +229,15 @@ class DeployV2Command(ToolkitCommand):
         return results
 
     @classmethod
-    def read_build_directory(cls, build_dir: Path, include: Sequence[str] | None = None) -> ReadBuildDirectory:
+    def read_build_lineage(cls, build_dir: Path) -> BuildLineage | None:
+        if (lineage_path := (build_dir / BuildLineage.filename)).exists():
+            return BuildLineage.from_yaml_file(lineage_path)
+        return None
+
+    @classmethod
+    def read_build_directory(
+        cls, build_dir: Path, include: Sequence[str] | None = None, build_lineage: BuildLineage | None = None
+    ) -> ReadBuildDirectory:
         """Reads the build directory and returns a structured representation of the resources to be deployed.
 
         Args:
@@ -249,10 +258,9 @@ class DeployV2Command(ToolkitCommand):
         # Note we support running without linage. This is for example used when deploying resources
         # with the upload command.from
         cdf_project: str | None = None
-        if (lineage_path := (build_dir / BuildLineage.filename)).exists():
-            lineage = BuildLineage.from_yaml_file(lineage_path)
-            lineage.validate_source_files_unchanged()
-            cdf_project = lineage.cdf_project
+        if build_lineage:
+            build_lineage.validate_source_files_unchanged()
+            cdf_project = build_lineage.cdf_project
         include_set = set(include) if include else None
         invalid_resource_dirs: list[Path] = []
         resource_directories: list[ResourceDirectory] = []

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -201,9 +201,7 @@ class DeployV2Command(ToolkitCommand):
 
         client = env_vars.get_client(is_strict_validation=build_dir.is_strict_validation)
 
-        self._validate_cdf_project(
-            build_dir, options.operation, options.cdf_project, env_vars.CDF_PROJECT, client.console
-        )
+        self._validate_cdf_project(build_dir, options.operation, options.cdf_project, env_vars.CDF_PROJECT)
         self._display_startup(options.operation, build_dir.path, client.config.project, client.console)
         self._display_read_dir(build_dir, client.console, options.verbose)
 
@@ -369,7 +367,6 @@ class DeployV2Command(ToolkitCommand):
         operation: str,
         cli_cdf_project: str | None,
         client_cdf_project: str,
-        console: Console,
     ) -> None:
         """Validates that the user is deploying to the CDF project they intended"""
         if cli_cdf_project is not None and cli_cdf_project != client_cdf_project:

--- a/cognite_toolkit/_cdf_tk/cruds/_resource_cruds/raw.py
+++ b/cognite_toolkit/_cdf_tk/cruds/_resource_cruds/raw.py
@@ -184,14 +184,14 @@ class RawTableCRUD(ResourceContainerCRUD[RawTableId, RAWTableRequest, RAWTableRe
     def get_id(cls, item: RAWTableResponse | RAWTableRequest | dict) -> RawTableId:
         if isinstance(item, dict):
             missing: list[str] = []
-            table_key = "tablename"
             if "dbName" not in item:
                 missing.append("dbName")
             if "tableName" in item:
-                table_key = "name"
+                table_key = "tableName"
             elif "name" in item:
                 table_key = "name"
             else:
+                table_key = "<missing>"
                 missing.append("tableName")
 
             if missing:

--- a/cognite_toolkit/_cdf_tk/cruds/_resource_cruds/raw.py
+++ b/cognite_toolkit/_cdf_tk/cruds/_resource_cruds/raw.py
@@ -183,10 +183,21 @@ class RawTableCRUD(ResourceContainerCRUD[RawTableId, RAWTableRequest, RAWTableRe
     @classmethod
     def get_id(cls, item: RAWTableResponse | RAWTableRequest | dict) -> RawTableId:
         if isinstance(item, dict):
-            if missing := tuple(k for k in {"dbName", "tableName"} if k not in item):
+            missing: list[str] = []
+            table_key = "tablename"
+            if "dbName" not in item:
+                missing.append("dbName")
+            if "tableName" in item:
+                table_key = "name"
+            elif "name" in item:
+                table_key = "name"
+            else:
+                missing.append("tableName")
+
+            if missing:
                 # We need to raise a KeyError with all missing keys to get the correct error message.
                 raise KeyError(*missing)
-            return RawTableId(db_name=item["dbName"], name=item["tableName"])
+            return RawTableId(db_name=item["dbName"], name=item[table_key])
         return RawTableId(db_name=item.db_name, name=item.name)
 
     @classmethod

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_data_classes.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_data_classes.py
@@ -4,7 +4,9 @@ import pytest
 import yaml
 from pydantic import TypeAdapter
 
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import BuildVariable, RelativeDirPath
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._lineage import ResourceLineageItem
 
 
 @pytest.fixture(scope="session")
@@ -197,3 +199,23 @@ query: >-
 
         with pytest.raises(NotImplementedError, match=r"'.txt' is not supported"):
             variable.get_pattern_replace_pair(".txt")  # type: ignore[arg-type]
+
+
+class TestBuildLinage:
+    def test_deserialize_resource_lineage(self, tmp_path: Path) -> None:
+        source_file = tmp_path / "file1.txt"
+        built_file = tmp_path / "file2.txt"
+        source_file.touch()
+        built_file.touch()
+        data = {
+            "sourceFile": source_file.as_posix(),
+            "sourceHash": "123",
+            "type": {
+                "resource_folder": "files",
+                "kind": "FileMetadata",
+            },
+            "builtFile": built_file.as_posix(),
+            "identifier": {"externalId": "some_id"},
+        }
+        linage = ResourceLineageItem.model_validate(data)
+        assert isinstance(linage.identifier, ExternalId)

--- a/tests/test_unit/test_cli/test_command_sequences.py
+++ b/tests/test_unit/test_cli/test_command_sequences.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import respx
 from pytest import MonkeyPatch
 
 from cognite_toolkit._cdf_tk.commands import (
@@ -257,6 +258,7 @@ def test_build_deploy_v2_complete_orgs(
     toolkit_client_approval: ApprovalToolkitClient,
     env_vars_with_client: EnvironmentVariables,
     data_regression,
+    respx_mock: respx.MockRouter,
 ) -> None:
     BuildV2Command(silent=True, skip_tracking=True).build(
         client=env_vars_with_client.get_client(),
@@ -270,6 +272,8 @@ def test_build_deploy_v2_complete_orgs(
         os.environ,
         {"CDF_ENVIRON": "pytest", "CDF_BUILD_TYPE": "dev"},
     ):
+        respx_mock.route(url__regex=r".*/raw/dbs/[^/]+/tables/[^/]+/rows(?:\?.*)?$").respond(status_code=200)
+
         DeployV2Command(silent=True, skip_tracking=True).deploy(
             env_vars=env_vars_with_client,
             user_build_dir=build_tmp_path,

--- a/tests/test_unit/test_cli/test_command_sequences.py
+++ b/tests/test_unit/test_cli/test_command_sequences.py
@@ -272,6 +272,7 @@ def test_build_deploy_v2_complete_orgs(
         os.environ,
         {"CDF_ENVIRON": "pytest", "CDF_BUILD_TYPE": "dev"},
     ):
+        # Mock /raw/dbs/{dbName}/tables/{tableName}/rows as the deploy command uploads RAW rows.
         respx_mock.route(url__regex=r".*/raw/dbs/[^/]+/tables/[^/]+/rows(?:\?.*)?$").respond(status_code=200)
 
         DeployV2Command(silent=True, skip_tracking=True).deploy(


### PR DESCRIPTION
# Description

Support for uploading RAW tables in deploy v2. 

I did this in two steps:
1. Added identifier, required a small trick see comment in code.
2. Find all raw tables in the linage yaml and call the UploadCommand


<img width="1624" height="233" alt="image" src="https://github.com/user-attachments/assets/f917bced-61d6-4dda-be3c-7afea670311a" />



## Bump

- [ ] Patch
- [x] Skip

## Changelog
