### PR TITLE
[CDF-27695]  😅Last minute adjustment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
       - name: "Pre-processing for demo environment"
         run: uv run python ./demo/preproc.py --modules all
       - name: "Build the templates"
-        run: uv run cdf build --config-yaml demo_project/demo -o demo_project
+        run: uv run cdf build --config-yaml demo_project/config.demo.yaml -o demo_project
       - name: "Verify and create access rights"
         run: uv run cdf auth verify --no-prompt
         # Temporarly suspending while investigating

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
       - name: "Pre-processing for demo environment"
         run: uv run python ./demo/preproc.py --modules all
       - name: "Build the templates"
-        run: uv run cdf build --config-yaml demo -o demo_project
+        run: uv run cdf build --config-yaml demo_project/demo -o demo_project
       - name: "Verify and create access rights"
         run: uv run cdf auth verify --no-prompt
         # Temporarly suspending while investigating

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -34,7 +34,7 @@ jobs:
       - name: "Pre-processing for demo environment"
         run: uv run python ./demo/preproc.py
       - name: "Build the templates"
-        run: uv run cdf build --config-yaml demo -o ./demo_project
+        run: uv run cdf build --config-yaml demo_project/demo -o ./demo_project
       - name: "Verify and create access rights"
         run: uv run cdf auth verify --no-prompt
       - name: "Deploy the templates"

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -34,7 +34,7 @@ jobs:
       - name: "Pre-processing for demo environment"
         run: uv run python ./demo/preproc.py
       - name: "Build the templates"
-        run: uv run cdf build --config-yaml demo_project/demo -o ./demo_project
+        run: uv run cdf build --config-yaml demo_project/config.demo.yaml -o ./demo_project
       - name: "Verify and create access rights"
         run: uv run cdf auth verify --no-prompt
       - name: "Deploy the templates"

--- a/cognite_toolkit/_cdf_tk/apps/_core_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_core_app.py
@@ -3,6 +3,7 @@
 import contextlib
 from dataclasses import dataclass
 from datetime import date
+from enum import Enum
 from pathlib import Path
 from typing import Annotated, Union
 
@@ -40,6 +41,11 @@ class Common:
 
 CDF_TOML = CDFToml.load(Path.cwd())
 TODAY = date.today()
+
+
+class InsightFormat(str, Enum):
+    csv = "csv"
+    json = "json"
 
 
 def _version_callback(value: bool) -> None:
@@ -295,6 +301,13 @@ class CoreApp(typer.Typer):
                 help="Deprecated. Prefer --config-yaml. If set and --config-yaml is omitted, uses <organization-dir>/config.<env>.yaml.",
             ),
         ] = None,
+        insight_format: Annotated[
+            InsightFormat,
+            typer.Option(
+                "--insight-format",
+                help="File format for the insights file written to the build directory.",
+            ),
+        ] = InsightFormat.csv,
         verbose: Annotated[
             bool,
             typer.Option(
@@ -328,6 +341,7 @@ class CoreApp(typer.Typer):
             config_yaml=config_yaml,
             user_selected_modules=selected,
             verbose=verbose,
+            insight_format=insight_format.value,
         )
 
         cmd.run(

--- a/cognite_toolkit/_cdf_tk/apps/_core_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_core_app.py
@@ -276,11 +276,14 @@ class CoreApp(typer.Typer):
             ),
         ] = None,
         config_yaml: Annotated[
-            str | None,
+            Path | None,
             typer.Option(
                 "--config-yaml",
                 "-c",
-                help="The name of the config YAML file to use. It expected to be named config.<name>.yaml and be located in the organization directory.",
+                exists=True,
+                file_okay=True,
+                dir_okay=False,
+                help="Path to the config YAML file (for example config.<env>.yaml under the organization directory).",
             ),
         ] = None,
         verbose: Annotated[
@@ -305,7 +308,7 @@ class CoreApp(typer.Typer):
         parameter = BuildParameters(
             organization_dir=organization_dir,
             build_dir=build_dir,
-            config_yaml_name=config_yaml,
+            config_yaml=config_yaml,
             user_selected_modules=selected,
             verbose=verbose,
         )

--- a/cognite_toolkit/_cdf_tk/apps/_core_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_core_app.py
@@ -22,10 +22,11 @@ from cognite_toolkit._cdf_tk.commands import (
     DeployOptions,
     DeployV2Command,
 )
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import BuildParameters
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import BuildParameters, ConfigYAML
 from cognite_toolkit._cdf_tk.commands.clean import AVAILABLE_DATA_TYPES
 from cognite_toolkit._cdf_tk.exceptions import ToolkitFileNotFoundError
 from cognite_toolkit._cdf_tk.feature_flags import Flags
+from cognite_toolkit._cdf_tk.tk_warnings import ToolkitDeprecationWarning
 from cognite_toolkit._cdf_tk.utils import get_cicd_environment, humanize_collection
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 from cognite_toolkit._version import __version__ as current_version
@@ -286,6 +287,14 @@ class CoreApp(typer.Typer):
                 help="Path to the config YAML file (for example config.<env>.yaml under the organization directory).",
             ),
         ] = None,
