### PR TITLE
[CDF-27674] 😁 Introduce logger with aggregation

### DIFF
--- a/cognite_toolkit/_cdf_tk/storageio/logger.py
+++ b/cognite_toolkit/_cdf_tk/storageio/logger.py
@@ -45,7 +45,7 @@ class LogIssue(LogEntry):
     message: str
 
 
-OperationStatus: TypeAlias = Literal["success", "failure", "unchanged", "pending", "skipped"]
+OperationStatus: TypeAlias = Literal["success", "failure", "pending", "skipped"]
 
 
 class ItemTracker:

--- a/cognite_toolkit/_cdf_tk/storageio/logger.py
+++ b/cognite_toolkit/_cdf_tk/storageio/logger.py
@@ -259,12 +259,31 @@ class FileWithAggregationLogger(DataLogger):
         for id in ids:
             if id not in self.aggregations_by_ids:
                 self.aggregations_by_ids[id] = []
+            else:
+                self.log(
+                    LogEntryV2(
+                        id=id,
+                        label="Toolkit bug - multiple registrations",
+                        severity=Severity.warning,
+                        message=f"Multiple registrations for {id}",
+                    )
+                )
 
     def _update_aggregation(self, entries: list[LogEntry]) -> None:
         for entry in entries:
             if isinstance(entry, LogEntryV2):
                 if entry.id in self.aggregations_by_ids:
                     self.aggregations_by_ids[entry.id].append(entry)
+                else:
+                    self.aggregations_by_ids[entry.id] = [entry]
+                    self.log(
+                        LogEntryV2(
+                            id=entry.id,
+                            label="Toolkit bug - missing registration",
+                            severity=Severity.warning,
+                            message=f"Missing registration for {id}",
+                        )
+                    )
 
     def log(self, entry: LogEntry | Sequence[LogEntry]) -> None:
         entries = list(entry) if isinstance(entry, Sequence) else [entry]

--- a/cognite_toolkit/_cdf_tk/storageio/logger.py
+++ b/cognite_toolkit/_cdf_tk/storageio/logger.py
@@ -1,12 +1,15 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import Enum
 from threading import Lock
 from typing import Literal, TypeAlias
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic.alias_generators import to_camel
 
+from cognite_toolkit._cdf_tk.utils import humanize_collection
 from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter
 
 
@@ -14,6 +17,28 @@ class LogEntry(BaseModel, alias_generator=to_camel, extra="ignore", populate_by_
     """Represents a log entry for tracking storage I/O operations."""
 
     id: str
+
+
+class Severity(Enum):
+    failure = 1
+    warning = 2
+    info = 3
+
+
+class LogAggregation(LogEntry):
+    """Storing the aggregated log entries"""
+
+    heading: str
+    severity: Severity
+    attributes: set[str] | None = None
+    attribute_display_name: str | None = None
+
+
+class LogEntryV2(LogAggregation):
+    message: str = Field(description="The details of the log entry.")
+
+    def as_aggregation(self) -> LogAggregation:
+        return LogAggregation.model_validate(self.model_dump(), extra="ignore")
 
 
 class LogIssue(LogEntry):
@@ -180,3 +205,81 @@ class FileDataLogger(DataLogger):
         """Log a detailed entry to the file."""
         entries = entry if isinstance(entry, Sequence) else [entry]
         self._writer.write_chunks([e.model_dump(by_alias=True) for e in entries])
+
+
+@dataclass
+class HeadingResult:
+    heading: str
+    count: int
+    most_common_attributes: list[str] | None = None
+    attribute_name: str | None = None
+
+    def display_message(self) -> str:
+        suffix = ""
+        if self.most_common_attributes and self.attribute_name:
+            suffix = (
+                f" Most common {self.attribute_name}: {humanize_collection(self.most_common_attributes, sort=False)}"
+            )
+        return f"{self.heading}: {self.count} items.{suffix}"
+
+
+@dataclass
+class ItemsResult:
+    status: OperationStatus
+    count: int
+    headings: list[HeadingResult]
+
+    def display_message(self) -> str:
+        return f"{self.status}: {self.count} items."
+
+
+class FileWithAggregationLogger(DataLogger):
+    BATCH_SIZE = 1000
+
+    def __init__(self, writer: NDJsonWriter) -> None:
+        self.tracker = NoOpTracker()
+        self._writer = writer
+        self._batch: list[LogEntry] = []
+        self.aggregations_by_ids: dict[str, list[LogAggregation]] = {}
+
+    def __enter__(self) -> "FileWithAggregationLogger":
+        return self
+
+    def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: object) -> None:
+        self._write_to_file()
+        return None
+
+    def register(self, ids: list[str]) -> None:
+        for id in ids:
+            if id not in self.aggregations_by_ids:
+                self.aggregations_by_ids[id] = []
+
+    def _update_aggregation(self, entries: list[LogEntry]) -> None:
+        for entry in entries:
+            if isinstance(entry, LogEntryV2):
+                if entry.id in self.aggregations_by_ids:
+                    self.aggregations_by_ids[entry.id].append(entry)
+
+    def log(self, entry: LogEntry | Sequence[LogEntry]) -> None:
+        entries = list(entry) if isinstance(entry, Sequence) else [entry]
+        self._update_aggregation(entries)
+        self._batch.extend(entries)
+        if len(self._batch) >= self.BATCH_SIZE:
+            self._write_to_file()
+
+    def _write_to_file(self) -> None:
+        if self._batch:
+            self._writer.write_chunks([e.model_dump(by_alias=True) for e in self._batch])
+            self._batch.clear()
+
+    def finalize(self) -> list[ItemsResult]:
+        """Finalize logging and return aggregated results.
+
+        Flushes any remaining entries to file and aggregates logged entries
+        by severity and heading.
+
+        Returns:
+            List of ItemsResult grouped by status (derived from severity).
+        """
+        self._write_to_file()
+        raise NotImplementedError()

