### PR TITLE
[CDF-27690] Add data model as deployment dependency for agents

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/agent.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/agent.py
@@ -2,7 +2,7 @@ from collections.abc import Hashable, Iterable, Sequence
 from typing import Any, Literal, final
 
 from cognite_toolkit._cdf_tk.client._resource_base import Identifier
-from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.client.identifiers import DataModelId, ExternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.agent import AgentRequest, AgentResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.group import (
     AclType,
@@ -11,11 +11,12 @@ from cognite_toolkit._cdf_tk.client.resource_classes.group import (
     ScopeDefinition,
 )
 from cognite_toolkit._cdf_tk.resource_ios._base_ios import ResourceIO
+from cognite_toolkit._cdf_tk.resource_ios._resource_ios.datamodel import DataModelIO
 from cognite_toolkit._cdf_tk.resource_ios._resource_ios.function import FunctionIO
 from cognite_toolkit._cdf_tk.utils.diff_list import diff_list_hashable, diff_list_identifiable
 from cognite_toolkit._cdf_tk.utils.file import sanitize_filename
 from cognite_toolkit._cdf_tk.yaml_classes import AgentYAML
-from cognite_toolkit._cdf_tk.yaml_classes.agent import CallFunction
+from cognite_toolkit._cdf_tk.yaml_classes.agent import CallFunction, QueryKnowledgeGraph
 
 
 @final
@@ -25,7 +26,7 @@ class AgentIO(ResourceIO[ExternalId, AgentRequest, AgentResponse]):
     resource_write_cls = AgentRequest
     kind = "Agent"
     yaml_cls = AgentYAML
-    dependencies = frozenset({FunctionIO})
+    dependencies = frozenset({FunctionIO, DataModelIO})
     _doc_base_url = ""
     _doc_url = "https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/main_ai_agents_post/"
 
@@ -49,12 +50,29 @@ class AgentIO(ResourceIO[ExternalId, AgentRequest, AgentResponse]):
             if tool.get("type") == "callFunction":
                 if ext_id := tool.get("configuration", {}).get("externalId"):
                     yield FunctionIO, ExternalId(external_id=ext_id)
+            elif tool.get("type") == "queryKnowledgeGraph":
+                for data_model in tool.get("configuration", {}).get("dataModels", []):
+                    space = data_model.get("space")
+                    external_id = data_model.get("externalId")
+                    version = data_model.get("version")
+                    if space and external_id and version:
+                        yield DataModelIO, DataModelId(space=space, external_id=external_id, version=str(version))
 
     @classmethod
     def get_dependencies(cls, resource: AgentYAML) -> Iterable[tuple[type[ResourceIO], Identifier]]:
         for tool in resource.tools or []:
             if isinstance(tool, CallFunction):
                 yield FunctionIO, ExternalId(external_id=tool.configuration.external_id)
+            elif isinstance(tool, QueryKnowledgeGraph):
+                for data_model in tool.configuration.data_models:
+                    yield (
+                        DataModelIO,
+                        DataModelId(
+                            space=data_model.space,
+                            external_id=data_model.external_id,
+                            version=data_model.version,
+                        ),
+                    )
 
     @classmethod
     def get_minimum_scope(cls, items: Sequence[AgentRequest]) -> ScopeDefinition:

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_agent.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_agent.py
@@ -1,0 +1,117 @@
+from collections.abc import Hashable
+
+import pytest
+
+from cognite_toolkit._cdf_tk.client.identifiers import DataModelId, ExternalId
+from cognite_toolkit._cdf_tk.resource_ios import DataModelIO, FunctionIO, ResourceIO
+from cognite_toolkit._cdf_tk.resource_ios._resource_ios.agent import AgentIO
+
+
+class TestAgentIODependencies:
+    def test_datamodel_is_in_class_dependencies(self) -> None:
+        assert DataModelIO in AgentIO.dependencies
+
+    def test_function_is_in_class_dependencies(self) -> None:
+        assert FunctionIO in AgentIO.dependencies
+
+    @pytest.mark.parametrize(
+        "item, expected",
+        [
+            pytest.param(
+                {
+                    "externalId": "my_agent",
+                    "tools": [
+                        {
+                            "type": "callFunction",
+                            "name": "call_fn",
+                            "description": "Calls a function",
+                            "configuration": {"externalId": "my_function"},
+                        }
+                    ],
+                },
+                [(FunctionIO, ExternalId(external_id="my_function"))],
+                id="callFunction tool yields FunctionIO dependency",
+            ),
+            pytest.param(
+                {
+                    "externalId": "my_agent",
+                    "tools": [
+                        {
+                            "type": "queryKnowledgeGraph",
+                            "name": "query_kg",
+                            "description": "Queries the knowledge graph",
+                            "configuration": {
+                                "dataModels": [
+                                    {
+                                        "space": "my_space",
+                                        "externalId": "my_data_model",
+                                        "version": "v1",
+                                        "viewExternalIds": ["MyView"],
+                                    }
+                                ],
+                                "instanceSpaces": {"type": "all"},
+                            },
+                        }
+                    ],
+                },
+                [
+                    (
+                        DataModelIO,
+                        DataModelId(space="my_space", external_id="my_data_model", version="v1"),
+                    )
+                ],
+                id="queryKnowledgeGraph tool yields DataModelIO dependency",
+            ),
+            pytest.param(
+                {
+                    "externalId": "my_agent",
+                    "tools": [
+                        {
+                            "type": "queryKnowledgeGraph",
+                            "name": "query_kg",
+                            "description": "Queries the knowledge graph",
+                            "configuration": {
+                                "dataModels": [
+                                    {
+                                        "space": "space_a",
+                                        "externalId": "model_a",
+                                        "version": "1",
+                                        "viewExternalIds": ["ViewA"],
+                                    },
+                                    {
+                                        "space": "space_b",
+                                        "externalId": "model_b",
+                                        "version": "2",
+                                        "viewExternalIds": ["ViewB"],
+                                    },
+                                ],
+                                "instanceSpaces": {"type": "all"},
+                            },
+                        }
+                    ],
+                },
+                [
+                    (DataModelIO, DataModelId(space="space_a", external_id="model_a", version="1")),
+                    (DataModelIO, DataModelId(space="space_b", external_id="model_b", version="2")),
+                ],
+                id="queryKnowledgeGraph with multiple data models yields multiple DataModelIO dependencies",
+            ),
+            pytest.param(
+                {"externalId": "my_agent", "tools": []},
+                [],
+                id="agent with no tools yields no dependencies",
+            ),
+            pytest.param(
+                {
+                    "externalId": "my_agent",
+                    "tools": [{"type": "analyzeImage", "name": "analyze_img", "description": "Analyzes an image"}],
+                },
+                [],
+                id="tool with no dependency yields nothing",
+            ),
+        ],
+    )
+    def test_get_dependent_items(self, item: dict, expected: list[tuple[type[ResourceIO], Hashable]]) -> None:
+        actual = list(AgentIO.get_dependent_items(item))
+
+        assert actual == expected


### PR DESCRIPTION
# Description

Agents were being deployed before data model resources (spaces, containers, views, data models), which could leave non-functional agents deployed when data model deployment failed. This adds `DataModelIO` to `AgentIO.dependencies` so the topological sorter always places data model resources before agents.

Also tracks per-agent data model dependencies from `queryKnowledgeGraph` tools in `get_dependent_items` and `get_dependencies`.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Agents are now deployed after data model resources, preventing non-functional agents from being deployed when data model deployment fails