### PR TITLE
[CDF-27655] ⚙fix; hide sensitive strings for functions

### DIFF
--- a/cognite_toolkit/_cdf_tk/cruds/_resource_cruds/function.py
+++ b/cognite_toolkit/_cdf_tk/cruds/_resource_cruds/function.py
@@ -338,6 +338,10 @@ class FunctionCRUD(ResourceCRUD[ExternalId, FunctionRequest, FunctionResponse]):
             resource["fileId"] = -1  # Placeholder, will be set in create()
         return FunctionRequest.model_validate(resource)
 
+    def sensitive_strings(self, item: FunctionRequest) -> Iterable[str]:
+        if item.secrets:
+            yield from item.secrets.values()
+
     def dump_resource(self, resource: FunctionResponse, local: dict[str, Any] | None = None) -> dict[str, Any]:
         if resource.status == "Failed":
             dumped = self.dump_id(ExternalId(external_id=resource.external_id or resource.name))

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_base.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_base.py
@@ -34,6 +34,7 @@ from cognite_toolkit._cdf_tk.cruds import (
     CRUDS_BY_FOLDER_NAME,
     CRUDS_BY_FOLDER_NAME_INCLUDE_ALPHA,
     RESOURCE_CRUD_LIST,
+    FunctionCRUD,
     FunctionScheduleCRUD,
     GroupResourceScopedCRUD,
     HostedExtractorDestinationCRUD,
@@ -311,6 +312,17 @@ authentication:
 """,
         {"my_super_secret_42"},
         id="FunctionScheduleLoader",
+    )
+    yield pytest.param(
+        FunctionCRUD,
+        """externalId: my_function
+name: My Function
+secrets:
+  FIRST: first_secret_value
+  SECOND: second_secret_value
+""",
+        {"first_secret_value", "second_secret_value"},
+        id="FunctionLoader with secrets",
     )
     yield pytest.param(
         TransformationCRUD,


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Toolkit no longer prints function secrets in the logs when running `cdf deploy`. 