--- a/cognite_toolkit/_cdf_tk/storageio/logger.py
+++ b/cognite_toolkit/_cdf_tk/storageio/logger.py
@@ -183,6 +183,8 @@ class DataLogger(ABC):
         """Log a detailed entry."""
         raise NotImplementedError()
 
+    def register(self, ids: list[str]) -> None: ...
+
 
 class NoOpLogger(DataLogger):
     """A no-op logger that discards all log entries and does no tracking."""
@@ -227,7 +229,7 @@ class LabelResult:
 class ItemsResult:
     status: OperationStatus
     count: int
-    labels: dict[str, LabelResult] = field(default_factory=dict)
+    labels: list[LabelResult] = field(default_factory=list)
 
     def display_message(self) -> str:
         return f"{self.status}: {self.count} items."
@@ -283,28 +285,35 @@ class FileWithAggregationLogger(DataLogger):
             List of ItemsResult grouped by status (derived from severity).
         """
         result_by_status: dict[OperationStatus, ItemsResult] = {}
+        label_result_by_status_label: dict[OperationStatus, dict[str, LabelResult]] = {}
         for aggregations in self.aggregations_by_ids.values():
             min_severity = min((agg.severity.value for agg in aggregations), default=self.NO_WARNINGS)
             status = self._severity_to_status(min_severity, is_dry_run)
             if status not in result_by_status:
-                result_by_status[status] = ItemsResult(status=status, count=1)
-            result = result_by_status[status]
-            result.count += 1
+                result_by_status[status] = ItemsResult(status=status, count=0)
+            result_by_status[status].count += 1
+            if status not in label_result_by_status_label:
+                label_result_by_status_label[status] = {}
+            label_result_by_id = label_result_by_status_label[status]
 
             for aggregation in aggregations:
                 if aggregation.severity.value != min_severity:
                     # We filter out all labels which are on a different severity level
                     # such that we only display the most severe issues for each item.
                     continue
-                if aggregation.label not in result.labels:
-                    result.labels[aggregation.label] = LabelResult(
+                if aggregation.label not in label_result_by_id:
+                    label_result_by_id[aggregation.label] = LabelResult(
                         label=aggregation.label,
                         count=0,
                         attribute_name=aggregation.attribute_display_name,
                     )
-                result.labels[aggregation.label].count += 1
+                label_result_by_id[aggregation.label].count += 1
                 if aggregation.attributes:
-                    result.labels[aggregation.label].attribute_counter.update(aggregation.attributes)
+                    label_result_by_id[aggregation.label].attribute_counter.update(aggregation.attributes)
+
+        for result in result_by_status.values():
+            if result.status in label_result_by_status_label:
+                result.labels.extend(label_result_by_status_label[result.status].values())
 
         return list(result_by_status.values())
 

--- a/cognite_toolkit/_cdf_tk/storageio/logger.py
+++ b/cognite_toolkit/_cdf_tk/storageio/logger.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
-from collections import defaultdict
+from collections import Counter, defaultdict
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from threading import Lock
 from typing import Literal, TypeAlias
@@ -22,7 +22,6 @@ class LogEntry(BaseModel, alias_generator=to_camel, extra="ignore", populate_by_
 class Severity(Enum):
     failure = 1
     warning = 2
-    info = 3
 
 
 class LogAggregation(LogEntry):
@@ -226,10 +225,18 @@ class HeadingResult:
 
 
 @dataclass
+class _HeadingTmp:
+    heading: str
+    count: int
+    counter: Counter[str] = field(default_factory=Counter)
+    attribute_name: str | None = None
+
+
+@dataclass
 class ItemsResult:
     status: OperationStatus
     count: int
-    headings: list[HeadingResult]
+    headings: list[HeadingResult] = field(default_factory=list)
 
     def display_message(self) -> str:
         return f"{self.status}: {self.count} items."
@@ -237,6 +244,7 @@ class ItemsResult:
 
 class FileWithAggregationLogger(DataLogger):
     BATCH_SIZE = 1000
+    NO_WARNINGS = 999
 
     def __init__(self, writer: NDJsonWriter) -> None:
         self.tracker = NoOpTracker()
@@ -274,7 +282,7 @@ class FileWithAggregationLogger(DataLogger):
             self._writer.write_chunks([e.model_dump(by_alias=True) for e in self._batch])
             self._batch.clear()
 
-    def finalize(self) -> list[ItemsResult]:
+    def finalize(self, is_dry_run: bool) -> list[ItemsResult]:
         """Finalize logging and return aggregated results.
 
         Flushes any remaining entries to file and aggregates logged entries