+        build_env_name: Annotated[
+            str | None,
+            typer.Option(
+                "--env",
+                "-e",
+                help="Deprecated. Prefer --config-yaml. If set and --config-yaml is omitted, uses <organization-dir>/config.<env>.yaml.",
+            ),
+        ] = None,
         verbose: Annotated[
             bool,
             typer.Option(
@@ -304,6 +313,14 @@ class CoreApp(typer.Typer):
             client = EnvironmentVariables.create_from_environment().get_client(console=console)
 
         cmd = BuildV2Command(print_warning=True, client=client)
+
+        if build_env_name is not None:
+            ToolkitDeprecationWarning(
+                feature="the --env / -e option in cdf build",
+                alternative="--config-yaml / -c with the path to your config file (for example <organization-dir>/config.<env>.yaml)",
+            ).print_warning()
+            if config_yaml is None:
+                config_yaml = organization_dir / ConfigYAML.get_filename(build_env_name)
 
         parameter = BuildParameters(
             organization_dir=organization_dir,

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -110,7 +110,12 @@ class BuildV2Command(ToolkitCommand):
             finished_at=datetime.now(timezone.utc),
         )
 
-        self._display_build_folder(build_folder, parameters.config_yaml_name or "", console, parameters.verbose)
+        self._display_build_folder(
+            build_folder,
+            parameters.config_yaml.name if parameters.config_yaml else "",
+            console,
+            parameters.verbose,
+        )
 
         self._write_results(build_folder, client.config.project if client else None)
 
@@ -123,9 +128,7 @@ class BuildV2Command(ToolkitCommand):
 
         # Set up the variables
         organization_dir = parameters.organization_dir
-        config_yaml_path: Path | None = None
-        if parameters.config_yaml_name:
-            config_yaml_path = organization_dir / ConfigYAML.get_filename(parameters.config_yaml_name)
+        config_yaml_path: Path | None = parameters.config_yaml.resolve() if parameters.config_yaml else None
         module_directory = parameters.modules_directory
 
         # Execute the checks.
@@ -356,15 +359,14 @@ class BuildV2Command(ToolkitCommand):
             if errors:
                 raise ToolkitValueError("Invalid module selection:\n" + "\n".join(f"- {error}" for error in errors))
 
-        if parameters.config_yaml_name:
+        if parameters.config_yaml:
+            config_path = parameters.config_yaml.resolve()
             try:
-                config = ConfigYAML.from_yaml_file(
-                    ConfigYAML.get_filepath(parameters.organization_dir, parameters.config_yaml_name)
-                )
+                config = ConfigYAML.from_yaml_file(config_path)
             except ValidationError as e:
                 errors = humanize_validation_error(e)
                 raise ToolkitValueError(
-                    f"Config YAML file '{parameters.config_yaml_name}' is invalid:\n{'- '.join(errors)}"
+                    f"Config YAML file '{config_path.as_posix()}' is invalid:\n{'- '.join(errors)}"
                 ) from e
             if not parameters.user_selected_modules and config.environment.selected:
                 selected, errors = cls._parse_user_selection(config.environment.selected, parameters.organization_dir)
@@ -774,7 +776,7 @@ class BuildV2Command(ToolkitCommand):
         return validation_results
 
     def _display_build_folder(
-        self, build_folder: BuildFolder, config_yaml_name: str, console: Console, verbose: bool
+        self, build_folder: BuildFolder, config_yaml_filename: str, console: Console, verbose: bool
     ) -> None:
         module_count = len(build_folder.built_modules)
         resource_count = sum(len(module.resources) for module in build_folder.built_modules)
@@ -807,7 +809,7 @@ class BuildV2Command(ToolkitCommand):
         if unresolved_file_count:
             summary_lines.append(
                 f"[yellow]![/] [bold]{unresolved_file_count}[/] resource files have unresolved variables.\n    These files were read, but the unresolved variables were not substituted.\n"
-                f"    Make sure to define the variables in the config.{config_yaml_name}.yaml file and that they are correctly placed in the variables section matching the file path."
+                f"    Make sure to define the variables in the {config_yaml_filename or 'config YAML'} file and that they are correctly placed in the variables section matching the file path."
             )
             border_color = max(border_color, 2)
 
@@ -924,7 +926,7 @@ class BuildV2Command(ToolkitCommand):
                 fix = ""
                 if misplaced := (set(failed_file.unresolved_variables) & available_variable_names):
                     fix = (
-                        f"Unresolved variable(s) {humanize_collection(misplaced)} are likely misplaced in the config.{config_yaml_name}.yaml.\n"
+                        f"Unresolved variable(s) {humanize_collection(misplaced)} are likely misplaced in the {config_yaml_filename or 'config YAML file'}.\n"
                         "Make sure they are placed correctly in the variables section matching the file path."
                     )
 

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -114,6 +114,7 @@ class BuildV2Command(ToolkitCommand):
             parameters.config_yaml.name if parameters.config_yaml else "",
             console,
             parameters.verbose,
+            parameters.insight_path,
         )
 
         self._write_results(build_folder, parameters, client.config.project if client else None)
@@ -775,7 +776,12 @@ class BuildV2Command(ToolkitCommand):
         return validation_results
 
     def _display_build_folder(
-        self, build_folder: BuildFolder, config_yaml_filename: str, console: Console, verbose: bool
+        self,
+        build_folder: BuildFolder,
+        config_yaml_filename: str,
+        console: Console,
+        verbose: bool,
+        insight_path: Path,
     ) -> None:
         module_count = len(build_folder.built_modules)
         resource_count = sum(len(module.resources) for module in build_folder.built_modules)
@@ -892,6 +898,11 @@ class BuildV2Command(ToolkitCommand):
                     f"[dim]... and {len(all_insights) - 10} more insights not shown[/]",
                     style="dim",
                 )
