### PR TITLE
[CDF-27689] Fix KeyError when API omits optional fields in dump_resource

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product.py
@@ -81,7 +81,7 @@ class DataProductIO(ResourceIO[ExternalId, DataProductRequest, DataProductRespon
         ]
         for key, default in defaults:
             if dumped.get(key) == default and key not in local:
-                dumped.pop(key)
+                dumped.pop(key, None)
         return dumped
 
     def create(self, items: Sequence[DataProductRequest]) -> list[DataProductResponse]:

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
@@ -90,7 +90,7 @@ class DataProductVersionIO(ResourceIO[DataProductVersionId, DataProductVersionRe
         }
         for key, default in defaults.items():
             if dumped.get(key) == default and key not in local:
-                dumped.pop(key)
+                dumped.pop(key, None)
         return dumped
 
     def create(self, items: Sequence[DataProductVersionRequest]) -> list[DataProductVersionResponse]:

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/timeseries.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/timeseries.py
@@ -136,7 +136,7 @@ class TimeSeriesCRUD(ResourceContainerIO[ExternalId, TimeSeriesRequest, TimeSeri
                 ("metadata", {}),
             ]:
                 if dumped.get(key) == default and key not in local_dict:
-                    dumped.pop(key)
+                    dumped.pop(key, None)
         return dumped
 
     def create(self, items: Sequence[TimeSeriesRequest]) -> list[TimeSeriesResponse]:

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_data_product_version.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_data_product_version.py
@@ -1,0 +1,51 @@
+"""Unit tests for DataProductVersionIO."""
+
+from cognite_toolkit._cdf_tk.client.resource_classes.data_product_version import (
+    DataProductVersionQuality,
+    DataProductVersionResponse,
+)
+from cognite_toolkit._cdf_tk.client.testing import ToolkitClientMock
+from cognite_toolkit._cdf_tk.resource_ios._resource_ios.data_product_version import DataProductVersionIO
+
+
+class TestDataProductVersionIODumpResource:
+    def test_dump_resource_without_quality_does_not_raise(self) -> None:
+        """Regression test for CDF-27689: dump_resource must not crash when the API
+        response omits the optional 'quality' field."""
+        client = ToolkitClientMock()
+        io = DataProductVersionIO(client, None, None)
+
+        resource = DataProductVersionResponse(
+            data_product_external_id="my-product",
+            version="1.0.0",
+            created_time=0,
+            last_updated_time=0,
+            quality=None,
+        )
+
+        dumped = io.dump_resource(resource)
+
+        assert "quality" not in dumped
+
+    def test_dump_resource_with_quality_preserved_when_in_local(self) -> None:
+        """When quality is present in the local file it must not be stripped from the dump."""
+        client = ToolkitClientMock()
+        io = DataProductVersionIO(client, None, None)
+
+        resource = DataProductVersionResponse(
+            data_product_external_id="my-product",
+            version="1.0.0",
+            created_time=0,
+            last_updated_time=0,
+            quality=DataProductVersionQuality(rules=[]),
+        )
+
+        local = {
+            "dataProductExternalId": "my-product",
+            "version": "1.0.0",
+            "quality": None,
+        }
+
+        dumped = io.dump_resource(resource, local)
+
+        assert "quality" in dumped


### PR DESCRIPTION
# Description

`dump_resource` in several resource IOs prunes default-valued fields using a
`dumped.get(key) == default → dumped.pop(key)` loop. When the API response
omits an optional field entirely, `get` returns `None` (matching the default),
but the key is absent from the dict, causing `KeyError: 'quality'` on `pop`.

Fixed by changing `dumped.pop(key)` → `dumped.pop(key, None)` in:
- `DataProductVersionIO.dump_resource` (original reporter)
- `DataProductIO.dump_resource` (same pattern)
- `TimeSeriesCRUD.dump_resource` (same pattern)

Added a regression test for `DataProductVersionIO`.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Fix `KeyError` in `dump_resource` when the API response omits an optional field
  (e.g. `quality` in data product versions, `metadata` in time series).