@@ -283,5 +291,52 @@ class FileWithAggregationLogger(DataLogger):
         Returns:
             List of ItemsResult grouped by status (derived from severity).
         """
-        self._write_to_file()
-        raise NotImplementedError()
+        result_by_status: dict[OperationStatus, ItemsResult] = {}
+        headings_by_status: dict[OperationStatus, dict[str, _HeadingTmp]] = {}
+        for aggregations in self.aggregations_by_ids.values():
+            min_severity = min((agg.severity.value for agg in aggregations), default=self.NO_WARNINGS)
+            status = self._severity_to_status(min_severity, is_dry_run)
+            if status not in result_by_status:
+                result_by_status[status] = ItemsResult(status=status, count=1)
+            result_by_status[status].count += 1
+
+            if status not in headings_by_status:
+                headings_by_status[status] = {}
+            for aggregation in aggregations:
+                if aggregation.severity.value != min_severity:
+                    # We filter out all headings which are on a different severity level
+                    # such that we only display the most severe issues for each item.
+                    continue
+                if aggregation.heading not in headings_by_status[status]:
+                    headings_by_status[status][aggregation.heading] = _HeadingTmp(
+                        heading=aggregation.heading,
+                        count=0,
+                        attribute_name=aggregation.attribute_display_name,
+                    )
+                headings_by_status[status][aggregation.heading].count += 1
+                if aggregation.attributes:
+                    headings_by_status[status][aggregation.heading].counter.update(aggregation.attributes)
+
+        results: list[ItemsResult] = []
+        for status, result in result_by_status.items():
+            heading_results: list[HeadingResult] = []
+            for tmp in headings_by_status[status].values():
+                most_common_attributes = [attr for attr, _ in tmp.counter.most_common(5)]
+                heading_results.append(
+                    HeadingResult(
+                        heading=tmp.heading,
+                        count=tmp.count,
+                        most_common_attributes=most_common_attributes if most_common_attributes else None,
+                        attribute_name=tmp.attribute_name,
+                    )
+                )
+            result.headings.extend(heading_results)
+        return results
+
+    def _severity_to_status(self, min_severity: int, is_dry_run: bool) -> OperationStatus:
+        if min_severity == Severity.failure.value:
+            return "failure"
+        elif min_severity == Severity.warning.value:
+            return "pending-with-warning" if is_dry_run else "success-with-warning"
+        else:
+            return "pending" if is_dry_run else "success"

--- a/cognite_toolkit/_cdf_tk/storageio/logger.py
+++ b/cognite_toolkit/_cdf_tk/storageio/logger.py
@@ -239,12 +239,13 @@ class ItemsResult:
 
 
 class FileWithAggregationLogger(DataLogger):
-    BATCH_SIZE = 1000
-    NO_WARNINGS = 0
+    BATCH_SIZE: int = 1000
+    NO_WARNINGS: int = 0
 
     def __init__(self, writer: NDJsonWriter) -> None:
         self.tracker = NoOpTracker()
         self._writer = writer
+        self._lock = Lock()
         self._batch: list[LogEntry] = []
         self.aggregations_by_ids: dict[str, list[LogAggregation]] = {}
 
@@ -256,88 +257,98 @@ class FileWithAggregationLogger(DataLogger):
         return None
 
     def register(self, ids: list[str]) -> None:
-        for id in ids:
-            if id not in self.aggregations_by_ids:
-                self.aggregations_by_ids[id] = []
-            else:
-                self.log(
-                    LogEntryV2(
-                        id=id,
-                        label="Toolkit bug - multiple registrations",
-                        severity=Severity.warning,
-                        message=f"Multiple registrations for {id}",
+        with self._lock:
+            for id in ids:
+                if id not in self.aggregations_by_ids:
+                    self.aggregations_by_ids[id] = []
+                else:
+                    self._log_unlocked(
+                        LogEntryV2(
+                            id=id,
+                            label="Toolkit bug - multiple registrations",
+                            severity=Severity.warning,
+                            message=f"Multiple registrations for {id}",
+                        )
                     )
-                )
 
-    def _update_aggregation(self, entries: list[LogEntry]) -> None:
+    def _update_aggregation_unlocked(self, entries: list[LogEntry]) -> None:
+        """Internal method to update aggregations without acquiring the lock."""
         for entry in entries:
             if isinstance(entry, LogEntryV2):
                 if entry.id in self.aggregations_by_ids:
-                    self.aggregations_by_ids[entry.id].append(entry)
+                    self.aggregations_by_ids[entry.id].append(entry.as_aggregation())
                 else:
-                    self.aggregations_by_ids[entry.id] = [entry]
-                    self.log(
+                    self.aggregations_by_ids[entry.id] = [entry.as_aggregation()]
+                    self._log_unlocked(
                         LogEntryV2(
                             id=entry.id,
                             label="Toolkit bug - missing registration",
                             severity=Severity.warning,
-                            message=f"Missing registration for {id}",
+                            message=f"Missing registration for {entry.id}",
                         )
                     )
 
-    def log(self, entry: LogEntry | Sequence[LogEntry]) -> None:
+    def _log_unlocked(self, entry: LogEntry | Sequence[LogEntry]) -> None:
+        """Internal method to log entries without acquiring the lock."""
         entries = list(entry) if isinstance(entry, Sequence) else [entry]
-        self._update_aggregation(entries)
+        self._update_aggregation_unlocked(entries)
         self._batch.extend(entries)
         if len(self._batch) >= self.BATCH_SIZE:
-            self._write_to_file()
+            self._write_to_file_unlocked()
 
-    def _write_to_file(self) -> None:
+    def log(self, entry: LogEntry | Sequence[LogEntry]) -> None:
+        with self._lock:
+            self._log_unlocked(entry)
+
+    def _write_to_file_unlocked(self) -> None:
+        """Internal method to write to file without acquiring the lock."""
         if self._batch:
             self._writer.write_chunks([e.model_dump(by_alias=True) for e in self._batch])
             self._batch.clear()
 
+    def _write_to_file(self) -> None:
+        with self._lock:
+            self._write_to_file_unlocked()
+
     def finalize(self, is_dry_run: bool) -> list[ItemsResult]:
         """Finalize logging and return aggregated results.
