### PR TITLE
[CDF-27718] 💸Reduce strictness

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -262,7 +262,7 @@ class BuildV2Command(ToolkitCommand):
             errors.append("ambiguous selected")
         if misplaced_modules_count:
             summary_lines.append(
-                f"[red]✗[/] [bold]{misplaced_modules_count}[/] modules are located directly under the another module."
+                f"[yellow]![/] {misplaced_modules_count}[/] modules are located directly under the another module."
             )
             border_color = max(border_color, 1)
         if non_existing_module_count:
@@ -273,7 +273,7 @@ class BuildV2Command(ToolkitCommand):
             errors.append("non existing modules")
         if invalid_variable_count:
             summary_lines.append(
-                f"[red]✗[/] [bold]{invalid_variable_count}[/] invalid variables found across modules and config YAML."
+                f"[yellow]![/] [bold]{invalid_variable_count}[/] invalid variables found across modules and config YAML."
             )
             border_color = max(border_color, 1)
         if orphan_yaml_count:

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -264,8 +264,7 @@ class BuildV2Command(ToolkitCommand):
             summary_lines.append(
                 f"[red]✗[/] [bold]{misplaced_modules_count}[/] modules are located directly under the another module."
             )
-            border_color = 2
-            errors.append("misplaced modules")
+            border_color = max(border_color, 1)
         if non_existing_module_count:
             summary_lines.append(
                 f"[red]✗[/] [bold]{non_existing_module_count}[/] user-selected module names did not match any module directory."
@@ -276,8 +275,7 @@ class BuildV2Command(ToolkitCommand):
             summary_lines.append(
                 f"[red]✗[/] [bold]{invalid_variable_count}[/] invalid variables found across modules and config YAML."
             )
-            border_color = 2
-            errors.append("invalid variables")
+            border_color = max(border_color, 1)
         if orphan_yaml_count:
             summary_lines.append(
                 f"[yellow]![/] [bold]{orphan_yaml_count}[/] YAML files found directly under the modules directory that are not part of any module."


### PR DESCRIPTION
# Description

We are deciding that this is too strict for `0.8`. It is sufficent to inform the user about these issues. By reducing the strictness, the transition from `v0.7->v0.8` will become simpler.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Changed

- Running `cdf build` no longer raises an error if you have variables that are not matching your folder structure, or you have modules located in other modules resulting in them being ignored. These are now warnings instead. 
