### PR TITLE
[CDF-27697] Add soft-deleted instance limit warning to instance purge confirmation flow

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_purge.py
+++ b/cognite_toolkit/_cdf_tk/apps/_purge.py
@@ -14,6 +14,7 @@ from cognite_toolkit._cdf_tk.storageio.selectors import (
     InstanceViewSelector,
     SelectedView,
 )
+from cognite_toolkit._cdf_tk.tk_warnings import ToolkitDeprecationWarning
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 from cognite_toolkit._cdf_tk.utils.cli_args import parse_view_str
 from cognite_toolkit._cdf_tk.utils.interactive_select import (
@@ -195,7 +196,7 @@ class PurgeApp(typer.Typer):
             typer.Option(
                 "--yes",
                 "-y",
-                help="Automatically confirm that you are sure you want to purge the space.",
+                help="Deprecated. Purge operations now always require manual confirmation.",
             ),
         ] = False,
         verbose: Annotated[
@@ -212,12 +213,10 @@ class PurgeApp(typer.Typer):
         cmd = PurgeCommand(client=client)
 
         if auto_yes:
-            print(
-                "[yellow]DEPRECATED:[/yellow] The [bold]--yes[/bold] / [bold]-y[/bold] flag is deprecated for "
-                "[bold]cdf data purge space[/bold] and this flag will be removed in a future release. "
-                "Purging data is an operation that should always be performed manually — "
-                "confirmation prompts are now always required."
-            )
+            ToolkitDeprecationWarning(
+                feature="--yes / -y flag in cdf data purge space",
+                alternative="manual confirmation — purging data is an operation that must now always be performed manually",
+            ).print_warning()
             auto_yes = False
 
         if space is None:
@@ -318,7 +317,7 @@ class PurgeApp(typer.Typer):
             typer.Option(
                 "--yes",
                 "-y",
-                help="Automatically confirm that you are sure you want to purge the instances.",
+                help="Deprecated. Purge operations now always require manual confirmation.",
             ),
         ] = False,
         verbose: Annotated[
@@ -335,12 +334,10 @@ class PurgeApp(typer.Typer):
         cmd = PurgeCommand(client=client)
 
         if auto_yes:
-            print(
-                "[yellow]DEPRECATED:[/yellow] The [bold]--yes[/bold] / [bold]-y[/bold] flag is deprecated for "
-                "[bold]cdf data purge instances[/bold] and this flag will be removed in a future release. "
-                "Purging data is an operation that must always be performed manually — "
-                "confirmation prompts are now always required."
-            )
+            ToolkitDeprecationWarning(
+                feature="--yes / -y flag in cdf data purge instances",
+                alternative="manual confirmation — purging data is an operation that must now always be performed manually",
+            ).print_warning()
             auto_yes = False
 
         # TEMPORARY: The GET /models/statistics endpoint requires datamodelsAcl:read with All scope.

--- a/cognite_toolkit/_cdf_tk/apps/_purge.py
+++ b/cognite_toolkit/_cdf_tk/apps/_purge.py
@@ -7,7 +7,7 @@ import typer
 from rich import print
 
 from cognite_toolkit._cdf_tk.commands import PurgeCommand
-from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
+from cognite_toolkit._cdf_tk.exceptions import AuthorizationError, ToolkitValueError
 from cognite_toolkit._cdf_tk.storageio.selectors import (
     InstanceFileSelector,
     InstanceSelector,
@@ -21,6 +21,7 @@ from cognite_toolkit._cdf_tk.utils.interactive_select import (
     DataModelingSelect,
     ViewSelectFilter,
 )
+from cognite_toolkit._cdf_tk.utils.validate_access import ValidateAccess
 
 
 class InstanceTypeEnum(str, Enum):
@@ -324,6 +325,12 @@ class PurgeApp(typer.Typer):
         """This command will delete the contents of the specified instances."""
         client = EnvironmentVariables.create_from_environment().get_client()
         cmd = PurgeCommand(client=client)
+
+        # TEMPORARY: The GET /models/statistics endpoint requires datamodelsAcl:read with All scope.
+        # This check will be removed once DMS limits are available through the limits service.
+        validator = ValidateAccess(client, default_operation="purge")
+        if validator.data_model(["read"]) is not None:
+            raise AuthorizationError("Purging instances currently requires datamodelsAcl:read with All scope.")
 
         is_interactive = view is None and instance_list is None
         selector: InstanceSelector

--- a/cognite_toolkit/_cdf_tk/apps/_purge.py
+++ b/cognite_toolkit/_cdf_tk/apps/_purge.py
@@ -211,6 +211,15 @@ class PurgeApp(typer.Typer):
         client = EnvironmentVariables.create_from_environment().get_client()
         cmd = PurgeCommand(client=client)
 
+        if auto_yes:
+            print(
+                "[yellow]DEPRECATED:[/yellow] The [bold]--yes[/bold] / [bold]-y[/bold] flag is deprecated for "
+                "[bold]cdf data purge space[/bold] and this flag will be removed in a future release. "
+                "Purging data is an operation that should always be performed manually — "
+                "confirmation prompts are now always required."
+            )
+            auto_yes = False
+
         if space is None:
             # Is Interactive
             interactive = DataModelingSelect(client, operation="purge")
@@ -237,7 +246,6 @@ class PurgeApp(typer.Typer):
                 delete_datapoints=delete_datapoints,
                 delete_file_content=delete_file_content,
                 dry_run=dry_run,
-                auto_yes=auto_yes,
                 verbose=verbose,
             )
         )
@@ -326,6 +334,15 @@ class PurgeApp(typer.Typer):
         client = EnvironmentVariables.create_from_environment().get_client()
         cmd = PurgeCommand(client=client)
 
+        if auto_yes:
+            print(
+                "[yellow]DEPRECATED:[/yellow] The [bold]--yes[/bold] / [bold]-y[/bold] flag is deprecated for "
+                "[bold]cdf data purge instances[/bold] and this flag will be removed in a future release. "
+                "Purging data is an operation that must always be performed manually — "
+                "confirmation prompts are now always required."
+            )
+            auto_yes = False
+
         # TEMPORARY: The GET /models/statistics endpoint requires datamodelsAcl:read with All scope.
         # This check will be removed once DMS limits are available through the limits service.
         validator = ValidateAccess(client, default_operation="purge")
@@ -367,7 +384,6 @@ class PurgeApp(typer.Typer):
                 selector=selector,
                 unlink=unlink,
                 dry_run=dry_run,
-                auto_yes=auto_yes,
                 verbose=verbose,
             )
         )

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -8,7 +8,7 @@ from typing import Any, Literal, cast
 import questionary
 from cognite.client.data_classes import DataSetUpdate
 from cognite.client.data_classes.data_modeling import Edge
-from cognite.client.data_classes.data_modeling.statistics import ProjectStatistics, SpaceStatistics
+from cognite.client.data_classes.data_modeling.statistics import SpaceStatistics
 from cognite.client.exceptions import CogniteAPIError
 from pydantic import JsonValue
 from rich import print
@@ -283,7 +283,7 @@ class PurgeCommand(ToolkitCommand):
             self._print_instance_purge_soft_delete_panel(client, instance_count)
             if not auto_yes:
                 acknowledge_risks = questionary.confirm(
-                    "Do you understand the soft-delete resource limit impact and wish to continue?",
+                    "Step 1 of 2: Do you understand the soft-delete resource limit impact and wish to continue?",
                     default=False,
                 ).ask()
                 if not acknowledge_risks:
@@ -644,12 +644,11 @@ class PurgeCommand(ToolkitCommand):
     def _print_instance_purge_soft_delete_panel(
         client: ToolkitClient,
         instances_to_delete: int,
-        project_statistics: ProjectStatistics | None = None,
     ) -> None:
         """Step 1 panel: soft-delete resource limit impact and related notices."""
         intro = "\n".join(
             [
-                "[red]WARNING:[/red] By continuing this operation you will be deleting instances, which consumes your CDF project-wide [bold]soft-delete resource limit[/bold] for instances. "
+                "By continuing this operation you will be deleting instances, which consumes your CDF project-wide [bold]soft-delete resource limit[/bold] for instances. "
                 "If that resource limit is exhausted, you will not be able to delete any more instances until the soft-deleted data expires and is hard-deleted per the retention policy, which can take multiple days (see "
                 "https://docs.cognite.com/cdf/dm/dm_concepts/dm_ingestion#soft-deletion for details).",
                 "",
@@ -665,12 +664,10 @@ class PurgeCommand(ToolkitCommand):
             "is no longer needed or valid."
         )
 
-        stats = project_statistics
-        if stats is None:
-            try:
-                stats = client.data_modeling.statistics.project()
-            except Exception:
-                stats = None
+        try:
+            stats = client.data_modeling.statistics.project()
+        except Exception:
+            stats = None
 
         if stats is not None:
             inst_stats = stats.instances
@@ -689,9 +686,9 @@ class PurgeCommand(ToolkitCommand):
         print(
             Panel(
                 Group(Text.from_markup(intro), Text(""), middle, Text(""), Text.from_markup(note)),
-                title="Purging instances: Please acknowledge the potential risk involved",
+                title="Purging instances: Please acknowledge the following",
                 title_align="left",
-                border_style="red",
+                border_style="yellow",
                 expand=False,
             )
         )
@@ -722,7 +719,7 @@ class PurgeCommand(ToolkitCommand):
             self._print_instance_purge_soft_delete_panel(client, total)
             if not auto_yes:
                 acknowledge_risks = questionary.confirm(
-                    "Do you understand the soft-delete resource limit impact and wish to continue?",
+                    "Step 1 of 2: Do you understand the soft-delete resource limit impact and wish to continue?",
                     default=False,
                 ).ask()
                 if not acknowledge_risks:

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -212,7 +212,6 @@ class PurgeCommand(ToolkitCommand):
         delete_datapoints: bool = False,
         delete_file_content: bool = False,
         dry_run: bool = False,
-        auto_yes: bool = False,
         verbose: bool = False,
     ) -> DeployResults:
         stats = client.data_modeling.statistics.spaces.retrieve(selected_space)
@@ -232,20 +231,18 @@ class PurgeCommand(ToolkitCommand):
         if not dry_run:
             if instance_count > 0:
                 self._print_instance_purge_soft_delete_panel(client, instance_count)
-                if not auto_yes:
-                    acknowledge_soft_delete = questionary.confirm(
-                        "Do you understand the soft-delete resource limit impact and wish to continue?",
-                        default=False,
-                    ).ask()
-                    if not acknowledge_soft_delete:
-                        return DeployResults([], "purge", dry_run=dry_run)
-            self._print_panel("space", selected_space)
-            if not auto_yes:
-                confirm = questionary.confirm(
-                    f"Are you really sure you want to purge the {selected_space!r} space?", default=False
+                acknowledge_soft_delete = questionary.confirm(
+                    "Do you understand the soft-delete resource limit impact and wish to continue?",
+                    default=False,
                 ).ask()
-                if not confirm:
+                if not acknowledge_soft_delete:
                     return DeployResults([], "purge", dry_run=dry_run)
+            self._print_panel("space", selected_space)
+            confirm = questionary.confirm(
+                f"Are you really sure you want to purge the {selected_space!r} space?", default=False
+            ).ask()
+            if not confirm:
+                return DeployResults([], "purge", dry_run=dry_run)
 
         # ValidateAuth
         if include_space or (stats.containers + stats.views + stats.data_models) > 0:
@@ -635,7 +632,6 @@ class PurgeCommand(ToolkitCommand):
         client: ToolkitClient,
         selector: InstanceSelector,
         dry_run: bool = False,
-        auto_yes: bool = False,
         unlink: bool = True,
         verbose: bool = False,
     ) -> DeleteResults:
@@ -654,22 +650,19 @@ class PurgeCommand(ToolkitCommand):
             return DeleteResults()
         if not dry_run:
             self._print_instance_purge_soft_delete_panel(client, total)
-            if not auto_yes:
-                acknowledge_soft_delete = questionary.confirm(
-                    "Do you understand the soft-delete resource limit impact and wish to continue?",
-                    default=False,
-                ).ask()
-                if not acknowledge_soft_delete:
-                    return DeleteResults()
-                self._print_panel("instances", str(selector))
-                confirm_purge = questionary.confirm(
-                    f"Are you sure you want to purge all {total:,} instances in {selector!s}?",
-                    default=False,
-                ).ask()
-                if not confirm_purge:
-                    return DeleteResults()
-            else:
-                self._print_panel("instances", str(selector))
+            acknowledge_soft_delete = questionary.confirm(
+                "Do you understand the soft-delete resource limit impact and wish to continue?",
+                default=False,
+            ).ask()
+            if not acknowledge_soft_delete:
+                return DeleteResults()
+            self._print_panel("instances", str(selector))
+            confirm_purge = questionary.confirm(
+                f"Are you sure you want to purge all {total:,} instances in {selector!s}?",
+                default=False,
+            ).ask()
+            if not confirm_purge:
+                return DeleteResults()
 
         process: Callable[[Sequence[InstanceDefinitionId]], list[dict[str, JsonVal]]] = self._prepare
         if unlink:

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -15,7 +15,6 @@ from rich import print
 from rich.console import Console
 from rich.panel import Panel
 
-
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client._resource_base import RequestItem
 from cognite_toolkit._cdf_tk.client.http_client import (
@@ -76,7 +75,6 @@ from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 from cognite_toolkit._cdf_tk.utils.validate_access import ValidateAccess
 
 from ._base import ToolkitCommand
-
 
 
 @dataclass
@@ -594,8 +592,10 @@ class PurgeCommand(ToolkitCommand):
         bar_width = 44
 
         bar = "".join(
-            "[yellow]█[/yellow]" if (i + 0.5) / bar_width * limit < used
-            else "[bright_magenta]█[/bright_magenta]" if (i + 0.5) / bar_width * limit < min(projected, limit)
+            "[yellow]█[/yellow]"
+            if (i + 0.5) / bar_width * limit < used
+            else "[bright_magenta]█[/bright_magenta]"
+            if (i + 0.5) / bar_width * limit < min(projected, limit)
             else "[dim]░[/dim]"
             for i in range(bar_width)
         )

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -78,7 +78,7 @@ from cognite_toolkit._cdf_tk.utils.validate_access import ValidateAccess
 from ._base import ToolkitCommand
 
 
-def _soft_delete_budget_bar(used: int, limit: int, purge_add: int, bar_width: int = 44) -> Group:
+def _soft_delete_resource_limit_bar(used: int, limit: int, purge_add: int, bar_width: int = 44) -> Group:
     """One bar, same scale 0…limit: yellow = already soft-deleted, magenta = this purge, dim = headroom left."""
     if limit <= 0:
         return Group(Text("Soft-delete limit not available from statistics.", style="dim"))
@@ -283,7 +283,7 @@ class PurgeCommand(ToolkitCommand):
             self._print_instance_purge_soft_delete_panel(client, instance_count)
             if not auto_yes:
                 acknowledge_risks = questionary.confirm(
-                    "Do you understand the soft-delete budget impact and wish to continue?",
+                    "Do you understand the soft-delete resource limit impact and wish to continue?",
                     default=False,
                 ).ask()
                 if not acknowledge_risks:
@@ -646,11 +646,11 @@ class PurgeCommand(ToolkitCommand):
         instances_to_delete: int,
         project_statistics: ProjectStatistics | None = None,
     ) -> None:
-        """Step 1 panel: soft-delete budget impact and related notices."""
+        """Step 1 panel: soft-delete resource limit impact and related notices."""
         intro = "\n".join(
             [
-                "[red]WARNING:[/red] By continuing this operation you will be deleting instances, which consumes your CDF project-wide [bold]soft-delete budget[/bold] for instances. "
-                "If that budget is exhausted, you will not be able to delete any more instances until the soft-deleted data expires and is hard-deleted per the retention policy, which can take multiple days (see "
+                "[red]WARNING:[/red] By continuing this operation you will be deleting instances, which consumes your CDF project-wide [bold]soft-delete resource limit[/bold] for instances. "
+                "If that resource limit is exhausted, you will not be able to delete any more instances until the soft-deleted data expires and is hard-deleted per the retention policy, which can take multiple days (see "
                 "https://docs.cognite.com/cdf/dm/dm_concepts/dm_ingestion#soft-deletion for details).",
                 "",
                 f"[bold]This purge targets up to {instances_to_delete:,} instance(s).[/bold] Each deleted instance counts toward "
@@ -674,7 +674,7 @@ class PurgeCommand(ToolkitCommand):
 
         if stats is not None:
             inst_stats = stats.instances
-            middle: Text | Group = _soft_delete_budget_bar(
+            middle: Text | Group = _soft_delete_resource_limit_bar(
                 inst_stats.soft_deleted_instances,
                 inst_stats.soft_deleted_instances_limit,
                 instances_to_delete,
@@ -683,7 +683,7 @@ class PurgeCommand(ToolkitCommand):
             middle = Text.from_markup(
                 f"[dim]Could not retrieve soft-delete usage from the project statistics API.[/dim]\n\n"
                 f"This purge still targets up to [bold]{instances_to_delete:,}[/bold] instance(s); each deletion counts "
-                "toward your soft-delete budget and moves you closer to the limit."
+                "toward your soft-delete resource limit and moves you closer to the limit."
             )
 
         print(
@@ -722,7 +722,7 @@ class PurgeCommand(ToolkitCommand):
             self._print_instance_purge_soft_delete_panel(client, total)
             if not auto_yes:
                 acknowledge_risks = questionary.confirm(
-                    "Do you understand the soft-delete budget impact and wish to continue?",
+                    "Do you understand the soft-delete resource limit impact and wish to continue?",
                     default=False,
                 ).ask()
                 if not acknowledge_risks:

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -12,9 +12,9 @@ from cognite.client.data_classes.data_modeling.statistics import SpaceStatistics
 from cognite.client.exceptions import CogniteAPIError
 from pydantic import JsonValue
 from rich import print
-from rich.console import Console, Group
+from rich.console import Console
 from rich.panel import Panel
-from rich.text import Text
+
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client._resource_base import RequestItem
@@ -77,62 +77,6 @@ from cognite_toolkit._cdf_tk.utils.validate_access import ValidateAccess
 
 from ._base import ToolkitCommand
 
-
-def _soft_delete_resource_limit_bar(used: int, limit: int, purge_add: int, bar_width: int = 44) -> Group:
-    """One bar, same scale 0…limit: yellow = already soft-deleted, magenta = this purge, dim = headroom left."""
-    if limit <= 0:
-        return Group(Text("Soft-delete limit not available from statistics.", style="dim"))
-
-    used = max(0, used)
-    purge_add = max(0, purge_add)
-    projected = used + purge_add
-    remaining_after = max(0, limit - projected)
-
-    key = Text()
-    key.append("█ ", style="yellow")
-    key.append("already soft-deleted   ", style="dim")
-    key.append("█ ", style="bright_magenta")
-    key.append("this purge   ", style="dim")
-    key.append("░", style="dim")
-    key.append(" remaining", style="dim")
-
-    bar_line = Text()
-    for i in range(bar_width):
-        pos = (i + 0.5) / bar_width * limit
-        if pos < used:
-            bar_line.append("█", style="yellow")
-        elif pos < min(projected, limit):
-            bar_line.append("█", style="bright_magenta")
-        else:
-            bar_line.append("░", style="dim")
-
-    summary = Text()
-    summary.append("Limit ", style="dim")
-    summary.append(f"{limit:,}", style="bold")
-    summary.append("  ·  ", style="dim")
-    summary.append(f"{used:,}", style="yellow")
-    summary.append(" + ", style="dim")
-    summary.append(f"{purge_add:,}", style="bright_magenta")
-    summary.append(" → ", style="dim")
-    summary.append(f"{projected:,}", style="bold")
-    summary.append(" total soft-deleted (est.)", style="dim")
-    summary.append("  ·  ", style="dim")
-    summary.append(f"{remaining_after:,}", style="green")
-    summary.append(" remaining", style="dim")
-
-    if projected > limit:
-        return Group(
-            key,
-            Text(""),
-            bar_line,
-            summary,
-            Text(""),
-            Text(
-                f"Estimated total {projected:,} soft-deleted is above the limit ({limit:,}).",
-                style="bold red",
-            ),
-        )
-    return Group(key, Text(""), bar_line, summary)
 
 
 @dataclass
@@ -642,35 +586,43 @@ class PurgeCommand(ToolkitCommand):
         instances_to_delete: int,
     ) -> None:
         """Step 1 panel: soft-delete resource limit impact and related notices."""
-        stats = client.data_modeling.statistics.project()
-        resource_usage_bar = _soft_delete_resource_limit_bar(
-            stats.instances.soft_deleted_instances,
-            stats.instances.soft_deleted_instances_limit,
-            instances_to_delete,
+        inst_stats = client.data_modeling.statistics.project().instances
+        used = max(0, inst_stats.soft_deleted_instances)
+        limit = inst_stats.soft_deleted_instances_limit
+        projected = used + instances_to_delete
+        remaining_after = max(0, limit - projected)
+        bar_width = 44
+
+        bar = "".join(
+            "[yellow]█[/yellow]" if (i + 0.5) / bar_width * limit < used
+            else "[bright_magenta]█[/bright_magenta]" if (i + 0.5) / bar_width * limit < min(projected, limit)
+            else "[dim]░[/dim]"
+            for i in range(bar_width)
+        )
+        resource_usage_bar = (
+            "[yellow]█[/yellow] [dim]already soft-deleted   [/dim]"
+            "[bright_magenta]█[/bright_magenta] [dim]this purge   [/dim]"
+            "[dim]░ remaining[/dim]\n\n"
+            f"{bar}\n"
+            f"[dim]Limit [/dim][bold]{limit:,}[/bold][dim]  ·  [/dim]"
+            f"[yellow]{used:,}[/yellow][dim] + [/dim][bright_magenta]{instances_to_delete:,}[/bright_magenta]"
+            f"[dim] → [/dim][bold]{projected:,}[/bold][dim] total soft-deleted (est.)  ·  [/dim]"
+            f"[green]{remaining_after:,}[/green][dim] remaining[/dim]"
         )
 
-        dialog_text = (
-            Text.from_markup(
+        print(
+            Panel(
                 "By continuing this operation you will be deleting instances, which consumes your CDF project-wide "
                 "[bold]soft-delete resource limit[/bold] for instances. If that resource limit is exhausted, you will "
                 "not be able to delete any more instances until the soft-deleted data expires and is hard-deleted per "
                 "the retention policy, which can take multiple days (see "
                 "https://docs.cognite.com/cdf/dm/dm_concepts/dm_ingestion#soft-deletion for details).\n\n"
                 f"[bold]This purge targets up to {instances_to_delete:,} instance(s).[/bold] Each deleted instance "
-                "counts toward the total soft-delete limit below.\n"
-            ),
-            resource_usage_bar,
-            Text.from_markup(
-                "\n[bold]NOTE:[/bold] Please be aware, if you intended to delete containers or views, this does not "
+                f"counts toward the total soft-delete limit below.\n\n{resource_usage_bar}\n\n"
+                "[bold]NOTE:[/bold] Please be aware, if you intended to delete containers or views, this does not "
                 "require deleting instances. You can delete or change schema resources (containers, views, data models) "
                 "without purging the instance data first. Only run an instance purge when you intend to remove specific "
-                "data which was either ingested by error or is no longer needed or valid."
-            ),
-        )
-
-        print(
-            Panel(
-                Group(*dialog_text),
+                "data which was either ingested by error or is no longer needed or valid.",
                 title="Purging instances: Please acknowledge the following",
                 title_align="left",
                 border_style="yellow",

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -281,7 +281,7 @@ class PurgeCommand(ToolkitCommand):
 
         validator = ValidateAccess(client, "purge")
         # TEMPORARY: The GET /models/statistics endpoint requires datamodelsAcl:read with All scope.
-        # This block will be removed once the limits service is available.
+        # This check will be removed once DMS limits are available through the limits service.
         if instance_count > 0 and validator.data_model(["read"]) is not None:
             raise AuthorizationError(
                 "Purging spaces containing instances currently requires datamodelsAcl:read with All scope."
@@ -695,10 +695,6 @@ class PurgeCommand(ToolkitCommand):
         if unlink:
             self.validate_timeseries_access(validator)
             self.validate_file_access(validator)
-        # TEMPORARY: The GET /models/statistics endpoint requires datamodelsAcl:read with All scope.
-        # This block will be removed once the limits service is available.
-        if validator.data_model(["read"]) is not None:
-            raise AuthorizationError("Purging instances currently requires datamodelsAcl:read with All scope.")
 
         total = io.count(selector)
         if total is None or total == 0:

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -724,7 +724,7 @@ class PurgeCommand(ToolkitCommand):
                 ).ask()
                 if not acknowledge_soft_delete:
                     return DeleteResults()
-                self._print_panel("instances", str(selector), title="Purge instances — cannot be undone")
+                self._print_panel("instances", str(selector))
                 confirm_purge = questionary.confirm(
                     f"Are you sure you want to purge all {total:,} instances in {selector!s}?",
                     default=False,
@@ -732,7 +732,7 @@ class PurgeCommand(ToolkitCommand):
                 if not confirm_purge:
                     return DeleteResults()
             else:
-                self._print_panel("instances", str(selector), title="Purge instances — cannot be undone")
+                self._print_panel("instances", str(selector))
 
         process: Callable[[Sequence[InstanceDefinitionId]], list[dict[str, JsonVal]]] = self._prepare
         if unlink:

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -642,35 +642,35 @@ class PurgeCommand(ToolkitCommand):
         instances_to_delete: int,
     ) -> None:
         """Step 1 panel: soft-delete resource limit impact and related notices."""
-        intro = "\n".join(
-            [
-                "By continuing this operation you will be deleting instances, which consumes your CDF project-wide [bold]soft-delete resource limit[/bold] for instances. "
-                "If that resource limit is exhausted, you will not be able to delete any more instances until the soft-deleted data expires and is hard-deleted per the retention policy, which can take multiple days (see "
-                "https://docs.cognite.com/cdf/dm/dm_concepts/dm_ingestion#soft-deletion for details).",
-                "",
-                f"[bold]This purge targets up to {instances_to_delete:,} instance(s).[/bold] Each deleted instance counts toward "
-                "the total soft-delete limit below.",
-            ]
-        )
-
-        note = (
-            "[bold]NOTE:[/bold] Please be aware, if you intended to delete containers or views, this does not require deleting instances. You can delete or "
-            "change schema resources (containers, views, data models) without purging the instance data first. Only run "
-            "an instance purge when you intend to remove specific data which was either ingested by error or "
-            "is no longer needed or valid."
-        )
-
         stats = client.data_modeling.statistics.project()
-        inst_stats = stats.instances
-        middle = _soft_delete_resource_limit_bar(
-            inst_stats.soft_deleted_instances,
-            inst_stats.soft_deleted_instances_limit,
+        resource_usage_bar = _soft_delete_resource_limit_bar(
+            stats.instances.soft_deleted_instances,
+            stats.instances.soft_deleted_instances_limit,
             instances_to_delete,
+        )
+
+        dialog_text = (
+            Text.from_markup(
+                "By continuing this operation you will be deleting instances, which consumes your CDF project-wide "
+                "[bold]soft-delete resource limit[/bold] for instances. If that resource limit is exhausted, you will "
+                "not be able to delete any more instances until the soft-deleted data expires and is hard-deleted per "
+                "the retention policy, which can take multiple days (see "
+                "https://docs.cognite.com/cdf/dm/dm_concepts/dm_ingestion#soft-deletion for details).\n\n"
+                f"[bold]This purge targets up to {instances_to_delete:,} instance(s).[/bold] Each deleted instance "
+                "counts toward the total soft-delete limit below.\n"
+            ),
+            resource_usage_bar,
+            Text.from_markup(
+                "\n[bold]NOTE:[/bold] Please be aware, if you intended to delete containers or views, this does not "
+                "require deleting instances. You can delete or change schema resources (containers, views, data models) "
+                "without purging the instance data first. Only run an instance purge when you intend to remove specific "
+                "data which was either ingested by error or is no longer needed or valid."
+            ),
         )
 
         print(
             Panel(
-                Group(Text.from_markup(intro), Text(""), middle, Text(""), Text.from_markup(note)),
+                Group(*dialog_text),
                 title="Purging instances: Please acknowledge the following",
                 title_align="left",
                 border_style="yellow",

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -8,12 +8,13 @@ from typing import Any, Literal, cast
 import questionary
 from cognite.client.data_classes import DataSetUpdate
 from cognite.client.data_classes.data_modeling import Edge
-from cognite.client.data_classes.data_modeling.statistics import SpaceStatistics
+from cognite.client.data_classes.data_modeling.statistics import ProjectStatistics, SpaceStatistics
 from cognite.client.exceptions import CogniteAPIError
 from pydantic import JsonValue
 from rich import print
-from rich.console import Console
+from rich.console import Console, Group
 from rich.panel import Panel
+from rich.text import Text
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client._resource_base import RequestItem
@@ -75,6 +76,63 @@ from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 from cognite_toolkit._cdf_tk.utils.validate_access import ValidateAccess
 
 from ._base import ToolkitCommand
+
+
+def _soft_delete_budget_bar(used: int, limit: int, purge_add: int, bar_width: int = 44) -> Group:
+    """One bar, same scale 0…limit: yellow = already soft-deleted, magenta = this purge, dim = headroom left."""
+    if limit <= 0:
+        return Group(Text("Soft-delete limit not available from statistics.", style="dim"))
+
+    used = max(0, used)
+    purge_add = max(0, purge_add)
+    projected = used + purge_add
+    remaining_after = max(0, limit - projected)
+
+    key = Text()
+    key.append("█ ", style="yellow")
+    key.append("already soft-deleted   ", style="dim")
+    key.append("█ ", style="bright_magenta")
+    key.append("this purge   ", style="dim")
+    key.append("░", style="dim")
+    key.append(" remaining", style="dim")
+
+    bar_line = Text()
+    for i in range(bar_width):
+        pos = (i + 0.5) / bar_width * limit
+        if pos < used:
+            bar_line.append("█", style="yellow")
+        elif pos < min(projected, limit):
+            bar_line.append("█", style="bright_magenta")
+        else:
+            bar_line.append("░", style="dim")
+
+    summary = Text()
+    summary.append("Limit ", style="dim")
+    summary.append(f"{limit:,}", style="bold")
+    summary.append("  ·  ", style="dim")
+    summary.append(f"{used:,}", style="yellow")
+    summary.append(" + ", style="dim")
+    summary.append(f"{purge_add:,}", style="bright_magenta")
+    summary.append(" → ", style="dim")
+    summary.append(f"{projected:,}", style="bold")
+    summary.append(" total soft-deleted (est.)", style="dim")
+    summary.append("  ·  ", style="dim")
+    summary.append(f"{remaining_after:,}", style="green")
+    summary.append(" remaining", style="dim")
+
+    if projected > limit:
+        return Group(
+            key,
+            Text(""),
+            bar_line,
+            summary,
+            Text(""),
+            Text(
+                f"Estimated total {projected:,} soft-deleted is above the limit ({limit:,}).",
+                style="bold red",
+            ),
+        )
+    return Group(key, Text(""), bar_line, summary)
 
 
 @dataclass
@@ -215,20 +273,40 @@ class PurgeCommand(ToolkitCommand):
         auto_yes: bool = False,
         verbose: bool = False,
     ) -> DeployResults:
-        # Warning Messages
-        if not dry_run:
-            self._print_panel("space", selected_space)
-
-        if not dry_run and not auto_yes:
-            confirm = questionary.confirm(
-                f"Are you really sure you want to purge the {selected_space!r} space?", default=False
-            ).ask()
-            if not confirm:
-                return DeployResults([], "purge", dry_run=dry_run)
-
         stats = client.data_modeling.statistics.spaces.retrieve(selected_space)
         if stats is None:
             raise ToolkitMissingResourceError(f"Space {selected_space!r} does not exist")
+
+        instance_count = stats.nodes + stats.edges
+
+        if not dry_run and instance_count > 0:
+            self._print_instance_purge_soft_delete_panel(client, instance_count)
+            if not auto_yes:
+                acknowledge_risks = questionary.confirm(
+                    "Do you understand the soft-delete budget impact and wish to continue?",
+                    default=False,
+                ).ask()
+                if not acknowledge_risks:
+                    return DeployResults([], "purge", dry_run=dry_run)
+                self._print_panel("instances", selected_space, title="Purge instances — cannot be undone")
+                confirm_instances = questionary.confirm(
+                    f"Step 2 of 2: Are you sure you want to purge up to {instance_count:,} instances "
+                    f"in space {selected_space!r} (nodes and edges)?",
+                    default=False,
+                ).ask()
+                if not confirm_instances:
+                    return DeployResults([], "purge", dry_run=dry_run)
+            else:
+                self._print_panel("instances", selected_space, title="Purge instances — cannot be undone")
+
+        elif not dry_run:
+            self._print_panel("space", selected_space)
+            if not auto_yes:
+                confirm = questionary.confirm(
+                    f"Are you really sure you want to purge the {selected_space!r} space?", default=False
+                ).ask()
+                if not confirm:
+                    return DeployResults([], "purge", dry_run=dry_run)
 
         # ValidateAuth
         validator = ValidateAccess(client, "purge")
@@ -549,13 +627,69 @@ class PurgeCommand(ToolkitCommand):
         return to_delete
 
     @staticmethod
-    def _print_panel(resource_type: str, resource: str) -> None:
+    def _print_panel(resource_type: str, resource: str, *, title: str | None = None) -> None:
         print(
             Panel(
                 f"[red]WARNING:[/red] This operation [bold]cannot be undone[/bold]! "
                 f"Resources in {resource!r} are permanently deleted",
                 style="bold",
-                title=f"Purge {resource_type}",
+                title=title or f"Purge {resource_type}",
+                title_align="left",
+                border_style="red",
+                expand=False,
+            )
+        )
+
+    @staticmethod
+    def _print_instance_purge_soft_delete_panel(
+        client: ToolkitClient,
+        instances_to_delete: int,
+        project_statistics: ProjectStatistics | None = None,
+    ) -> None:
+        """Step 1 panel: soft-delete budget impact and related notices."""
+        intro = "\n".join(
+            [
+                "[red]WARNING:[/red] By continuing this operation you will be deleting instances, which consumes your CDF project-wide [bold]soft-delete budget[/bold] for instances. "
+                "If that budget is exhausted, you will not be able to delete any more instances until the soft-deleted data expires and is hard-deleted per the retention policy, which can take multiple days (see "
+                "https://docs.cognite.com/cdf/dm/dm_concepts/dm_ingestion#soft-deletion for details).",
+                "",
+                f"[bold]This purge targets up to {instances_to_delete:,} instance(s).[/bold] Each deleted instance counts toward "
+                "the total soft-delete limit below.",
+            ]
+        )
+
+        note = (
+            "[bold]NOTE:[/bold] Please be aware, if you intended to delete containers or views, this does not require deleting instances. You can delete or "
+            "change schema resources (containers, views, data models) without purging the instance data first. Only run "
+            "an instance purge when you intend to remove specific data which was either ingested by error or "
+            "is no longer needed or valid."
+        )
+
+        stats = project_statistics
+        if stats is None:
+            try:
+                stats = client.data_modeling.statistics.project()
+            except Exception:
+                stats = None
+
+        if stats is not None:
+            inst_stats = stats.instances
+            middle: Text | Group = _soft_delete_budget_bar(
+                inst_stats.soft_deleted_instances,
+                inst_stats.soft_deleted_instances_limit,
+                instances_to_delete,
+            )
+        else:
+            middle = Text.from_markup(
+                f"[dim]Could not retrieve soft-delete usage from the project statistics API.[/dim]\n\n"
+                f"This purge still targets up to [bold]{instances_to_delete:,}[/bold] instance(s); each deletion counts "
+                "toward your soft-delete budget and moves you closer to the limit."
+            )
+
+        print(
+            Panel(
+                Group(Text.from_markup(intro), Text(""), middle, Text(""), Text.from_markup(note)),
+                title="Purging instances: Please acknowledge the potential risk involved",
                 title_align="left",
                 border_style="red",
                 expand=False,
@@ -585,14 +719,23 @@ class PurgeCommand(ToolkitCommand):
             print("No instances found.")
             return DeleteResults()
         if not dry_run:
-            self._print_panel("instances", str(selector))
+            self._print_instance_purge_soft_delete_panel(client, total)
             if not auto_yes:
-                confirm = questionary.confirm(
-                    f"Are you really sure you want to purge all {total:,} instances in {selector!s}?",
+                acknowledge_risks = questionary.confirm(
+                    "Do you understand the soft-delete budget impact and wish to continue?",
                     default=False,
                 ).ask()
-                if not confirm:
+                if not acknowledge_risks:
                     return DeleteResults()
+                self._print_panel("instances", str(selector), title="Purge instances — cannot be undone")
+                confirm_purge = questionary.confirm(
+                    f"Step 2 of 2: Are you sure you want to purge all {total:,} instances in {selector!s}?",
+                    default=False,
+                ).ask()
+                if not confirm_purge:
+                    return DeleteResults()
+            else:
+                self._print_panel("instances", str(selector), title="Purge instances — cannot be undone")
 
         process: Callable[[Sequence[InstanceDefinitionId]], list[dict[str, JsonVal]]] = self._prepare
         if unlink:

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -623,13 +623,13 @@ class PurgeCommand(ToolkitCommand):
         return to_delete
 
     @staticmethod
-    def _print_panel(resource_type: str, resource: str, *, title: str | None = None) -> None:
+    def _print_panel(resource_type: str, resource: str) -> None:
         print(
             Panel(
                 f"[red]WARNING:[/red] This operation [bold]cannot be undone[/bold]! "
                 f"Resources in {resource!r} are permanently deleted",
                 style="bold",
-                title=title or f"Purge {resource_type}",
+                title=f"Purge {resource_type}",
                 title_align="left",
                 border_style="red",
                 expand=False,
@@ -660,24 +660,13 @@ class PurgeCommand(ToolkitCommand):
             "is no longer needed or valid."
         )
 
-        try:
-            stats = client.data_modeling.statistics.project()
-        except Exception:
-            stats = None
-
-        if stats is not None:
-            inst_stats = stats.instances
-            middle: Text | Group = _soft_delete_resource_limit_bar(
-                inst_stats.soft_deleted_instances,
-                inst_stats.soft_deleted_instances_limit,
-                instances_to_delete,
-            )
-        else:
-            middle = Text.from_markup(
-                f"[dim]Could not retrieve soft-delete usage from the project statistics API.[/dim]\n\n"
-                f"This purge still targets up to [bold]{instances_to_delete:,}[/bold] instance(s); each deletion counts "
-                "toward your soft-delete resource limit and moves you closer to the limit."
-            )
+        stats = client.data_modeling.statistics.project()
+        inst_stats = stats.instances
+        middle = _soft_delete_resource_limit_bar(
+            inst_stats.soft_deleted_instances,
+            inst_stats.soft_deleted_instances_limit,
+            instances_to_delete,
+        )
 
         print(
             Panel(

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -279,27 +279,24 @@ class PurgeCommand(ToolkitCommand):
 
         instance_count = stats.nodes + stats.edges
 
-        if not dry_run and instance_count > 0:
-            self._print_instance_purge_soft_delete_panel(client, instance_count)
-            if not auto_yes:
-                acknowledge_risks = questionary.confirm(
-                    "Step 1 of 2: Do you understand the soft-delete resource limit impact and wish to continue?",
-                    default=False,
-                ).ask()
-                if not acknowledge_risks:
-                    return DeployResults([], "purge", dry_run=dry_run)
-                self._print_panel("instances", selected_space, title="Purge instances — cannot be undone")
-                confirm_instances = questionary.confirm(
-                    f"Step 2 of 2: Are you sure you want to purge up to {instance_count:,} instances "
-                    f"in space {selected_space!r} (nodes and edges)?",
-                    default=False,
-                ).ask()
-                if not confirm_instances:
-                    return DeployResults([], "purge", dry_run=dry_run)
-            else:
-                self._print_panel("instances", selected_space, title="Purge instances — cannot be undone")
+        validator = ValidateAccess(client, "purge")
+        # TEMPORARY: The GET /models/statistics endpoint requires datamodelsAcl:read with All scope.
+        # This block will be removed once the limits service is available.
+        if instance_count > 0 and validator.data_model(["read"]) is not None:
+            raise AuthorizationError(
+                "Purging spaces containing instances currently requires datamodelsAcl:read with All scope."
+            )
 
-        elif not dry_run:
+        if not dry_run:
+            if instance_count > 0:
+                self._print_instance_purge_soft_delete_panel(client, instance_count)
+                if not auto_yes:
+                    acknowledge_soft_delete = questionary.confirm(
+                        "Do you understand the soft-delete resource limit impact and wish to continue?",
+                        default=False,
+                    ).ask()
+                    if not acknowledge_soft_delete:
+                        return DeployResults([], "purge", dry_run=dry_run)
             self._print_panel("space", selected_space)
             if not auto_yes:
                 confirm = questionary.confirm(
@@ -309,7 +306,6 @@ class PurgeCommand(ToolkitCommand):
                     return DeployResults([], "purge", dry_run=dry_run)
 
         # ValidateAuth
-        validator = ValidateAccess(client, "purge")
         if include_space or (stats.containers + stats.views + stats.data_models) > 0:
             # We check for write even in dry-run mode. This is because dry-run is expected to fail
             # if the user cannot perform the purge.
@@ -710,6 +706,10 @@ class PurgeCommand(ToolkitCommand):
         if unlink:
             self.validate_timeseries_access(validator)
             self.validate_file_access(validator)
+        # TEMPORARY: The GET /models/statistics endpoint requires datamodelsAcl:read with All scope.
+        # This block will be removed once the limits service is available.
+        if validator.data_model(["read"]) is not None:
+            raise AuthorizationError("Purging instances currently requires datamodelsAcl:read with All scope.")
 
         total = io.count(selector)
         if total is None or total == 0:
@@ -718,11 +718,11 @@ class PurgeCommand(ToolkitCommand):
         if not dry_run:
             self._print_instance_purge_soft_delete_panel(client, total)
             if not auto_yes:
-                acknowledge_risks = questionary.confirm(
+                acknowledge_soft_delete = questionary.confirm(
                     "Step 1 of 2: Do you understand the soft-delete resource limit impact and wish to continue?",
                     default=False,
                 ).ask()
-                if not acknowledge_risks:
+                if not acknowledge_soft_delete:
                     return DeleteResults()
                 self._print_panel("instances", str(selector), title="Purge instances — cannot be undone")
                 confirm_purge = questionary.confirm(

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -719,14 +719,14 @@ class PurgeCommand(ToolkitCommand):
             self._print_instance_purge_soft_delete_panel(client, total)
             if not auto_yes:
                 acknowledge_soft_delete = questionary.confirm(
-                    "Step 1 of 2: Do you understand the soft-delete resource limit impact and wish to continue?",
+                    "Do you understand the soft-delete resource limit impact and wish to continue?",
                     default=False,
                 ).ask()
                 if not acknowledge_soft_delete:
                     return DeleteResults()
                 self._print_panel("instances", str(selector), title="Purge instances — cannot be undone")
                 confirm_purge = questionary.confirm(
-                    f"Step 2 of 2: Are you sure you want to purge all {total:,} instances in {selector!s}?",
+                    f"Are you sure you want to purge all {total:,} instances in {selector!s}?",
                     default=False,
                 ).ask()
                 if not confirm_purge:

--- a/tests/test_unit/test_cdf_tk/test_commands/conftest.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/conftest.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def project_statistics_response() -> dict[str, Any]:
+    """Minimal valid DMS project statistics response (incl. soft-delete fields)."""
+    return {
+        "spaces": {"count": 5, "limit": 100},
+        "containers": {"count": 42, "limit": 1000},
+        "views": {"count": 123, "limit": 2000},
+        "dataModels": {"count": 8, "limit": 500},
+        "containerProperties": {"count": 1234, "limit": 100},
+        "instances": {
+            "edges": 5000,
+            "softDeletedEdges": 100,
+            "nodes": 10000,
+            "softDeletedNodes": 200,
+            "instances": 15000,
+            "instancesLimit": 5000000,
+            "softDeletedInstances": 300,
+            "softDeletedInstancesLimit": 10000000,
+        },
+        "concurrentReadLimit": 10,
+        "concurrentWriteLimit": 5,
+        "concurrentDeleteLimit": 3,
+    }

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
@@ -30,7 +30,6 @@ from cognite_toolkit._cdf_tk.rules._dependencies import DependencyRuleSet
 BASE_URL = "http://neat.cognitedata.com"
 
 
-
 @pytest.fixture()
 def tlk_client(toolkit_config: ToolkitClientConfig) -> ToolkitClient:
     return ToolkitClient(config=toolkit_config)

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
@@ -30,30 +30,6 @@ from cognite_toolkit._cdf_tk.rules._dependencies import DependencyRuleSet
 BASE_URL = "http://neat.cognitedata.com"
 
 
-@pytest.fixture
-def example_statistics_response() -> dict:
-    """Example DMS statistics API response."""
-    return {
-        "spaces": {"count": 5, "limit": 100},
-        "containers": {"count": 42, "limit": 1000},
-        "views": {"count": 123, "limit": 2000},
-        "dataModels": {"count": 8, "limit": 500},
-        "containerProperties": {"count": 1234, "limit": 100},
-        "instances": {
-            "edges": 5000,
-            "softDeletedEdges": 100,
-            "nodes": 10000,
-            "softDeletedNodes": 200,
-            "instances": 15000,
-            "instancesLimit": 5000000,
-            "softDeletedInstances": 300,
-            "softDeletedInstancesLimit": 10000000,
-        },
-        "concurrentReadLimit": 10,
-        "concurrentWriteLimit": 5,
-        "concurrentDeleteLimit": 3,
-    }
-
 
 @pytest.fixture()
 def tlk_client(toolkit_config: ToolkitClientConfig) -> ToolkitClient:
@@ -62,7 +38,7 @@ def tlk_client(toolkit_config: ToolkitClientConfig) -> ToolkitClient:
 
 @pytest.fixture()
 def empty_cdf(
-    toolkit_config: ToolkitClientConfig, example_statistics_response: dict, respx_mock: respx.MockRouter
+    toolkit_config: ToolkitClientConfig, project_statistics_response: dict, respx_mock: respx.MockRouter
 ) -> respx.MockRouter:
     config = toolkit_config
     empty_response: dict[str, Any] = {
@@ -87,7 +63,7 @@ def empty_cdf(
         ("/models/views", empty_response),
         ("/models/datamodels", empty_response),
         ("/models/spaces", empty_response),
-        ("/models/statistics", example_statistics_response),
+        ("/models/statistics", project_statistics_response),
     ]:
         respx_mock.get(
             config.create_api_url(endpoint),

--- a/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
@@ -116,6 +116,31 @@ def files_by_node_id(
     return result
 
 
+@pytest.fixture
+def project_statistics_response() -> dict[str, Any]:
+    """Minimal valid DMS project statistics response (incl. soft-delete budget fields)."""
+    return {
+        "spaces": {"count": 5, "limit": 100},
+        "containers": {"count": 42, "limit": 1000},
+        "views": {"count": 123, "limit": 2000},
+        "dataModels": {"count": 8, "limit": 500},
+        "containerProperties": {"count": 1234, "limit": 100},
+        "instances": {
+            "edges": 5000,
+            "softDeletedEdges": 100,
+            "nodes": 10000,
+            "softDeletedNodes": 200,
+            "instances": 15000,
+            "instancesLimit": 5000000,
+            "softDeletedInstances": 300,
+            "softDeletedInstancesLimit": 10000000,
+        },
+        "concurrentReadLimit": 10,
+        "concurrentWriteLimit": 5,
+        "concurrentDeleteLimit": 3,
+    }
+
+
 @pytest.fixture()
 def purge_responses(
     rsps: responses.RequestsMock, toolkit_config: ToolkitClientConfig
@@ -188,6 +213,7 @@ class TestPurgeInstances:
         instance_type: str,
         purge_client: ToolkitClient,
         purge_responses: responses.RequestsMock,
+        project_statistics_response: dict[str, Any],
         respx_mock: respx.MockRouter,
         cognite_timeseries_2000_list: NodeList[CogniteTimeSeries],
         timeseries_by_node_id: dict[dm.NodeId, dict[str, Any]],
@@ -198,6 +224,12 @@ class TestPurgeInstances:
         rsps = purge_responses
         instances = cognite_timeseries_2000_list if instance_type == "timeseries" else cognite_files_2000_list
         client = purge_client
+        if not dry_run:
+            rsps.add(
+                responses.GET,
+                config.create_api_url("/models/statistics"),
+                json=project_statistics_response,
+            )
         rsps.add(
             responses.POST,
             config.create_api_url("/models/instances/aggregate"),
@@ -276,6 +308,7 @@ class TestPurgeSpace:
         delete_file_content: bool,
         purge_client: ToolkitClient,
         purge_responses: responses.RequestsMock,
+        project_statistics_response: dict[str, Any],
         respx_mock: respx.MockRouter,
     ) -> None:
         config = purge_client.config
@@ -297,6 +330,12 @@ class TestPurgeSpace:
                 ).dump()
             },
         )
+        if not dry_run:
+            rsps.add(
+                responses.GET,
+                config.create_api_url("/models/statistics"),
+                json=project_statistics_response,
+            )
 
         def delete_callback(request: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=request.content)

--- a/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
@@ -145,14 +145,8 @@ def project_statistics_response() -> dict[str, Any]:
 def purge_responses(
     rsps: responses.RequestsMock,
     toolkit_config: ToolkitClientConfig,
-    project_statistics_response: dict[str, Any],
 ) -> Iterator[responses.RequestsMock]:
     config = toolkit_config
-    rsps.add(
-        responses.GET,
-        config.create_api_url("/models/statistics"),
-        json=project_statistics_response,
-    )
     rsps.add(
         responses.GET,
         f"{config.base_url}/api/v1/token/inspect",
@@ -220,6 +214,7 @@ class TestPurgeInstances:
         instance_type: str,
         purge_client: ToolkitClient,
         purge_responses: responses.RequestsMock,
+        project_statistics_response: dict[str, Any],
         respx_mock: respx.MockRouter,
         cognite_timeseries_2000_list: NodeList[CogniteTimeSeries],
         timeseries_by_node_id: dict[dm.NodeId, dict[str, Any]],
@@ -230,6 +225,12 @@ class TestPurgeInstances:
         rsps = purge_responses
         instances = cognite_timeseries_2000_list if instance_type == "timeseries" else cognite_files_2000_list
         client = purge_client
+        if not dry_run:
+            rsps.add(
+                responses.GET,
+                config.create_api_url("/models/statistics"),
+                json=project_statistics_response,
+            )
         rsps.add(
             responses.POST,
             config.create_api_url("/models/instances/aggregate"),
@@ -308,6 +309,7 @@ class TestPurgeSpace:
         delete_file_content: bool,
         purge_client: ToolkitClient,
         purge_responses: responses.RequestsMock,
+        project_statistics_response: dict[str, Any],
         respx_mock: respx.MockRouter,
     ) -> None:
         config = purge_client.config
@@ -329,6 +331,12 @@ class TestPurgeSpace:
                 ).dump()
             },
         )
+        if not dry_run:
+            rsps.add(
+                responses.GET,
+                config.create_api_url("/models/statistics"),
+                json=project_statistics_response,
+            )
 
         def delete_callback(request: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=request.content)

--- a/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
@@ -116,7 +116,6 @@ def files_by_node_id(
     return result
 
 
-
 @pytest.fixture()
 def purge_responses(
     rsps: responses.RequestsMock,

--- a/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
@@ -2,6 +2,7 @@ import itertools
 import json
 from collections.abc import Iterator
 from typing import Any
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -195,11 +196,14 @@ class TestPurgeInstances:
         timeseries_by_node_id: dict[dm.NodeId, dict[str, Any]],
         cognite_files_2000_list: NodeList[CogniteFile],
         files_by_node_id: dict[dm.NodeId, dict[str, Any]],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         config = purge_client.config
         rsps = purge_responses
         instances = cognite_timeseries_2000_list if instance_type == "timeseries" else cognite_files_2000_list
         client = purge_client
+        questionary_mock = MagicMock()
+        monkeypatch.setattr("cognite_toolkit._cdf_tk.commands._purge.questionary", questionary_mock)
         if not dry_run:
             rsps.add(
                 responses.GET,
@@ -263,7 +267,6 @@ class TestPurgeInstances:
             client,
             InstanceViewSelector(view=SelectedView(space="cdf_cdm", external_id="CogniteTimeSeries", version="v1")),
             dry_run=dry_run,
-            auto_yes=True,
             unlink=unlink,
             verbose=False,
         )
@@ -286,10 +289,13 @@ class TestPurgeSpace:
         purge_responses: responses.RequestsMock,
         project_statistics_response: dict[str, Any],
         respx_mock: respx.MockRouter,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         config = purge_client.config
         space = "test_space"
         rsps = purge_responses
+        questionary_mock = MagicMock()
+        monkeypatch.setattr("cognite_toolkit._cdf_tk.commands._purge.questionary", questionary_mock)
         container_count = 10
         view_count = 15
         data_model_count = 3
@@ -388,7 +394,6 @@ class TestPurgeSpace:
             delete_datapoints=delete_datapoints,
             delete_file_content=delete_file_content,
             dry_run=dry_run,
-            auto_yes=True,
             verbose=False,
         )
         expected_node_count = (

--- a/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
@@ -143,9 +143,16 @@ def project_statistics_response() -> dict[str, Any]:
 
 @pytest.fixture()
 def purge_responses(
-    rsps: responses.RequestsMock, toolkit_config: ToolkitClientConfig
+    rsps: responses.RequestsMock,
+    toolkit_config: ToolkitClientConfig,
+    project_statistics_response: dict[str, Any],
 ) -> Iterator[responses.RequestsMock]:
     config = toolkit_config
+    rsps.add(
+        responses.GET,
+        config.create_api_url("/models/statistics"),
+        json=project_statistics_response,
+    )
     rsps.add(
         responses.GET,
         f"{config.base_url}/api/v1/token/inspect",
@@ -213,7 +220,6 @@ class TestPurgeInstances:
         instance_type: str,
         purge_client: ToolkitClient,
         purge_responses: responses.RequestsMock,
-        project_statistics_response: dict[str, Any],
         respx_mock: respx.MockRouter,
         cognite_timeseries_2000_list: NodeList[CogniteTimeSeries],
         timeseries_by_node_id: dict[dm.NodeId, dict[str, Any]],
@@ -224,12 +230,6 @@ class TestPurgeInstances:
         rsps = purge_responses
         instances = cognite_timeseries_2000_list if instance_type == "timeseries" else cognite_files_2000_list
         client = purge_client
-        if not dry_run:
-            rsps.add(
-                responses.GET,
-                config.create_api_url("/models/statistics"),
-                json=project_statistics_response,
-            )
         rsps.add(
             responses.POST,
             config.create_api_url("/models/instances/aggregate"),
@@ -308,7 +308,6 @@ class TestPurgeSpace:
         delete_file_content: bool,
         purge_client: ToolkitClient,
         purge_responses: responses.RequestsMock,
-        project_statistics_response: dict[str, Any],
         respx_mock: respx.MockRouter,
     ) -> None:
         config = purge_client.config
@@ -330,12 +329,6 @@ class TestPurgeSpace:
                 ).dump()
             },
         )
-        if not dry_run:
-            rsps.add(
-                responses.GET,
-                config.create_api_url("/models/statistics"),
-                json=project_statistics_response,
-            )
 
         def delete_callback(request: httpx.Request) -> httpx.Response:
             return httpx.Response(200, content=request.content)

--- a/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
@@ -116,30 +116,6 @@ def files_by_node_id(
     return result
 
 
-@pytest.fixture
-def project_statistics_response() -> dict[str, Any]:
-    """Minimal valid DMS project statistics response (incl. soft-delete budget fields)."""
-    return {
-        "spaces": {"count": 5, "limit": 100},
-        "containers": {"count": 42, "limit": 1000},
-        "views": {"count": 123, "limit": 2000},
-        "dataModels": {"count": 8, "limit": 500},
-        "containerProperties": {"count": 1234, "limit": 100},
-        "instances": {
-            "edges": 5000,
-            "softDeletedEdges": 100,
-            "nodes": 10000,
-            "softDeletedNodes": 200,
-            "instances": 15000,
-            "instancesLimit": 5000000,
-            "softDeletedInstances": 300,
-            "softDeletedInstancesLimit": 10000000,
-        },
-        "concurrentReadLimit": 10,
-        "concurrentWriteLimit": 5,
-        "concurrentDeleteLimit": 3,
-    }
-
 
 @pytest.fixture()
 def purge_responses(

--- a/tests_smoke/test_commands/test_purge.py
+++ b/tests_smoke/test_commands/test_purge.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import TypeVar
+from unittest.mock import MagicMock
 
 import pytest
 from cognite.client import data_modeling as dm
@@ -361,6 +362,7 @@ class TestPurgeSmoke:
         file_ts_nodes: tuple[tuple[dm.NodeId, int], tuple[dm.NodeId, int]],
         toolkit_client: ToolkitClient,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         client = toolkit_client
         (file_node, file_id), (ts_node, ts_id) = file_ts_nodes
@@ -374,6 +376,8 @@ class TestPurgeSmoke:
             encoding="utf-8",
         )
 
+        monkeypatch.setattr("cognite_toolkit._cdf_tk.commands._purge.questionary", MagicMock())
+
         purge = PurgeCommand(silent=True)
 
         results = purge.instances(
@@ -382,7 +386,6 @@ class TestPurgeSmoke:
             dry_run=False,
             unlink=True,
             verbose=False,
-            auto_yes=True,
         )
         if results.deleted != 2:
             raise AssertionError(f"Expected 2 deleted instances from purge, got {results.deleted!r}")


### PR DESCRIPTION
# Description

Introduces a two-step confirmation flow when purging instances using `cdf data purge ...`. Step 1 shows a panel with a visual bar displaying already-consumed usage, projected impact of the purge, and remaining headroom until the limit — helping users understand the impact of the delete operation on this budget before consuming from it. Step 2 in this flow is the already existing irreversibility warning. Tests are updated to mock the project statistics API call that backs the new panel.

<img width="1295" height="507" alt="Screenshot 2026-04-16 at 15 46 26 1" src="https://github.com/user-attachments/assets/fcb31fb0-a78b-4166-baac-2f9ea4e0bb60" />

NOTE: With this PR, we will now fail consistently and explicitly with a custom error if the user does not have `datamodelsAcl` with `all` scope. This is needed because we want to in a later PR also block the user completely from running a purge on instances if they are nearing the soft-delete limit. Currently this endpoint requires this scope in order to be queried, so without that access the user cannot see how much usage the project has. I expect this will be solved when DMS has limits implemented in the Limits service, where everyone can see the limits in place. At that point we can move over to query that API, and open up the possibility of doing purge again without `all` scope.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Changed

- Breaking change: Added a confirmation dialog when running `cdf data purge instances`  and `cdf data purge space` when purging spaces with instances. Deleting instances fills up a per-project soft-delete resource limit in CDF which should not be exceeded. The new dialog shows current usage and projected consumption relative to the project limit before the user confirms.

- Breaking change: Running `cdf data purge instances` and `cdf data purge space` that targets spaces with instances will now display an error if you don't have `datamodelsAcl` with  with `all` scope. This will be required to verify that you can safely perform a purge. 

- Breaking change: The `--yes` flag for `cdf data purge instances` and  `cdf data purge space` have been disabled in order to prevent usage in CI/CD. Running a purge should always be a manual operation. 