-
-        Flushes any remaining entries to file and aggregates logged entries
-        by severity and label.
 
         Returns:
             List of ItemsResult grouped by status (derived from severity).
         """
-        result_by_status: dict[OperationStatus, ItemsResult] = {}
-        label_result_by_status_label: dict[OperationStatus, dict[str, LabelResult]] = {}
-        for aggregations in self.aggregations_by_ids.values():
-            max_severity = max((agg.severity.value for agg in aggregations), default=self.NO_WARNINGS)
-            status = self._severity_to_status(max_severity, is_dry_run)
-            if status not in result_by_status:
-                result_by_status[status] = ItemsResult(status=status, count=0, severity=max_severity)
-            result_by_status[status].count += 1
-            if status not in label_result_by_status_label:
-                label_result_by_status_label[status] = {}
-            label_result_by_id = label_result_by_status_label[status]
+        with self._lock:
+            result_by_status: dict[OperationStatus, ItemsResult] = {}
+            label_result_by_status_label: dict[OperationStatus, dict[str, LabelResult]] = {}
+            for aggregations in self.aggregations_by_ids.values():
+                max_severity = max((agg.severity.value for agg in aggregations), default=self.NO_WARNINGS)
+                status = self._severity_to_status(max_severity, is_dry_run)
+                if status not in result_by_status:
+                    result_by_status[status] = ItemsResult(status=status, count=0, severity=max_severity)
+                result_by_status[status].count += 1
+                if status not in label_result_by_status_label:
+                    label_result_by_status_label[status] = {}
+                label_result_by_id = label_result_by_status_label[status]
 
-            for aggregation in aggregations:
-                if aggregation.severity.value != max_severity:
-                    # We filter out all labels which are on a different severity level
-                    # such that we only display the most severe issues for each item.
-                    continue
-                if aggregation.label not in label_result_by_id:
-                    label_result_by_id[aggregation.label] = LabelResult(
-                        label=aggregation.label,
-                        count=0,
-                        attribute_name=aggregation.attribute_display_name,
-                    )
-                label_result_by_id[aggregation.label].count += 1
-                if aggregation.attributes:
-                    label_result_by_id[aggregation.label].attribute_counter.update(aggregation.attributes)
+                for aggregation in aggregations:
+                    if aggregation.severity.value != max_severity:
+                        # We filter out all labels which are on a different severity level
+                        # such that we only display the most severe issues for each item.
+                        continue
+                    if aggregation.label not in label_result_by_id:
+                        label_result_by_id[aggregation.label] = LabelResult(
+                            label=aggregation.label,
+                            count=0,
+                            attribute_name=aggregation.attribute_display_name,
+                        )
+                    label_result_by_id[aggregation.label].count += 1
+                    if aggregation.attributes:
+                        label_result_by_id[aggregation.label].attribute_counter.update(aggregation.attributes)
 
-        for result in result_by_status.values():
-            if result.status in label_result_by_status_label:
-                result.labels.extend(label_result_by_status_label[result.status].values())
+            for result in result_by_status.values():
+                if result.status in label_result_by_status_label:
+                    result.labels.extend(label_result_by_status_label[result.status].values())
 
-        return list(result_by_status.values())
+            return list(result_by_status.values())
 
     def _severity_to_status(self, max_severity: int, is_dry_run: bool) -> OperationStatus:
         if max_severity == Severity.failure.value:

--- a/cognite_toolkit/_cdf_tk/storageio/logger.py
+++ b/cognite_toolkit/_cdf_tk/storageio/logger.py
@@ -8,7 +8,7 @@ from typing import Literal, TypeAlias
 
 from pydantic import BaseModel, Field
 from pydantic.alias_generators import to_camel
-from rich import print
+from rich.console import Console
 from rich.tree import Tree
 
 from cognite_toolkit._cdf_tk.utils import humanize_collection
@@ -22,8 +22,8 @@ class LogEntry(BaseModel, alias_generator=to_camel, extra="ignore", populate_by_
 
 
 class Severity(Enum):
-    failure = 1
-    warning = 2
+    warning = 1
+    failure = 2
 
 
 class LogAggregation(LogEntry):
@@ -240,7 +240,7 @@ class ItemsResult:
 
 class FileWithAggregationLogger(DataLogger):
     BATCH_SIZE = 1000
-    NO_WARNINGS = 999
+    NO_WARNINGS = 0
 
     def __init__(self, writer: NDJsonWriter) -> None:
         self.tracker = NoOpTracker()
@@ -290,17 +290,17 @@ class FileWithAggregationLogger(DataLogger):
         result_by_status: dict[OperationStatus, ItemsResult] = {}
         label_result_by_status_label: dict[OperationStatus, dict[str, LabelResult]] = {}
         for aggregations in self.aggregations_by_ids.values():
-            min_severity = min((agg.severity.value for agg in aggregations), default=self.NO_WARNINGS)
-            status = self._severity_to_status(min_severity, is_dry_run)
+            max_severity = max((agg.severity.value for agg in aggregations), default=self.NO_WARNINGS)
+            status = self._severity_to_status(max_severity, is_dry_run)
             if status not in result_by_status:
-                result_by_status[status] = ItemsResult(status=status, count=0, severity=min_severity)
+                result_by_status[status] = ItemsResult(status=status, count=0, severity=max_severity)
             result_by_status[status].count += 1
             if status not in label_result_by_status_label:
                 label_result_by_status_label[status] = {}
             label_result_by_id = label_result_by_status_label[status]
 
             for aggregation in aggregations:
-                if aggregation.severity.value != min_severity:
+                if aggregation.severity.value != max_severity:
                     # We filter out all labels which are on a different severity level
                     # such that we only display the most severe issues for each item.
                     continue
@@ -320,16 +320,16 @@ class FileWithAggregationLogger(DataLogger):
 
         return list(result_by_status.values())
 
-    def _severity_to_status(self, min_severity: int, is_dry_run: bool) -> OperationStatus:
-        if min_severity == Severity.failure.value:
+    def _severity_to_status(self, max_severity: int, is_dry_run: bool) -> OperationStatus:
+        if max_severity == Severity.failure.value:
             return "failure"
-        elif min_severity == Severity.warning.value:
+        elif max_severity == Severity.warning.value:
             return "pending-with-warning" if is_dry_run else "success-with-warning"
         else:
             return "pending" if is_dry_run else "success"
 
 
-def display_item_results(items: list[ItemsResult]) -> None:
+def display_item_results(items: list[ItemsResult], console: Console) -> None:
     """Display item results using rich formatting.
 
     Shows a tree view of items grouped by status, with their labels and counts.
@@ -346,11 +346,11 @@ def display_item_results(items: list[ItemsResult]) -> None:
         "pending-with-warning": ("yellow", "○"),
     }
 
-    for item in sorted(items, key=lambda item: item.severity):
+    for item in sorted(items, key=lambda item: item.severity, reverse=True):
         style, icon = status_styles.get(item.status, ("white", "•"))
         tree = Tree(f"[{style}]{icon} {item.status}[/{style}]: {item.count} items")
 
         for label_result in item.labels:
             tree.add(f"[dim]{label_result.display_message()}[/dim]")
 
-        print(tree)
+        console.print(tree)

