### PR TITLE
[CDF-27716] 💹 Avoid accumulating view in integration tests.

### DIFF
--- a/tests/test_integration/test_cruds/test_resource_cruds.py
+++ b/tests/test_integration/test_cruds/test_resource_cruds.py
@@ -633,7 +633,7 @@ inputSchema:
 
 
 @pytest.fixture(scope="module")
-def a_container(toolkit_client: ToolkitClient, toolkit_space: dm.Space) -> Iterable[dm.Container]:
+def container_ephemeral(toolkit_client: ToolkitClient, toolkit_space: dm.Space) -> Iterable[dm.Container]:
     a_container = toolkit_client.data_modeling.containers.apply(
         dm.ContainerApply(
             name=f"container_test_resource_loaders_{RUN_UNIQUE_ID}",
@@ -647,7 +647,7 @@ def a_container(toolkit_client: ToolkitClient, toolkit_space: dm.Space) -> Itera
 
 
 @pytest.fixture(scope="module")
-def persistent_container(toolkit_client: ToolkitClient, toolkit_space: dm.Space) -> ContainerResponse:
+def container_persistent(toolkit_client: ToolkitClient, toolkit_space: dm.Space) -> ContainerResponse:
     return toolkit_client.tool.containers.create(
         [
             ContainerRequest(
@@ -661,7 +661,7 @@ def persistent_container(toolkit_client: ToolkitClient, toolkit_space: dm.Space)
 
 @pytest.fixture(scope="module")
 def two_views(
-    toolkit_client: ToolkitClient, toolkit_space: dm.Space, a_container: dm.Container
+    toolkit_client: ToolkitClient, toolkit_space: dm.Space, container_ephemeral: dm.Container
 ) -> Iterable[dm.ViewList]:
     created_views = toolkit_client.data_modeling.views.apply(
         [
@@ -670,7 +670,9 @@ def two_views(
                 external_id=f"first_view{RUN_UNIQUE_ID}",
                 version="1",
                 properties={
-                    "name": dm.MappedPropertyApply(container=a_container.as_id(), container_property_identifier="name")
+                    "name": dm.MappedPropertyApply(
+                        container=container_ephemeral.as_id(), container_property_identifier="name"
+                    )
                 },
             ),
             dm.ViewApply(
@@ -679,7 +681,7 @@ def two_views(
                 version="1",
                 properties={
                     "alsoName": dm.MappedPropertyApply(
-                        container=a_container.as_id(), container_property_identifier="name", name="name2"
+                        container=container_ephemeral.as_id(), container_property_identifier="name", name="name2"
                     )
                 },
             ),
@@ -1131,7 +1133,7 @@ class TestNodeLoader:
 
 class TestViewLoader:
     def test_no_implement_not_redeployed(
-        self, toolkit_client: ToolkitClient, toolkit_space: dm.Space, persistent_container: ContainerResponse
+        self, toolkit_client: ToolkitClient, toolkit_space: dm.Space, container_persistent: ContainerResponse
     ) -> None:
         definition_yaml = f"""space: {toolkit_space.space}
 externalId: ToolkitTestNoImplementsNotRedeployed
@@ -1140,8 +1142,8 @@ implements: []
 properties:
   name:
     container:
-      space: {persistent_container.space}
-      externalId: {persistent_container.external_id}
+      space: {container_persistent.space}
+      externalId: {container_persistent.external_id}
       type: container
     containerPropertyIdentifier: name
         """

--- a/tests/test_integration/test_cruds/test_resource_cruds.py
+++ b/tests/test_integration/test_cruds/test_resource_cruds.py
@@ -660,7 +660,7 @@ def container_persistent(toolkit_client: ToolkitClient, toolkit_space: dm.Space)
 
 
 @pytest.fixture(scope="module")
-def two_views(
+def two_views_ephemeral(
     toolkit_client: ToolkitClient, toolkit_space: dm.Space, container_ephemeral: dm.Container
 ) -> Iterable[dm.ViewList]:
     created_views = toolkit_client.data_modeling.views.apply(
@@ -693,15 +693,18 @@ def two_views(
 
 class TestDataModelLoader:
     def test_create_update_delete(
-        self, toolkit_client: ToolkitClient, toolkit_space: dm.Space, two_views: dm.ViewList
+        self, toolkit_client: ToolkitClient, toolkit_space: dm.Space, two_views_ephemeral: dm.ViewList
     ) -> None:
         loader = DataModelIO(toolkit_client, None)
-        view_list = two_views.as_ids()
+        view_list = two_views_ephemeral.as_ids()
         assert len(view_list) == 2, "Expected 2 views in the test data model"
         my_model = DataModelRequest(
             name="My model",
             description="Original description",
-            views=[ViewId(space=view.space, external_id=view.external_id, version=view.version) for view in two_views],
+            views=[
+                ViewId(space=view.space, external_id=view.external_id, version=view.version)
+                for view in two_views_ephemeral
+            ],
             space=toolkit_space.space,
             external_id=f"tmp_test_create_update_delete_data_model_{RUN_UNIQUE_ID}",
             version="1",

--- a/tests/test_integration/test_cruds/test_resource_cruds.py
+++ b/tests/test_integration/test_cruds/test_resource_cruds.py
@@ -1117,7 +1117,7 @@ class TestViewLoader:
         self, toolkit_client: ToolkitClient, toolkit_space: dm.Space, a_container: dm.Container
     ) -> None:
         definition_yaml = f"""space: {toolkit_space.space}
-externalId: ToolkitTestNoImplementsNotRedeployed{RUN_UNIQUE_ID}
+externalId: ToolkitTestNoImplementsNotRedeployed
 version: v1
 implements: []
 properties:

--- a/tests/test_integration/test_cruds/test_resource_cruds.py
+++ b/tests/test_integration/test_cruds/test_resource_cruds.py
@@ -33,9 +33,13 @@ from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, RawTableId
 from cognite_toolkit._cdf_tk.client.resource_classes.asset import AssetRequest
 from cognite_toolkit._cdf_tk.client.resource_classes.cognite_file import CogniteFileRequest
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
+    ContainerPropertyDefinition,
+    ContainerRequest,
+    ContainerResponse,
     DataModelRequest,
     InstanceSource,
     NodeRequest,
+    TextProperty,
     ViewId,
     ViewRequest,
 )
@@ -643,6 +647,19 @@ def a_container(toolkit_client: ToolkitClient, toolkit_space: dm.Space) -> Itera
 
 
 @pytest.fixture(scope="module")
+def persistent_container(toolkit_client: ToolkitClient, toolkit_space: dm.Space) -> ContainerResponse:
+    return toolkit_client.tool.containers.create(
+        [
+            ContainerRequest(
+                space=toolkit_space.space,
+                external_id="persistent_container_toolkit_integration_tests",
+                properties={"name": ContainerPropertyDefinition(type=TextProperty())},
+            )
+        ]
+    )[0]
+
+
+@pytest.fixture(scope="module")
 def two_views(
     toolkit_client: ToolkitClient, toolkit_space: dm.Space, a_container: dm.Container
 ) -> Iterable[dm.ViewList]:
@@ -1114,7 +1131,7 @@ class TestNodeLoader:
 
 class TestViewLoader:
     def test_no_implement_not_redeployed(
-        self, toolkit_client: ToolkitClient, toolkit_space: dm.Space, a_container: dm.Container
+        self, toolkit_client: ToolkitClient, toolkit_space: dm.Space, persistent_container: ContainerResponse
     ) -> None:
         definition_yaml = f"""space: {toolkit_space.space}
 externalId: ToolkitTestNoImplementsNotRedeployed
@@ -1123,8 +1140,8 @@ implements: []
 properties:
   name:
     container:
-      space: {a_container.space}
-      externalId: {a_container.external_id}
+      space: {persistent_container.space}
+      externalId: {persistent_container.external_id}
       type: container
     containerPropertyIdentifier: name
         """


### PR DESCRIPTION
# Description

The offending test expects a persistent view, but uses a random ID causing creation for each test run.

Ran purge to cleanup - note that all resources needed for integration tests are auto-created by the tests that needs them.

<img width="873" height="634" alt="image" src="https://github.com/user-attachments/assets/34384ba9-eab6-4cb7-b68d-118c58f282f9" />


## Bump

- [ ] Patch
- [x] Skip
