### PR TITLE
[CDF-27603]🚃Dumping insights to csv.

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_insights.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_insights.py
@@ -40,6 +40,11 @@ class Recommendation(InsightDefinition):
 Insight: TypeAlias = ModelSyntaxWarning | ConsistencyError | Recommendation
 
 
+def _normalize_csv_cell(text: str) -> str:
+    """Normalize line breaks so CSV cells stay readable and consistent across platforms."""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
 class InsightList(UserList[Insight]):
     """A list of insights that can be sorted by type and message."""
 
@@ -88,21 +93,25 @@ class InsightList(UserList[Insight]):
     def to_csv(self) -> str:
         """Returns a CSV formatted string representation of the insights.
 
+        Uses a Unix-style CSV dialect (LF-only record separators, all fields quoted) so
+        ``message`` and ``fix`` may contain newlines without corrupting row boundaries.
+        Carriage returns inside cells are normalized to LF newlines.
+
         Returns:
             CSV formatted string with columns: insight_type, code, message, fix
         """
         output = io.StringIO()
         fieldnames = ["insight_type", "code", "message", "fix"]
-        writer = csv.DictWriter(output, fieldnames=fieldnames)
+        writer = csv.DictWriter(output, fieldnames=fieldnames, dialect=csv.unix_dialect)
         writer.writeheader()
 
         for insight in self.data:
             writer.writerow(
                 {
-                    "insight_type": insight.insight_type(),
-                    "code": insight.code or "",
-                    "message": insight.message,
-                    "fix": insight.fix or "",
+                    "insight_type": _normalize_csv_cell(insight.insight_type()),
+                    "code": _normalize_csv_cell(insight.code or ""),
+                    "message": _normalize_csv_cell(insight.message),
+                    "fix": _normalize_csv_cell(insight.fix or ""),
                 }
             )
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_insights.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_insights.py
@@ -1,0 +1,44 @@
+import csv
+import io
+
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import (
+    ConsistencyError,
+    InsightList,
+    Recommendation,
+)
+
+
+def test_insight_list_to_csv_preserves_multiline_message_and_fix() -> None:
+    """Multiline and special characters round-trip via the csv module; rows use LF only."""
+    insights = InsightList(
+        [
+            ConsistencyError(
+                message="summary line\nnext line",
+                code="ERR-1",
+                fix="do this\r\nthen that",
+            ),
+            Recommendation(
+                message='text with "quotes" and, commas',
+                code=None,
+                fix="single",
+            ),
+        ]
+    )
+
+    csv_text = insights.to_csv()
+    assert "\r\n" not in csv_text, "record separators must be LF-only (unix CSV dialect)"
+    rows = list(csv.DictReader(io.StringIO(csv_text), dialect=csv.unix_dialect))
+    assert rows == [
+        {
+            "insight_type": "ConsistencyError",
+            "code": "ERR-1",
+            "message": "summary line\nnext line",
+            "fix": "do this\nthen that",
+        },
+        {
+            "insight_type": "Recommendation",
+            "code": "",
+            "message": 'text with "quotes" and, commas',
+            "fix": "single",
+        },
+    ]


### PR DESCRIPTION
# Description

Dumping insights to CSV in build V2, works as expected when opened in Excel
<img width="513" height="121" alt="image" src="https://github.com/user-attachments/assets/452ed506-6a43-4877-8aa1-e0a3dea9d6fe" />

**note** The issue described in the Jira task is not a problem. It looks strange when you open a csv file in text editor, but it works as expected when parsing it in either excel or python.

## Bump

- [ ] Patch
- [x] Skip

