### PR TITLE
🐛 Fix hosted_extractor client credentials validation by using correct scopes field name

### DIFF
--- a/cognite_toolkit/_cdf_tk/yaml_classes/hosted_extractor_source.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/hosted_extractor_source.py
@@ -121,7 +121,7 @@ class ClientCredentials(Authentication):
     token_url: str = Field(
         description="URL to fetch authentication tokens from",
     )
-    scopes: str = Field(
+    scopes: str | list[str] = Field(
         description="A space separated list of scopes",
     )
     default_expires_in: str | None = Field(

--- a/cognite_toolkit/_cdf_tk/yaml_classes/hosted_extractor_source.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/hosted_extractor_source.py
@@ -121,7 +121,7 @@ class ClientCredentials(Authentication):
     token_url: str = Field(
         description="URL to fetch authentication tokens from",
     )
-    scope: str = Field(
+    scopes: str = Field(
         description="A space separated list of scopes",
     )
     default_expires_in: str | None = Field(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_hosted_extractor_source.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_hosted_extractor_source.py
@@ -113,7 +113,7 @@ def invalid_hosted_extractor_source_test_cases() -> Iterable:
                 "type": "clientCredentials",
                 "client_id": "id",
                 "token_url": "https://token.url",
-                "scope": "scope",
+                "scopes": "scope",
                 # missing client_secret
             },
         },
@@ -214,7 +214,7 @@ def invalid_hosted_extractor_source_test_cases() -> Iterable:
                 "type": "clientCredentials",
                 "clientId": "id",
                 "tokenUrl": "https://token.url",
-                "scope": "scope",
+                "scopes": "scope",
                 # missing client_secret
             },
         },


### PR DESCRIPTION
# Description

Fixed validation error for `hosted_extractor` resources with client credentials authentication. The YAML schema was incorrectly using the singular field name `scope` instead of the plural `scopes` required by the Cognite API. This mismatch caused `ResourceFormatWarning` when users provided the correct API field name. Updated the schema to use `scopes` to match the client resource class and API specification.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Fixed validation error for hosted_extractor resources with client credentials auth by changing `scope` field to `scopes` in `ClientCredentials` YAML class to match API requirements