### PR TITLE
😅Handle before v0.8

### DIFF
--- a/tests/test_unit/test_cdf_tk/test_cruds/test_base.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_base.py
@@ -451,14 +451,17 @@ class TestResourceCRUDs:
 
     @pytest.mark.parametrize("loader_cls, local_file, expected_strings", list(sensitive_strings_test_cases()))
     def test_sensitive_strings(
-        self, loader_cls: type[ResourceCRUD], local_file: str, expected_strings: set[str]
+        self, loader_cls: type[ResourceCRUD], local_file: str, expected_strings: set[str], tmp_path: Path
     ) -> None:
         with monkeypatch_toolkit_client() as client:
             client.iam.sessions.create.return_value = CreatedSession(123, "READY", "my-nonce")
-            loader = loader_cls.create_loader(client)
+            loader = loader_cls.create_loader(client, build_dir=tmp_path)
 
         file = MagicMock(spec=Path)
         file.read_text.return_value = local_file
+        parent = MagicMock(spec=Path)
+        parent.name = loader_cls.folder_name
+        file.parent = parent
         loaded_dict = loader.load_resource_file(file)[0]
         loaded = loader.load_resource(loaded_dict)
 


### PR DESCRIPTION
# Description

Failing test on running without alpha flags. 

Issue is that before v0.8, FunctionCRUD requires special location of the configuration file and access to the build folder. 

## Bump

- [ ] Patch
- [x] Skip

