### PR TITLE
[CDF-27678] Align DataProductVersion schema with new API spec

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_product_version.py
@@ -19,14 +19,10 @@ class ViewInstanceSpaces(BaseModelObject):
 
 
 class DataProductVersionView(BaseModelObject):
-    external_id: str
-    instance_spaces: ViewInstanceSpaces = Field(default_factory=ViewInstanceSpaces)
-
-
-class DataProductVersionDataModel(BaseModelObject):
+    space: SpaceId
     external_id: str
     version: str
-    views: list[DataProductVersionView] = Field(default_factory=list)
+    instance_spaces: ViewInstanceSpaces = Field(default_factory=ViewInstanceSpaces)
 
 
 class DataProductVersionTerms(BaseModelObject):
@@ -37,7 +33,7 @@ class DataProductVersionTerms(BaseModelObject):
 class DataProductVersion(BaseModelObject):
     data_product_external_id: str = Field(exclude=True)
     version: SemanticVersion
-    data_model: DataProductVersionDataModel
+    views: list[DataProductVersionView] = Field(default_factory=list)
     status: Literal["draft", "published", "deprecated"] = "draft"
     description: str | None = None
     terms: DataProductVersionTerms | None = None
@@ -53,7 +49,7 @@ class DataProductVersionRequest(DataProductVersion, UpdatableRequestResource):
     container_fields: ClassVar[frozenset[str]] = frozenset()
 
     def as_update(self, mode: Literal["patch", "replace"]) -> dict[str, Any]:
-        # The versions update API uses nested {set}/{setNull}/{modify} operators
+        # The versions update API uses nested {set}/{setNull}/{modify}/{add} operators
         # instead of a flat body, so we must build the payload manually.
         update_item: dict[str, Any] = {"version": self.version}
         update: dict[str, Any] = {}
@@ -77,10 +73,8 @@ class DataProductVersionRequest(DataProductVersion, UpdatableRequestResource):
             if terms_modify:
                 update["terms"] = {"modify": terms_modify}
 
-        if "dataModel" in dumped and dumped["dataModel"] is not None:
-            views = dumped["dataModel"].get("views")
-            if views is not None:
-                update["dataModel"] = {"modify": {"views": {"set": views}}}
+        if dumped.get("views"):
+            update["views"] = {"add": dumped["views"]}
 
         update_item["update"] = update
         return update_item

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_product_version.py
@@ -7,7 +7,7 @@ from cognite_toolkit._cdf_tk.client._resource_base import (
     ResponseResource,
     UpdatableRequestResource,
 )
-from cognite_toolkit._cdf_tk.client.identifiers import DataProductVersionId, SemanticVersion
+from cognite_toolkit._cdf_tk.client.identifiers import DataProductVersionId, RuleSetVersionId, SemanticVersion
 from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 
 SpaceId = Annotated[str, Field(pattern=SPACE_FORMAT_PATTERN, max_length=43)]
@@ -30,6 +30,10 @@ class DataProductVersionTerms(BaseModelObject):
     limitations: str | None = None
 
 
+class DataProductVersionQuality(BaseModelObject):
+    rules: list[RuleSetVersionId] = Field(default_factory=list)
+
+
 class DataProductVersion(BaseModelObject):
     data_product_external_id: str = Field(exclude=True)
     version: SemanticVersion
@@ -37,6 +41,7 @@ class DataProductVersion(BaseModelObject):
     status: Literal["draft", "published", "deprecated"] = "draft"
     description: str | None = None
     terms: DataProductVersionTerms | None = None