--- a/cognite_toolkit/_cdf_tk/storageio/logger.py
+++ b/cognite_toolkit/_cdf_tk/storageio/logger.py
@@ -8,6 +8,8 @@ from typing import Literal, TypeAlias
 
 from pydantic import BaseModel, Field
 from pydantic.alias_generators import to_camel
+from rich import print
+from rich.tree import Tree
 
 from cognite_toolkit._cdf_tk.utils import humanize_collection
 from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter
@@ -221,7 +223,7 @@ class LabelResult:
         suffix = ""
         if self.attribute_counter and self.attribute_name:
             most_common_attributes = [attr for attr, _ in self.attribute_counter.most_common(most_common)]
-            suffix = f" Most common {self.attribute_name}: {humanize_collection(most_common_attributes, sort=False)}"
+            suffix = f" Most common {self.attribute_name}: {humanize_collection(most_common_attributes, sort=False)}."
         return f"{self.label}: {self.count} items.{suffix}"
 
 
@@ -229,6 +231,7 @@ class LabelResult:
 class ItemsResult:
     status: OperationStatus
     count: int
+    severity: int
     labels: list[LabelResult] = field(default_factory=list)
 
     def display_message(self) -> str:
@@ -290,7 +293,7 @@ class FileWithAggregationLogger(DataLogger):
             min_severity = min((agg.severity.value for agg in aggregations), default=self.NO_WARNINGS)
             status = self._severity_to_status(min_severity, is_dry_run)
             if status not in result_by_status:
-                result_by_status[status] = ItemsResult(status=status, count=0)
+                result_by_status[status] = ItemsResult(status=status, count=0, severity=min_severity)
             result_by_status[status].count += 1
             if status not in label_result_by_status_label:
                 label_result_by_status_label[status] = {}
@@ -324,3 +327,30 @@ class FileWithAggregationLogger(DataLogger):
             return "pending-with-warning" if is_dry_run else "success-with-warning"
         else:
             return "pending" if is_dry_run else "success"
+
+
+def display_item_results(items: list[ItemsResult]) -> None:
+    """Display item results using rich formatting.
+
+    Shows a tree view of items grouped by status, with their labels and counts.
+    """
+    if not items:
+        return
+
+    status_styles: dict[OperationStatus, tuple[str, str]] = {
+        "success": ("green", "✓"),
+        "failure": ("red", "✗"),
+        "pending": ("cyan", "○"),
+        "skipped": ("dim", "⊘"),
+        "success-with-warning": ("yellow", "⚠"),
+        "pending-with-warning": ("yellow", "○"),
+    }
+
+    for item in sorted(items, key=lambda item: item.severity):
+        style, icon = status_styles.get(item.status, ("white", "•"))
+        tree = Tree(f"[{style}]{icon} {item.status}[/{style}]: {item.count} items")
+
+        for label_result in item.labels:
+            tree.add(f"[dim]{label_result.display_message()}[/dim]")
+
+        print(tree)

--- a/cognite_toolkit/_cdf_tk/storageio/logger.py
+++ b/cognite_toolkit/_cdf_tk/storageio/logger.py
@@ -212,31 +212,22 @@ class FileDataLogger(DataLogger):
 class HeadingResult:
     heading: str
     count: int
-    most_common_attributes: list[str] | None = None
+    attribute_counter: Counter[str] = field(default_factory=Counter)
     attribute_name: str | None = None
 
-    def display_message(self) -> str:
+    def display_message(self, most_common: int = 5) -> str:
         suffix = ""
-        if self.most_common_attributes and self.attribute_name:
-            suffix = (
-                f" Most common {self.attribute_name}: {humanize_collection(self.most_common_attributes, sort=False)}"
-            )
+        if self.attribute_counter and self.attribute_name:
+            most_common_attributes = [attr for attr, _ in self.attribute_counter.most_common(most_common)]
+            suffix = f" Most common {self.attribute_name}: {humanize_collection(most_common_attributes, sort=False)}"
         return f"{self.heading}: {self.count} items.{suffix}"
-
-
-@dataclass
-class _HeadingTmp:
-    heading: str
-    count: int
-    counter: Counter[str] = field(default_factory=Counter)
-    attribute_name: str | None = None
 
 
 @dataclass
 class ItemsResult:
     status: OperationStatus
     count: int
-    headings: list[HeadingResult] = field(default_factory=list)
+    headings: dict[str, HeadingResult] = field(default_factory=dict)
 
     def display_message(self) -> str:
         return f"{self.status}: {self.count} items."
