### PR TITLE
[CDF-27680] Fix cdf dump extraction-pipeline producing malformed config files

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/extraction_pipeline.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/extraction_pipeline.py
@@ -388,10 +388,9 @@ class ExtractionPipelineConfigIO(
             parent_external_ids = [pid for pid in parent_ids if isinstance(pid, ExternalId)]
         for parent_id in parent_external_ids:
             try:
-                for configs in self.client.tool.extraction_pipelines.configs.iterate(
-                    external_id=parent_id.external_id, limit=None
-                ):
-                    yield from configs
+                yield from self.client.tool.extraction_pipelines.configs.retrieve(
+                    [ExtractionPipelineConfigId(external_id=parent_id.external_id)]
+                )
             except ToolkitAPIError as e:
                 if e.code == 404 and "There is no config stored" in e.message:
                     continue


### PR DESCRIPTION
# Description

Fixes a regression introduced in #2521 where `ExtractionPipelineConfigIO._iterate` was changed to use `configs.iterate()`, which hits `GET /extpipes/config/revisions`. This is an endpoint that returns revision metadata only — without the `config` content field. Since `config` is an optional pydantic field, `dump(exclude_unset=True)` silently omitted it, producing empty config files. This PR changes to using `configs.retrieve()`, which hits `GET /extpipes/config` and returns the latest revision with content. Pipelines without a config are silently skipped as expected.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fixes an issue which caused `cdf dump extraction-pipeline`, to produce a malformed extraction pipeline configuration file.
