### PR TITLE
[CDF-27675] 🧱 Replace logger migration

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -2,7 +2,7 @@ import re
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Generic, get_args
+from typing import Generic
 
 from rich import print
 from rich.console import Console
@@ -37,7 +37,11 @@ from cognite_toolkit._cdf_tk.storageio import (
     T_Selector,
     UploadableStorageIO,
 )
-from cognite_toolkit._cdf_tk.storageio.logger import FileDataLogger, OperationStatus
+from cognite_toolkit._cdf_tk.storageio.logger import (
+    FileWithAggregationLogger,
+    ItemsResult,
+    display_item_results,
+)
 from cognite_toolkit._cdf_tk.storageio.progress import Bookmark, CursorBookmark, ProgressYAML
 from cognite_toolkit._cdf_tk.utils import humanize_collection, safe_write, sanitize_filename
 from cognite_toolkit._cdf_tk.utils.file import yaml_safe_dump
@@ -45,20 +49,7 @@ from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter, Uncompressed
 from cognite_toolkit._cdf_tk.utils.producer_worker import ProducerWorkerExecutor
 
 from .data_model import INSTANCE_SOURCE_VIEW_ID, MODEL_ID, RESOURCE_VIEW_MAPPING_VIEW_ID
-from .issues import WriteIssue
-
-
-@dataclass
-class OperationIssue:
-    message: str
-    count: int
-
-
-@dataclass
-class MigrationStatusResult:
-    status: OperationStatus
-    issues: list[OperationIssue]
-    count: int
+from .issues import WriteIssue, write_issue_as_migration_entry
 
 
 @dataclass
@@ -81,7 +72,7 @@ class MigrationCommand(ToolkitCommand):
         dry_run: bool = False,
         verbose: bool = False,
         user_log_filestem: str | None = None,
-    ) -> dict[str, list[MigrationStatusResult]]:
+    ) -> dict[str, list[ItemsResult]]:
         self.validate_migration_model_available(data.client)
         log_dir.mkdir(parents=True, exist_ok=True)
         log_filestem = self._create_logfile_stem(log_dir, user_log_filestem, data.KIND)
@@ -101,60 +92,86 @@ class MigrationCommand(ToolkitCommand):
                 self.validate_stream_capacity(data.client, data.stream_external_id, needed_capacity)
             else:
                 self.validate_available_capacity(data.client, needed_capacity)
-        results_by_selector: dict[str, list[MigrationStatusResult]] = {}
+        results_by_selector: dict[str, list[ItemsResult]] = {}
         with (
             NDJsonWriter(
                 log_dir, kind="MigrationIssues", default_filestem=log_filestem, compression=Uncompressed
             ) as log_file,
             HTTPClient(config=data.client.config) as write_client,
         ):