@@ -292,46 +283,30 @@ class FileWithAggregationLogger(DataLogger):
             List of ItemsResult grouped by status (derived from severity).
         """
         result_by_status: dict[OperationStatus, ItemsResult] = {}
-        headings_by_status: dict[OperationStatus, dict[str, _HeadingTmp]] = {}
         for aggregations in self.aggregations_by_ids.values():
             min_severity = min((agg.severity.value for agg in aggregations), default=self.NO_WARNINGS)
             status = self._severity_to_status(min_severity, is_dry_run)
             if status not in result_by_status:
                 result_by_status[status] = ItemsResult(status=status, count=1)
-            result_by_status[status].count += 1
+            result = result_by_status[status]
+            result.count += 1
 
-            if status not in headings_by_status:
-                headings_by_status[status] = {}
             for aggregation in aggregations:
                 if aggregation.severity.value != min_severity:
                     # We filter out all headings which are on a different severity level
                     # such that we only display the most severe issues for each item.
                     continue
-                if aggregation.heading not in headings_by_status[status]:
-                    headings_by_status[status][aggregation.heading] = _HeadingTmp(
+                if aggregation.heading not in result.headings:
+                    result.headings[aggregation.heading] = HeadingResult(
                         heading=aggregation.heading,
                         count=0,
                         attribute_name=aggregation.attribute_display_name,
                     )
-                headings_by_status[status][aggregation.heading].count += 1
+                result.headings[aggregation.heading].count += 1
                 if aggregation.attributes:
-                    headings_by_status[status][aggregation.heading].counter.update(aggregation.attributes)
+                    result.headings[aggregation.heading].attribute_counter.update(aggregation.attributes)
 
-        results: list[ItemsResult] = []
-        for status, result in result_by_status.items():
-            heading_results: list[HeadingResult] = []
-            for tmp in headings_by_status[status].values():
-                most_common_attributes = [attr for attr, _ in tmp.counter.most_common(5)]
-                heading_results.append(
-                    HeadingResult(
-                        heading=tmp.heading,
-                        count=tmp.count,
-                        most_common_attributes=most_common_attributes if most_common_attributes else None,
-                        attribute_name=tmp.attribute_name,
-                    )
-                )
-            result.headings.extend(heading_results)
-        return results
+        return list(result_by_status.values())
 
     def _severity_to_status(self, min_severity: int, is_dry_run: bool) -> OperationStatus:
         if min_severity == Severity.failure.value:

--- a/cognite_toolkit/_cdf_tk/storageio/logger.py
+++ b/cognite_toolkit/_cdf_tk/storageio/logger.py
@@ -27,7 +27,7 @@ class Severity(Enum):
 class LogAggregation(LogEntry):
     """Storing the aggregated log entries"""
 
-    heading: str
+    label: str
     severity: Severity
     attributes: set[str] | None = None
     attribute_display_name: str | None = None
@@ -209,8 +209,8 @@ class FileDataLogger(DataLogger):
 
 
 @dataclass
-class HeadingResult:
-    heading: str
+class LabelResult:
+    label: str
     count: int
     attribute_counter: Counter[str] = field(default_factory=Counter)
     attribute_name: str | None = None
@@ -220,14 +220,14 @@ class HeadingResult:
         if self.attribute_counter and self.attribute_name:
             most_common_attributes = [attr for attr, _ in self.attribute_counter.most_common(most_common)]
             suffix = f" Most common {self.attribute_name}: {humanize_collection(most_common_attributes, sort=False)}"
-        return f"{self.heading}: {self.count} items.{suffix}"
+        return f"{self.label}: {self.count} items.{suffix}"
 
 
 @dataclass
 class ItemsResult:
     status: OperationStatus
     count: int
-    headings: dict[str, HeadingResult] = field(default_factory=dict)
+    labels: dict[str, LabelResult] = field(default_factory=dict)
 
     def display_message(self) -> str:
         return f"{self.status}: {self.count} items."
@@ -277,7 +277,7 @@ class FileWithAggregationLogger(DataLogger):
         """Finalize logging and return aggregated results.
 
         Flushes any remaining entries to file and aggregates logged entries
-        by severity and heading.
+        by severity and label.
 
         Returns:
             List of ItemsResult grouped by status (derived from severity).
@@ -293,18 +293,18 @@ class FileWithAggregationLogger(DataLogger):
 
             for aggregation in aggregations:
                 if aggregation.severity.value != min_severity:
-                    # We filter out all headings which are on a different severity level
+                    # We filter out all labels which are on a different severity level
                     # such that we only display the most severe issues for each item.
                     continue
-                if aggregation.heading not in result.headings:
-                    result.headings[aggregation.heading] = HeadingResult(
-                        heading=aggregation.heading,
+                if aggregation.label not in result.labels:
+                    result.labels[aggregation.label] = LabelResult(
+                        label=aggregation.label,
                         count=0,
                         attribute_name=aggregation.attribute_display_name,
                     )
-                result.headings[aggregation.heading].count += 1
+                result.labels[aggregation.label].count += 1
                 if aggregation.attributes:
-                    result.headings[aggregation.heading].attribute_counter.update(aggregation.attributes)
+                    result.labels[aggregation.label].attribute_counter.update(aggregation.attributes)
 
         return list(result_by_status.values())
 

--- a/cognite_toolkit/_cdf_tk/storageio/logger.py
+++ b/cognite_toolkit/_cdf_tk/storageio/logger.py
@@ -45,7 +45,9 @@ class LogIssue(LogEntry):
     message: str
 
 
-OperationStatus: TypeAlias = Literal["success", "failure", "pending", "skipped"]
+OperationStatus: TypeAlias = Literal[
+    "success", "failure", "pending", "skipped", "success-with-warning", "pending-with-warning"
+]
 
 
 class ItemTracker:

--- a/tests/test_integration/test_commands/test_migrate_command.py
+++ b/tests/test_integration/test_commands/test_migrate_command.py
@@ -122,7 +122,14 @@ class TestMigrateAssetsCommand:
             dry_run=True,
         )
         results = {item.status: item.count for item in result[str(selector)]}
-        assert results == {"failure": 0, "pending": 2, "success": 0, "unchanged": 0, "skipped": 0}
+        assert results == {
+            "failure": 0,
+            "pending": 2,
+            "success": 0,
+            "pending-with-warning": 0,
+            "success-with-warning": 0,
+            "skipped": 0,
+        }
 
 
 class TestMigrateEventsCommand:
@@ -146,7 +153,14 @@ class TestMigrateEventsCommand:
             dry_run=True,
         )
         results = {item.status: item.count for item in result[str(selector)]}
-        assert results == {"failure": 0, "pending": 1, "success": 0, "unchanged": 0, "skipped": 0}
+        assert results == {
+            "failure": 0,
+            "pending": 1,
+            "success": 0,
+            "pending-with-warning": 0,
+            "success-with-warning": 0,
+            "skipped": 0,
+        }
 
 
 class TestMigrateTimeSeriesCommand:
@@ -170,7 +184,14 @@ class TestMigrateTimeSeriesCommand:
             dry_run=True,
         )
         results = {item.status: item.count for item in result[str(selector)]}
-        assert results == {"failure": 0, "pending": 1, "success": 0, "unchanged": 0, "skipped": 0}
+        assert results == {
+            "failure": 0,
+            "pending": 1,
+            "success": 0,
+            "pending-with-warning": 0,
+            "success-with-warning": 0,
+            "skipped": 0,
+        }
 
 
 class TestMigrateFileMetadataCommand:
@@ -194,7 +215,14 @@ class TestMigrateFileMetadataCommand:
             dry_run=True,
         )
         results = {item.status: item.count for item in result[str(selector)]}
-        assert results == {"failure": 0, "pending": 1, "success": 0, "unchanged": 0, "skipped": 0}
+        assert results == {
+            "failure": 0,
+            "pending": 1,
+            "success": 0,
+            "pending-with-warning": 0,
+            "success-with-warning": 0,
+            "skipped": 0,
+        }
 
 
 class TestMigrateAnnotations:
@@ -217,7 +245,14 @@ class TestMigrateAnnotations:
             verbose=True,
         )
         results = {item.status: item.count for item in result[str(selector)]}
-        assert results == {"failure": 0, "pending": 2, "success": 0, "unchanged": 0, "skipped": 0}
+        assert results == {
+            "failure": 0,
+            "pending": 2,
+            "success": 0,
+            "pending-with-warning": 0,
+            "success-with-warning": 0,
+            "skipped": 0,
+        }
 
 
 @pytest.fixture()
@@ -284,9 +319,14 @@ class TestMigrateFiles:
         )
         actual_result = {item.status: item.count for item in result[str(selected_cdm_file)]}
 
-        assert actual_result == {"failure": 1, "pending": 0, "success": 0, "unchanged": 0, "skipped": 0}, (
-            "Expected failure as the file is already a CDM file."
-        )
+        assert actual_result == {
+            "failure": 1,
+            "pending": 0,
+            "success": 0,
+            "pending-with-warning": 0,
+            "success-with-warning": 0,
+            "skipped": 0,
+        }, "Expected failure as the file is already a CDM file."
 
     def test_skip_linked_file(
         self, toolkit_client: ToolkitClient, selected_cdm_file: MigrationCSVFileSelector, tmp_path: Path
@@ -304,9 +344,14 @@ class TestMigrateFiles:
 
         actual_result = {item.status: item.count for item in result[str(selected_cdm_file)]}
 
-        assert actual_result == {"failure": 0, "pending": 0, "success": 0, "unchanged": 0, "skipped": 1}, (
-            "File already exists."
-        )
+        assert actual_result == {
+            "failure": 0,
+            "pending": 0,
+            "success": 0,
+            "pending-with-warning": 0,
+            "success-with-warning": 0,
+            "skipped": 1,
+        }, "File already exists."
 
 
 class TestMigrateEventsToRecordsCommand:
@@ -342,4 +387,11 @@ class TestMigrateEventsToRecordsCommand:
             dry_run=True,
         )
         results = {item.status: item.count for item in result[str(selector)]}
-        assert results == {"failure": 0, "pending": 1, "success": 0, "unchanged": 0, "skipped": 0}
+        assert results == {
+            "failure": 0,
+            "pending": 1,
+            "success": 0,
+            "pending-with-warning": 0,
+            "success-with-warning": 0,
+            "skipped": 0,
+        }

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -360,7 +360,14 @@ class TestMigrationCommand:
         assert actual_instances == expected_instance
         result = results_by_selector[str(selector)]
         actual_results = {status.status: status.count for status in result}
-        assert actual_results == {"failure": 0, "pending": 0, "success": len(assets), "unchanged": 0, "skipped": 0}
+        assert actual_results == {
+            "failure": 0,
+            "pending": 0,
+            "success": len(assets),
+            "pending-with-warning": 0,
+            "success-with-warning": 0,
+            "skipped": 0,
+        }
 
     @pytest.mark.usefixtures("mock_statistics", "resource_view_mappings")
     def test_migrate_resume(
@@ -467,7 +474,14 @@ class TestMigrationCommand:
 
         result = results_by_selector[str(selector)]
         actual_results = {status.status: status.count for status in result}
-        assert actual_results == {"failure": 0, "pending": 0, "success": 1, "unchanged": 0, "skipped": 0}
+        assert actual_results == {
+            "failure": 0,
+            "pending": 0,
+            "success": 1,
+            "pending-with-warning": 0,
+            "success-with-warning": 0,
+            "skipped": 0,
+        }
 
         progress = ProgressYAML.try_load(logs, filestem=str(selector))
         assert progress is not None
@@ -607,7 +621,14 @@ class TestMigrationCommand:
         )
         result = results_by_selector[str(selector)]
         actual_results = {status.status: status.count for status in result}
-        assert actual_results == {"failure": 0, "pending": 0, "success": len(annotations), "unchanged": 0, "skipped": 0}
+        assert actual_results == {
+            "failure": 0,
+            "pending": 0,
+            "success": len(annotations),
+            "pending-with-warning": 0,
+            "success-with-warning": 0,
+            "skipped": 0,
+        }
 
         # Check that the annotations were uploaded
         last_call = respx_mock.calls[-1]
@@ -806,7 +827,14 @@ class TestMigrationCommand:
             )
         result = results_by_selector[str(selector)]
         actual_results = {status.status: status.count for status in result}
-        assert actual_results == {"failure": 0, "pending": 0, "success": len(charts), "unchanged": 0, "skipped": 0}
+        assert actual_results == {
+            "failure": 0,
+            "pending": 0,
+            "success": len(charts),
+            "pending-with-warning": 0,
+            "success-with-warning": 0,
+            "skipped": 0,
+        }
 
         calls = respx_mock.calls
         assert len(calls) == 5
@@ -1038,7 +1066,14 @@ class TestMigrationCommand:
 
         result = results_by_selector[str(selector)]
         actual_results = {status.status: status.count for status in result}