+            insight_destination = relative_to_if_possible(insight_path)
+            console.print(
+                f"[dim]All insights are written to {insight_destination.as_posix()}[/]",
+                style="dim",
+            )
         if verbose and unresolved_files:
             table = Table(title="Files with unresolved variables", expand=False, show_edge=False)
             table.add_column("Path")
@@ -972,11 +983,10 @@ class BuildV2Command(ToolkitCommand):
     def _write_results(self, build: BuildFolder, parameters: BuildParameters, cdf_project: str | None = None) -> None:
         """Write build results including lineage information and insights to the build folder."""
 
+        insight_file = parameters.insight_path
         if parameters.insight_format == "csv":
-            insight_file = build.build_dir / "insights.csv"
             insight_file_content = build.all_insights.to_csv()
         else:
-            insight_file = build.build_dir / "insights.json"
             insight_file_content = build.all_insights.to_json()
         if insight_file_content.strip():
             safe_write(insight_file, insight_file_content)

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -116,7 +116,7 @@ class BuildV2Command(ToolkitCommand):
             parameters.verbose,
         )
 
-        self._write_results(build_folder, client.config.project if client else None)
+        self._write_results(build_folder, parameters, client.config.project if client else None)
 
         # Todo: Some mixpanel tracking.
         return build_folder
