### PR TITLE
[CDF-27698] 📈Charts with monitoring jobs

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -2,7 +2,6 @@ import json
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from functools import cached_property
 from typing import Any, ClassVar, Generic, Literal, TypeVar
 from uuid import uuid4
 
@@ -448,10 +447,6 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
         ):
             raise self.client.tool.token.create_error(missing_acl, action="migrate charts")
 
-    @cached_property
-    def _me(self) -> str:
-        return self.client.user_profiles.me().user_identifier
-
     def map(self, source: Sequence[ChartResponse]) -> Sequence[ChartRequest | None]:
         event_ids_by_chart_external_id = self._populate_cache(source)
         output: list[ChartRequest | None] = []
@@ -460,20 +455,6 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
         chart_dest = "Charts (data modeling)"
         for item in source:
             identifier = item.external_id
-            if any(job.user_identifier != self._me for job in item.monitoring_jobs or []):
-                log_entries.append(
-                    MigrationEntryV2(
-                        id=identifier,
-                        label="Monitoring job owned by different user",
-                        severity=Severity.failure,
-                        source=chart_src,
-                        destination=chart_dest,
-                        message="Monitoring job(s) owned by different user",
-                    )
-                )
-                output.append(None)
-                continue
-
             mapped_item, issue = self._map_single_item(
                 item, event_ids_by_chart_external_id.get(item.external_id, set())
             )

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -51,7 +51,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.three_d import (
     AssetMappingDMRequestId,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.timeseries import TimeSeriesResponse
-from cognite_toolkit._cdf_tk.client.resource_classes.user_profile import UserProfile
 from cognite_toolkit._cdf_tk.client.resource_classes.view_to_view_mapping import ViewToViewMapping
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.commands._migrate.conversion import ConnectionCreator
@@ -432,11 +431,6 @@ class TestChartMapper:
             )
             client.migration.lookup.time_series = time_series_lookup
             assert source.monitoring_jobs
-            user_identifier = source.monitoring_jobs[0].user_identifier
-            assert user_identifier is not None
-            client.user_profiles.me.return_value = UserProfile(
-                user_identifier=user_identifier, identity_type="USER", last_updated_time=1
-            )
 
             event_node_ids = [NodeId(space=target_space, external_id=f"event_{i}") for i in range(event_count)]
             client.tool.events.list.return_value = [


### PR DESCRIPTION
# Description

Manually tested. Note it is hard to have an automated test that one user creates a chart that another user have craeted.

<img width="1006" height="408" alt="image" src="https://github.com/user-attachments/assets/8af8bd8e-a44d-48b0-b463-f72aa4eef753" />


## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- [alpah] Migrating charts with monitoring jobs is supported.