-        assert actual_results == {"failure": 0, "pending": 0, "success": 1, "unchanged": 0, "skipped": 0}
+        assert actual_results == {
+            "failure": 0,
+            "pending": 0,
+            "success": 1,
+            "pending-with-warning": 0,
+            "success-with-warning": 0,
+            "skipped": 0,
+        }
 
         upsert_calls = [
             c
@@ -1288,4 +1323,11 @@ class TestMigrationCommand:
         assert len(upload_body["items"]) == len(events)
 
         actual_results = {status.status: status.count for status in results_by_selector[str(selector)]}
-        assert actual_results == {"failure": 0, "pending": 0, "success": len(events), "unchanged": 0, "skipped": 0}
+        assert actual_results == {
+            "failure": 0,
+            "pending": 0,
+            "success": len(events),
+            "pending-with-warning": 0,
+            "success-with-warning": 0,
+            "skipped": 0,
+        }

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_logger.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_logger.py
@@ -1,13 +1,19 @@
+from collections import Counter
 from unittest.mock import MagicMock
 
 import pytest
 
 from cognite_toolkit._cdf_tk.storageio.logger import (
     FileDataLogger,
+    FileWithAggregationLogger,
+    ItemsResult,
+    LabelResult,
     LogEntry,
+    LogEntryV2,
     MemoryOperationTracker,
     NoOpLogger,
     NoOpTracker,
+    Severity,
 )
 from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter
 
@@ -87,3 +93,59 @@ class TestFileDataLogger:
             [{"id": "2"}, {"id": "3"}],
         ]
         assert isinstance(logger.tracker, MemoryOperationTracker)
+
+
+class TestFileWithAggregationLogger:
+    def test_finalize(self) -> None:
+        with FileWithAggregationLogger(MagicMock(spec=NDJsonWriter)) as logger:
+            self._simulate_log_entries(logger)
+
+            results = logger.finalize(is_dry_run=False)
+
+        assert results == [
+            ItemsResult(status="success", count=1),
+            ItemsResult(status="failure", count=1, labels=[LabelResult("Could not write", count=1)]),
+            ItemsResult(
+                status="success-with-warning",
+                count=2,
+                labels=[
+                    LabelResult(
+                        "ignored values",
+                        count=2,
+                        attribute_name="ignored properties",
+                        attribute_counter=Counter(["attribute", "attribute37", "attribute37"]),
+                    )
+                ],
+            ),
+        ]
+
+    def _simulate_log_entries(self, logger: FileWithAggregationLogger) -> None:
+        logger.register(["item_success", "item_failure", "item_warning1", "item_warning2"])
+
+        logger.log(
+            LogEntryV2(id="item_failure", severity=Severity.warning, label="ignored values", message="Will be ignored")
+        )
+        logger.log(
+            LogEntryV2(id="item_failure", severity=Severity.failure, label="Could not write", message="Will be kept.")
+        )
+
+        logger.log(
+            LogEntryV2(
+                id="item_warning1",
+                severity=Severity.warning,
+                label="ignored values",
+                message="Will be kept as there is no failure",
+                attributes={"attribute", "attribute37"},
+                attribute_display_name="ignored properties",
+            )
+        )
+        logger.log(
+            LogEntryV2(
+                id="item_warning2",
+                severity=Severity.warning,
+                label="ignored values",
+                message="Will be kept as there is no failure",
+                attributes={"attribute37"},
+                attribute_display_name="ignored properties",
+            )
+        )

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_logger.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_logger.py
@@ -104,12 +104,17 @@ class TestFileWithAggregationLogger:
             results = logger.finalize(is_dry_run=False)
 
         assert results == [
-            ItemsResult(status="success", count=1, severity=999),
-            ItemsResult(status="failure", count=1, labels=[LabelResult("Could not write", count=1)], severity=1),
+            ItemsResult(status="success", count=1, severity=0),
+            ItemsResult(
+                status="failure",
+                count=1,
+                labels=[LabelResult("Could not write", count=1)],
+                severity=Severity.failure.value,
+            ),
             ItemsResult(
                 status="success-with-warning",
                 count=2,
-                severity=2,
+                severity=Severity.warning.value,
                 labels=[
                     LabelResult(
                         "ignored values",
@@ -122,7 +127,7 @@ class TestFileWithAggregationLogger:
         ]
 
         # Just to ensure that no exception is raised.
-        display_item_results(results)
+        display_item_results(results, MagicMock())
 
     def _simulate_log_entries(self, logger: FileWithAggregationLogger) -> None:
         logger.register(["item_success", "item_failure", "item_warning1", "item_warning2"])

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_logger.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_logger.py
@@ -14,6 +14,7 @@ from cognite_toolkit._cdf_tk.storageio.logger import (
     NoOpLogger,
     NoOpTracker,
     Severity,
+    display_item_results,
 )
 from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter
 
@@ -103,11 +104,12 @@ class TestFileWithAggregationLogger:
             results = logger.finalize(is_dry_run=False)
 
         assert results == [
-            ItemsResult(status="success", count=1),
-            ItemsResult(status="failure", count=1, labels=[LabelResult("Could not write", count=1)]),
+            ItemsResult(status="success", count=1, severity=999),
+            ItemsResult(status="failure", count=1, labels=[LabelResult("Could not write", count=1)], severity=1),
             ItemsResult(
                 status="success-with-warning",
                 count=2,
+                severity=2,
                 labels=[
                     LabelResult(
                         "ignored values",
@@ -118,6 +120,9 @@ class TestFileWithAggregationLogger:
                 ],
             ),
         ]
+
+        # Just to ensure that no exception is raised.
+        display_item_results(results)
 
     def _simulate_log_entries(self, logger: FileWithAggregationLogger) -> None:
         logger.register(["item_success", "item_failure", "item_warning1", "item_warning2"])


### PR DESCRIPTION
# Description

<img width="742" height="113" alt="image" src="https://github.com/user-attachments/assets/4a214bfc-825d-4461-abda-f04fdbd131c0" />


Instead of having a logger + a tracker introduce a single logger that does both. This reduces the effort for the user of the logger for what to log. Furthermore, this also enables us to not think about stacking log entries before calling .log. Instead the logger itself ensures that write to file is done in batches. 

This will help all data plugins: download, upload, migration, and purge.

## Bump

- [ ] Patch
- [x] Skip