-            logger = FileDataLogger(log_file)
-            data.logger = logger
-            mapper.logger = logger
-            for step in plan:
-                if step.message:
-                    console.print(step.message)
-                if step.is_completed:
-                    continue
-
-                selected = step.selector
-                logger.tracker.reset()
-                mapper.prepare(selected)
-
-                executor = ProducerWorkerExecutor[Page[T_DataResponse], Page[T_DataRequest]](
-                    download_iterable=data.stream_data(selected, bookmark=step.bookmark),
-                    process=self._convert(mapper),
-                    write=self._upload(
-                        selected, write_client, data, dry_run, log_dir, step.total_count, step.completed_count
-                    ),
-                    total_item_count=step.total_count,
-                    max_queue_size=10,
-                    download_description=f"Downloading {selected.display_name}",
-                    process_description="Converting",
-                    write_description="Uploading",
-                    console=console,
+            with FileWithAggregationLogger(log_file) as logger:
+                self._run_migration_steps(
+                    plan=plan,
+                    data=data,
+                    mapper=mapper,
+                    logger=logger,
+                    write_client=write_client,
+                    log_dir=log_dir,
+                    dry_run=dry_run,
                     verbose=verbose,
+                    console=console,
+                    results_by_selector=results_by_selector,
                 )
 
-                executor.run(start_item=step.completed_count)
-                total = executor.downloaded_items
-
-                results = self._create_status_summary(logger)
-                results_by_selector[str(selected)] = results
-
-                self._print_rich_tables(results, console)
-                self._print_txt(results, log_dir, f"{selected!s}Items", console)
-                progress = ProgressYAML.try_load(log_dir, filestem=str(selected))
-                if progress is not None:
-                    progress.status = executor.result
-                    progress.dump_to_file(log_dir, filestem=str(selected))
-                executor.raise_on_error()
-
-                action = "Would migrate" if dry_run else "Migrating"
-                target = "records" if isinstance(data, RecordsMigrationIO) else "instances"
-                console.print(f"{action} {total:,} {selected.display_name} to {target}.")
-
         return results_by_selector
+
+    def _run_migration_steps(
+        self,
+        plan: Sequence[MigrationStep],
+        data: UploadableStorageIO[T_Selector, T_DataResponse, T_DataRequest],
+        mapper: DataMapper[T_Selector, T_DataResponse, T_DataRequest],
+        logger: FileWithAggregationLogger,
+        write_client: HTTPClient,
+        log_dir: Path,
+        dry_run: bool,
+        verbose: bool,
+        console: Console,
+        results_by_selector: dict[str, list[ItemsResult]],
+    ) -> None:
+        data.logger = logger
+        mapper.logger = logger
+        for step in plan:
+            if step.message:
+                console.print(step.message)
+            if step.is_completed:
+                continue
+
+            selected = step.selector
+            logger.reset()
+            mapper.prepare(selected)
+
+            executor = ProducerWorkerExecutor[Page[T_DataResponse], Page[T_DataRequest]](
+                download_iterable=data.stream_data(selected, bookmark=step.bookmark),
+                process=self._convert(mapper),
+                write=self._upload(
+                    selected, write_client, data, dry_run, log_dir, step.total_count, step.completed_count
+                ),
+                total_item_count=step.total_count,
+                max_queue_size=10,
+                download_description=f"Downloading {selected.display_name}",
+                process_description="Converting",
+                write_description="Uploading",
+                console=console,
+                verbose=verbose,
+            )
+
+            executor.run(start_item=step.completed_count)
+            total = executor.downloaded_items
+
+            items_results = logger.finalize(dry_run)
+            results_by_selector[str(selected)] = items_results
+
+            display_item_results(items_results, console)
+            self._print_txt(items_results, log_dir, f"{selected!s}Items", console)
+            progress = ProgressYAML.try_load(log_dir, filestem=str(selected))
+            if progress is not None:
+                progress.status = executor.result
+                progress.dump_to_file(log_dir, filestem=str(selected))
+            executor.raise_on_error()
+
+            action = "Would migrate" if dry_run else "Migrating"
+            target = "records" if isinstance(data, RecordsMigrationIO) else "instances"
+            console.print(f"{action} {total:,} {selected.display_name} to {target}.")
 
     def _create_plan(
         self,
@@ -247,33 +264,7 @@ class MigrationCommand(ToolkitCommand):
 
         return f"{base_logstem}run{next_run}-"
 
-    # Todo: Move to the logger module
-    @classmethod
-    def _create_status_summary(cls, logger: FileDataLogger) -> list[MigrationStatusResult]:
-        results: list[MigrationStatusResult] = []
-        status_counts = logger.tracker.get_status_counts()
-        for status in get_args(OperationStatus):
-            issue_counts = logger.tracker.get_issue_counts(status)
-            issues = [OperationIssue(message=issue, count=count) for issue, count in issue_counts.items()]
-            result = MigrationStatusResult(
-                status=status,
-                issues=issues,
-                count=status_counts.get(status, 0),
-            )
-            results.append(result)
-        return results
-
-    def _print_rich_tables(self, results: list[MigrationStatusResult], console: Console) -> None:
-        table = Table(title="Migration Summary", show_lines=True)
-        table.add_column("Status", style="bold")
-        table.add_column("Count", justify="right", style="bold")
-        table.add_column("Issues", style="bold")
-        for result in results:
-            issues_str = "\n".join(f"{issue.message}: {issue.count}" for issue in result.issues) or ""
-            table.add_row(result.status, str(result.count), issues_str)
-        console.print(table)
-
-    def _print_txt(self, results: list[MigrationStatusResult], log_dir: Path, filestem: str, console: Console) -> None:
+    def _print_txt(self, results: list[ItemsResult], log_dir: Path, filestem: str, console: Console) -> None:
         summary_file = log_dir / f"{filestem}_migration_summary.txt"
         with summary_file.open("w", encoding="utf-8") as f:
             f.write("Migration Summary\n")
@@ -281,10 +272,10 @@ class MigrationCommand(ToolkitCommand):
             for result in results:
                 f.write(f"Status: {result.status}\n")
                 f.write(f"Count: {result.count}\n")
-                f.write("Issues:\n")
-                if result.issues:
-                    for issue in result.issues:
-                        f.write(f"  - {issue.message}: {issue.count}\n")
+                f.write("Labels:\n")
+                if result.labels:
+                    for label in result.labels:
+                        f.write(f"  - {label.display_message()}\n")
                 else:
                     f.write("  None\n")
                 f.write("\n")
@@ -326,16 +317,13 @@ class MigrationCommand(ToolkitCommand):
             if not page:
                 return None
             if dry_run:
-                target.logger.tracker.finalize_item([item.tracking_id for item in page.items], "pending")
                 return None
 
             responses = target.upload_items(data_chunk=page, http_client=write_client, selector=selected)
 
-            # Todo: Move logging into the UploadableStorageIO class
             issues: list[WriteIssue] = []
             for item in responses:
                 if isinstance(item, ItemsSuccessResponse):
-                    target.logger.tracker.finalize_item(item.ids, "success")
                     continue
                 if isinstance(item, ItemsFailedResponse):
                     error = item.error
@@ -347,10 +335,12 @@ class MigrationCommand(ToolkitCommand):
                         issue = WriteIssue(id=str(id_), status_code=0, message=item.error_message)
                         issues.append(issue)
 
-                if isinstance(item, ItemsFailedResponse | ItemsFailedRequest):
-                    target.logger.tracker.finalize_item(item.ids, "failure")
             if issues:
-                target.logger.log(issues)
+                destination = target.KIND
+                source = str(selected)
+                target.logger.log(
+                    [write_issue_as_migration_entry(issue, source=source, destination=destination) for issue in issues]
+                )
 
             migrate_count += sum(len(response.ids) for response in responses)
             ProgressYAML(

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -40,6 +40,7 @@ from cognite_toolkit._cdf_tk.storageio import (
 from cognite_toolkit._cdf_tk.storageio.logger import (
     FileWithAggregationLogger,
     ItemsResult,
+    Severity,
     display_item_results,
 )
 from cognite_toolkit._cdf_tk.storageio.progress import Bookmark, CursorBookmark, ProgressYAML
@@ -49,7 +50,7 @@ from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter, Uncompressed
 from cognite_toolkit._cdf_tk.utils.producer_worker import ProducerWorkerExecutor
 
 from .data_model import INSTANCE_SOURCE_VIEW_ID, MODEL_ID, RESOURCE_VIEW_MAPPING_VIEW_ID
-from .issues import WriteIssue, write_issue_as_migration_entry
+from .issues import MigrationEntryV2
 
 
 @dataclass
@@ -321,26 +322,34 @@ class MigrationCommand(ToolkitCommand):
 
             responses = target.upload_items(data_chunk=page, http_client=write_client, selector=selected)
 
-            issues: list[WriteIssue] = []
             for item in responses:
                 if isinstance(item, ItemsSuccessResponse):
                     continue
                 if isinstance(item, ItemsFailedResponse):
                     error = item.error
                     for id_ in item.ids:
-                        issue = WriteIssue(id=str(id_), status_code=error.code, message=error.message)
-                        issues.append(issue)
+                        target.logger.log(
+                            MigrationEntryV2(
+                                id=id_,
+                                severity=Severity.failure,
+                                label=f"Failed to write to CDF: {error.code}",
+                                message=error.message,
+                                source=str(selected),
+                                destination=target.KIND,
+                            )
+                        )
                 elif isinstance(item, ItemsFailedRequest):
                     for id_ in item.ids:
-                        issue = WriteIssue(id=str(id_), status_code=0, message=item.error_message)
-                        issues.append(issue)
-
-            if issues:
-                destination = target.KIND
-                source = str(selected)
-                target.logger.log(
-                    [write_issue_as_migration_entry(issue, source=source, destination=destination) for issue in issues]
-                )
+                        target.logger.log(
+                            MigrationEntryV2(
+                                id=id_,
+                                severity=Severity.failure,
+                                label="Failed to write to CDF: Request failed",
+                                message=item.error_message,
+                                source=str(selected),
+                                destination=target.KIND,
+                            )
+                        )
 
             migrate_count += sum(len(response.ids) for response in responses)
             ProgressYAML(

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -93,26 +93,25 @@ class MigrationCommand(ToolkitCommand):
                 self.validate_stream_capacity(data.client, data.stream_external_id, needed_capacity)
             else:
                 self.validate_available_capacity(data.client, needed_capacity)
-        results_by_selector: dict[str, list[ItemsResult]] = {}
+
         with (
             NDJsonWriter(
                 log_dir, kind="MigrationIssues", default_filestem=log_filestem, compression=Uncompressed
             ) as log_file,
             HTTPClient(config=data.client.config) as write_client,
+            FileWithAggregationLogger(log_file) as logger,
         ):
-            with FileWithAggregationLogger(log_file) as logger:
-                self._run_migration_steps(
-                    plan=plan,
-                    data=data,
-                    mapper=mapper,
-                    logger=logger,
-                    write_client=write_client,
-                    log_dir=log_dir,
-                    dry_run=dry_run,
-                    verbose=verbose,
-                    console=console,
-                    results_by_selector=results_by_selector,
-                )
+            results_by_selector = self._run_migration_steps(
+                plan=plan,
+                data=data,
+                mapper=mapper,
+                logger=logger,
+                write_client=write_client,
+                log_dir=log_dir,
+                dry_run=dry_run,
+                verbose=verbose,
+                console=console,
+            )
 
         return results_by_selector
 
@@ -127,8 +126,8 @@ class MigrationCommand(ToolkitCommand):
         dry_run: bool,
         verbose: bool,
         console: Console,
-        results_by_selector: dict[str, list[ItemsResult]],
-    ) -> None:
+    ) -> dict[str, list[ItemsResult]]:
+        results_by_selector: dict[str, list[ItemsResult]] = {}
         data.logger = logger
         mapper.logger = logger
         for step in plan:
@@ -173,6 +172,7 @@ class MigrationCommand(ToolkitCommand):
             action = "Would migrate" if dry_run else "Migrating"
             target = "records" if isinstance(data, RecordsMigrationIO) else "instances"
             console.print(f"{action} {total:,} {selected.display_name} to {target}.")
+        return results_by_selector
 
     def _create_plan(
         self,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -161,7 +161,7 @@ class MigrationCommand(ToolkitCommand):
             items_results = logger.finalize(dry_run)
             results_by_selector[str(selected)] = items_results
 
-            display_item_results(items_results, console)
+            display_item_results(items_results, title=f"Finished {selected.display_name}", console=console)
             self._print_txt(items_results, log_dir, f"{selected!s}Items", console)
             progress = ProgressYAML.try_load(log_dir, filestem=str(selected))
             if progress is not None:

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -164,7 +164,7 @@ class AssetCentricMapper(
     def _migration_entries_for_conversion(
         self,
         item: AssetCentricMapping[T_AssetCentricResourceExtended],
-        conversion_issue: ConversionIssue,
+        issue: ConversionIssue,
         mapping_failed: bool,
     ) -> list[MigrationEntryV2]:
         mapping = item.mapping
@@ -172,18 +172,20 @@ class AssetCentricMapper(
         source = f"{mapping.resource_type}:{mapping.id}"
         destination = str(mapping.instance_id)
         entries: list[MigrationEntryV2] = []
-        if conversion_issue.missing_instance_space:
+        if issue.missing_instance_space:
             entries.append(
                 MigrationEntryV2(
                     id=item_id,
                     label="Missing instance space",
-                    message=str(conversion_issue.missing_instance_space),
-                    severity=Severity.warning,
+                    message=str(issue.missing_instance_space),
+                    severity=Severity.failure,
                     source=source,
                     destination=destination,
+                    attributes={issue.missing_instance_space},
+                    attribute_display_name="space",
                 )
             )
-        if conversion_issue.no_mappable_properties:
+        if issue.no_mappable_properties:
             entries.append(
                 MigrationEntryV2(
                     id=item_id,
@@ -194,51 +196,61 @@ class AssetCentricMapper(
                     destination=destination,
                 )
             )
-        if conversion_issue.failed_conversions:
+        if issue.failed_conversions:
+            errors = "; ".join(conv.display_name for conv in issue.failed_conversions)
             entries.append(
                 MigrationEntryV2(
                     id=item_id,
                     label="Failed conversions",
-                    message=f"{len(conversion_issue.failed_conversions)} property conversion(s) failed",
+                    message=errors,
                     severity=Severity.warning,
                     source=source,
                     destination=destination,
+                    attributes={conv.property_id for conv in issue.failed_conversions},
+                    attribute_display_name="properties",
                 )
             )
-        if conversion_issue.invalid_instance_property_types:
+        if issue.invalid_instance_property_types:
+            errors = "; ".join(prop.display_name for prop in issue.invalid_instance_property_types)
             entries.append(
                 MigrationEntryV2(
                     id=item_id,
                     label="Invalid instance property types",
-                    message=f"{len(conversion_issue.invalid_instance_property_types)} invalid type(s)",
+                    message=errors,
                     severity=Severity.warning,
                     source=source,
                     destination=destination,
+                    attributes={prop.property_id for prop in issue.invalid_instance_property_types},
+                    attribute_display_name="properties",
                 )
             )
-        if conversion_issue.missing_asset_centric_properties:
+        if issue.missing_asset_centric_properties:
             entries.append(
                 MigrationEntryV2(
                     id=item_id,
                     label="Missing asset-centric properties",
-                    message=f"Missing: {humanize_collection(conversion_issue.missing_asset_centric_properties)}",
+                    message=f"Missing: {humanize_collection(issue.missing_asset_centric_properties)}",
                     severity=Severity.warning,
                     source=source,
                     destination=destination,
+                    attributes=set(issue.missing_asset_centric_properties),
+                    attribute_display_name="properties",
                 )
             )
-        if conversion_issue.missing_instance_properties:
+        if issue.missing_instance_properties:
             entries.append(
                 MigrationEntryV2(
                     id=item_id,
                     label="Missing data modeling properties",
-                    message=f"Missing: {humanize_collection(conversion_issue.missing_instance_properties)}",
+                    message=f"Missing: {humanize_collection(issue.missing_instance_properties)}",
                     severity=Severity.warning,
                     source=source,
                     destination=destination,
+                    attributes=set(issue.missing_instance_properties),
+                    attribute_display_name="properties",
                 )
             )
-        if conversion_issue.ignored_asset_centric_properties:
+        if issue.ignored_asset_centric_properties:
             entries.append(
                 MigrationEntryV2(
                     id=item_id,
@@ -247,13 +259,13 @@ class AssetCentricMapper(
                     severity=Severity.warning,
                     source=source,
                     destination=destination,
-                    attributes=set(conversion_issue.ignored_asset_centric_properties),
+                    attributes=set(issue.ignored_asset_centric_properties),
                     attribute_display_name="ignored properties",
                 )
             )
         if mapping_failed:
             msg = "Could not build target resource."
-            if not entries and not conversion_issue.has_issues:
+            if not entries and not issue.has_issues:
                 msg = (
                     "No properties could be mapped to the target container, at least one property is required "
                     "to create a record"
@@ -474,6 +486,8 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
                         severity=Severity.warning,
                         source=chart_src,
                         destination=chart_dest,
+                        attributes={str(id_) for id_ in issue.missing_timeseries_ids},
+                        attribute_display_name="timeseries IDs",
                     )
                 )
             if issue.missing_timeseries_external_ids:
@@ -485,6 +499,8 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
                         severity=Severity.warning,
                         source=chart_src,
                         destination=chart_dest,
+                        attributes=set(issue.missing_timeseries_external_ids),
+                        attribute_display_name="timeseries external IDs",
                     )
                 )
             if issue.missing_timeseries_identifier:
@@ -496,6 +512,8 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
                         severity=Severity.warning,
                         source=chart_src,
                         destination=chart_dest,
+                        attributes=set(issue.missing_timeseries_identifier),
+                        attribute_display_name="timeseries identifiers",
                     )
                 )
 
@@ -915,6 +933,8 @@ class CanvasMapper(DataMapper[CanvasSelector, IndustrialCanvasResponse, Industri
                         severity=Severity.warning,
                         source=canvas_src,
                         destination=canvas_dest,
+                        attributes={str(ref) for ref in issue.missing_reference_ids},
+                        attribute_display_name="timeseries/file/event/asset references",
                     )
                 )
             if issue.files_missing_content:
@@ -926,6 +946,8 @@ class CanvasMapper(DataMapper[CanvasSelector, IndustrialCanvasResponse, Industri
                         severity=Severity.warning,
                         source=canvas_src,
                         destination=canvas_dest,
+                        attributes={str(ref) for ref in issue.files_missing_content},
+                        attribute_display_name="file references with missing content",
                     )
                 )
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -79,12 +79,15 @@ from cognite_toolkit._cdf_tk.commands._migrate.issues import (
     ChartMigrationIssue,
     ConversionIssue,
     InstanceConversionIssue,
+    MigrationEntryV2,
     ThreeDModelMigrationIssue,
+    instance_conversion_issue_as_migration_entry,
+    migration_log_entry,
 )
 from cognite_toolkit._cdf_tk.constants import MISSING_INSTANCE_SPACE
 from cognite_toolkit._cdf_tk.exceptions import ToolkitMigrationError, ToolkitValueError
 from cognite_toolkit._cdf_tk.storageio import T_DataRequest, T_DataResponse, T_Selector
-from cognite_toolkit._cdf_tk.storageio.logger import DataLogger, NoOpLogger
+from cognite_toolkit._cdf_tk.storageio.logger import DataLogger, NoOpLogger, Severity
 from cognite_toolkit._cdf_tk.storageio.selectors import (
     CanvasSelector,
     ChartSelector,
@@ -145,38 +148,129 @@ class AssetCentricMapper(
     ) -> tuple[T_DataRequest | None, ConversionIssue]:
         raise NotImplementedError
 
+    def _migration_entries_for_conversion(
+        self,
+        item: AssetCentricMapping[T_AssetCentricResourceExtended],
+        conversion_issue: ConversionIssue,
+        mapping_failed: bool,
+    ) -> list[MigrationEntryV2]:
+        mapping = item.mapping
+        item_id = str(mapping.as_asset_centric_id())
+        source = f"{mapping.resource_type}:{mapping.id}"
+        destination = str(mapping.instance_id)
+        entries: list[MigrationEntryV2] = []
+        if conversion_issue.missing_instance_space:
+            entries.append(
+                migration_log_entry(
+                    item_id,
+                    label="Missing instance space",
+                    message=str(conversion_issue.missing_instance_space),
+                    severity=Severity.warning,
+                    source=source,
+                    destination=destination,
+                )
+            )
+        if conversion_issue.no_mappable_properties:
+            entries.append(
+                migration_log_entry(
+                    item_id,
+                    label="No mappable properties",
+                    message="No properties could be mapped to target",
+                    severity=Severity.warning,
+                    source=source,
+                    destination=destination,
+                )
+            )
+        if conversion_issue.failed_conversions:
+            entries.append(
+                migration_log_entry(
+                    item_id,
+                    label="Failed conversions",
+                    message=f"{len(conversion_issue.failed_conversions)} property conversion(s) failed",
+                    severity=Severity.warning,
+                    source=source,
+                    destination=destination,
+                )
+            )
+        if conversion_issue.invalid_instance_property_types:
+            entries.append(
+                migration_log_entry(
+                    item_id,
+                    label="Invalid instance property types",
+                    message=f"{len(conversion_issue.invalid_instance_property_types)} invalid type(s)",
+                    severity=Severity.warning,
+                    source=source,
+                    destination=destination,
+                )
+            )
+        if conversion_issue.missing_asset_centric_properties:
+            entries.append(
+                migration_log_entry(
+                    item_id,
+                    label="Missing asset-centric properties",
+                    message=f"Missing: {humanize_collection(conversion_issue.missing_asset_centric_properties)}",
+                    severity=Severity.warning,
+                    source=source,
+                    destination=destination,
+                )
+            )
+        if conversion_issue.missing_instance_properties:
+            entries.append(
+                migration_log_entry(
+                    item_id,
+                    label="Missing data modeling properties",
+                    message=f"Missing: {humanize_collection(conversion_issue.missing_instance_properties)}",
+                    severity=Severity.warning,
+                    source=source,
+                    destination=destination,
+                )
+            )
+        if conversion_issue.ignored_asset_centric_properties:
+            entries.append(
+                migration_log_entry(
+                    item_id,
+                    label="Ignored asset-centric properties",
+                    message="Some source properties were ignored",
+                    severity=Severity.warning,
+                    source=source,
+                    destination=destination,
+                    attributes=set(conversion_issue.ignored_asset_centric_properties),
+                    attribute_display_name="ignored properties",
+                )
+            )
+        if mapping_failed:
+            msg = "Could not build target resource."
+            if not entries and not conversion_issue.has_issues:
+                msg = (
+                    "No properties could be mapped to the target container, at least one property is required "
+                    "to create a record"
+                )
+            entries.append(
+                migration_log_entry(
+                    item_id,
+                    label="Conversion failed",
+                    message=msg,
+                    severity=Severity.failure,
+                    source=source,
+                    destination=destination,
+                )
+            )
+        return entries
+
     def map(
         self, source: Sequence[AssetCentricMapping[T_AssetCentricResourceExtended]]
     ) -> Sequence[T_DataRequest | None]:
         self._direct_relation_cache.update(item.resource for item in source)
         output: list[T_DataRequest | None] = []
-        issues: list[ConversionIssue] = []
+        log_entries: list[MigrationEntryV2] = []
         for item in source:
             result, conversion_issue = self._map_single_item(item)
-            identifier = str(item.mapping.as_asset_centric_id())
-
-            if conversion_issue.missing_instance_space:
-                self.logger.tracker.add_issue(identifier, "Missing instance space")
-            if conversion_issue.no_mappable_properties:
-                self.logger.tracker.add_issue(identifier, "No properties could be mapped to target")
-            if conversion_issue.failed_conversions:
-                self.logger.tracker.add_issue(identifier, "Failed conversions")
-            if conversion_issue.invalid_instance_property_types:
-                self.logger.tracker.add_issue(identifier, "Invalid instance property types")
-            if conversion_issue.missing_asset_centric_properties:
-                self.logger.tracker.add_issue(identifier, "Missing asset-centric properties")
-            if conversion_issue.missing_instance_properties:
-                self.logger.tracker.add_issue(identifier, "Missing data modeling properties")
-            if conversion_issue.ignored_asset_centric_properties:
-                self.logger.tracker.add_issue(identifier, "Ignored asset-centric properties")
-
-            if conversion_issue.has_issues:
-                issues.append(conversion_issue)
-            if result is None:
-                self.logger.tracker.finalize_item(identifier, "failure")
+            log_entries.extend(
+                self._migration_entries_for_conversion(item, conversion_issue, result is None),
+            )
             output.append(result)
-        if issues:
-            self.logger.log(issues)
+        if log_entries:
+            self.logger.log(log_entries)
         return output
 
 
@@ -313,11 +407,6 @@ class AssetCentricToRecordMapper(AssetCentricMapper[T_AssetCentricResourceExtend
         )
         if mapping.instance_id.space == MISSING_INSTANCE_SPACE:
             conversion_issue.missing_instance_space = f"Missing instance space for dataset ID {mapping.data_set_id!r}"
-        if record is None and not conversion_issue.has_issues:
-            self.logger.tracker.add_issue(
-                str(item.mapping.as_asset_centric_id()),
-                "No properties could be mapped to the target container, at least one property is required to create a record",
-            )
         return record, conversion_issue
 
 
@@ -333,14 +422,24 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
     def map(self, source: Sequence[ChartResponse]) -> Sequence[ChartRequest | None]:
         event_ids_by_chart_external_id = self._populate_cache(source)
         output: list[ChartRequest | None] = []
-        issues: list[ChartMigrationIssue] = []
+        log_entries: list[MigrationEntryV2] = []
+        chart_src = "Charts"
+        chart_dest = "Charts (data modeling)"
         for item in source:
             identifier = item.external_id
             if item.data.scheduled_calculation_collection or item.data.monitoring_jobs:
-                # These are not yet supported.
                 output.append(None)
-                issues.append(self._create_missing_support_issue(item))
-                self.logger.tracker.finalize_item(identifier, "failure")
+                support_issue = self._create_missing_support_issue(item)
+                log_entries.append(
+                    migration_log_entry(
+                        identifier,
+                        label="Unsupported chart features",
+                        message="; ".join(support_issue.errors),
+                        severity=Severity.failure,
+                        source=chart_src,
+                        destination=chart_dest,
+                    )
+                )
                 continue
 
             mapped_item, issue = self._map_single_item(
@@ -348,20 +447,64 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
             )
 
             if issue.missing_timeseries_ids:
-                self.logger.tracker.add_issue(identifier, "Missing timeseries IDs")
+                log_entries.append(
+                    migration_log_entry(
+                        identifier,
+                        label="Missing timeseries IDs",
+                        message="One or more timeseries are missing internal IDs",
+                        severity=Severity.warning,
+                        source=chart_src,
+                        destination=chart_dest,
+                    )
+                )
             if issue.missing_timeseries_external_ids:
-                self.logger.tracker.add_issue(identifier, "Missing timeseries external IDs")
+                log_entries.append(
+                    migration_log_entry(
+                        identifier,
+                        label="Missing timeseries external IDs",
+                        message="One or more timeseries are missing external IDs",
+                        severity=Severity.warning,
+                        source=chart_src,
+                        destination=chart_dest,
+                    )
+                )
             if issue.missing_timeseries_identifier:
-                self.logger.tracker.add_issue(identifier, "Missing timeseries identifier")
+                log_entries.append(
+                    migration_log_entry(
+                        identifier,
+                        label="Missing timeseries identifier",
+                        message="One or more timeseries elements lack identifiers",
+                        severity=Severity.warning,
+                        source=chart_src,
+                        destination=chart_dest,
+                    )
+                )
 
-            if issue.has_issues:
-                issues.append(issue)
-
-            if mapped_item is None:
-                self.logger.tracker.finalize_item(identifier, "failure")
+            if issue.has_issues and mapped_item is None:
+                log_entries.append(
+                    migration_log_entry(
+                        identifier,
+                        label="Chart migration failed",
+                        message="; ".join(issue.errors) if issue.errors else "Chart could not be migrated",
+                        severity=Severity.failure,
+                        source=chart_src,
+                        destination=chart_dest,
+                    )
+                )
+            elif mapped_item is None:
+                log_entries.append(
+                    migration_log_entry(
+                        identifier,
+                        label="Chart migration failed",
+                        message="Chart could not be migrated",
+                        severity=Severity.failure,
+                        source=chart_src,
+                        destination=chart_dest,
+                    )
+                )
             output.append(mapped_item)
-        if issues:
-            self.logger.log(issues)
+        if log_entries:
+            self.logger.log(log_entries)
         return output
 
     def _create_missing_support_issue(self, item: ChartResponse) -> ChartMigrationIssue:
@@ -634,25 +777,51 @@ class CanvasMapper(DataMapper[CanvasSelector, IndustrialCanvasResponse, Industri
         file_node_ids = self._populate_cache(source)
         cognite_file_by_id = {file.as_id(): file for file in self.client.tool.cognite_files.retrieve(file_node_ids)}
         output: list[IndustrialCanvasRequest | None] = []
-        issues: list[CanvasMigrationIssue] = []
+        log_entries: list[MigrationEntryV2] = []
+        canvas_src = "Industrial Canvas"
+        canvas_dest = "Industrial Canvas (data modeling)"
         for item in source:
             mapped_item, issue = self._map_single_item(item, cognite_file_by_id)
-            identifier = item.name
+            identifier = item.external_id
 
             if issue.missing_reference_ids:
-                self.logger.tracker.add_issue(identifier, "Missing reference IDs")
+                log_entries.append(
+                    migration_log_entry(
+                        identifier,
+                        label="Missing reference IDs",
+                        message=f"Missing {len(issue.missing_reference_ids)} reference(s)",
+                        severity=Severity.warning,
+                        source=canvas_src,
+                        destination=canvas_dest,
+                    )
+                )
             if issue.files_missing_content:
-                self.logger.tracker.add_issue(identifier, "File missing content")
-
-            if issue.has_issues:
-                issues.append(issue)
+                log_entries.append(
+                    migration_log_entry(
+                        identifier,
+                        label="File missing content",
+                        message=f"{len(issue.files_missing_content)} file(s) lack uploaded content",
+                        severity=Severity.warning,
+                        source=canvas_src,
+                        destination=canvas_dest,
+                    )
+                )
 
             if mapped_item is None:
-                self.logger.tracker.finalize_item(identifier, "failure")
+                log_entries.append(
+                    migration_log_entry(
+                        identifier,
+                        label="Canvas migration failed",
+                        message="Canvas could not be migrated",
+                        severity=Severity.failure,
+                        source=canvas_src,
+                        destination=canvas_dest,
+                    )
+                )
 
             output.append(mapped_item)
-        if issues:
-            self.logger.log(issues)
+        if log_entries:
+            self.logger.log(log_entries)
         return output
 
     @property
@@ -786,23 +955,39 @@ class ThreeDMapper(DataMapper[ThreeDSelector, ThreeDModelClassicResponse, ThreeD
     def map(self, source: Sequence[ThreeDModelClassicResponse]) -> Sequence[ThreeDMigrationRequest | None]:
         self._populate_cache(source)
         output: list[ThreeDMigrationRequest | None] = []
-        issues: list[ThreeDModelMigrationIssue] = []
+        log_entries: list[MigrationEntryV2] = []
+        src_3d = "3D models"
+        dest_3d = "3D models (data modeling)"
         for item in source:
             mapped_item, issue = self._map_single_item(item)
             identifier = item.name
-
-            if issue.error_message:
-                for error in issue.error_message:
-                    self.logger.tracker.add_issue(identifier, error)
-
-            if issue.has_issues:
-                issues.append(issue)
-
             if mapped_item is None:
-                self.logger.tracker.finalize_item(identifier, "failure")
+                log_entries.append(
+                    migration_log_entry(
+                        identifier,
+                        label="3D model migration failed",
+                        message="; ".join(issue.error_message)
+                        if issue.error_message
+                        else "Model could not be migrated",
+                        severity=Severity.failure,
+                        source=src_3d,
+                        destination=dest_3d,
+                    )
+                )
+            elif issue.error_message:
+                log_entries.append(
+                    migration_log_entry(
+                        identifier,
+                        label="3D model migration issue",
+                        message="; ".join(issue.error_message),
+                        severity=Severity.warning,
+                        source=src_3d,
+                        destination=dest_3d,
+                    )
+                )
             output.append(mapped_item)
-        if issues:
-            self.logger.log(issues)
+        if log_entries:
+            self.logger.log(log_entries)
         return output
 
     def _populate_cache(self, source: Sequence[ThreeDModelClassicResponse]) -> None:
@@ -873,25 +1058,41 @@ class ThreeDMapper(DataMapper[ThreeDSelector, ThreeDModelClassicResponse, ThreeD
 class ThreeDAssetMapper(DataMapper[ThreeDSelector, AssetMappingClassicResponse, AssetMappingDMRequestId]):
     def map(self, source: Sequence[AssetMappingClassicResponse]) -> Sequence[AssetMappingDMRequestId | None]:
         output: list[AssetMappingDMRequestId | None] = []
-        issues: list[ThreeDModelMigrationIssue] = []
+        log_entries: list[MigrationEntryV2] = []
         self._populate_cache(source)
+        src_map = "3D asset mappings"
+        dest_map = "3D asset mappings (data modeling)"
         for item in source:
             mapped_item, issue = self._map_single_item(item)
             identifier = f"AssetMapping_{item.model_id!s}_{item.revision_id!s}_{item.asset_id!s}"
-
-            if issue.error_message:
-                for error in issue.error_message:
-                    self.logger.tracker.add_issue(identifier, error)
-
-            if issue.has_issues:
-                issues.append(issue)
-
             if mapped_item is None:
-                self.logger.tracker.finalize_item(identifier, "failure")
+                log_entries.append(
+                    migration_log_entry(
+                        identifier,
+                        label="Asset mapping migration failed",
+                        message="; ".join(issue.error_message)
+                        if issue.error_message
+                        else "Mapping could not be migrated",
+                        severity=Severity.failure,
+                        source=src_map,
+                        destination=dest_map,
+                    )
+                )
+            elif issue.error_message:
+                log_entries.append(
+                    migration_log_entry(
+                        identifier,
+                        label="Asset mapping migration issue",
+                        message="; ".join(issue.error_message),
+                        severity=Severity.warning,
+                        source=src_map,
+                        destination=dest_map,
+                    )
+                )
 
             output.append(mapped_item)
-        if issues:
-            self.logger.log(issues)
+        if log_entries:
+            self.logger.log(log_entries)
         return output
 
     def _populate_cache(self, source: Sequence[AssetMappingClassicResponse]) -> None:
@@ -1004,7 +1205,6 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, InstanceResponse, InstanceRequ
                 issue_by_node_id[node_id] = InstanceConversionIssue(
                     id=str(node_id), errors=[f"No target space mapping for source space '{node.space}'"]
                 )
-                self.logger.tracker.finalize_item(str(node.as_id()), "failure")
                 continue
             mapped_node, edges, issue = self._map_single_node(
                 node, other_side_by_edge_type_and_direction_by_source[node.as_id()]
@@ -1025,7 +1225,14 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, InstanceResponse, InstanceRequ
         self._check_existence_of_required_targets(mapped_instances, issue_by_node_id)
 
         if issue_by_node_id:
-            self.logger.log(list(issue_by_node_id.values()))
+            self.logger.log(
+                [
+                    instance_conversion_issue_as_migration_entry(
+                        issue, source="FDM instances", destination="CDM instances"
+                    )
+                    for issue in issue_by_node_id.values()
+                ]
+            )
         return mapped_instances
 
     def _get_view_ids(self, source: Sequence[InstanceResponse]) -> set[ViewId]:
@@ -1351,11 +1558,18 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, InstanceResp
             mapped_item, issue = self._create_single_schedule(duplicated_schedules, template_edges, template_id_edges)
             if issue.has_issues:
                 issues.append(issue)
-            if mapped_item is None:
-                self.logger.tracker.finalize_item(str(duplicated_schedules[0].as_id()), "failure")
+            elif mapped_item is None:
+                issues.append(issue)
             output.append(mapped_item)
         if issues:
-            self.logger.log(issues)
+            self.logger.log(
+                [
+                    instance_conversion_issue_as_migration_entry(
+                        issue, source="InField schedules (legacy)", destination="InField schedules (CDM)"
+                    )
+                    for issue in issues
+                ]
+            )
         return output
 
     def _as_schedules_and_edges(
@@ -1389,8 +1603,6 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, InstanceResp
                             ],
                         )
                     )
-
-                    self.logger.tracker.finalize_item(str(item.as_id()), "failure")
             elif isinstance(item, EdgeResponse):
                 if item.type == self.TEMPLATE_EDGE_TYPE:
                     template_edges_by_item_id[item.end_node].append(
@@ -1409,7 +1621,6 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, InstanceResp
                             ],
                         )
                     )
-                    self.logger.tracker.finalize_item(str(item.as_id()), "failure")
         return schedules, template_edges_by_item_id, template_item_edges_by_schedule_id, issues
 
     def _calculate_schedule_hash(self, properties: dict[str, JsonValue | NodeId | list[NodeId]]) -> str:

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -96,7 +96,6 @@ from cognite_toolkit._cdf_tk.commands._migrate.issues import (
     MigrationEntryV2,
     ThreeDModelMigrationIssue,
     instance_conversion_issue_as_migration_entry,
-    migration_log_entry,
 )
 from cognite_toolkit._cdf_tk.constants import MISSING_INSTANCE_SPACE
 from cognite_toolkit._cdf_tk.exceptions import ToolkitMigrationError, ToolkitValueError
@@ -175,8 +174,8 @@ class AssetCentricMapper(
         entries: list[MigrationEntryV2] = []
         if conversion_issue.missing_instance_space:
             entries.append(
-                migration_log_entry(
-                    item_id,
+                MigrationEntryV2(
+                    id=item_id,
                     label="Missing instance space",
                     message=str(conversion_issue.missing_instance_space),
                     severity=Severity.warning,
@@ -186,8 +185,8 @@ class AssetCentricMapper(
             )
         if conversion_issue.no_mappable_properties:
             entries.append(
-                migration_log_entry(
-                    item_id,
+                MigrationEntryV2(
+                    id=item_id,
                     label="No mappable properties",
                     message="No properties could be mapped to target",
                     severity=Severity.warning,
@@ -197,8 +196,8 @@ class AssetCentricMapper(
             )
         if conversion_issue.failed_conversions:
             entries.append(
-                migration_log_entry(
-                    item_id,
+                MigrationEntryV2(
+                    id=item_id,
                     label="Failed conversions",
                     message=f"{len(conversion_issue.failed_conversions)} property conversion(s) failed",
                     severity=Severity.warning,
@@ -208,8 +207,8 @@ class AssetCentricMapper(
             )
         if conversion_issue.invalid_instance_property_types:
             entries.append(
-                migration_log_entry(
-                    item_id,
+                MigrationEntryV2(
+                    id=item_id,
                     label="Invalid instance property types",
                     message=f"{len(conversion_issue.invalid_instance_property_types)} invalid type(s)",
                     severity=Severity.warning,
@@ -219,8 +218,8 @@ class AssetCentricMapper(
             )
         if conversion_issue.missing_asset_centric_properties:
             entries.append(
-                migration_log_entry(
-                    item_id,
+                MigrationEntryV2(
+                    id=item_id,
                     label="Missing asset-centric properties",
                     message=f"Missing: {humanize_collection(conversion_issue.missing_asset_centric_properties)}",
                     severity=Severity.warning,
@@ -230,8 +229,8 @@ class AssetCentricMapper(
             )
         if conversion_issue.missing_instance_properties:
             entries.append(
-                migration_log_entry(
-                    item_id,
+                MigrationEntryV2(
+                    id=item_id,
                     label="Missing data modeling properties",
                     message=f"Missing: {humanize_collection(conversion_issue.missing_instance_properties)}",
                     severity=Severity.warning,
@@ -241,8 +240,8 @@ class AssetCentricMapper(
             )
         if conversion_issue.ignored_asset_centric_properties:
             entries.append(
-                migration_log_entry(
-                    item_id,
+                MigrationEntryV2(
+                    id=item_id,
                     label="Ignored asset-centric properties",
                     message="Some source properties were ignored",
                     severity=Severity.warning,
@@ -260,8 +259,8 @@ class AssetCentricMapper(
                     "to create a record"
                 )
             entries.append(
-                migration_log_entry(
-                    item_id,
+                MigrationEntryV2(
+                    id=item_id,
                     label="Conversion failed",
                     message=msg,
                     severity=Severity.failure,
@@ -450,8 +449,8 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
             identifier = item.external_id
             if any(job.user_identifier != self._me for job in item.monitoring_jobs or []):
                 log_entries.append(
-                    migration_log_entry(
-                        identifier,
+                    MigrationEntryV2(
+                        id=identifier,
                         label="Monitoring job owned by different user",
                         severity=Severity.failure,
                         source=chart_src,
@@ -468,8 +467,8 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
 
             if issue.missing_timeseries_ids:
                 log_entries.append(
-                    migration_log_entry(
-                        identifier,
+                    MigrationEntryV2(
+                        id=identifier,
                         label="Missing timeseries IDs",
                         message="One or more timeseries are missing internal IDs",
                         severity=Severity.warning,
@@ -479,8 +478,8 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
                 )
             if issue.missing_timeseries_external_ids:
                 log_entries.append(
-                    migration_log_entry(
-                        identifier,
+                    MigrationEntryV2(
+                        id=identifier,
                         label="Missing timeseries external IDs",
                         message="One or more timeseries are missing external IDs",
                         severity=Severity.warning,
@@ -490,8 +489,8 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
                 )
             if issue.missing_timeseries_identifier:
                 log_entries.append(
-                    migration_log_entry(
-                        identifier,
+                    MigrationEntryV2(
+                        id=identifier,
                         label="Missing timeseries identifier",
                         message="One or more timeseries elements lack identifiers",
                         severity=Severity.warning,
@@ -502,8 +501,8 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
 
             if issue.has_issues and mapped_item is None:
                 log_entries.append(
-                    migration_log_entry(
-                        identifier,
+                    MigrationEntryV2(
+                        id=identifier,
                         label="Chart migration failed",
                         message="; ".join(issue.errors) if issue.errors else "Chart could not be migrated",
                         severity=Severity.failure,
@@ -513,8 +512,8 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
                 )
             elif mapped_item is None:
                 log_entries.append(
-                    migration_log_entry(
-                        identifier,
+                    MigrationEntryV2(
+                        id=identifier,
                         label="Chart migration failed",
                         message="Chart could not be migrated",
                         severity=Severity.failure,
@@ -909,8 +908,8 @@ class CanvasMapper(DataMapper[CanvasSelector, IndustrialCanvasResponse, Industri
 
             if issue.missing_reference_ids:
                 log_entries.append(
-                    migration_log_entry(
-                        identifier,
+                    MigrationEntryV2(
+                        id=identifier,
                         label="Missing reference IDs",
                         message=f"Missing {len(issue.missing_reference_ids)} reference(s)",
                         severity=Severity.warning,
@@ -920,8 +919,8 @@ class CanvasMapper(DataMapper[CanvasSelector, IndustrialCanvasResponse, Industri
                 )
             if issue.files_missing_content:
                 log_entries.append(
-                    migration_log_entry(
-                        identifier,
+                    MigrationEntryV2(
+                        id=identifier,
                         label="File missing content",
                         message=f"{len(issue.files_missing_content)} file(s) lack uploaded content",
                         severity=Severity.warning,
@@ -932,8 +931,8 @@ class CanvasMapper(DataMapper[CanvasSelector, IndustrialCanvasResponse, Industri
 
             if mapped_item is None:
                 log_entries.append(
-                    migration_log_entry(
-                        identifier,
+                    MigrationEntryV2(
+                        id=identifier,
                         label="Canvas migration failed",
                         message="Canvas could not be migrated",
                         severity=Severity.failure,
@@ -1086,8 +1085,8 @@ class ThreeDMapper(DataMapper[ThreeDSelector, ThreeDModelClassicResponse, ThreeD
             identifier = item.name
             if mapped_item is None:
                 log_entries.append(
-                    migration_log_entry(
-                        identifier,
+                    MigrationEntryV2(
+                        id=identifier,
                         label="3D model migration failed",
                         message="; ".join(issue.error_message)
                         if issue.error_message
@@ -1099,8 +1098,8 @@ class ThreeDMapper(DataMapper[ThreeDSelector, ThreeDModelClassicResponse, ThreeD
                 )
             elif issue.error_message:
                 log_entries.append(
-                    migration_log_entry(
-                        identifier,
+                    MigrationEntryV2(
+                        id=identifier,
                         label="3D model migration issue",
                         message="; ".join(issue.error_message),
                         severity=Severity.warning,
@@ -1190,8 +1189,8 @@ class ThreeDAssetMapper(DataMapper[ThreeDSelector, AssetMappingClassicResponse, 
             identifier = f"AssetMapping_{item.model_id!s}_{item.revision_id!s}_{item.asset_id!s}"
             if mapped_item is None:
                 log_entries.append(
-                    migration_log_entry(
-                        identifier,
+                    MigrationEntryV2(
+                        id=identifier,
                         label="Asset mapping migration failed",
                         message="; ".join(issue.error_message)
                         if issue.error_message
@@ -1203,8 +1202,8 @@ class ThreeDAssetMapper(DataMapper[ThreeDSelector, AssetMappingClassicResponse, 
                 )
             elif issue.error_message:
                 log_entries.append(
-                    migration_log_entry(
-                        identifier,
+                    MigrationEntryV2(
+                        id=identifier,
                         label="Asset mapping migration issue",
                         message="; ".join(issue.error_message),
                         severity=Severity.warning,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
@@ -214,17 +214,6 @@ class WriteIssue(MigrationIssue):
     message: str | None = None
 
 
-def write_issue_as_migration_entry(issue: WriteIssue, *, source: str, destination: str) -> MigrationEntryV2:
-    return MigrationEntryV2(
-        id=issue.id,
-        label="Write failed",
-        message=f"HTTP {issue.status_code}: {issue.message or ''}",
-        severity=Severity.failure,
-        source=source,
-        destination=destination,
-    )
-
-
 class InstanceConversionIssue(MigrationIssue):
     """Represents an instance conversion issue encountered during migration."""
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
@@ -31,29 +31,6 @@ class MigrationEntryV2(LogEntryV2):
     )
 
 
-def migration_log_entry(
-    item_id: str,
-    *,
-    label: str,
-    message: str,
-    severity: Severity,
-    source: str,
-    destination: str,
-    attributes: set[str] | None = None,
-    attribute_display_name: str | None = None,
-) -> MigrationEntryV2:
-    return MigrationEntryV2(
-        id=item_id,
-        label=label,
-        severity=severity,
-        message=message,
-        source=source,
-        destination=destination,
-        attributes=attributes,
-        attribute_display_name=attribute_display_name,
-    )
-
-
 class ThreeDModelMigrationIssue(MigrationIssue):
     """Represents a 3D model migration issue encountered during migration.
 
@@ -238,8 +215,8 @@ class WriteIssue(MigrationIssue):
 
 
 def write_issue_as_migration_entry(issue: WriteIssue, *, source: str, destination: str) -> MigrationEntryV2:
-    return migration_log_entry(
-        issue.id,
+    return MigrationEntryV2(
+        id=issue.id,
         label="Write failed",
         message=f"HTTP {issue.status_code}: {issue.message or ''}",
         severity=Severity.failure,
@@ -263,8 +240,8 @@ class InstanceConversionIssue(MigrationIssue):
 def instance_conversion_issue_as_migration_entry(
     issue: InstanceConversionIssue, *, source: str, destination: str
 ) -> MigrationEntryV2:
-    return migration_log_entry(
-        issue.id,
+    return MigrationEntryV2(
+        id=issue.id,
         label="Instance conversion",
         message="; ".join(issue.errors) if issue.errors else "Conversion issue",
         severity=Severity.failure,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
@@ -201,19 +201,6 @@ class ConversionIssue(MigrationIssue):
         }
 
 
-class WriteIssue(MigrationIssue):
-    """Represents a write issue encountered during migration.
-
-    Attributes:
-        status_code (int): The HTTP status code returned during the write operation.
-        message (str | None): An optional message providing additional details about the write issue.
-    """
-
-    type: Literal["write"] = "write"
-    status_code: int
-    message: str | None = None
-
-
 class InstanceConversionIssue(MigrationIssue):
     """Represents an instance conversion issue encountered during migration."""
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
@@ -104,6 +104,10 @@ class FailedConversion(BaseModel, alias_generator=to_camel, extra="ignore", popu
     value: str | int | float | bool | None | list | dict
     error: str
 
+    @property
+    def display_name(self) -> str:
+        return f"Failed conversion for property '{self.property_id}' with value '{self.value}': {self.error}"
+
 
 class InvalidPropertyDataType(BaseModel, alias_generator=to_camel, extra="ignore", populate_by_name=True):
     """Represents a property with an invalid type during migration.
@@ -116,6 +120,10 @@ class InvalidPropertyDataType(BaseModel, alias_generator=to_camel, extra="ignore
 
     property_id: str
     expected_type: str
+
+    @property
+    def display_name(self) -> str:
+        return f"Invalid property type for property '{self.property_id}'. Expected {self.expected_type}"
 
 
 class ConversionIssue(MigrationIssue):

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
@@ -180,7 +180,7 @@ def instance_conversion_issue_as_migration_entry(
         id=issue.id,
         label="Instance conversion",
         message="; ".join(issue.errors) if issue.errors else "Conversion issue",
-        severity=Severity.failure,
+        severity=Severity.warning,
         source=source,
         destination=destination,
     )

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
@@ -6,7 +6,7 @@ from pydantic.alias_generators import to_camel
 from cognite_toolkit._cdf_tk.client.identifiers import NodeUntypedId
 from cognite_toolkit._cdf_tk.client.resource_classes.migration import AssetCentricId
 from cognite_toolkit._cdf_tk.client.resource_classes.records import RecordId
-from cognite_toolkit._cdf_tk.storageio.logger import LogEntry
+from cognite_toolkit._cdf_tk.storageio.logger import LogEntry, LogEntryV2
 
 
 class MigrationIssue(LogEntry):
@@ -22,6 +22,13 @@ class MigrationIssue(LogEntry):
     def dump(self) -> dict[str, Any]:
         """Serialize the MigrationIssue to a dictionary."""
         return self.model_dump(by_alias=True)
+
+
+class MigrationEntryV2(LogEntryV2):
+    source: str = Field(description="The source for the item. For example, assets.")
+    destination: str = Field(
+        description="The destination for the item. Typically a given View. For example, cdf_cdm:CogniteAsset(version=v1)."
+    )
 
 
 class ThreeDModelMigrationIssue(MigrationIssue):

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
@@ -91,46 +91,6 @@ class CanvasMigrationIssue(MigrationIssue):
         return bool(self.missing_reference_ids or self.files_missing_content)
 
 
-class ReadIssue(MigrationIssue):
-    """Represents a read issue encountered during migration."""
-
-    ...
-
-
-class ReadFileIssue(ReadIssue):
-    """Represents a read issue encountered during migration of a file.
-
-    Attributes:
-        row_no (int): The row number in the CSV file where the issue occurred.
-        error (str | None): An optional error message providing additional details about the read issue.
-    """
-
-    type: Literal["fileRead"] = "fileRead"
-
-    row_no: int
-    error: str | None = None
-
-
-class ReadAPIIssue(ReadIssue):
-    """Represents a read issue encountered during migration from the API.
-
-    Attributes:
-        asset_centric_id (AssetCentricId): The identifier of the asset-centric resource that could not be read.
-        error (str | None): An optional error message providing additional details about the read issue.
-    """
-
-    type: Literal["apiRead"] = "apiRead"
-    asset_centric_id: AssetCentricId
-    error: str | None = None
-
-    @field_serializer("asset_centric_id")
-    def serialize_asset_centric_id(self, asset_centric_id: AssetCentricId) -> dict[str, Any]:
-        return {
-            "resourceType": asset_centric_id.resource_type,
-            "id": asset_centric_id.id_,
-        }
-
-
 class FailedConversion(BaseModel, alias_generator=to_camel, extra="ignore", populate_by_name=True):
     """Represents a property that failed to convert during migration.
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/issues.py
@@ -6,7 +6,7 @@ from pydantic.alias_generators import to_camel
 from cognite_toolkit._cdf_tk.client.identifiers import NodeUntypedId
 from cognite_toolkit._cdf_tk.client.resource_classes.migration import AssetCentricId
 from cognite_toolkit._cdf_tk.client.resource_classes.records import RecordId
-from cognite_toolkit._cdf_tk.storageio.logger import LogEntry, LogEntryV2
+from cognite_toolkit._cdf_tk.storageio.logger import LogEntry, LogEntryV2, Severity
 
 
 class MigrationIssue(LogEntry):
@@ -28,6 +28,29 @@ class MigrationEntryV2(LogEntryV2):
     source: str = Field(description="The source for the item. For example, assets.")
     destination: str = Field(
         description="The destination for the item. Typically a given View. For example, cdf_cdm:CogniteAsset(version=v1)."
+    )
+
+
+def migration_log_entry(
+    item_id: str,
+    *,
+    label: str,
+    message: str,
+    severity: Severity,
+    source: str,
+    destination: str,
+    attributes: set[str] | None = None,
+    attribute_display_name: str | None = None,
+) -> MigrationEntryV2:
+    return MigrationEntryV2(
+        id=item_id,
+        label=label,
+        severity=severity,
+        message=message,
+        source=source,
+        destination=destination,
+        attributes=attributes,
+        attribute_display_name=attribute_display_name,
     )
 
 
@@ -210,6 +233,17 @@ class WriteIssue(MigrationIssue):
     message: str | None = None
 
 
+def write_issue_as_migration_entry(issue: WriteIssue, *, source: str, destination: str) -> MigrationEntryV2:
+    return migration_log_entry(
+        issue.id,
+        label="Write failed",
+        message=f"HTTP {issue.status_code}: {issue.message or ''}",
+        severity=Severity.failure,
+        source=source,
+        destination=destination,
+    )
+
+
 class InstanceConversionIssue(MigrationIssue):
     """Represents an instance conversion issue encountered during migration."""
 
@@ -220,3 +254,16 @@ class InstanceConversionIssue(MigrationIssue):
     def has_issues(self) -> bool:
         """Check if there are any issues recorded in this InstanceConversionIssue."""
         return bool(self.errors)
+
+
+def instance_conversion_issue_as_migration_entry(
+    issue: InstanceConversionIssue, *, source: str, destination: str
+) -> MigrationEntryV2:
+    return migration_log_entry(
+        issue.id,
+        label="Instance conversion",
+        message="; ".join(issue.errors) if issue.errors else "Conversion issue",
+        severity=Severity.failure,
+        source=source,
+        destination=destination,
+    )

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
@@ -61,7 +61,7 @@ from .data_classes import (
 )
 from .data_model import INSTANCE_SOURCE_VIEW_ID
 from .default_mappings import ASSET_ANNOTATIONS_ID, FILE_ANNOTATIONS_ID
-from .issues import MigrationEntryV2, migration_log_entry
+from .issues import MigrationEntryV2
 from .selectors import AssetCentricMigrationSelector, MigrateDataSetSelector, MigrationCSVFileSelector
 
 
@@ -236,8 +236,8 @@ class AssetCentricMigrationIO(
         for instance_id, data in data_by_instance_id.items():
             if instance_id in existing_ids:
                 skipped_entries.append(
-                    migration_log_entry(
-                        data.tracking_id,
+                    MigrationEntryV2(
+                        id=data.tracking_id,
                         label="Skipped",
                         message="Instance already exists in CDF.",
                         severity=Severity.skipped,
@@ -283,8 +283,8 @@ class AssetCentricMigrationIO(
                         res.error_message if isinstance(res, ItemsFailedResponse | ItemsFailedRequest) else "<unknown>"
                     )
                     failure_entries.append(
-                        migration_log_entry(
-                            id_,
+                        MigrationEntryV2(
+                            id=id_,
                             label="Pending instance ID link failed",
                             message=msg,
                             severity=Severity.failure,
@@ -360,8 +360,8 @@ class RecordsMigrationIO(AssetCentricMigrationIO):
             pair = (upload_item.item.space, upload_item.item.external_id)
             if pair in existing_pairs:
                 skipped_records.append(
-                    migration_log_entry(
-                        upload_item.tracking_id,
+                    MigrationEntryV2(
+                        id=upload_item.tracking_id,
                         label="Skipped",
                         message="Record already exists in the stream.",
                         severity=Severity.skipped,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
@@ -37,6 +37,7 @@ from cognite_toolkit._cdf_tk.storageio import (
     UploadableStorageIO,
 )
 from cognite_toolkit._cdf_tk.storageio._base import Bookmark, DataItem, Page
+from cognite_toolkit._cdf_tk.storageio.logger import Severity
 from cognite_toolkit._cdf_tk.storageio.progress import CursorBookmark, FileBookmark, NoBookmark
 from cognite_toolkit._cdf_tk.storageio.selectors import (
     ThreeDModelFilteredSelector,
@@ -60,7 +61,7 @@ from .data_classes import (
 )
 from .data_model import INSTANCE_SOURCE_VIEW_ID
 from .default_mappings import ASSET_ANNOTATIONS_ID, FILE_ANNOTATIONS_ID
-from .issues import WriteIssue
+from .issues import MigrationEntryV2, migration_log_entry
 from .selectors import AssetCentricMigrationSelector, MigrateDataSetSelector, MigrationCSVFileSelector
 
 
@@ -114,13 +115,12 @@ class AssetCentricMigrationIO(
                 f"The following instance spaces do not exist in CDF: {humanize_collection(missing)}. Please create these spaces before running the migration."
             )
 
-        yield from (
-            Page(
+        for items in iterator:
+            page = Page(
                 worker_id="main",
                 items=[DataItem(tracking_id=str(item.mapping.as_asset_centric_id()), item=item) for item in items],
             )
-            for items in iterator
-        )
+            yield self.emit_registered_page(page)
 
     def _stream_from_csv(
         self,
@@ -232,11 +232,23 @@ class AssetCentricMigrationIO(
         data_by_instance_id = {item.item.as_id(): item for item in data_chunk.items}
         existing_ids = {item.as_id() for item in self.client.tool.instances.retrieve(list(data_by_instance_id.keys()))}
         to_create: list[DataItem[InstanceRequest]] = []
+        skipped_entries: list[MigrationEntryV2] = []
         for instance_id, data in data_by_instance_id.items():
             if instance_id in existing_ids:
-                self.logger.tracker.finalize_item(data.tracking_id, "skipped")
+                skipped_entries.append(
+                    migration_log_entry(
+                        data.tracking_id,
+                        label="Skipped",
+                        message="Instance already exists in CDF.",
+                        severity=Severity.skipped,
+                        source=self.KIND,
+                        destination="instances",
+                    )
+                )
             else:
                 to_create.append(data)
+        if skipped_entries:
+            self.logger.log(skipped_entries)
 
         return data_chunk.create_from(to_create)
 
@@ -249,7 +261,7 @@ class AssetCentricMigrationIO(
         """Links asset-centric resources to their (uncreated) instances using the pending-instance-ids endpoint."""
         config = http_client.config
         successful_linked: set[str] = set()
-        failure_issues: list[WriteIssue] = []
+        failure_entries: list[MigrationEntryV2] = []
         for batch in chunker_sequence(data_chunk.items, self.CHUNK_SIZE):
             batch_results = http_client.request_items_retries(
                 message=ItemsRequest(
@@ -266,19 +278,22 @@ class AssetCentricMigrationIO(
                 if isinstance(res, ItemsSuccessResponse):
                     successful_linked.update(res.ids)
                     continue
-                for id in res.ids:
-                    self.logger.tracker.finalize_item(id, "failure")
-                    failure_issues.append(
-                        WriteIssue(
-                            id=id,
-                            status_code=res.status_code if isinstance(res, ItemsFailedResponse) else -1,
-                            message=res.error_message
-                            if isinstance(res, ItemsFailedResponse | ItemsFailedRequest)
-                            else "<unknown>",
+                for id_ in res.ids:
+                    msg = (
+                        res.error_message if isinstance(res, ItemsFailedResponse | ItemsFailedRequest) else "<unknown>"
+                    )
+                    failure_entries.append(
+                        migration_log_entry(
+                            id_,
+                            label="Pending instance ID link failed",
+                            message=msg,
+                            severity=Severity.failure,
+                            source="AssetCentric linking",
+                            destination=self.KIND,
                         )
                     )
-        if failure_issues:
-            self.logger.log(failure_issues)
+        if failure_entries:
+            self.logger.log(failure_entries)
         to_upload = [item for item in data_chunk.items if item.tracking_id in successful_linked]
         return data_chunk.create_from(to_upload)
 
@@ -319,7 +334,7 @@ class RecordsMigrationIO(AssetCentricMigrationIO):
     def _remove_existing(self, data_chunk: Page[RecordRequest]) -> Page[RecordRequest]:  # type: ignore[override]
         """Return a page with items whose (space, externalId) are not already in the stream.
 
-        Marks skipped items on the logger tracker.
+        Logs skipped items on the migration logger.
         """
         if not data_chunk.items:
             return data_chunk
@@ -340,12 +355,25 @@ class RecordsMigrationIO(AssetCentricMigrationIO):
                 existing_pairs.add((record.space, record.external_id))
 
         to_upload: list[DataItem[RecordRequest]] = []
+        skipped_records: list[MigrationEntryV2] = []
         for upload_item in data_chunk.items:
             pair = (upload_item.item.space, upload_item.item.external_id)
             if pair in existing_pairs:
-                self.logger.tracker.finalize_item(upload_item.tracking_id, "skipped")
+                skipped_records.append(
+                    migration_log_entry(
+                        upload_item.tracking_id,
+                        label="Skipped",
+                        message="Record already exists in the stream.",
+                        severity=Severity.skipped,
+                        source=self.KIND,
+                        destination="records",
+                    )
+                )
             else:
                 to_upload.append(upload_item)
+
+        if skipped_records:
+            self.logger.log(skipped_records)
 
         return data_chunk.create_from(to_upload)
 
@@ -425,13 +453,12 @@ class AnnotationMigrationIO(
             iterator = self._stream_from_csv(selector, limit, file_location)
         else:
             raise ToolkitNotImplementedError(f"Selector {type(selector)} is not supported for stream_data")
-        yield from (
-            Page(
+        for items in iterator:
+            page = Page(
                 worker_id="main",
-                items=[DataItem(tracking_id=f"Annotation_{item.mapping.id}", item=item) for item in items],
+                items=[DataItem(tracking_id=str(item.mapping.as_asset_centric_id()), item=item) for item in items],
             )
-            for items in iterator
-        )
+            yield self.emit_registered_page(page)
 
     def _stream_from_dataset(
         self, selector: MigrateDataSetSelector, limit: int | None = None
@@ -577,10 +604,12 @@ class ThreeDMigrationIO(UploadableStorageIO[ThreeDSelector, ThreeDModelClassicRe
             total += len(items)
             if items:
                 bm: Bookmark = CursorBookmark(cursor=response.next_cursor) if response.next_cursor else NoBookmark()
-                yield Page(
-                    worker_id="main",
-                    items=[DataItem(tracking_id=item.name, item=item) for item in items],
-                    bookmark=bm,
+                yield self.emit_registered_page(
+                    Page(
+                        worker_id="main",
+                        items=[DataItem(tracking_id=item.name, item=item) for item in items],
+                        bookmark=bm,
+                    )
                 )
             if response.next_cursor is None:
                 break
@@ -686,16 +715,18 @@ class ThreeDAssetMappingMigrationIO(
                         bm: Bookmark = (
                             CursorBookmark(cursor=response.next_cursor) if response.next_cursor else NoBookmark()
                         )
-                        yield Page(
-                            worker_id="main",
-                            items=[
-                                DataItem(
-                                    tracking_id=f"AssetMapping_{item.model_id!s}_{item.revision_id!s}_{item.asset_id!s}",
-                                    item=item,
-                                )
-                                for item in items
-                            ],
-                            bookmark=bm,
+                        yield self.emit_registered_page(
+                            Page(
+                                worker_id="main",
+                                items=[
+                                    DataItem(
+                                        tracking_id=f"AssetMapping_{item.model_id!s}_{item.revision_id!s}_{item.asset_id!s}",
+                                        item=item,
+                                    )
+                                    for item in items
+                                ],
+                                bookmark=bm,
+                            )
                         )
                     if response.next_cursor is None:
                         break

--- a/cognite_toolkit/_cdf_tk/storageio/_annotations.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_annotations.py
@@ -51,7 +51,7 @@ class AnnotationIO(StorageIO[AssetCentricSelector, AnnotationResponse]):
                             )
                             for item in chunk
                         ]
-                        yield Page(worker_id="main", items=items, bookmark=NoBookmark())
+                        yield self.emit_registered_page(Page(worker_id="main", items=items, bookmark=NoBookmark()))
                         total += len(chunk)
                         if limit is not None and total >= limit:
                             return

--- a/cognite_toolkit/_cdf_tk/storageio/_applications.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_applications.py
@@ -38,7 +38,7 @@ from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 
 from ._base import Bookmark, DataItem, Page, UploadableStorageIO
-from .logger import LogIssue
+from .logger import LogEntryV2, Severity
 from .progress import NoBookmark
 from .selectors import (
     AllChartsSelector,
@@ -120,10 +120,12 @@ class ChartIO(UploadableStorageIO[ChartSelector, ChartResponse, ChartRequest]):
         for chunk in chunker_sequence(selected_charts, self.CHUNK_SIZE):
             if not self._skip_backend_services:
                 self._download_backend_services(chunk)
-            yield Page(
-                worker_id="main",
-                items=[DataItem(tracking_id=item.external_id, item=item) for item in chunk],
-                bookmark=NoBookmark(),
+            yield self.emit_registered_page(
+                Page(
+                    worker_id="main",
+                    items=[DataItem(tracking_id=item.external_id, item=item) for item in chunk],
+                    bookmark=NoBookmark(),
+                )
             )
 
     def _download_backend_services(self, chunk: list[ChartResponse]) -> None:
@@ -260,7 +262,16 @@ class ChartIO(UploadableStorageIO[ChartSelector, ChartResponse, ChartRequest]):
             elif item.item.external_id not in self.existing_charts:
                 to_create.append(item)
             else:
-                self.logger.tracker.finalize_item(item.tracking_id, "skipped")
+                self.logger.log(
+                    [
+                        LogEntryV2(
+                            id=item.tracking_id,
+                            label="Skipped",
+                            message="Chart already exists and skip-existing is enabled.",
+                            severity=Severity.skipped,
+                        )
+                    ]
+                )
 
         if not self._skip_backend_services:
             failed_charts = self._upload_backend_services(to_create + to_update)
@@ -304,17 +315,19 @@ class ChartIO(UploadableStorageIO[ChartSelector, ChartResponse, ChartRequest]):
         items: list[DataItem[ChartRequest]],
         get_requests: Callable[[ChartRequest], Sequence[TChartBackendRequest] | None],
         duplicate_label: str,
-    ) -> tuple[dict[ExternalId, tuple[TChartBackendRequest, str]], list[LogIssue]]:
+    ) -> tuple[dict[ExternalId, tuple[TChartBackendRequest, str]], list[LogEntryV2]]:
         by_external_id: dict[ExternalId, tuple[TChartBackendRequest, str]] = {}
-        log_entries: list[LogIssue] = []
+        log_entries: list[LogEntryV2] = []
         for item in items:
             for request in get_requests(item.item) or []:
                 ext_id = request.as_id()
                 if ext_id in by_external_id:
                     log_entries.append(
-                        LogIssue(
+                        LogEntryV2(
                             id=item.tracking_id,
+                            label=f"Duplicated {duplicate_label}",
                             message=f"Duplicated {duplicate_label} ID {ext_id} in chart {item.item.external_id}",
+                            severity=Severity.warning,
                         )
                     )
                 else:
@@ -328,8 +341,8 @@ class ChartIO(UploadableStorageIO[ChartSelector, ChartResponse, ChartRequest]):
         update: Callable[[Sequence[TChartBackendRequest]], list[TChartBackendResponse]],
         create: Callable[[Sequence[TChartBackendRequest]], list[TChartBackendResponse]],
         resource_kind: str,
-    ) -> tuple[list[LogIssue], set[ExternalId], dict[ExternalId, TChartBackendResponse]]:
-        log_entries: list[LogIssue] = []
+    ) -> tuple[list[LogEntryV2], set[ExternalId], dict[ExternalId, TChartBackendResponse]]:
+        log_entries: list[LogEntryV2] = []
         failed: set[ExternalId] = set()
         succeeded: dict[ExternalId, TChartBackendResponse] = {}
         for ext_id, (request, tracking_id) in unique_by_id.items():
@@ -338,14 +351,21 @@ class ChartIO(UploadableStorageIO[ChartSelector, ChartResponse, ChartRequest]):
                     updated = update([request])[0]
                 except ToolkitAPIError as e:
                     log_entries.append(
-                        LogIssue(id=tracking_id, message=f"Failed to update {resource_kind} {ext_id}: {e}")
+                        LogEntryV2(
+                            id=tracking_id,
+                            label=f"Update {resource_kind}",
+                            message=f"Failed to update {resource_kind} {ext_id}: {e}",
+                            severity=Severity.failure,
+                        )
                     )
                     failed.add(ext_id)
                 except IndexError:
                     log_entries.append(
-                        LogIssue(
+                        LogEntryV2(
                             id=tracking_id,
+                            label=f"Update {resource_kind}",
                             message=f"Failed to update {resource_kind} {ext_id}. No response returned.",
+                            severity=Severity.failure,
                         )
                     )
                     failed.add(ext_id)
@@ -360,10 +380,12 @@ class ChartIO(UploadableStorageIO[ChartSelector, ChartResponse, ChartRequest]):
                         request.nonce = self.client.iam.sessions.create(session_type="TOKEN_EXCHANGE").nonce
                     else:
                         log_entries.append(
-                            LogIssue(
+                            LogEntryV2(
                                 id=tracking_id,
+                                label=f"Create {resource_kind}",
                                 message=f"Failed to create {resource_kind} {ext_id}: missing nonce. "
                                 "Either run skip-strict-mode or use device code credentials.",
+                                severity=Severity.failure,
                             )
                         )
                         failed.add(ext_id)
@@ -372,14 +394,21 @@ class ChartIO(UploadableStorageIO[ChartSelector, ChartResponse, ChartRequest]):
                     created = create([request])[0]
                 except ToolkitAPIError as e:
                     log_entries.append(
-                        LogIssue(id=tracking_id, message=f"Failed to create {resource_kind} {ext_id}: {e}")
+                        LogEntryV2(
+                            id=tracking_id,
+                            label=f"Create {resource_kind}",
+                            message=f"Failed to create {resource_kind} {ext_id}: {e}",
+                            severity=Severity.failure,
+                        )
                     )
                     failed.add(ext_id)
                 except IndexError:
                     log_entries.append(
-                        LogIssue(
+                        LogEntryV2(
                             id=tracking_id,
+                            label=f"Create {resource_kind}",
                             message=f"Failed to create {resource_kind}. No response returned.",
+                            severity=Severity.failure,
                         )
                     )
                     failed.add(ext_id)
@@ -389,7 +418,7 @@ class ChartIO(UploadableStorageIO[ChartSelector, ChartResponse, ChartRequest]):
 
     def _upload_backend_services(self, items: list[DataItem[ChartRequest]]) -> set[str]:
         """Uploads the backend services monitoring jobs and scheduled calculations for each Chart. Returns a set of external IDs of Charts that failed to upload backend services."""
-        log_entries: list[LogIssue] = []
+        log_entries: list[LogEntryV2] = []
 
         monitoring_job_by_id, monitoring_dup_logs = self._collect_unique_backend_requests(
             items, lambda chart: chart.monitoring_jobs, "monitoring job"
@@ -445,11 +474,21 @@ class ChartIO(UploadableStorageIO[ChartSelector, ChartResponse, ChartRequest]):
             )
             if job_failed or calculation_failed:
                 failed_charts.add(chart.external_id)
+                parts: list[str] = []
                 if job_failed:
-                    self.logger.tracker.add_issue(item.tracking_id, "Failed upserting monitoring jobs")
+                    parts.append("Failed upserting monitoring jobs")
                 if calculation_failed:
-                    self.logger.tracker.add_issue(item.tracking_id, "Failed upserting scheduled calculations")
-                self.logger.tracker.finalize_item(item.tracking_id, "failure")
+                    parts.append("Failed upserting scheduled calculations")
+                self.logger.log(
+                    [
+                        LogEntryV2(
+                            id=item.tracking_id,
+                            label="Chart backend upload failed",
+                            message="; ".join(parts),
+                            severity=Severity.failure,
+                        )
+                    ]
+                )
                 continue
 
             if chart.data.monitoring_jobs:
@@ -513,24 +552,30 @@ class CanvasIO(UploadableStorageIO[CanvasSelector, IndustrialCanvasResponse, Ind
         for chunk in chunker_sequence(canvas_ids, self.CHUNK_SIZE):
             items = self.client.canvas.retrieve(NodeId.from_str_ids(chunk, space=CANVAS_INSTANCE_SPACE))
             self._log_retrieve_issues(chunk, items)
-            yield Page(
-                worker_id="main",
-                items=[DataItem(tracking_id=item.external_id, item=item) for item in items],
-                bookmark=NoBookmark(),
+            yield self.emit_registered_page(
+                Page(
+                    worker_id="main",
+                    items=[DataItem(tracking_id=item.external_id, item=item) for item in items],
+                    bookmark=NoBookmark(),
+                )
             )
 
     def _log_retrieve_issues(self, chunk: tuple[str, ...], items: list[IndustrialCanvasResponse]) -> None:
         found = {item.external_id for item in items}
         not_found = sorted(set(chunk) - found)
         if not_found:
+            self.logger.register(not_found)
             self.logger.log(
                 [
-                    LogIssue(id=not_found_item, message=f"Did not find {not_found_item} in CDF")
+                    LogEntryV2(
+                        id=not_found_item,
+                        label="Canvas not found",
+                        message=f"Did not find {not_found_item} in CDF",
+                        severity=Severity.failure,
+                    )
                     for not_found_item in not_found
                 ]
             )
-            for not_found_item in not_found:
-                self.logger.tracker.finalize_item(str(not_found_item), "failure")
 
     def count(self, selector: CanvasSelector) -> int | None:
         if not isinstance(selector, CanvasExternalIdSelector):

--- a/cognite_toolkit/_cdf_tk/storageio/_applications.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_applications.py
@@ -266,7 +266,7 @@ class ChartIO(UploadableStorageIO[ChartSelector, ChartResponse, ChartRequest]):
                     [
                         LogEntryV2(
                             id=item.tracking_id,
-                            label="Skipped",
+                            label="Chart existing and skip-existing enabled",
                             message="Chart already exists and skip-existing is enabled.",
                             severity=Severity.skipped,
                         )
@@ -353,7 +353,7 @@ class ChartIO(UploadableStorageIO[ChartSelector, ChartResponse, ChartRequest]):
                     log_entries.append(
                         LogEntryV2(
                             id=tracking_id,
-                            label=f"Update {resource_kind}",
+                            label=f"Failed update {resource_kind}. Code {e.code}",
                             message=f"Failed to update {resource_kind} {ext_id}: {e}",
                             severity=Severity.failure,
                         )
@@ -363,7 +363,7 @@ class ChartIO(UploadableStorageIO[ChartSelector, ChartResponse, ChartRequest]):
                     log_entries.append(
                         LogEntryV2(
                             id=tracking_id,
-                            label=f"Update {resource_kind}",
+                            label=f"Failed update {resource_kind}. No response.",
                             message=f"Failed to update {resource_kind} {ext_id}. No response returned.",
                             severity=Severity.failure,
                         )
@@ -382,7 +382,7 @@ class ChartIO(UploadableStorageIO[ChartSelector, ChartResponse, ChartRequest]):
                         log_entries.append(
                             LogEntryV2(
                                 id=tracking_id,
-                                label=f"Create {resource_kind}",
+                                label=f"Failed creating {resource_kind}",
                                 message=f"Failed to create {resource_kind} {ext_id}: missing nonce. "
                                 "Either run skip-strict-mode or use device code credentials.",
                                 severity=Severity.failure,
@@ -396,7 +396,7 @@ class ChartIO(UploadableStorageIO[ChartSelector, ChartResponse, ChartRequest]):
                     log_entries.append(
                         LogEntryV2(
                             id=tracking_id,
-                            label=f"Create {resource_kind}",
+                            label=f"Failed creation {resource_kind}. Code {e.code}",
                             message=f"Failed to create {resource_kind} {ext_id}: {e}",
                             severity=Severity.failure,
                         )
@@ -406,7 +406,7 @@ class ChartIO(UploadableStorageIO[ChartSelector, ChartResponse, ChartRequest]):
                     log_entries.append(
                         LogEntryV2(
                             id=tracking_id,
-                            label=f"Create {resource_kind}",
+                            label=f"Failed creation {resource_kind}",
                             message=f"Failed to create {resource_kind}. No response returned.",
                             severity=Severity.failure,
                         )

--- a/cognite_toolkit/_cdf_tk/storageio/_asset_centric.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_asset_centric.py
@@ -329,18 +329,20 @@ class AssetDataIO(UploadableAssetCentricIO[AssetResponse, AssetRequest]):
             )
             self._collect_dependencies(page.items, selector)
             bm: Bookmark = CursorBookmark(cursor=page.next_cursor) if page.next_cursor else NoBookmark()
-            yield Page(
-                worker_id="main",
-                items=[
-                    DataItem(
-                        tracking_id=item.external_id
-                        if item.external_id is not None
-                        else self._create_identifier(item.id),
-                        item=item,
-                    )
-                    for item in page.items
-                ],
-                bookmark=bm,
+            yield self.emit_registered_page(
+                Page(
+                    worker_id="main",
+                    items=[
+                        DataItem(
+                            tracking_id=item.external_id
+                            if item.external_id is not None
+                            else self._create_identifier(item.id),
+                            item=item,
+                        )
+                        for item in page.items
+                    ],
+                    bookmark=bm,
+                )
             )
             total_count += len(page.items)
             if page.next_cursor is None or (limit is not None and total_count >= limit):
@@ -471,18 +473,20 @@ class FileMetadataDataIO(AssetCentricIO[FileMetadataResponse]):
             )
             self._collect_dependencies(page.items, selector)
             bm: Bookmark = CursorBookmark(cursor=page.next_cursor) if page.next_cursor else NoBookmark()
-            yield Page(
-                worker_id="main",
-                items=[
-                    DataItem(
-                        tracking_id=item.external_id
-                        if item.external_id is not None
-                        else self._create_identifier(item.id),
-                        item=item,
-                    )
-                    for item in page.items
-                ],
-                bookmark=bm,
+            yield self.emit_registered_page(
+                Page(
+                    worker_id="main",
+                    items=[
+                        DataItem(
+                            tracking_id=item.external_id
+                            if item.external_id is not None
+                            else self._create_identifier(item.id),
+                            item=item,
+                        )
+                        for item in page.items
+                    ],
+                    bookmark=bm,
+                )
             )
             total_count += len(page.items)
             if page.next_cursor is None or (limit is not None and total_count >= limit):
@@ -543,18 +547,20 @@ class TimeSeriesDataIO(UploadableAssetCentricIO[TimeSeriesResponse, TimeSeriesRe
             )
             self._collect_dependencies(page.items, selector)
             bm: Bookmark = CursorBookmark(cursor=page.next_cursor) if page.next_cursor else NoBookmark()
-            yield Page(
-                worker_id="main",
-                items=[
-                    DataItem(
-                        tracking_id=item.external_id
-                        if item.external_id is not None
-                        else self._create_identifier(item.id),
-                        item=item,
-                    )
-                    for item in page.items
-                ],
-                bookmark=bm,
+            yield self.emit_registered_page(
+                Page(
+                    worker_id="main",
+                    items=[
+                        DataItem(
+                            tracking_id=item.external_id
+                            if item.external_id is not None
+                            else self._create_identifier(item.id),
+                            item=item,
+                        )
+                        for item in page.items
+                    ],
+                    bookmark=bm,
+                )
             )
             total_count += len(page.items)
             if page.next_cursor is None or (limit is not None and total_count >= limit):
@@ -693,18 +699,20 @@ class EventDataIO(UploadableAssetCentricIO[EventResponse, EventRequest]):
             )
             self._collect_dependencies(page.items, selector)
             bm: Bookmark = CursorBookmark(cursor=page.next_cursor) if page.next_cursor else NoBookmark()
-            yield Page(
-                worker_id="main",
-                items=[
-                    DataItem(
-                        tracking_id=item.external_id
-                        if item.external_id is not None
-                        else self._create_identifier(item.id),
-                        item=item,
-                    )
-                    for item in page.items
-                ],
-                bookmark=bm,
+            yield self.emit_registered_page(
+                Page(
+                    worker_id="main",
+                    items=[
+                        DataItem(
+                            tracking_id=item.external_id
+                            if item.external_id is not None
+                            else self._create_identifier(item.id),
+                            item=item,
+                        )
+                        for item in page.items
+                    ],
+                    bookmark=bm,
+                )
             )
             total_count += len(page.items)
             if page.next_cursor is None or (limit is not None and total_count >= limit):

--- a/cognite_toolkit/_cdf_tk/storageio/_base.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_base.py
@@ -112,6 +112,12 @@ class StorageIO(ABC, Generic[T_Selector, T_DataResponse]):
         self.client = client
         self.logger: DataLogger = NoOpLogger()
 
+    def emit_registered_page(self, page: "Page[T_DataResponse]") -> "Page[T_DataResponse]":
+        """Register all item tracking IDs with the current logger, then return the page for yielding."""
+        if page.items:
+            self.logger.register([item.tracking_id for item in page.items])
+        return page
+
     @abstractmethod
     def stream_data(
         self,

--- a/cognite_toolkit/_cdf_tk/storageio/_datapoints.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_datapoints.py
@@ -172,7 +172,7 @@ class DatapointsIO(
                 batch_count += ts_limit
                 if batch_count >= self.MAX_PER_REQUEST_DATAPOINTS:
                     if page := self._fetch_datapoints_batch(batch, config):
-                        yield page
+                        yield self.emit_registered_page(page)
                     batch = []
                     batch_count = 0
 
@@ -187,7 +187,7 @@ class DatapointsIO(
                     )
                     batch_count += left_over
             if batch and (page := self._fetch_datapoints_batch(batch, config)):
-                yield page
+                yield self.emit_registered_page(page)
 
     def _fetch_datapoints_batch(self, batch: list[dict[str, Any]], config: Any) -> Page[DataPointListResponse] | None:
         response = self.client.http_client.request_single_retries(

--- a/cognite_toolkit/_cdf_tk/storageio/_file_content.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_file_content.py
@@ -132,7 +132,7 @@ class FileContentIO(UploadableStorageIO[FileContentSelector, MetadataWithFilePat
                 )
                 for item in downloaded_files
             ]
-            yield Page(items=items, worker_id="Main", bookmark=NoBookmark())
+            yield self.emit_registered_page(Page(items=items, worker_id="Main", bookmark=NoBookmark()))
 
     def _retrieve_metadata(self, identifiers: Sequence[FileIdentifier]) -> Sequence[FileMetadataResponse] | None:
         config = self.client.config

--- a/cognite_toolkit/_cdf_tk/storageio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_instances.py
@@ -179,7 +179,7 @@ class InstanceIO(
                     DataItem(tracking_id=f"{item.space}:{item.external_id}", item=item)
                     for item in self.client.tool.instances.retrieve(chunk)
                 ]
-                yield Page(worker_id="main", items=items, bookmark=NoBookmark())
+                yield self.emit_registered_page(Page(worker_id="main", items=items, bookmark=NoBookmark()))
         elif isinstance(selector, InstanceQuerySelector):
             yield from self._instance_by_query(selector.create_query(), limit, init_cursor)
         else:
@@ -251,12 +251,14 @@ class InstanceIO(
                 for item in items
             ]
             next_cursor = batch.root_cursor
-            yield Page(
-                worker_id="main",
-                items=wrapped_items,
-                bookmark=CursorBookmark(cursor=next_cursor, source="sync" if endpoint == "sync" else "regular")
-                if next_cursor
-                else NoBookmark(),
+            yield self.emit_registered_page(
+                Page(
+                    worker_id="main",
+                    items=wrapped_items,
+                    bookmark=CursorBookmark(cursor=next_cursor, source="sync" if endpoint == "sync" else "regular")
+                    if next_cursor
+                    else NoBookmark(),
+                )
             )
 
     def _instances_with_container_properties(
@@ -278,14 +280,16 @@ class InstanceIO(
                 wrapped_items = [
                     DataItem(tracking_id=f"{item.space}:{item.external_id}", item=item) for item in page.items
                 ]
-                yield Page(
-                    worker_id="main",
-                    items=wrapped_items,
-                    bookmark=CursorBookmark(
-                        cursor=page.next_cursor, source="sync" if selector.endpoint == "sync" else "regular"
+                yield self.emit_registered_page(
+                    Page(
+                        worker_id="main",
+                        items=wrapped_items,
+                        bookmark=CursorBookmark(
+                            cursor=page.next_cursor, source="sync" if selector.endpoint == "sync" else "regular"
+                        )
+                        if page.next_cursor
+                        else NoBookmark(),
                     )
-                    if page.next_cursor
-                    else NoBookmark(),
                 )
             if page.next_cursor is None or (limit is not None and total >= limit) or not page.items:
                 break

--- a/cognite_toolkit/_cdf_tk/storageio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_instances.py
@@ -36,6 +36,7 @@ from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 
 from . import StorageIOConfig
 from ._base import Bookmark, ConfigurableStorageIO, DataItem, Page, UploadableStorageIO
+from .logger import LogEntryV2, Severity
 from .progress import CursorBookmark, NoBookmark
 from .selectors import InstanceFileSelector, InstanceSelector, InstanceSpaceSelector, InstanceViewSelector, SelectedView
 from .selectors._instances import InstanceQuerySelector
@@ -170,20 +171,34 @@ class InstanceIO(
     ) -> Iterable[Page]:
         init_cursor = bookmark.cursor if isinstance(bookmark, CursorBookmark) else None
         if isinstance(selector, InstanceViewSelector) and selector.edge_types and selector.instance_type == "node":
-            yield from self._instances_with_container_and_edge_properties(selector, limit, init_cursor)
+            pages = self._instances_with_container_and_edge_properties(selector, limit, init_cursor)
         elif isinstance(selector, InstanceViewSelector | InstanceSpaceSelector):
-            yield from self._instances_with_container_properties(selector, limit, init_cursor)
+            pages = self._instances_with_container_properties(selector, limit, init_cursor)
         elif isinstance(selector, InstanceFileSelector):
             for chunk in chunker_sequence(selector.ids, self.CHUNK_SIZE):
+                ids = [f"{item.space}:{item.external_id}" for item in chunk]
+                self.logger.register(ids)
                 items = [
                     DataItem(tracking_id=f"{item.space}:{item.external_id}", item=item)
                     for item in self.client.tool.instances.retrieve(chunk)
                 ]
-                yield self.emit_registered_page(Page(worker_id="main", items=items, bookmark=NoBookmark()))
+                if missing_ids := (set(ids) - {item.tracking_id for item in items}):
+                    for item_id in missing_ids:
+                        self.logger.log(
+                            LogEntryV2(
+                                id=item_id,
+                                label="Missing in CDF",
+                                severity=Severity.failure,
+                                message=f"The {item_id} was not found in CDF",
+                            )
+                        )
+                yield Page(worker_id="main", items=items, bookmark=NoBookmark())
+            return
         elif isinstance(selector, InstanceQuerySelector):
-            yield from self._instance_by_query(selector.create_query(), limit, init_cursor)
+            pages = self._instance_by_query(selector.create_query(), limit, init_cursor)
         else:
             raise NotImplementedError()
+        yield from (self.emit_registered_page(page) for page in pages)
 
     def _instances_with_container_and_edge_properties(
         self, selector: InstanceViewSelector, limit: int | None, init_cursor: str | None = None
@@ -251,14 +266,12 @@ class InstanceIO(
                 for item in items
             ]
             next_cursor = batch.root_cursor
-            yield self.emit_registered_page(
-                Page(
-                    worker_id="main",
-                    items=wrapped_items,
-                    bookmark=CursorBookmark(cursor=next_cursor, source="sync" if endpoint == "sync" else "regular")
-                    if next_cursor
-                    else NoBookmark(),
-                )
+            yield Page(
+                worker_id="main",
+                items=wrapped_items,
+                bookmark=CursorBookmark(cursor=next_cursor, source="sync" if endpoint == "sync" else "regular")
+                if next_cursor
+                else NoBookmark(),
             )
 
     def _instances_with_container_properties(
@@ -280,16 +293,14 @@ class InstanceIO(
                 wrapped_items = [
                     DataItem(tracking_id=f"{item.space}:{item.external_id}", item=item) for item in page.items
                 ]
-                yield self.emit_registered_page(
-                    Page(
-                        worker_id="main",
-                        items=wrapped_items,
-                        bookmark=CursorBookmark(
-                            cursor=page.next_cursor, source="sync" if selector.endpoint == "sync" else "regular"
-                        )
-                        if page.next_cursor
-                        else NoBookmark(),
+                yield Page(
+                    worker_id="main",
+                    items=wrapped_items,
+                    bookmark=CursorBookmark(
+                        cursor=page.next_cursor, source="sync" if selector.endpoint == "sync" else "regular"
                     )
+                    if page.next_cursor
+                    else NoBookmark(),
                 )
             if page.next_cursor is None or (limit is not None and total >= limit) or not page.items:
                 break

--- a/cognite_toolkit/_cdf_tk/storageio/_raw.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_raw.py
@@ -57,9 +57,11 @@ class RawIO(
             partitions=None,
             chunk_size=self.CHUNK_SIZE,
         ):
-            yield Page(
-                worker_id="main",
-                items=[DataItem(tracking_id=str(item.key), item=item) for item in chunk],
+            yield self.emit_registered_page(
+                Page(
+                    worker_id="main",
+                    items=[DataItem(tracking_id=str(item.key), item=item) for item in chunk],
+                )
             )
 
     def upload_items(

--- a/cognite_toolkit/_cdf_tk/storageio/_records.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_records.py
@@ -168,7 +168,7 @@ class RecordIO(
                     if sync_response.next_cursor is not None
                     else NoBookmark()
                 )
-                yield Page(worker_id="main", items=items, bookmark=page_bookmark)
+                yield self.emit_registered_page(Page(worker_id="main", items=items, bookmark=page_bookmark))
             if not sync_response.has_next or total >= effective_limit:
                 break
 

--- a/cognite_toolkit/_cdf_tk/storageio/logger.py
+++ b/cognite_toolkit/_cdf_tk/storageio/logger.py
@@ -256,6 +256,11 @@ class FileWithAggregationLogger(DataLogger):
         self._write_to_file()
         return None
 
+    def reset(self) -> None:
+        """Reset all tracking data."""
+        with self._lock:
+            self.aggregations_by_ids.clear()
+
     def register(self, ids: list[str]) -> None:
         with self._lock:
             for id in ids:

--- a/cognite_toolkit/_cdf_tk/storageio/logger.py
+++ b/cognite_toolkit/_cdf_tk/storageio/logger.py
@@ -23,7 +23,8 @@ class LogEntry(BaseModel, alias_generator=to_camel, extra="ignore", populate_by_
 
 class Severity(Enum):
     warning = 1
-    failure = 2
+    skipped = 2
+    failure = 3
 
 
 class LogAggregation(LogEntry):
@@ -209,7 +210,7 @@ class FileDataLogger(DataLogger):
     def log(self, entry: LogEntry | Sequence[LogEntry]) -> None:
         """Log a detailed entry to the file."""
         entries = entry if isinstance(entry, Sequence) else [entry]
-        self._writer.write_chunks([e.model_dump(by_alias=True) for e in entries])
+        self._writer.write_chunks([e.model_dump(by_alias=True, mode="json") for e in entries])
 
 
 @dataclass
@@ -308,7 +309,7 @@ class FileWithAggregationLogger(DataLogger):
     def _write_to_file_unlocked(self) -> None:
         """Internal method to write to file without acquiring the lock."""
         if self._batch:
-            self._writer.write_chunks([e.model_dump(by_alias=True) for e in self._batch])
+            self._writer.write_chunks([e.model_dump(by_alias=True, mode="json") for e in self._batch])
             self._batch.clear()
 
     def _write_to_file(self) -> None:
@@ -358,10 +359,11 @@ class FileWithAggregationLogger(DataLogger):
     def _severity_to_status(self, max_severity: int, is_dry_run: bool) -> OperationStatus:
         if max_severity == Severity.failure.value:
             return "failure"
-        elif max_severity == Severity.warning.value:
+        if max_severity == Severity.skipped.value:
+            return "skipped"
+        if max_severity == Severity.warning.value:
             return "pending-with-warning" if is_dry_run else "success-with-warning"
-        else:
-            return "pending" if is_dry_run else "success"
+        return "pending" if is_dry_run else "success"
 
 
 def display_item_results(items: list[ItemsResult], console: Console) -> None:

--- a/cognite_toolkit/_cdf_tk/storageio/logger.py
+++ b/cognite_toolkit/_cdf_tk/storageio/logger.py
@@ -8,7 +8,8 @@ from typing import Literal, TypeAlias
 
 from pydantic import BaseModel, Field
 from pydantic.alias_generators import to_camel
-from rich.console import Console
+from rich.console import Console, Group
+from rich.panel import Panel
 from rich.tree import Tree
 
 from cognite_toolkit._cdf_tk.utils import humanize_collection
@@ -366,7 +367,7 @@ class FileWithAggregationLogger(DataLogger):
         return "pending" if is_dry_run else "success"
 
 
-def display_item_results(items: list[ItemsResult], console: Console) -> None:
+def display_item_results(items: list[ItemsResult], title: str, console: Console) -> None:
     """Display item results using rich formatting.
 
     Shows a tree view of items grouped by status, with their labels and counts.
@@ -383,6 +384,7 @@ def display_item_results(items: list[ItemsResult], console: Console) -> None:
         "pending-with-warning": ("yellow", "○"),
     }
 
+    trees: list[Tree] = []
     for item in sorted(items, key=lambda item: item.severity, reverse=True):
         style, icon = status_styles.get(item.status, ("white", "•"))
         tree = Tree(f"[{style}]{icon} {item.status}[/{style}]: {item.count} items")
@@ -390,4 +392,7 @@ def display_item_results(items: list[ItemsResult], console: Console) -> None:
         for label_result in item.labels:
             tree.add(f"[dim]{label_result.display_message()}[/dim]")
 
-        console.print(tree)
+        trees.append(tree)
+
+    console.print()
+    console.print(Panel(Group(*trees), title=f"[bold]{title}[/bold]", expand=False))

--- a/tests/test_integration/test_commands/test_migrate_command.py
+++ b/tests/test_integration/test_commands/test_migrate_command.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 
 import pytest
@@ -37,8 +37,23 @@ from cognite_toolkit._cdf_tk.commands._migrate.migration_io import (
     RecordsMigrationIO,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import MigrateDataSetSelector, MigrationCSVFileSelector
+from cognite_toolkit._cdf_tk.storageio.logger import ItemsResult
 from tests.test_integration.conftest import HierarchyMinimal
 from tests.test_integration.constants import RUN_UNIQUE_ID
+
+
+def _migration_status_totals(results: Sequence[ItemsResult]) -> dict[str, int]:
+    totals = {
+        "failure": 0,
+        "pending": 0,
+        "success": 0,
+        "pending-with-warning": 0,
+        "success-with-warning": 0,
+        "skipped": 0,
+    }
+    for item in results:
+        totals[item.status] += item.count
+    return totals
 
 
 @pytest.fixture()
@@ -121,12 +136,12 @@ class TestMigrateAssetsCommand:
             log_dir=tmp_path,
             dry_run=True,
         )
-        results = {item.status: item.count for item in result[str(selector)]}
+        results = _migration_status_totals(result[str(selector)])
         assert results == {
             "failure": 0,
-            "pending": 2,
+            "pending": 0,
             "success": 0,
-            "pending-with-warning": 0,
+            "pending-with-warning": 2,
             "success-with-warning": 0,
             "skipped": 0,
         }
@@ -152,12 +167,12 @@ class TestMigrateEventsCommand:
             log_dir=tmp_path,
             dry_run=True,
         )
-        results = {item.status: item.count for item in result[str(selector)]}
+        results = _migration_status_totals(result[str(selector)])
         assert results == {
             "failure": 0,
-            "pending": 1,
+            "pending": 0,
             "success": 0,
-            "pending-with-warning": 0,
+            "pending-with-warning": 1,
             "success-with-warning": 0,
             "skipped": 0,
         }
@@ -183,12 +198,12 @@ class TestMigrateTimeSeriesCommand:
             log_dir=tmp_path,
             dry_run=True,
         )
-        results = {item.status: item.count for item in result[str(selector)]}
+        results = _migration_status_totals(result[str(selector)])
         assert results == {
             "failure": 0,
-            "pending": 1,
+            "pending": 0,
             "success": 0,
-            "pending-with-warning": 0,
+            "pending-with-warning": 1,
             "success-with-warning": 0,
             "skipped": 0,
         }
@@ -214,12 +229,12 @@ class TestMigrateFileMetadataCommand:
             log_dir=tmp_path,
             dry_run=True,
         )
-        results = {item.status: item.count for item in result[str(selector)]}
+        results = _migration_status_totals(result[str(selector)])
         assert results == {
             "failure": 0,
-            "pending": 1,
+            "pending": 0,
             "success": 0,
-            "pending-with-warning": 0,
+            "pending-with-warning": 1,
             "success-with-warning": 0,
             "skipped": 0,
         }
@@ -244,12 +259,12 @@ class TestMigrateAnnotations:
             dry_run=True,
             verbose=True,
         )
-        results = {item.status: item.count for item in result[str(selector)]}
+        results = _migration_status_totals(result[str(selector)])
         assert results == {
             "failure": 0,
-            "pending": 2,
+            "pending": 0,
             "success": 0,
-            "pending-with-warning": 0,
+            "pending-with-warning": 2,
             "success-with-warning": 0,
             "skipped": 0,
         }
@@ -317,7 +332,7 @@ class TestMigrateFiles:
             log_dir=tmp_path,
             dry_run=False,
         )
-        actual_result = {item.status: item.count for item in result[str(selected_cdm_file)]}
+        actual_result = _migration_status_totals(result[str(selected_cdm_file)])
 
         assert actual_result == {
             "failure": 1,
@@ -342,7 +357,7 @@ class TestMigrateFiles:
             dry_run=False,
         )
 
-        actual_result = {item.status: item.count for item in result[str(selected_cdm_file)]}
+        actual_result = _migration_status_totals(result[str(selected_cdm_file)])
 
         assert actual_result == {
             "failure": 0,
@@ -386,12 +401,12 @@ class TestMigrateEventsToRecordsCommand:
             log_dir=tmp_path,
             dry_run=True,
         )
-        results = {item.status: item.count for item in result[str(selector)]}
+        results = _migration_status_totals(result[str(selector)])
         assert results == {
             "failure": 0,
-            "pending": 1,
+            "pending": 0,
             "success": 0,
-            "pending-with-warning": 0,
+            "pending-with-warning": 1,
             "success-with-warning": 0,
             "skipped": 0,
         }

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from collections import Counter
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -92,11 +92,26 @@ from cognite_toolkit._cdf_tk.commands._migrate.migration_io import (
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import MigrationCSVFileSelector
 from cognite_toolkit._cdf_tk.exceptions import ToolkitMigrationError, ToolkitValueError
 from cognite_toolkit._cdf_tk.storageio import CanvasIO, ChartIO
+from cognite_toolkit._cdf_tk.storageio.logger import ItemsResult
 from cognite_toolkit._cdf_tk.storageio.progress import CursorBookmark, ProgressYAML
 from cognite_toolkit._cdf_tk.storageio.selectors import (
     CanvasExternalIdSelector,
     ChartExternalIdSelector,
 )
+
+
+def _migration_status_totals(results: Sequence[ItemsResult]) -> dict[str, int]:
+    totals = {
+        "failure": 0,
+        "pending": 0,
+        "success": 0,
+        "pending-with-warning": 0,
+        "success-with-warning": 0,
+        "skipped": 0,
+    }
+    for item in results:
+        totals[item.status] += item.count
+    return totals
 
 
 @pytest.fixture
@@ -359,13 +374,13 @@ class TestMigrationCommand:
         ]
         assert actual_instances == expected_instance
         result = results_by_selector[str(selector)]
-        actual_results = {status.status: status.count for status in result}
+        actual_results = _migration_status_totals(result)
         assert actual_results == {
             "failure": 0,
             "pending": 0,
-            "success": len(assets),
+            "success": 0,
             "pending-with-warning": 0,
-            "success-with-warning": 0,
+            "success-with-warning": len(assets),
             "skipped": 0,
         }
 
@@ -473,13 +488,13 @@ class TestMigrationCommand:
         assert bookmark.cursor == "resume-cursor-1"
 
         result = results_by_selector[str(selector)]
-        actual_results = {status.status: status.count for status in result}
+        actual_results = _migration_status_totals(result)
         assert actual_results == {
             "failure": 0,
             "pending": 0,
-            "success": 1,
+            "success": 0,
             "pending-with-warning": 0,
-            "success-with-warning": 0,
+            "success-with-warning": 1,
             "skipped": 0,
         }
 
@@ -620,13 +635,13 @@ class TestMigrationCommand:
             verbose=True,
         )
         result = results_by_selector[str(selector)]
-        actual_results = {status.status: status.count for status in result}
+        actual_results = _migration_status_totals(result)
         assert actual_results == {
             "failure": 0,
             "pending": 0,
-            "success": len(annotations),
+            "success": 0,
             "pending-with-warning": 0,
-            "success-with-warning": 0,
+            "success-with-warning": len(annotations),
             "skipped": 0,
         }
 
@@ -826,7 +841,7 @@ class TestMigrationCommand:
                 verbose=True,
             )
         result = results_by_selector[str(selector)]
-        actual_results = {status.status: status.count for status in result}
+        actual_results = _migration_status_totals(result)
         assert actual_results == {
             "failure": 0,
             "pending": 0,
@@ -1065,13 +1080,13 @@ class TestMigrationCommand:
         )
 
         result = results_by_selector[str(selector)]
-        actual_results = {status.status: status.count for status in result}
+        actual_results = _migration_status_totals(result)
         assert actual_results == {
             "failure": 0,
             "pending": 0,
-            "success": 1,
+            "success": 0,
             "pending-with-warning": 0,
-            "success-with-warning": 0,
+            "success-with-warning": 1,
             "skipped": 0,
         }
 
@@ -1322,12 +1337,12 @@ class TestMigrationCommand:
         upload_body = json.loads(ingest_records.calls[0].request.content)
         assert len(upload_body["items"]) == len(events)
 
-        actual_results = {status.status: status.count for status in results_by_selector[str(selector)]}
+        actual_results = _migration_status_totals(results_by_selector[str(selector)])
         assert actual_results == {
             "failure": 0,
             "pending": 0,
-            "success": len(events),
+            "success": 0,
             "pending-with-warning": 0,
-            "success-with-warning": 0,
+            "success-with-warning": len(events),
             "skipped": 0,
         }

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -70,10 +70,10 @@ from cognite_toolkit._cdf_tk.commands._migrate.data_mapper import (
     InFieldLegacyToCDMScheduleMapper,
     ThreeDAssetMapper,
 )
-from cognite_toolkit._cdf_tk.commands._migrate.issues import CanvasMigrationIssue
+from cognite_toolkit._cdf_tk.commands._migrate.issues import MigrationEntryV2
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import MigrationCSVFileSelector
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
-from cognite_toolkit._cdf_tk.storageio.logger import DataLogger, OperationTracker
+from cognite_toolkit._cdf_tk.storageio.logger import DataLogger
 from tests.data import MIGRATION_DIR
 
 
@@ -320,7 +320,6 @@ class TestThreeDAssetMapper:
 
             mapper = ThreeDAssetMapper(client)
             logger = MagicMock(spec=DataLogger)
-            logger.tracker = MagicMock(spec_set=OperationTracker)
             mapper.logger = logger
             mapped = mapper.map([response])[0]
 
@@ -332,13 +331,17 @@ class TestThreeDAssetMapper:
 
             if isinstance(expected, AssetMappingDMRequestId):
                 logger.log.assert_not_called()
-                logger.tracker.add_issue.assert_not_called()
                 assert mapped is not None
                 assert mapped.model_dump() == expected.model_dump()
             else:
-                _, message = logger.tracker.add_issue.call_args.args
+                logger.log.assert_called_once()
+                log_entries = logger.log.call_args[0][0]
+                assert isinstance(log_entries, list)
+                assert len(log_entries) == 1
+                entry = log_entries[0]
+                assert isinstance(entry, MigrationEntryV2)
                 assert mapped is None, "Expected no mapped result"
-                assert message == expected
+                assert expected in entry.message
 
 
 class TestCanvasMapper:
@@ -378,7 +381,6 @@ class TestCanvasMapper:
 
             mapper = CanvasMapper(client, dry_run=False, skip_on_missing_ref=False)
             logger = MagicMock(spec=DataLogger)
-            logger.tracker = MagicMock(spec_set=OperationTracker)
             mapper.logger = logger
 
             actual = mapper.map([input_canvas])[0]
@@ -400,8 +402,9 @@ class TestCanvasMapper:
         entry = logger.log.call_args[0][0]
         assert isinstance(entry, list)
         first = entry[0]
-        assert isinstance(first, CanvasMigrationIssue)
-        assert first.files_missing_content == [NodeId(space="my_space", external_id="file_1")]
+        assert isinstance(first, MigrationEntryV2)
+        assert first.label == "File missing content"
+        assert "my_space:file_1" in first.attributes
 
 
 class TestChartMapper:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_migration_issues.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_migration_issues.py
@@ -1,5 +1,3 @@
-from typing import Literal
-
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import NodeId
 from cognite_toolkit._cdf_tk.client.resource_classes.migration import (
     AssetCentricId,
@@ -8,44 +6,10 @@ from cognite_toolkit._cdf_tk.commands._migrate.issues import (
     ConversionIssue,
     FailedConversion,
     InvalidPropertyDataType,
-    ReadAPIIssue,
-    ReadFileIssue,
-    ReadIssue,
 )
 
 
 class TestMigrationIssues:
-    def test_read_file_issue(self) -> None:
-        issue = ReadFileIssue(id="issue-1", row_no=10, error="Cannot read column 'id' value is not an integer")
-        assert issue.dump() == {
-            "id": "issue-1",
-            "type": "fileRead",
-            "rowNo": 10,
-            "error": "Cannot read column 'id' value is not an integer",
-        }
-
-    def test_read_api_issue(self) -> None:
-        asset_centric_id = AssetCentricId(resource_type="asset", id_=123)
-        issue = ReadAPIIssue(id="issue-2", asset_centric_id=asset_centric_id, error="API error")
-        assert issue.dump() == {
-            "id": "issue-2",
-            "type": "apiRead",
-            "assetCentricId": {"resourceType": "asset", "id": 123},
-            "error": "API error",
-        }
-
-    def test_read_issue_subclass(self) -> None:
-        class CustomReadIssue(ReadIssue):
-            type: Literal["customRead"] = "customRead"
-            custom_field: str
-
-        issue = CustomReadIssue(id="issue-3", custom_field="custom value")
-        assert issue.dump() == {
-            "id": "issue-3",
-            "type": "customRead",
-            "customField": "custom value",
-        }
-
     def test_conversion_issue_minimal(self) -> None:
         asset_centric_id = AssetCentricId(resource_type="asset", id_=456)
         instance_id = NodeId(space="test_space", external_id="test_instance")

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_migration_issues.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_migration_issues.py
@@ -11,7 +11,6 @@ from cognite_toolkit._cdf_tk.commands._migrate.issues import (
     ReadAPIIssue,
     ReadFileIssue,
     ReadIssue,
-    WriteIssue,
 )
 
 
@@ -96,24 +95,4 @@ class TestMigrationIssues:
             "ignoredAssetCentricProperties": [],
             "missingInstanceSpace": None,
             "noMappableProperties": False,
-        }
-
-    def test_write_issue_minimal(self) -> None:
-        write_issue = WriteIssue(id="issue-6", status_code=400)
-
-        assert write_issue.dump() == {
-            "id": "issue-6",
-            "type": "write",
-            "statusCode": 400,
-            "message": None,
-        }
-
-    def test_write_issue_with_message(self) -> None:
-        write_issue = WriteIssue(id="issue-7", status_code=500, message="Internal server error occurred")
-
-        assert write_issue.dump() == {
-            "id": "issue-7",
-            "type": "write",
-            "statusCode": 500,
-            "message": "Internal server error occurred",
         }

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_logger.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_logger.py
@@ -127,7 +127,7 @@ class TestFileWithAggregationLogger:
         ]
 
         # Just to ensure that no exception is raised.
-        display_item_results(results, MagicMock())
+        display_item_results(results, "Title", MagicMock())
 
     def _simulate_log_entries(self, logger: FileWithAggregationLogger) -> None:
         logger.register(["item_success", "item_failure", "item_warning1", "item_warning2"])


### PR DESCRIPTION
# Description

<img width="634" height="421" alt="image" src="https://github.com/user-attachments/assets/ddd0f7e1-d6eb-46b7-a2ed-cd6c7b73d0ed" />

* Adding register calls for all `StorageIO`.
* Switch to use the new LogEntryV2 which contains labels for aggregation.  

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Improved

- [alpha] All `cdf migrate` commands have now improved logging and terminal output. 
