### PR TITLE
[CDF-27649] 🤖 Handle known ACL and unknown scope/action + AgentExternalIdScope

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
@@ -609,7 +609,7 @@ def _handle_unknown_acl(value: Any) -> Any:
             try:
                 return TypeAdapter(acl_class).validate_python(value)
             except ValidationError as err:
-                if any(not _is_unknown_scope_or_action(error) for error in err.errors()):
+                if all(not _is_unknown_scope_or_action(error) for error in err.errors()):
                     raise err
                 # If the ACL contains an unknown scope or action, we treat it as an
                 # unknown acl.
@@ -620,7 +620,9 @@ def _is_unknown_scope_or_action(error: ErrorDetails) -> bool:
     loc = error["loc"]
     if not loc:
         return False
-    return error["type"] == "literal_error" and (loc == ("scope", "scope_name") or loc[0] == "actions")
+    is_unknown_action = loc[0] == "action" and isinstance(loc[-1], int)
+    is_unknown_scope = loc[0] == "scope" and loc[-1] == "scope_name"
+    return error["type"] == "literal_error" and (is_unknown_action or is_unknown_scope)
 
 
 AclType: TypeAlias = Annotated[

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
@@ -7,7 +7,7 @@ https://api-docs.cognite.com/20230101/tag/Groups/operation/createGroups
 from collections.abc import Sequence
 from typing import Annotated, Any, Literal, TypeAlias
 
-from pydantic import BeforeValidator, Field, TypeAdapter, ValidationError, model_serializer, model_validator
+from pydantic import BeforeValidator, Field, ValidationError, model_serializer, model_validator
 from pydantic_core import ErrorDetails
 from pydantic_core.core_schema import FieldSerializationInfo
 
@@ -595,7 +595,7 @@ def _get_acl_name(cls: type[Acl]) -> str | None:
 
 
 _KNOWN_ACLS = {
-    name: TypeAdapter(acl)
+    name: acl
     for acl in get_concrete_subclasses(Acl)
     if (name := _get_acl_name(acl)) is not None and name != "unknownAcl"
 }
@@ -605,9 +605,9 @@ def _handle_unknown_acl(value: Any) -> Any:
     if isinstance(value, Acl | UnknownAcl):
         return value
     if isinstance(value, dict) and isinstance(acl_name := value.get(ACL_NAME), str):
-        if acl_adapter := _KNOWN_ACLS.get(acl_name):
+        if acl_cls := _KNOWN_ACLS.get(acl_name):
             try:
-                return acl_adapter.validate_python(value)
+                return acl_cls.model_validate(value)
             except ValidationError as err:
                 if all(not _is_unknown_scope_or_action(error) for error in err.errors()):
                     raise err

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
@@ -595,7 +595,7 @@ def _get_acl_name(cls: type[Acl]) -> str | None:
 
 
 _KNOWN_ACLS = {
-    name: acl
+    name: TypeAdapter(acl)
     for acl in get_concrete_subclasses(Acl)
     if (name := _get_acl_name(acl)) is not None and name != "unknownAcl"
 }
@@ -605,9 +605,9 @@ def _handle_unknown_acl(value: Any) -> Any:
     if isinstance(value, Acl | UnknownAcl):
         return value
     if isinstance(value, dict) and isinstance(acl_name := value.get(ACL_NAME), str):
-        if acl_class := _KNOWN_ACLS.get(acl_name):
+        if acl_adapter := _KNOWN_ACLS.get(acl_name):
             try:
-                return TypeAdapter(acl_class).validate_python(value)
+                return acl_adapter.validate_python(value)
             except ValidationError as err:
                 if all(not _is_unknown_scope_or_action(error) for error in err.errors()):
                     raise err

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
@@ -7,7 +7,8 @@ https://api-docs.cognite.com/20230101/tag/Groups/operation/createGroups
 from collections.abc import Sequence
 from typing import Annotated, Any, Literal, TypeAlias
 
-from pydantic import BeforeValidator, Field, TypeAdapter, model_serializer, model_validator
+from pydantic import BeforeValidator, Field, TypeAdapter, ValidationError, model_serializer, model_validator
+from pydantic_core import ErrorDetails
 from pydantic_core.core_schema import FieldSerializationInfo
 
 from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject
@@ -603,10 +604,22 @@ def _handle_unknown_acl(value: Any) -> Any:
     if isinstance(value, Acl | UnknownAcl):
         return value
     if isinstance(value, dict) and isinstance(acl_name := value.get(ACL_NAME), str):
-        acl_class = _KNOWN_ACLS.get(acl_name)
-        if acl_class:
-            return TypeAdapter(acl_class).validate_python(value)
+        if acl_class := _KNOWN_ACLS.get(acl_name):
+            try:
+                return TypeAdapter(acl_class).validate_python(value)
+            except ValidationError as err:
+                if any(not _is_unknown_scope_or_action(error) for error in err.errors()):
+                    raise err
+                # If the ACL contains an unknown scope or action, we treat it as an
+                # unknown acl.
     return UnknownAcl.model_validate(value)
+
+
+def _is_unknown_scope_or_action(error: ErrorDetails) -> bool:
+    loc = error["loc"]
+    if not loc:
+        return False
+    return error["type"] == "literal_error" and (loc == ("scope", "scope_name") or loc[0] == "actions")
 
 
 AclType: TypeAlias = Annotated[

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
@@ -16,6 +16,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.group._constants import ACL
 from cognite_toolkit._cdf_tk.utils._auxiliary import get_concrete_subclasses
 
 from .scopes import (
+    AgentExternalIdScope,
     AllScope,
     AppConfigScope,
     AssetRootIDScope,
@@ -80,7 +81,7 @@ class AgentsAcl(Acl):
 
     acl_name: Literal["agentsAcl"] = Field("agentsAcl", exclude=True)
     actions: Sequence[Literal["READ", "WRITE", "RUN"]]
-    scope: AllScope
+    scope: AllScope | AgentExternalIdScope
 
 
 class AnalyticsAcl(Acl):

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/group/scopes.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/group/scopes.py
@@ -39,6 +39,11 @@ class ScopeDefinition(BaseModelObject):
         )
 
 
+class AgentExternalIdScope(ScopeDefinition):
+    scope_name: Literal["agentExternalIdScope"] = Field("agentExternalIdScope", exclude=True)
+    external_ids: list[str]
+
+
 class AllScope(ScopeDefinition):
     """Scope that applies to all resources."""
 
@@ -209,6 +214,7 @@ Scope: TypeAlias = Annotated[
         | ExperimentScope
         | AppConfigScope
         | PostgresGatewayUsersScope
+        | AgentExternalIdScope
         | UnknownScope
     ),
     BeforeValidator(_handle_unknown_scope),

--- a/cognite_toolkit/_cdf_tk/yaml_classes/capabilities.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/capabilities.py
@@ -44,6 +44,11 @@ class Scope(BaseModelResource):
         return {self._scope_name: serialized_data}
 
 
+class AgentExternalIdScope(Scope):
+    _scope_name = "agentExternalIdScope"
+    external_ids: list[str]
+
+
 class AllScope(Scope):
     _scope_name = "all"
 
@@ -171,7 +176,7 @@ class Capability(BaseModelResource):
 class AgentsAcl(Capability):
     _capability_name = "agentsAcl"
     actions: list[Literal["READ", "WRITE", "RUN"]]
-    scope: AllScope
+    scope: AllScope | AgentExternalIdScope
 
 
 class AnalyticsAcl(Capability):

--- a/tests/test_unit/test_cdf_tk/test_client/test_api_data_classes.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_api_data_classes.py
@@ -312,6 +312,19 @@ class TestGroupResponse:
 
         GroupResponse.model_validate(data)
 
+    def test_load_known_acl_with_unknown_scope_and_action(self) -> None:
+        data = {
+            "name": "Group 1",
+            "id": 37,
+            "isDeleted": False,
+            "capabilities": [
+                {"agentsAcl": {"actions": ["READ", "UNKNOWN_ACTION"], "scope": {"anUnknownScope": {"ids": [1, 2, 3]}}}}
+            ],
+        }
+        group = GroupResponse.model_validate(data)
+
+        assert group.dump() == data
+
 
 class TestPrincipalSerialization:
     def test_service_account_principal_round_trip(self) -> None:

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
@@ -11,6 +11,12 @@ from cognite_toolkit._cdf_tk.yaml_classes.capabilities import Capability
 def all_acls() -> Iterable:
     acl_list = [
         {"agentsAcl": {"actions": ["READ", "WRITE", "RUN"], "scope": {"all": {}}}},
+        {
+            "agentsAcl": {
+                "actions": ["READ", "WRITE", "RUN"],
+                "scope": {"agentExternalIdScope": {"externalIds": ["69de3ab6-a4be-4006-a80c-59438c75ea66"]}},
+            }
+        },
         {"annotationsAcl": {"actions": ["WRITE", "READ", "SUGGEST", "REVIEW"], "scope": {"all": {}}}},
         {"appConfigAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"appConfigAcl": {"actions": ["READ", "WRITE"], "scope": {"appScope": {"apps": ["SEARCH"]}}}},
@@ -210,7 +216,7 @@ class TestCapabilities:
             pytest.param(
                 {"agentsAcl": {"actions": ["READ", "LIST"], "scope": {"idScope": {"ids": ["my_agent"]}}}},
                 [
-                    "In field scope invalid scope name 'idScope'. Expected all",
+                    "In field scope invalid scope name 'idScope'. Expected agentExternalIdScope or all",
                     "In actions[2] input should be 'READ', 'WRITE' or 'RUN'. Got 'LIST'.",
                 ],
                 id="AgentsAcl with invalid scope and action",


### PR DESCRIPTION
# Description

Currently we fail ungracefully if you for example run `cdf dump group` and have a group with known ACL but unknown scope:

<img width="1090" height="146" alt="image" src="https://github.com/user-attachments/assets/5e3ac573-9371-4526-9d6e-7acc1425077d" />


## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Toolkit now gracefully handles groups with known ACLs, but unknown scope or actions.

### Added

- Toolkit now supports `agentExternalIdScope` for `agentsAcl`. 