@@ -969,12 +969,15 @@ class BuildV2Command(ToolkitCommand):
 
         return None
 
-    def _write_results(self, build: BuildFolder, cdf_project: str | None = None) -> None:
+    def _write_results(self, build: BuildFolder, parameters: BuildParameters, cdf_project: str | None = None) -> None:
         """Write build results including lineage information and insights to the build folder."""
 
-        insight_file = build.build_dir / "insights.csv"
-
-        insight_file_content = build.all_insights.to_csv()
+        if parameters.insight_format == "csv":
+            insight_file = build.build_dir / "insights.csv"
+            insight_file_content = build.all_insights.to_csv()
+        else:
+            insight_file = build.build_dir / "insights.json"
+            insight_file_content = build.all_insights.to_json()
         if insight_file_content.strip():
             safe_write(insight_file, insight_file_content)
 

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -96,8 +96,7 @@ class BuildV2Command(ToolkitCommand):
         built_modules = self._build_modules(build_source.modules, parameters.build_dir, console)
 
         plan = self._create_validation_plan(built_modules, client)
-        if parameters.verbose:
-            self._display_validation_plan(plan, console)
+        self._display_validation_plan(plan, console)
         validation_results = self._run_validation(plan, console)
 
         build_folder = BuildFolder(

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
@@ -16,10 +16,9 @@ from ._types import AbsoluteDirPath, AbsoluteFilePath, RelativeDirPath, Relative
 class BuildParameters(BaseModel):
     organization_dir: Path
     build_dir: Path = Field(default_factory=lambda: Path.cwd() / "build")
-    config_yaml_name: str | None = Field(
+    config_yaml: Path | None = Field(
         None,
-        description="The name of the configuration YAML file to use. It expected to be"
-        "named config.[name].yaml and be located in the organization directory.",
+        description="Path to the configuration YAML file (typically config.<env>.yaml under the organization directory).",
     )
     user_selected_modules: list[str] | None = Field(
         None,

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
@@ -1,6 +1,7 @@
 import builtins
 from datetime import datetime
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
@@ -27,6 +28,10 @@ class BuildParameters(BaseModel):
         "to build",
     )
     verbose: bool = False
+    insight_format: Literal["csv", "json"] = Field(
+        default="csv",
+        description="Format for the insights file written to the build directory.",
+    )
 
     @property
     def modules_directory(self) -> Path:

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
@@ -37,6 +37,10 @@ class BuildParameters(BaseModel):
     def modules_directory(self) -> Path:
         return self.organization_dir / MODULES
 
+    @property
+    def insight_path(self) -> Path:
+        return self.build_dir / f"insights.{self.insight_format}"
+
 
 class BuildSourceFiles(BaseModel):
     """The output of reading the source system.

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_insights.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_insights.py
@@ -1,5 +1,6 @@
 import csv
 import io
+import json
 from collections import UserList, defaultdict
 from typing import ClassVar, TypeAlias
 
@@ -118,3 +119,17 @@ class InsightList(UserList[Insight]):
             )
 
         return output.getvalue()
+
+    def to_json(self) -> str:
+        """Returns a JSON array of insight objects with keys insight_type, code, message, fix."""
+
+        rows = [
+            {
+                "insight_type": insight.insight_type(),
+                "code": insight.code,
+                "message": insight.message,
+                "fix": insight.fix,
+            }
+            for insight in self.data
+        ]
+        return json.dumps(rows, indent=2, ensure_ascii=False) + "\n"

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_insights.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_insights.py
@@ -125,7 +125,7 @@ class InsightList(UserList[Insight]):
 
         rows = [
             {
-                "insight_type": insight.insight_type(),
+                "insightType": insight.insight_type(),
                 "code": insight.code,
                 "message": insight.message,
                 "fix": insight.fix,

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
@@ -288,9 +288,9 @@ class TestValidateBuildParameters:
                 # Actually Config file is at org/config.name.yaml.
                 # I should just specify list of paths to create.
                 # If I put "org/modules/" it has no suffix so created as dir.
-                BuildParameters(organization_dir=Path("org"), config_yaml_name="dev"),
+                BuildParameters(organization_dir=Path("org"), config_yaml=Path("org/config.dev.yaml")),
                 ["cdf", "build", "-o", "org"],
-                "Config YAML file 'org/config.dev.yaml' not found",
+                "org/config.dev.yaml' not found",
                 id="Config YAML file not found",
             ),
             pytest.param(
@@ -317,7 +317,7 @@ class TestValidateBuildParameters:
             ),
             pytest.param(
                 [f"org/{MODULES}/", "org/config.dev.yaml"],
-                BuildParameters(organization_dir=Path("org"), config_yaml_name="dev"),
+                BuildParameters(organization_dir=Path("org"), config_yaml=Path("org/config.dev.yaml")),
                 ["cdf", "build", "-o", "org"],
                 None,
                 id="Success with config",
@@ -368,7 +368,7 @@ class TestReadFileSystem:
         parameters = BuildParameters(
             organization_dir=tmp_path,
             build_dir=Path("build"),
-            config_yaml_name="dev",
+            config_yaml=config_yaml,
             user_selected_modules=["module1", "module2"],
         )
         build_files = BuildV2Command._read_file_system(parameters)
@@ -392,7 +392,7 @@ class TestReadFileSystem:
     - modules/
 """)
         _ = create_resource_file(tmp_path, SpaceCRUD, SPACE_YAML)
-        parameters = BuildParameters(organization_dir=tmp_path, build_dir=Path("build"), config_yaml_name="dev")
+        parameters = BuildParameters(organization_dir=tmp_path, build_dir=Path("build"), config_yaml=config_yaml)
         with pytest.raises(ToolkitValueError) as exc_info:
             BuildV2Command._read_file_system(parameters)
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_insights.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_insights.py
@@ -54,6 +54,6 @@ def test_insight_list_to_json_matches_structural_fields() -> None:
     )
     parsed = json.loads(insights.to_json())
     assert parsed == [
-        {"insight_type": "ConsistencyError", "code": "C1", "message": "a", "fix": "f1"},
-        {"insight_type": "Recommendation", "code": None, "message": "b", "fix": None},
+        {"insightType": "ConsistencyError", "code": "C1", "message": "a", "fix": "f1"},
+        {"insightType": "Recommendation", "code": None, "message": "b", "fix": None},
     ]

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_insights.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_insights.py
@@ -1,5 +1,6 @@
 import csv
 import io
