### PR TITLE
Fix missing sessionsAcl from toolkit group when function schedules are deployed

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
@@ -30,6 +30,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.group import (
     FilesAcl,
     FunctionsAcl,
     ScopeDefinition,
+    SessionsAcl,
 )
 from cognite_toolkit._cdf_tk.exceptions import (
     ResourceCreationError,
@@ -668,7 +669,8 @@ class FunctionScheduleIO(ResourceIO[FunctionScheduleId, FunctionScheduleRequest,
 
     @classmethod
     def create_acl(cls, actions: set[Literal["READ", "WRITE"]], scope: ScopeDefinition) -> Iterable[AclType]:
-        yield from ()
+        if "WRITE" in actions:
+            yield SessionsAcl(actions=["CREATE"], scope=AllScope())
 
     @classmethod
     def dump_id(cls, id: FunctionScheduleId) -> dict[str, Any]:


### PR DESCRIPTION
# Description

`FunctionScheduleIO.create_acl` was left as `yield from ()` when the new `create_acl`
method was introduced in [#2655](https://github.com/cognitedata/toolkit/pull/2655). When
the old `get_required_capability` methods were subsequently removed in
[#2721](https://github.com/cognitedata/toolkit/pull/2721), `sessionsAcl` was silently lost from the toolkit
group generated by `cdf auth verify`. Per <https://docs.cognite.com/cdf/access/guides/capabilities>, `sessions:create` is required to schedule functions, meaning the deployment of function schedules fails without it

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fixes a `403 Forbidden` error that would occur when deploying function schedules through the default generated group for toolkit, `cognite_toolkit_service_principal`. This group now includes the required `sessions:create` capability to deploy function schedules.