### PR TITLE
[CDF-27656] 🐛InField schedules

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -1467,7 +1467,7 @@ class MigrateApp(typer.Typer):
             "cognite_app_data": "cognite_app_data",
         }
         infield_mappings = create_infield_data_mappings()
-        schedule_selector = create_infield_schedule_selector()
+        schedule_selector = create_infield_schedule_selector(instance_space=source_space)
         selectors: list[InstanceViewSelector | InstanceQuerySelector] = []
         schedule_mapping: ViewToViewMapping | None = None
         for mapping in infield_mappings:


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- [alpha] When running `cdf migrate infield-data`, Toolkit now only migrates the schedules in the space you selected.