### PR TITLE
🐛 Fix: Show user-friendly errors for invalid function parameters

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
@@ -487,10 +487,11 @@ class FunctionIO(ResourceIO[ExternalId, FunctionRequest, FunctionResponse]):
             try:
                 result = self.client.tool.functions.create([item_to_create])
             except ToolkitAPIError as e:
-                if e.code == 400:
-                    # Handle validation errors with user-friendly message
-                    raise ResourceCreationError(self._parse_validation_error(e, external_id)) from e
-                raise
+                # Handle any HTTP error with user-friendly message
+                raise ResourceCreationError(self._parse_validation_error(e, external_id)) from e
+            except Exception as e:
+                # Handle unexpected errors
+                raise ResourceCreationError(f"Failed to create function '{external_id}': {e!s}") from e
             if result:
                 created_item = result[0]
                 self._warn_if_cpu_or_memory_changed(created_item, item)
@@ -526,10 +527,11 @@ class FunctionIO(ResourceIO[ExternalId, FunctionRequest, FunctionResponse]):
             try:
                 result = self.client.tool.functions.create([item_to_create])
             except ToolkitAPIError as e:
-                if e.code == 400:
-                    # Handle validation errors with user-friendly message
-                    raise ResourceCreationError(self._parse_validation_error(e, external_id)) from e
-                raise
+                # Handle any HTTP error with user-friendly message
+                raise ResourceCreationError(self._parse_validation_error(e, external_id)) from e
+            except Exception as e:
+                # Handle unexpected errors
+                raise ResourceCreationError(f"Failed to create function '{external_id}': {e!s}") from e
             if result:
                 created_item = result[0]
                 self._warn_if_cpu_or_memory_changed(created_item, item)

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
@@ -448,7 +448,8 @@ class FunctionIO(ResourceIO[ExternalId, FunctionRequest, FunctionResponse]):
             # Format: "memory must lie in the range [0.1, 1.5]"
             return (
                 f"Failed to create function '{external_id}': {message}\n"
-                "Please check the function configuration in your YAML file and ensure all parameter values are within valid ranges."
+                "Please check the function configuration in your YAML file and ensure "
+                "all parameter values are within valid ranges."
             )
         else:
             # Generic validation error from the API

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
@@ -16,6 +16,7 @@ from rich.console import Console
 from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client._resource_base import Identifier
+from cognite_toolkit._cdf_tk.client.http_client import ToolkitAPIError
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, InternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.function import FunctionRequest, FunctionResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.function_schedule import (
@@ -428,6 +429,31 @@ class FunctionIO(ResourceIO[ExternalId, FunctionRequest, FunctionResponse]):
             self.client.functions.activate()
         return False
 
+    @staticmethod
+    def _parse_validation_error(api_error: ToolkitAPIError, external_id: str) -> str:
+        """Parse CDF API validation error and provide user-friendly message.
+
+        Args:
+            api_error: The ToolkitAPIError from the CDF API.
+            external_id: The external ID of the function being created.
+
+        Returns:
+            A user-friendly error message with field name and valid range.
+        """
+        message = api_error.message
+        # The API error message follows the pattern: "field must lie in the range [x, y]"
+        # or other validation errors like "field must be a valid value"
+        if "must lie in the range" in message:
+            # Extract the field name and range from the error message
+            # Format: "memory must lie in the range [0.1, 1.5]"
+            return (
+                f"Failed to create function '{external_id}': {message}\n"
+                "Please check the function configuration in your YAML file and ensure all parameter values are within valid ranges."
+            )
+        else:
+            # Generic validation error from the API
+            return f"Failed to create function '{external_id}': {message}"
+
     def create(self, items: Sequence[FunctionRequest]) -> list[FunctionResponse]:
         if not self._is_activated("create"):
             return []
@@ -457,7 +483,13 @@ class FunctionIO(ResourceIO[ExternalId, FunctionRequest, FunctionResponse]):
 
             # Create a copy with the file_id set
             item_to_create = FunctionRequest.model_validate({**item.dump(), "fileId": file_id.id})
-            result = self.client.tool.functions.create([item_to_create])
+            try:
+                result = self.client.tool.functions.create([item_to_create])
+            except ToolkitAPIError as e:
+                if e.code == 400:
+                    # Handle validation errors with user-friendly message
+                    raise ResourceCreationError(self._parse_validation_error(e, external_id)) from e
+                raise
             if result:
                 created_item = result[0]
                 self._warn_if_cpu_or_memory_changed(created_item, item)
@@ -490,7 +522,13 @@ class FunctionIO(ResourceIO[ExternalId, FunctionRequest, FunctionResponse]):
 
             # Create a copy with the file_id set
             item_to_create = item.model_copy(update={"fileId": file_id.id})
-            result = self.client.tool.functions.create([item_to_create])
+            try:
+                result = self.client.tool.functions.create([item_to_create])
+            except ToolkitAPIError as e:
+                if e.code == 400:
+                    # Handle validation errors with user-friendly message
+                    raise ResourceCreationError(self._parse_validation_error(e, external_id)) from e
+                raise
             if result:
                 created_item = result[0]
                 self._warn_if_cpu_or_memory_changed(created_item, item)

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_function.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_function.py
@@ -17,6 +17,7 @@ from cognite.client.data_classes.capabilities import FilesAcl, FunctionsAcl
 from cognite.client.exceptions import CogniteAPIError
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
+from cognite_toolkit._cdf_tk.client.http_client import ToolkitAPIError
 from cognite_toolkit._cdf_tk.client.identifiers import InternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.function import FunctionRequest, FunctionResponse
@@ -265,6 +266,30 @@ secrets:
             pytest.raises(ResourceCreationError, match="timed out"),
         ):
             function_io.create([item])
+
+    @pytest.mark.skipif(not Flags.v08.is_enabled(), reason="This test is only relevant for v0.8 and later")
+    def test_create_raises_user_friendly_error_on_validation_failure(self, function_io_with_file: FunctionIO) -> None:
+        """Test that ToolkitAPIError with 400 is converted to user-friendly ResourceCreationError."""
+        function_io = function_io_with_file
+        client = function_io.client
+        client.tool.filemetadata.await_file_uploaded.return_value = set(), 3.0
+
+        # Mock the functions.create to raise a validation error (HTTP 400)
+        validation_error = ToolkitAPIError(code=400, message="memory must lie in the range [0.1, 1.5].")
+        client.tool.functions.create.side_effect = validation_error
+
+        item = FunctionRequest(name="my_func", external_id="my_func", file_id=-1)
+
+        with (
+            patch.object(function_io, "_is_activated", return_value=True),
+            pytest.raises(ResourceCreationError) as exc_info,
+        ):
+            function_io.create([item])
+
+        error_message = str(exc_info.value)
+        assert "Failed to create function 'my_func'" in error_message
+        assert "memory must lie in the range [0.1, 1.5]" in error_message
+        assert "Please check the function configuration" in error_message
 
 
 class TestFunctionScheduleLoader:


### PR DESCRIPTION
# Description

Function deployment now catches HTTP 400 validation errors and converts them to user-friendly messages specifying which parameter is invalid and its valid range (e.g., "memory must lie in the range [0.1, 1.5]").

## Bump

- [ ] Patch
- [x] Skip

## Changelog

### Fixed

- Function deployment error handling for invalid parameter values (memory, cpu, etc.) now shows clear, actionable error messages instead of crashing with unhandled `ToolkitAPIError`