### PR TITLE
[CDF-27652] 🔧Fix bad thest

### DIFF
--- a/tests/test_integration/conftest.py
+++ b/tests/test_integration/conftest.py
@@ -58,7 +58,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.streams import (
 )
 from cognite_toolkit._cdf_tk.commands import CollectCommand
 from cognite_toolkit._cdf_tk.commands._migrate.data_model import INSTANCE_SOURCE_VIEW_ID
-from cognite_toolkit._cdf_tk.cruds import FunctionScheduleCRUD, RawDatabaseCRUD, RawTableCRUD
+from cognite_toolkit._cdf_tk.cruds import RawDatabaseCRUD, RawTableCRUD
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 from cognite_toolkit._cdf_tk.utils.cdf import ThrottlerState, raw_row_count
 from tests.constants import REPO_ROOT
@@ -277,35 +277,6 @@ def dummy_schedule(cognite_client: CogniteClient, dummy_function: Function) -> F
     if schedule.function_id is not None:
         schedule.function_id = None
     return schedule
-
-
-@pytest.fixture(scope="session")
-def persistent_schedule_with_data_yaml(
-    toolkit_client: ToolkitClient,
-    toolkit_client_config: ToolkitClientConfig,
-    dummy_function: Function,
-) -> str:
-    """YAML for a stable function schedule with input data; ensured once per session (not torn down)."""
-    assert isinstance(toolkit_client_config.credentials, OAuthClientCredentials)
-    cred = toolkit_client_config.credentials
-    schedule_yaml = f"""name: toolkit_test_not_redeploy_schedule_with_data
-functionExternalId: {dummy_function.external_id}
-cronExpression: 0 0 1 1 *
-data:
-  some: data
-authentication:
-  clientId: {cred.client_id}
-  clientSecret: {cred.client_secret}
-"""
-    loader = FunctionScheduleCRUD(toolkit_client, None, None)
-    filepath = MagicMock(spec=Path)
-    filepath.read_text.return_value = schedule_yaml
-    resource_dict = loader.load_resource_file(filepath, {})
-    resource = loader.load_resource(resource_dict[0])
-    identifier = loader.get_id(resource)
-    if not loader.retrieve([identifier]):
-        _ = loader.create([resource])
-    return schedule_yaml
 
 
 @pytest.fixture()

--- a/tests/test_integration/test_cruds/test_resource_cruds.py
+++ b/tests/test_integration/test_cruds/test_resource_cruds.py
@@ -164,24 +164,45 @@ class TestFunctionScheduleLoader:
         assert len(schedules) >= 1
         assert any(s.name == schedule.name for s in schedules)
 
+    # The function schedule service is fairly unstable, so we need to rerun the tests if they fail.
+    @pytest.mark.flaky(reruns=3, reruns_delay=10, only_rerun=["AssertionError"])
     def test_not_redeploy_schedule_with_data(
         self,
         toolkit_client: ToolkitClient,
-        persistent_schedule_with_data_yaml: str,
+        toolkit_client_config: ToolkitClientConfig,
+        dummy_function: Function,
     ) -> None:
+        assert isinstance(toolkit_client_config.credentials, OAuthClientCredentials)
+        cred = toolkit_client_config.credentials
+        schedule_name = f"toolkit_test_not_redeploy_schedule_with_data_{RUN_UNIQUE_ID}"
+        schedule_yaml = f"""name: {schedule_name}
+functionExternalId: {dummy_function.external_id}
+cronExpression: 0 0 1 1 *
+data:
+  some: data
+authentication:
+  clientId: {cred.client_id}
+  clientSecret: {cred.client_secret}
+"""
         loader = FunctionScheduleCRUD(toolkit_client, None, None)
         filepath = MagicMock(spec=Path)
-        filepath.read_text.return_value = persistent_schedule_with_data_yaml
+        filepath.read_text.return_value = schedule_yaml
 
-        worker = ResourceWorker(loader, "deploy")
-        resources = worker.prepare_resources([filepath])
-
-        assert {
-            "create": len(resources.to_create),
-            "change": len(resources.to_update),
-            "delete": len(resources.to_delete),
-            "unchanged": len(resources.unchanged),
-        } == {"create": 0, "change": 0, "delete": 0, "unchanged": 1}
+        resource_dict = loader.load_resource_file(filepath, {})
+        resource = loader.load_resource(resource_dict[0])
+        identifier = loader.get_id(resource)
+        try:
+            loader.create([resource])
+            worker = ResourceWorker(loader, "deploy")
+            resources = worker.prepare_resources([filepath])
+            assert {
+                "create": len(resources.to_create),
+                "change": len(resources.to_update),
+                "delete": len(resources.to_delete),
+                "unchanged": len(resources.unchanged),
+            } == {"create": 0, "change": 0, "delete": 0, "unchanged": 1}
+        finally:
+            loader.delete([identifier])
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
# Description

Switching the FunctionSchedule test `test_not_redeploy_schedule_with_data` from using a persistent to an ephemeral function schedule. This test checks that the function has not changed. However, since the function schedule depends on the credentials which is different locally and in the GitHub actions CLI - it will always be detected as changed. Creating and deleting for each run resolves the issue. 

## Bump

- [ ] Patch
- [x] Skip
