### PR TITLE
[CDF-27673] 🐛 Infield users

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -17,6 +17,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.conversion import (
     ConnectionCreator,
     InFieldAssetMapping,
     InFieldConditionMapping,
+    InFieldUserMapping,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.creators import (
     InfieldV2ConfigCreator,
@@ -1624,7 +1625,7 @@ class MigrateApp(typer.Typer):
             client,
             infield_mappings,
             connection_creator=connection_creator,
-            custom_properties_mappings=[InFieldConditionMapping(infield_mappings)],
+            custom_properties_mappings=[InFieldConditionMapping(infield_mappings), InFieldUserMapping()],
             custom_instance_mappings={
                 InFieldLegacyToCDMScheduleMapper.SCHEDULE_VIEW: InFieldLegacyToCDMScheduleMapper(
                     client, connection_creator, schedule_mapping

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -974,24 +974,21 @@ class InFieldUserMapping(CustomContainerPropertiesMapping):
     ) -> ConversionResult:
         created_properties: dict[str, JsonValue | NodeId | list[NodeId]] = {}
         issues: list[str] = []
-        if created_user := source_properties.get("createdBy"):
-            if isinstance(created_user, dict) and "externalId" in created_user:
-                created_properties["sourceCreatedUser"] = created_user["externalId"]
-            elif isinstance(created_user, NodeId):
-                created_properties["sourceCreatedUser"] = created_user.external_id
-            else:
-                issues.append(
-                    f"Invalid createdBy value {created_user!r} for view {context.source_view_id!s}: expected a dict with an externalId field or a NodeId."
-                )
-        if updated_user := source_properties.get("updatedBy"):
-            if isinstance(updated_user, dict) and "externalId" in updated_user:
-                created_properties["sourceUpdatedUser"] = updated_user["externalId"]
-            elif isinstance(updated_user, NodeId):
-                created_properties["sourceUpdatedUser"] = updated_user.external_id
-            else:
-                issues.append(
-                    f"Invalid updatedBy value {updated_user!r} for view {context.source_view_id!s}: expected a dict with an externalId field or a NodeId."
-                )
+
+        def _map_user(source_prop: str, target_prop: str) -> None:
+            if user := source_properties.get(source_prop):
+                if isinstance(user, dict) and "externalId" in user:
+                    created_properties[target_prop] = user["externalId"]
+                elif isinstance(user, NodeId):
+                    created_properties[target_prop] = user.external_id
+                else:
+                    issues.append(
+                        f"Invalid {source_prop} value {user!r} for view {context.source_view_id!s}: "
+                        "expected a dict with an externalId field or a NodeId."
+                    )
+
+        _map_user("createdBy", "sourceCreatedUser")
+        _map_user("updatedBy", "sourceUpdatedUser")
         return ConversionResult(container_properties=created_properties, errors=issues)
 
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -976,18 +976,18 @@ class InFieldUserMapping(CustomContainerPropertiesMapping):
         issues: list[str] = []
         if created_user := source_properties.get("createdBy"):
             if isinstance(created_user, dict) and "externalId" in created_user:
-                created_properties["sourceCreatedTime"] = created_user["externalId"]
+                created_properties["sourceCreatedUser"] = created_user["externalId"]
             elif isinstance(created_user, NodeId):
-                created_properties["sourceCreatedTime"] = created_user.external_id
+                created_properties["sourceCreatedUser"] = created_user.external_id
             else:
                 issues.append(
                     f"Invalid createdBy value {created_user!r} for view {context.source_view_id!s}: expected a dict with an externalId field or a NodeId."
                 )
         if updated_user := source_properties.get("updatedBy"):
             if isinstance(updated_user, dict) and "externalId" in updated_user:
-                created_properties["sourceUpdatedTime"] = updated_user["externalId"]
+                created_properties["sourceUpdatedUser"] = updated_user["externalId"]
             elif isinstance(updated_user, NodeId):
-                created_properties["sourceUpdatedTime"] = updated_user.external_id
+                created_properties["sourceUpdatedUser"] = updated_user.external_id
             else:
                 issues.append(
                     f"Invalid updatedBy value {updated_user!r} for view {context.source_view_id!s}: expected a dict with an externalId field or a NodeId."

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -941,6 +941,60 @@ class InFieldConditionMapping(CustomContainerPropertiesMapping):
         return ConversionResult(container_properties=created_properties, errors=issues)
 
 
+class InFieldUserMapping(CustomContainerPropertiesMapping):
+    """Custom mapping for the user property in the InField data migration.
+
+    This is needed because the user properties 'createdBy' and 'updatedBy' are mapped to two
+    properties in each. For example, the 'createdBy' is mapped to 'createdBy', and
+    'createdBy.externalId' -> sourceCreatedUser.
+
+    The ViewToView mapping does not support
+        - Mapping one properties in the source view to two properties in the destination view.
+        - Mapping nested property in the source to the destination.
+
+    """
+
+    VIEW_IDS: ClassVar[Set[ViewId]] = frozenset(
+        {
+            ViewId(space="cdf_apm", external_id="Action", version="v1"),
+            ViewId(space="cdf_apm", external_id="Checklist", version="v7"),
+            ViewId(space="cdf_apm", external_id="ChecklistItem", version="v7"),
+            ViewId(space="cdf_apm", external_id="Condition", version="v1"),
+            ViewId(space="cdf_apm", external_id="ConditionalAction", version="v1"),
+            ViewId(space="cdf_apm", external_id="MeasurementReading", version="v4"),
+            ViewId(space="cdf_apm", external_id="Observation", version="v5"),
+            ViewId(space="cdf_apm", external_id="Schedule", version="v4"),
+            ViewId(space="cdf_apm", external_id="Template", version="v9"),
+            ViewId(space="cdf_apm", external_id="TemplateItem", version="v7"),
+        }
+    )
+
+    def convert(
+        self, source_properties: dict[str, JsonValue | NodeId | list[NodeId]], context: ConversionContext
+    ) -> ConversionResult:
+        created_properties: dict[str, JsonValue | NodeId | list[NodeId]] = {}
+        issues: list[str] = []
+        if created_user := source_properties.get("createdBy"):
+            if isinstance(created_user, dict) and "externalId" in created_user:
+                created_properties["sourceCreatedTime"] = created_user["externalId"]
+            elif isinstance(created_user, NodeId):
+                created_properties["sourceCreatedTime"] = created_user.external_id
+            else:
+                issues.append(
+                    f"Invalid createdBy value {created_user!r} for view {context.source_view_id!s}: expected a dict with an externalId field or a NodeId."
+                )
+        if updated_user := source_properties.get("updatedBy"):
+            if isinstance(updated_user, dict) and "externalId" in updated_user:
+                created_properties["sourceUpdatedTime"] = updated_user["externalId"]
+            elif isinstance(updated_user, NodeId):
+                created_properties["sourceUpdatedTime"] = updated_user.external_id
+            else:
+                issues.append(
+                    f"Invalid updatedBy value {updated_user!r} for view {context.source_view_id!s}: expected a dict with an externalId field or a NodeId."
+                )
+        return ConversionResult(container_properties=created_properties, errors=issues)
+
+
 class InFieldAssetMapping(CustomConnectionMapping[NodeId]):
     """Custom cases in the InField data migration
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1092,9 +1092,10 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, InstanceResponse, InstanceRequ
         self._mappings_by_source_view: dict[ViewId, ViewToViewMapping] = {
             mapping.source_view: mapping for mapping in mappings
         }
-        self._custom_properties_mapping: dict[ViewId, CustomContainerPropertiesMapping] = {
-            view_id: mapping for mapping in (custom_properties_mappings or []) for view_id in mapping.VIEW_IDS
-        }
+        self._custom_properties_mapping: dict[ViewId, list[CustomContainerPropertiesMapping]] = defaultdict(list)
+        for mapping in custom_properties_mappings or []:
+            for view_id in mapping.VIEW_IDS:
+                self._custom_properties_mapping[view_id].append(mapping)
         self._custom_instance_mappings = custom_instance_mappings
         # These data structures are used to validate required direct relations, i.e.,
         # direct relation properties that requires that the target has properties in a
@@ -1225,12 +1226,11 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, InstanceResponse, InstanceRequ
             )
             special_properties: dict[str, JsonValue | NodeId | list[NodeId]] = {}
             if context.mapping.source_view in self._custom_properties_mapping:
-                special_results = self._custom_properties_mapping[context.mapping.source_view].convert(
-                    source_properties, context
-                )
-                issue.errors.extend(special_results.errors)
-                new_edges.extend(special_results.edges)
-                special_properties = special_results.container_properties
+                for custom_mapper in self._custom_properties_mapping[context.mapping.source_view]:
+                    special_results = custom_mapper.convert(source_properties, context)
+                    issue.errors.extend(special_results.errors)
+                    new_edges.extend(special_results.edges)
+                    special_properties.update(special_results.container_properties)
 
             container_results = convert_container_properties(source_properties, context)
             edge_results = convert_edges(other_side_by_edge_type_and_direction, context)

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -78,6 +78,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.conversion import (
     CustomContainerPropertiesMapping,
     DirectRelationCache,
     EdgeOtherSide,
+    InFieldUserMapping,
     asset_centric_to_dm,
     asset_centric_to_record,
     convert_container_properties,
@@ -1590,6 +1591,8 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, InstanceResp
             template_edges, template_item_edges, destination_view.properties, issue
         )
         created_properties.update(template_and_template_item_properties)
+        special_properties = InFieldUserMapping().convert(source_properties, context)
+        created_properties.update(special_properties.container_properties)
 
         return NodeRequest(
             space=new_id.space,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1592,6 +1592,7 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, InstanceResp
         )
         created_properties.update(template_and_template_item_properties)
         special_properties = InFieldUserMapping().convert(source_properties, context)
+        issue.errors.extend(special_properties.errors)
         created_properties.update(special_properties.container_properties)
 
         return NodeRequest(

--- a/tests_smoke/test_commands/test_migrate_infield/test_migrate_data.yml
+++ b/tests_smoke/test_commands/test_migrate_infield/test_migrate_data.yml
@@ -12,6 +12,7 @@ instances:
           externalId: 0083e7c3-946f-4d5d-958b-133963108ad9
           space: smoke_infield_migration_target_space
         order: 2
+        sourceCreatedUser: VJZrRM_kByZe-moErWilvg
         title: any comments ?
         type: message
   space: smoke_infield_migration_target_space
@@ -30,6 +31,8 @@ instances:
         max: 90
         min: 10
         order: 0
+        sourceCreatedUser: VJZrRM_kByZe-moErWilvg
+        sourceUpdatedUser: VJZrRM_kByZe-moErWilvg
         timeseries:
           externalId: Measurements Readings - Suu
           space: smoke_infield_migration_target_space
@@ -50,6 +53,7 @@ instances:
         endTime: '2025-02-20T12:30:00+00:00'
         freq: DAILY
         interval: '1'
+        sourceCreatedUser: VJZrRM_kByZe-moErWilvg
         startTime: '2025-02-20T08:30:00+00:00'
         template:
           externalId: 87f1ce17-c510-4359-9bbe-2ec7477b2cfe
@@ -99,6 +103,7 @@ instances:
         labels:
         - group:one Task group
         order: 141
+        sourceUpdatedUser: VJZrRM_kByZe-moErWilvg
         template:
           externalId: 87f1ce17-c510-4359-9bbe-2ec7477b2cfe
           space: smoke_infield_migration_target_space
@@ -122,7 +127,9 @@ instances:
           externalId: SmokeAsset
           space: smoke_infield_migration_target_space
         solutionTags: []
+        sourceCreatedUser: VJZrRM_kByZe-moErWilvg
         sourceId: 16a3587b-1927-40ed-8da9-4c55c041aeb5
+        sourceUpdatedUser: VJZrRM_kByZe-moErWilvg
         startTime: '2025-06-09T08:30:00+00:00'
         status: Ready
         title: ADSuu Template/Checklist
@@ -155,7 +162,9 @@ instances:
           space: smoke_infield_migration_target_space
         isArchived: false
         order: 6
+        sourceCreatedUser: VJZrRM_kByZe-moErWilvg
         sourceId: 202b7a05-1ba3-4058-9a16-3f9cc306067c
+        sourceUpdatedUser: VJZrRM_kByZe-moErWilvg
         startTime: '2025-06-09T08:30:00+00:00'
         title: 'task '
         updatedBy:
@@ -177,6 +186,8 @@ instances:
           space: cognite_app_data
         parameters:
           message: 'item is not okay '
+        sourceCreatedUser: VJZrRM_kByZe-moErWilvg
+        sourceUpdatedUser: VJZrRM_kByZe-moErWilvg
         updatedBy:
           externalId: VJZrRM_kByZe-moErWilvg
           space: cognite_app_data


### PR DESCRIPTION
# Description

See https://github.com/cognitedata/toolkit/pull/2858/changes#diff-dea81a2f4648a92b7eb9adfc619cf0fd1e7bf913e7c743480a26b21db4c0886c

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- [alpha] When running `cdf migrate infiel-data`, Toolkit now maps to `sourceCreatedUser` and `sourceUpdatedUser` for all views that has these properties. 
