### PR TITLE
[CDF-27677] ⬇ Logging downloads

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -728,7 +728,11 @@ class DownloadApp(typer.Typer):
 
         selectors = [
             # MyPy cannot see that resource_type is one of the allowed literals.
-            AssetSubtreeSelector(hierarchy=hierarchy, kind=resource_type, download_dir_name=f"hierarchy-{hierarchy}")  # type: ignore[arg-type]
+            AssetSubtreeSelector(
+                hierarchy=hierarchy,
+                kind=resource_type,  # type: ignore[arg-type]
+                download_dir_name=f"hierarchy-{sanitize_filename(hierarchy)}",
+            )
             for resource_type in ["Assets", "Events", "FileMetadata", "TimeSeries"]
         ]
         cmd.run(

--- a/cognite_toolkit/_cdf_tk/commands/_download.py
+++ b/cognite_toolkit/_cdf_tk/commands/_download.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable, Sequence
+from datetime import date
 from functools import partial
 from pathlib import Path
 
@@ -15,6 +16,7 @@ from cognite_toolkit._cdf_tk.storageio import (
     T_Selector,
     TableStorageIO,
 )
+from cognite_toolkit._cdf_tk.storageio.logger import FileWithAggregationLogger, display_item_results
 from cognite_toolkit._cdf_tk.storageio.progress import Bookmark, CursorBookmark, ProgressYAML
 from cognite_toolkit._cdf_tk.tk_warnings import LowSeverityWarning
 from cognite_toolkit._cdf_tk.utils.file import safe_write, sanitize_filename, yaml_safe_dump
@@ -22,7 +24,9 @@ from cognite_toolkit._cdf_tk.utils.fileio import (
     TABLE_WRITE_CLS_BY_FORMAT,
     Compression,
     FileWriter,
+    NDJsonWriter,
     SchemaColumn,
+    Uncompressed,
 )
 from cognite_toolkit._cdf_tk.utils.producer_worker import ProducerWorkerExecutor
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
@@ -122,9 +126,18 @@ class DownloadCommand(ToolkitCommand):
                     f"Cannot download {selector.kind} in {file_format!r} format. The {selector.kind!r} storage type does not support table schemas."
                 )
 
-            with FileWriter.create_from_format(
-                file_format, target_dir, selector.kind, compression_cls, columns=columns
-            ) as writer:
+            log_filestem = f"download_{date.today().strftime('%Y%m%d')}"
+            with (
+                FileWriter.create_from_format(
+                    file_format, target_dir, selector.kind, compression_cls, columns=columns
+                ) as writer,
+                NDJsonWriter(
+                    target_dir, kind="DownloadLogs", default_filestem=log_filestem, compression=Uncompressed
+                ) as log_file,
+                FileWithAggregationLogger(log_file) as logger,
+            ):
+                io.logger = logger
+
                 executor = ProducerWorkerExecutor[Page[T_ResourceResponse], Page[dict[str, JsonVal]]](
                     download_iterable=io.stream_data(selector, limit, bookmark=init_bookmark),
                     process=self.create_data_process(io=io, selector=selector, is_table=is_table),
@@ -143,6 +156,8 @@ class DownloadCommand(ToolkitCommand):
                     progress.status = executor.result
                     progress.dump_to_file(target_dir, filestem=self._download_filestem(filestem))
 
+                items_results = logger.finalize(is_dry_run=False)
+                display_item_results(items_results, title=f"Finished {selector.display_name}", console=console)
                 executor.raise_on_error()
                 file_count = writer.file_count
 

--- a/cognite_toolkit/_cdf_tk/storageio/_asset_centric.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_asset_centric.py
@@ -47,6 +47,7 @@ from ._base import (
     TableStorageIO,
     TableUploadableStorageIO,
 )
+from .logger import DataLogger
 from .progress import CursorBookmark, NoBookmark
 from .selectors import AssetCentricSelector, AssetSubtreeSelector, DataSetSelector
 
@@ -771,6 +772,16 @@ class HierarchyIO(ConfigurableStorageIO[AssetCentricSelector, AssetCentricResour
         bookmark: Bookmark | None = None,
     ) -> Iterable[Page[AssetCentricResource]]:
         yield from self.get_resource_io(selector.kind).stream_data(selector, limit, bookmark=bookmark)
+
+    @property
+    def logger(self) -> DataLogger:
+        return self.logger
+
+    @logger.setter
+    def logger(self, new_logger: DataLogger) -> None:
+        self._logger = new_logger
+        for subio in self._io_by_kind.values():
+            subio.logger = new_logger
 
     def count(self, selector: AssetCentricSelector) -> int | None:
         return self.get_resource_io(selector.kind).count(selector)

--- a/cognite_toolkit/_cdf_tk/storageio/_base.py
+++ b/cognite_toolkit/_cdf_tk/storageio/_base.py
@@ -110,7 +110,15 @@ class StorageIO(ABC, Generic[T_Selector, T_DataResponse]):
 
     def __init__(self, client: ToolkitClient) -> None:
         self.client = client
-        self.logger: DataLogger = NoOpLogger()
+        self._logger: DataLogger = NoOpLogger()
+
+    @property
+    def logger(self) -> DataLogger:
+        return self._logger
+
+    @logger.setter
+    def logger(self, new_logger: DataLogger) -> None:
+        self._logger = new_logger
 
     def emit_registered_page(self, page: "Page[T_DataResponse]") -> "Page[T_DataResponse]":
         """Register all item tracking IDs with the current logger, then return the page for yielding."""


### PR DESCRIPTION
# Description

Note there is typically not much going wrong in a download, but it is nice to get a proper summary at the end.

<img width="1025" height="732" alt="image" src="https://github.com/user-attachments/assets/1a2d7698-ad7d-4508-8108-9c3c82b42440" />
## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Improved

- All `cdf data download` now includes logs and summary in terminal output.


### Fixed

- Toolkit no longer raise a validation error if you download a hierarchy with invalid characters for a file system.