### PR TITLE
Fix duplicate -a short alias on cdf modules init

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_modules_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_modules_app.py
@@ -48,7 +48,6 @@ class ModulesApp(typer.Typer):
             bool,
             typer.Option(
                 "--all",
-                "-l",
                 help="Copy all available templates.",
             ),
         ] = False,

--- a/cognite_toolkit/_cdf_tk/apps/_modules_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_modules_app.py
@@ -48,7 +48,7 @@ class ModulesApp(typer.Typer):
             bool,
             typer.Option(
                 "--all",
-                "-a",
+                "-l",
                 help="Copy all available templates.",
             ),
         ] = False,


### PR DESCRIPTION
# Description

`cdf modules init --all` and `--clean` both used `-a` as their short alias, causing Click 8.2+ to emit a `UserWarning`. Since Click resolves duplicates to the last definition, `-a` was silently broken for `--all`. Removing the alias from `--all` eliminates the ambiguity.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- When running `cdf modules init`, the `--all` parameter no longer has the short alias `-a`, since this conflicted with another parameter. This removes the warning message which would previously show up when running this command.