### PR TITLE
[CDF-27577] 🚂 Allow concat list variables in Build v2

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_module.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_module.py
@@ -41,7 +41,7 @@ class BuildVariable(BaseModel):
                 pattern = rf"'{pattern}'|{pattern}|\"{pattern}\""
             elif substitution is None:
                 substitution = "null"
-            elif isinstance(substitution, list) and file_suffix == ".yaml":
+            elif isinstance(substitution, list) and (file_suffix == ".yaml" or file_suffix == ".yml"):
                 variable_token = rf"{{{{\s*{re.escape(self.name)}\s*}}}}"
                 pattern = rf"(?m)^(?P<indent>[ \t]*){variable_token}\s*$"
                 values = substitution

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_module.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_module.py
@@ -1,4 +1,6 @@
+import json
 import re
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Generic, Literal, TypeAlias, get_args
@@ -27,7 +29,9 @@ class BuildVariable(BaseModel):
     def name(self) -> str:
         return self.id.name
 
-    def get_pattern_replace_pair(self, file_suffix: FileSuffix = ".yaml") -> tuple[str, str]:
+    def get_pattern_replace_pair(
+        self, file_suffix: FileSuffix = ".yaml"
+    ) -> tuple[str, str | Callable[[re.Match[str]], str]]:
         substitution = self.value
         pattern = rf"{{{{\s*{self.name}\s*}}}}"
         if file_suffix in (".yaml", ".yml", ".json"):
@@ -37,12 +41,34 @@ class BuildVariable(BaseModel):
                 pattern = rf"'{pattern}'|{pattern}|\"{pattern}\""
             elif substitution is None:
                 substitution = "null"
+            elif isinstance(substitution, list) and file_suffix == ".yaml":
+                variable_token = rf"{{{{\s*{re.escape(self.name)}\s*}}}}"
+                pattern = rf"(?m)^(?P<indent>[ \t]*){variable_token}\s*$"
+                values = substitution
+
+                def replace_yaml_block_sequence(match: re.Match[str]) -> str:
+                    indent = match.group("indent")
+                    return "\n".join(f"{indent}- {BuildVariable._yaml_block_sequence_scalar(item)}" for item in values)
+
+                return pattern, replace_yaml_block_sequence
         elif file_suffix == ".sql":
             if isinstance(substitution, list):
                 substitution = self._format_list_as_sql_tuple(substitution)
         else:
             raise NotImplementedError(f"{file_suffix!r} is not supported for variable replacement")
         return pattern, str(substitution)
+
+    @staticmethod
+    def _yaml_block_sequence_scalar(value: str | bool | int | float) -> str:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, int | float):
+            return str(value)
+        if value.isdigit() or value.endswith(":"):
+            return json.dumps(value)
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_.-]*", value):
+            return value
+        return json.dumps(value)
 
     @staticmethod
     def _format_list_as_sql_tuple(replace: list[str | bool | int | float]) -> str:

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_module.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_module.py
@@ -43,14 +43,15 @@ class BuildVariable(BaseModel):
                 substitution = "null"
             elif isinstance(substitution, list) and (file_suffix == ".yaml" or file_suffix == ".yml"):
                 variable_token = rf"{{{{\s*{re.escape(self.name)}\s*}}}}"
-                pattern = rf"(?m)^(?P<indent>[ \t]*){variable_token}\s*$"
+                pattern = rf"(?m)^(?P<indent>[ \t]*){variable_token}\s*$|{variable_token}"
                 values = substitution
 
-                def replace_yaml_block_sequence(match: re.Match[str]) -> str:
-                    indent = match.group("indent")
-                    return "\n".join(f"{indent}- {self._yaml_block_sequence_scalar(item)}" for item in values)
+                def replace_yaml_list(match: re.Match[str]) -> str:
+                    if (indent := match.group("indent")) is not None:
+                        return "\n".join(f"{indent}- {self._yaml_block_sequence_scalar(item)}" for item in values)
+                    return str(substitution)
 
-                return pattern, replace_yaml_block_sequence
+                return pattern, replace_yaml_list
         elif file_suffix == ".sql":
             if isinstance(substitution, list):
                 substitution = self._format_list_as_sql_tuple(substitution)
@@ -64,7 +65,11 @@ class BuildVariable(BaseModel):
             return "true" if value else "false"
         if isinstance(value, int | float):
             return str(value)
-        if value.isdigit() or value.endswith(":"):
+        if (
+            value.isdigit()
+            or value.endswith(":")
+            or value.lower() in ("true", "false", "null", "yes", "no", "on", "off")
+        ):
             return json.dumps(value)
         if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_.-]*", value):
             return value

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_module.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_module.py
@@ -48,7 +48,7 @@ class BuildVariable(BaseModel):
 
                 def replace_yaml_block_sequence(match: re.Match[str]) -> str:
                     indent = match.group("indent")
-                    return "\n".join(f"{indent}- {BuildVariable._yaml_block_sequence_scalar(item)}" for item in values)
+                    return "\n".join(f"{indent}- {self._yaml_block_sequence_scalar(item)}" for item in values)
 
                 return pattern, replace_yaml_block_sequence
         elif file_suffix == ".sql":

--- a/cognite_toolkit/_cdf_tk/resource_ios/_base_ios.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_base_ios.py
@@ -439,7 +439,7 @@ class ResourceIO(Loader, ABC, Generic[T_Identifier, T_RequestResource, T_Respons
     def substitute_variables_content(cls, content: str, variables: "list[BuildVariable]") -> str:
         """Variable substitution in the content of a file. This is used in the build command.
 
-        This is overwritten in the TransformationCRUD to handle substitution in the query field.
+        This is overwritten in the TransformationIO to handle substitution in the query field.
         """
         # To avoid circular import
         from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import BuildVariable

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_data_classes.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_data_classes.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -150,6 +151,36 @@ query: >-
         loaded = yaml.safe_load(result)
 
         assert loaded["query"] == 'select "fpso_uny" as externalId, "UNY" as uid, "UNY" as description'
+
+    @pytest.mark.parametrize(
+        "yaml_content, expected",
+        [
+            pytest.param(
+                """instanceSpaces:
+{{ list_one }}
+{{ list_two }}
+""",
+                {"instanceSpaces": ["a", "b", "c", "d", "e"]},
+                id="Outer list",
+            ),
+            pytest.param(
+                """rules:
+  instanceSpace:
+    {{ list_one }}
+    {{ list_two }}
+             """,
+                {"rules": {"instanceSpace": ["a", "b", "c", "d", "e"]}},
+                id="Nested list",
+            ),
+        ],
+    )
+    def test_substitute_concat_lists(self, yaml_content: str, expected: dict[str, Any]) -> None:
+        variables = _create_variables({"list_one": ["a", "b", "c"], "list_two": ["d", "e"]})
+
+        result = BuildVariable.substitute(yaml_content, variables, ".yaml")
+        loaded = yaml.safe_load(result)
+
+        assert loaded == expected
 
     def test_format_list_as_sql_tuple_empty(self) -> None:
         """Test that empty lists become empty SQL tuples."""


### PR DESCRIPTION
# Description

If the user have the following in their `config.dev.yaml`

```yaml
...
variables:
  list_one:
  - a
  - b
  list_two:
  - c
  - d
```
And have a config file
```yaml
instanceSpaces:
{{ list_one }}
{{ list_two }}
````

Then, the variable substitution end with 
```yaml
instanceSpaces:
- a
- b
- c
- d
````

## Bump

- [ ] Patch
- [x] Skip

