### PR TITLE
[CDF-27666] Fix workflow Task validator when ValidationInfo.data is None

### DIFF
--- a/.cursor/skills/start-it/SKILL.md
+++ b/.cursor/skills/start-it/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: start-it
-description: Fetch Jira ticket details via Atlassian MCP, create a working branch, plan implementation, and begin coding. Use when the user says "start it".
+description: >-
+  Fetch Jira via Atlassian MCP (server user-atlassian), branch, plan, code.
+  Use when the user says "start it" or "start" with a Jira URL.
 ---
 
 # Start It
 
-When the user says **"start it"**:
+When the user says **"start it"** (or **"start"** with a Jira URL):
 
 ## 1. Get the Jira ticket
 
-- Ask the user for the **Jira ticket ID** (e.g. `CDF-1234`).
+- Accept either a **Jira ticket ID** (e.g. `CDF-1234`) or a **browse URL**
+  (e.g. `https://cognitedata.atlassian.net/browse/CDF-1234`).
+- From a URL, use the issue key after `/browse/`.
 
 ## 2. Fetch task details
 
-- Use the **Atlassian MCP tool** to retrieve the ticket details (summary, description, acceptance criteria, subtasks, etc.).
-- Present a brief summary of the task to the user so they can confirm it's the right ticket.
+- Use the **Atlassian MCP** server. In Cursor the server id is typically **`user-atlassian`**
+  (not `atlassian`). Read the MCP tool schema if invocation fails.
+- **Flow:**
+  1. Call **`getAccessibleAtlassianResources`** on `user-atlassian` and pick the site’s **`id`**
+     as `cloudId` (e.g. Cognite: `cognitedata.atlassian.net`).
+  2. Call **`getJiraIssue`** with `cloudId` and `issueIdOrKey` set to the ticket key (e.g. `CDF-1234`).
+- Use the response for summary, description, status, parent epic, components, subtasks, and comments.
+- Present a brief summary so the user can confirm it is the right ticket.
 
 ## 3. Create a working branch
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/workflow_version.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/workflow_version.py
@@ -147,10 +147,11 @@ class Task(BaseModelObject):
     @field_validator("parameters", mode="before")
     @classmethod
     def move_type_to_field(cls, value: Any, info: ValidationInfo) -> Any:
-        if not isinstance(value, dict) or "type" not in info.data:
+        data = info.data
+        if not isinstance(value, dict) or not isinstance(data, dict) or "type" not in data:
             return value
         value = dict(value)
-        value["type"] = info.data["type"]
+        value["type"] = data["type"]
         return value
 
     @field_serializer("type", mode="plain")

--- a/tests/test_unit/test_cdf_tk/test_client/test_cdf_apis.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_cdf_apis.py
@@ -75,7 +75,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.workflow_trigger import (
     WorkflowTriggerRequest,
     WorkflowTriggerResponse,
 )
-from cognite_toolkit._cdf_tk.client.resource_classes.workflow_version import WorkflowVersionResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.workflow_version import Task, WorkflowVersionResponse
 from tests.test_unit.test_cdf_tk.test_client.data import (
     CDFResource,
     get_example_minimum_responses,
@@ -1166,3 +1166,11 @@ class TestCDFResourceAPI:
         listed = api.list()
         assert len(listed) == 1
         assert listed[0].dump() == resource
+
+
+def test_task_move_type_to_field_handles_none_validation_data() -> None:
+    """Pydantic may supply ValidationInfo.data as None; avoid 'in' on None (deploy dry-run)."""
+    info = MagicMock()
+    info.data = None
+    params = {"function": {"externalId": "f"}}
+    assert Task.move_type_to_field(params, info) is params


### PR DESCRIPTION
# Description

Fixes workflow deploy dry-run failure tracked as Fusion bug **CDF-27666** (see https://cognitedata.atlassian.net/browse/CDF-27666). `Task.move_type_to_field` could raise `TypeError: argument of type 'NoneType' is not iterable` when Pydantic supplied `ValidationInfo.data` as `None` during workflow version JSON validation (e.g. toolkit 0.7.237). Guard with `isinstance(data, dict)` before using `in` or indexing. Adds `test_task_move_type_to_field_handles_none_validation_data`.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Workflow version response parsing no longer crashes when `Task.parameters` validator runs with a dict `value` and `ValidationInfo.data` is `None`.