+import json
 
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import (
     ConsistencyError,
@@ -41,4 +42,18 @@ def test_insight_list_to_csv_preserves_multiline_message_and_fix() -> None:
             "message": 'text with "quotes" and, commas',
             "fix": "single",
         },
+    ]
+
+
+def test_insight_list_to_json_matches_structural_fields() -> None:
+    insights = InsightList(
+        [
+            ConsistencyError(message="a", code="C1", fix="f1"),
+            Recommendation(message="b", code=None, fix=None),
+        ]
+    )
+    parsed = json.loads(insights.to_json())
+    assert parsed == [
+        {"insight_type": "ConsistencyError", "code": "C1", "message": "a", "fix": "f1"},
+        {"insight_type": "Recommendation", "code": None, "message": "b", "fix": None},
     ]

--- a/tests/test_unit/test_cli/test_command_sequences.py
+++ b/tests/test_unit/test_cli/test_command_sequences.py
@@ -265,7 +265,7 @@ def test_build_deploy_v2_complete_orgs(
         parameters=BuildParameters(
             organization_dir=organization_dir,
             build_dir=build_tmp_path,
-            config_yaml_name="dev",
+            config_yaml=organization_dir / "config.dev.yaml",
         ),
     )
     with patch.dict(


### PR DESCRIPTION
# Description
Adjustments to build v2

* Always show validation plan
* Make `--config-yaml` a path instead of str.
* Added `--env` for backwards compatiblity with deprecation warning.
* Added `--insight-format` to support both json and csv, in added this to the print information.

## Bump

- [ ] Patch
- [x] Skip