+    quality: DataProductVersionQuality | None = None
 
     def as_id(self) -> DataProductVersionId:
         return DataProductVersionId(

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
@@ -2,7 +2,7 @@ from collections.abc import Hashable, Iterable, Sequence
 from typing import Any, Literal, final
 
 from cognite_toolkit._cdf_tk.client._resource_base import Identifier
-from cognite_toolkit._cdf_tk.client.identifiers import DataProductVersionId, ExternalId
+from cognite_toolkit._cdf_tk.client.identifiers import DataProductVersionId, ExternalId, RuleSetVersionId
 from cognite_toolkit._cdf_tk.client.resource_classes.data_product_version import (
     DataProductVersionRequest,
     DataProductVersionResponse,
@@ -12,6 +12,7 @@ from cognite_toolkit._cdf_tk.resource_ios._base_ios import ResourceIO
 from cognite_toolkit._cdf_tk.yaml_classes import DataProductVersionYAML
 
 from .data_product import DataProductIO
+from .rulesets import RuleSetVersionIO
 
 
 @final
@@ -21,7 +22,7 @@ class DataProductVersionIO(ResourceIO[DataProductVersionId, DataProductVersionRe
     resource_write_cls = DataProductVersionRequest
     kind = "DataProductVersion"
     yaml_cls = DataProductVersionYAML
-    dependencies = frozenset({DataProductIO})
+    dependencies = frozenset({DataProductIO, RuleSetVersionIO})
     parent_resource = frozenset({DataProductIO})
     support_drop = True
     support_update = True
@@ -56,10 +57,18 @@ class DataProductVersionIO(ResourceIO[DataProductVersionId, DataProductVersionRe
     def get_dependent_items(cls, item: dict) -> Iterable[tuple[type[ResourceIO], Hashable]]:
         if "dataProductExternalId" in item:
             yield DataProductIO, ExternalId(external_id=item["dataProductExternalId"])
+        for rule in (item.get("quality") or {}).get("rules", []):
+            if "ruleSetExternalId" in rule and "version" in rule:
+                yield RuleSetVersionIO, RuleSetVersionId(
+                    rule_set_external_id=rule["ruleSetExternalId"], version=rule["version"]
+                )
 
     @classmethod
     def get_dependencies(cls, resource: DataProductVersionYAML) -> Iterable[tuple[type[ResourceIO], Identifier]]:
         yield DataProductIO, ExternalId(external_id=resource.data_product_external_id)
+        if resource.quality:
+            for rule in resource.quality.rules:
+                yield RuleSetVersionIO, rule.as_id()
 
     def dump_resource(
         self, resource: DataProductVersionResponse, local: dict[str, Any] | None = None
@@ -71,7 +80,7 @@ class DataProductVersionIO(ResourceIO[DataProductVersionId, DataProductVersionRe
         for key, value in dumped.items():
             if value == {}:
                 dumped[key] = None
-        defaults: dict[str, Any | None] = {"status": "draft", "description": None, "terms": None, "views": []}
+        defaults: dict[str, Any | None] = {"status": "draft", "description": None, "terms": None, "views": [], "quality": None}
         for key, default in defaults.items():
             if dumped.get(key) == default and key not in local:
                 dumped.pop(key)

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
@@ -81,7 +81,13 @@ class DataProductVersionIO(ResourceIO[DataProductVersionId, DataProductVersionRe
         for key, value in dumped.items():
             if value == {}:
                 dumped[key] = None
-        defaults: dict[str, Any | None] = {"status": "draft", "description": None, "terms": None, "views": [], "quality": None}
+        defaults: dict[str, Any | None] = {
+            "status": "draft",
+            "description": None,
+            "terms": None,
+            "views": [],
+            "quality": None,
+        }
         for key, default in defaults.items():
             if dumped.get(key) == default and key not in local:
                 dumped.pop(key)

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
@@ -59,8 +59,9 @@ class DataProductVersionIO(ResourceIO[DataProductVersionId, DataProductVersionRe
             yield DataProductIO, ExternalId(external_id=item["dataProductExternalId"])
         for rule in (item.get("quality") or {}).get("rules", []):
             if "ruleSetExternalId" in rule and "version" in rule:
-                yield RuleSetVersionIO, RuleSetVersionId(
-                    rule_set_external_id=rule["ruleSetExternalId"], version=rule["version"]
+                yield (
+                    RuleSetVersionIO,
+                    RuleSetVersionId(rule_set_external_id=rule["ruleSetExternalId"], version=rule["version"]),
                 )
 
     @classmethod

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
@@ -12,7 +12,6 @@ from cognite_toolkit._cdf_tk.resource_ios._base_ios import ResourceIO
 from cognite_toolkit._cdf_tk.yaml_classes import DataProductVersionYAML
 
 from .data_product import DataProductIO
-from .datamodel import DataModelIO
 
 
 @final
@@ -22,7 +21,7 @@ class DataProductVersionIO(ResourceIO[DataProductVersionId, DataProductVersionRe
     resource_write_cls = DataProductVersionRequest
     kind = "DataProductVersion"
     yaml_cls = DataProductVersionYAML
-    dependencies = frozenset({DataProductIO, DataModelIO})
+    dependencies = frozenset({DataProductIO})
     parent_resource = frozenset({DataProductIO})
     support_drop = True
     support_update = True
@@ -72,7 +71,7 @@ class DataProductVersionIO(ResourceIO[DataProductVersionId, DataProductVersionRe
         for key, value in dumped.items():
             if value == {}:
                 dumped[key] = None
-        defaults: dict[str, Any | None] = {"status": "draft", "description": None, "terms": None}
+        defaults: dict[str, Any | None] = {"status": "draft", "description": None, "terms": None, "views": []}
         for key, default in defaults.items():
             if dumped.get(key) == default and key not in local:
                 dumped.pop(key)

--- a/cognite_toolkit/_cdf_tk/yaml_classes/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/data_product_version.py
@@ -2,7 +2,7 @@ from typing import Annotated, Literal
 
 from pydantic import Field
 
-from cognite_toolkit._cdf_tk.client.identifiers import DataProductVersionId, SemanticVersion
+from cognite_toolkit._cdf_tk.client.identifiers import DataProductVersionId, RuleSetVersionId, SemanticVersion
 from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 
 from .base import BaseModelResource, ToolkitResource
@@ -37,6 +37,22 @@ class DataProductVersionTerms(BaseModelResource):
     )
 
 
+class DataProductVersionQualityRule(BaseModelResource):
+    rule_set_external_id: str = Field(description="External ID of the referenced rule set.")
+    version: SemanticVersion = Field(description="Version of the referenced rule set.")
+
+    def as_id(self) -> RuleSetVersionId:
+        return RuleSetVersionId(rule_set_external_id=self.rule_set_external_id, version=self.version)
+
+
+class DataProductVersionQuality(BaseModelResource):
+    rules: list[DataProductVersionQualityRule] = Field(
+        default_factory=list,
+        description="List of rule set version references applied to this data product version.",
+        max_length=50,
+    )
+
+
 class DataProductVersionYAML(ToolkitResource):
     data_product_external_id: str = Field(
         description="External ID of the parent data product.",
@@ -64,6 +80,10 @@ class DataProductVersionYAML(ToolkitResource):
     terms: DataProductVersionTerms | None = Field(
         default=None,
         description="Terms and conditions for using this data product version.",
+    )
+    quality: DataProductVersionQuality | None = Field(
+        default=None,
+        description="Data quality rules applied to this version.",
     )
 
     def as_id(self) -> DataProductVersionId:

--- a/cognite_toolkit/_cdf_tk/yaml_classes/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/data_product_version.py
@@ -20,19 +20,11 @@ class ViewInstanceSpaces(BaseModelResource):
 
 
 class DataProductVersionView(BaseModelResource):
-    external_id: str = Field(description="External ID of the view in the data model.")
+    space: SpaceId = Field(description="The space where the view is located.")
+    external_id: str = Field(description="External ID of the view.")
+    version: str = Field(description="Version of the view.")
     instance_spaces: ViewInstanceSpaces = Field(
         default_factory=ViewInstanceSpaces, description="Instance spaces for this view."
-    )
-
-
-class DataProductVersionDataModel(BaseModelResource):
-    external_id: str = Field(description="External ID of the referenced data model.")
-    version: str = Field(description="Version of the referenced data model.")
-    views: list[DataProductVersionView] = Field(
-        default_factory=list,
-        description="List of views with their instance spaces.",
-        max_length=100,
     )
 
 
@@ -55,8 +47,10 @@ class DataProductVersionYAML(ToolkitResource):
     version: SemanticVersion = Field(
         description="Semantic version of this data product version (major.minor.patch).",
     )
-    data_model: DataProductVersionDataModel = Field(
-        description="Immutable reference to the data model version associated with this data product version.",
+    views: list[DataProductVersionView] = Field(
+        default_factory=list,
+        description="Collection of view references (space, externalId, version, instanceSpaces) associated with this version.",
+        max_length=100,
     )
     status: Literal["draft", "published", "deprecated"] = Field(
         default="draft",

--- a/tests/test_unit/utils.py
+++ b/tests/test_unit/utils.py
@@ -363,6 +363,14 @@ class FakeCogniteResourceGenerator:
             if name == "locations" and model_cls is LocationFilterResponse:
                 # Special case for LocationFilter to avoid recursion.
                 value = None
+            elif field.annotation is str and field.metadata:
+                # Pydantic v2 unwraps Annotated[str, Field(pattern=...)] so field.annotation becomes
+                # plain str while constraints end up in field.metadata. Check those before falling back.
+                constraints = self._extract_str_constraints(list(field.metadata))
+                if constraints.get("pattern"):
+                    value = self._random_constrained_string(constraints)
+                else:
+                    value = self.create_value(field.annotation, var_name=field_id)
             else:
                 value = self.create_value(field.annotation, var_name=field_id)
             keyword_arguments[name] = value
@@ -540,12 +548,23 @@ class FakeCogniteResourceGenerator:
         return constraints
 
     def _random_constrained_string(self, constraints: dict[str, Any]) -> str:
+        import re
+
         min_len = constraints.get("min_length", 1)
         max_len = constraints.get("max_length", 10)
         length = min(max(min_len, 4), max_len)
         first = self._random.choice(string.ascii_lowercase)
         rest = self._random_string(length - 1, sample_from=string.ascii_lowercase + string.digits)
-        return first + rest
+        generated = first + rest
+
+        pattern = constraints.get("pattern")
+        if pattern and not re.match(pattern, generated):
+            # The generated string doesn't satisfy the pattern (e.g. semantic version a.b.c).
+            # Try a small set of sensible fallbacks before giving up.
+            for fallback in ("1.0.0", "a1", "v1", "x"):
+                if re.match(pattern, fallback):
+                    return fallback
+        return generated
 
     @classmethod
     def _type_checking(cls) -> dict[str, Any]:

--- a/tests/test_unit/utils.py
+++ b/tests/test_unit/utils.py
@@ -548,8 +548,6 @@ class FakeCogniteResourceGenerator:
         return constraints
 
     def _random_constrained_string(self, constraints: dict[str, Any]) -> str:
-        import re
-
         min_len = constraints.get("min_length", 1)
         max_len = constraints.get("max_length", 10)
         length = min(max(min_len, 4), max_len)


### PR DESCRIPTION
# Description

Aligns the toolkit's `DataProductVersion` model with the [current Data Products service contract](https://github.com/cognitedata/service-contracts/blob/master/versions/v1/dataproducts.preproc.yml).

**Schema changes:**

The API removed the `dataModel` wrapper object and replaced it with a flat `views` array directly on `DataProductVersion`. Each view reference now carries `space`, `externalId`, `version` and `instanceSpaces` fields. The update operation changed from `dataModel.modify.views.set` to `views.add`.

The `quality` field has been added, holding a list of `RuleSetVersionReference` objects (`ruleSetExternalId` + `version`). This is create-only (not present in `DataProductVersionPatch`). `RuleSetVersionIO` is now a declared dependency of `DataProductVersionIO`, so rule set versions are deployed before the data product versions that reference them.

**Changes in detail:**
- `DataProductVersionView` gains `space` and `version` fields (previously only `externalId` + `instanceSpaces`)
- `DataProductVersionDataModel` wrapper class removed — `views` now lives directly on `DataProductVersion`
- `as_update()` now sends `views: {add: [...]}` instead of `dataModel: {modify: {views: {set: [...]}}}`
- `DataProductVersionQuality` added with `rules: list[RuleSetVersionReference]` (create-only)
- `RuleSetVersionIO` added to `DataProductVersionIO.dependencies` to enforce deploy order
- `DataModelIO` removed from `DataProductVersionIO.dependencies` (no longer a data model reference)
- `dump_resource` strips `views: []` and `quality: null` defaults to reduce YAML diff noise
- Fixed `FakeCogniteResourceGenerator` to respect Pydantic v2 field-level string constraints (`pattern`/`min_length`/`max_length` stored in `field.metadata`) and handle complex regex patterns (e.g. semantic version) with sensible fallbacks

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- `DataProductVersion` schema now has a flat `views` array with `space`/`externalId`/`version`/`instanceSpaces` per view, replacing the removed `dataModel` wrapper.

### Added
- `quality.rules` (rule set version references) added to `DataProductVersion`.