### PR TITLE
[CDF-27651] 🚄Build v2 Avoid keeping bytes in memory

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shutil
 import sys
 from collections import Counter
 from collections.abc import Iterable, Sequence
@@ -655,6 +656,8 @@ class BuildV2Command(ToolkitCommand):
                         safe_write(extra_path, extra_file.content, encoding=BUILD_FOLDER_ENCODING)
                     elif extra_file.byte_content:
                         extra_path.write_bytes(extra_file.byte_content)
+                    else:
+                        shutil.copy2(extra_file.source_path, extra_path)
 
                 crud_cls = file.resource_type.crud_cls
                 if resource.validated:

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/file.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/file.py
@@ -351,7 +351,6 @@ def _iter_file_content_read_extras(
         source_path=source,
         source_hash=calculate_hash(source, shorten=True),
         suffix=source.suffix if source.suffix else ".bin",
-        byte_content=source.read_bytes(),
         description="file contents",
     )
 


### PR DESCRIPTION
# Description

Small performance optimization for Build v2. Avoid reading bytes into memory if it is not necessary. 

## Bump

- [ ] Patch
- [x] Skip

