### PR TITLE
[CDF-27717] ⬆Uploading file content

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -305,19 +305,34 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
                 )
             return SuccessResponse(status_code=response.status_code, body=response.text, content=response.content)
 
-    def get_upload_url(self, items: Sequence[ExternalId | InstanceId]) -> builtins.list[FileMetadataResponse]:
-        """Get a URL to upload a file to CDF for one or more file metadata entries."""
+    def get_upload_url(
+        self, items: Sequence[ExternalId | InstanceId], ignore_unknown_ids: bool = False
+    ) -> builtins.list[FileMetadataResponse]:
+        """Get a URL to upload a file to CDF for one or more file metadata entries.
+
+        Args:
+            items: Sequence of InternalId identifying the files to upload.
+            ignore_unknown_ids: Whether to ignore unknown identifiers.
+
+        Returns:
+            List of updated FileMetadataResponse objects.
+
+        """
         results: list[FileMetadataResponse] = []
         for item in items:
             # The API only supports one
-            url_request = RequestMessage(
+            request = RequestMessage(
                 endpoint_url=self._http_client.config.create_api_url("/files/uploadlink"),
                 method="POST",
                 body_content={"items": [item.dump()]},
             )
-            url_response = self._http_client.request_single_retries(url_request).get_success_or_raise(url_request)
-            responses_with_url = ResponseItems[FileMetadataResponse].model_validate_json(url_response.body).items
-            results.extend(responses_with_url)
+            response = self._http_client.request_single_retries(request)
+            if isinstance(response, SuccessResponse):
+                results.extend(ResponseItems[FileMetadataResponse].model_validate_json(response.body).items)
+            elif ignore_unknown_ids:
+                continue
+            else:
+                _ = response.get_success_or_raise(request)
         return results
 
     def get_download_url(

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -192,23 +192,6 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
         """
         return self._list(limit=limit)
 
-    def upload_content(self, data_content: bytes, upload_url: str, mime_type: str | None = None) -> HTTPResult:
-        """Uploads file content to CDF.
-
-        Args:
-            data_content: Content to be uploaded.
-            upload_url: Upload URL.
-            mime_type: MIME type to upload. None for no MIME type.
-        """
-        return self._http_client.request_single_retries(
-            RequestMessage(
-                endpoint_url=upload_url,
-                method="PUT",
-                content_type=mime_type or "application/octet-stream",
-                data_content=data_content,
-            )
-        )
-
     def set_pending_ids(self, items: Sequence[PendingInstanceId]) -> builtins.list[FileMetadataResponse]:
         """Set pending instance IDs for one or more file metadata entries.
 
@@ -262,6 +245,23 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             time.sleep(max(0, to_sleep))
             sleep_time *= 2
         return to_check, elapsed_time
+
+    def upload_content(self, data_content: bytes, upload_url: str, mime_type: str | None = None) -> HTTPResult:
+        """Uploads file content to CDF.
+
+        Args:
+            data_content: Content to be uploaded.
+            upload_url: Upload URL.
+            mime_type: MIME type to upload. None for no MIME type.
+        """
+        return self._http_client.request_single_retries(
+            RequestMessage(
+                endpoint_url=upload_url,
+                method="PUT",
+                content_type=mime_type or "application/octet-stream",
+                data_content=data_content,
+            )
+        )
 
     def upload_file(self, filepath: Path, upload_url: str, mime_type: str | None = None) -> SuccessResponse:
         """Upload a file to CDF using streaming to avoid loading entire file into memory.

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -1,7 +1,7 @@
 import builtins
 import io
 import time
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
 from typing import Any, Literal
 
@@ -25,6 +25,35 @@ from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import (
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.pending_instance_id import PendingInstanceId
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
+
+
+class _LimitedFileReader(Iterable[bytes]):
+    """A file-like wrapper that limits the number of bytes read from a file stream.
+
+    This allows httpx to stream content directly from disk in smaller chunks,
+    without loading the entire part into memory at once. Implements Iterable[bytes]
+    for compatibility with httpx's content parameter.
+    """
+
+    _CHUNK_SIZE = 64 * 1024  # 64 KB chunks
+
+    def __init__(self, file_stream: io.IOBase, limit: int) -> None:
+        self._file_stream = file_stream
+        self._limit = limit
+        self._remaining = limit
+
+    def __iter__(self) -> Iterator[bytes]:
+        while self._remaining > 0:
+            chunk_size = min(self._CHUNK_SIZE, self._remaining)
+            data = self._file_stream.read(chunk_size)
+            if not data:
+                break
+            self._remaining -= len(data)
+            yield data
+
+    def __len__(self) -> int:
+        """Return the total size for Content-Length header."""
+        return self._limit
 
 
 class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
@@ -308,7 +337,7 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
         """Upload a file to CDF in multiple parts using the provided upload URLs.
 
         The file is split uniformly across all upload URLs, with each part uploaded
-        to its corresponding URL.
+        to its corresponding URL. Uses streaming to avoid loading entire chunks into memory.
 
         Args:
             filepath: The local path to the file to upload.
@@ -333,11 +362,15 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             for i, upload_url in enumerate(upload_urls):
                 # Last part gets any remaining bytes
                 if i == num_parts - 1:
-                    chunk = file_stream.read()
+                    current_part_size = file_size - file_stream.tell()
                 else:
-                    chunk = file_stream.read(part_size)
+                    current_part_size = part_size
 
-                response = httpx.put(upload_url, content=chunk, headers=headers)
+                # Use a stream wrapper that limits reads to the part size,
+                # allowing httpx to stream directly from disk without loading the entire chunk into memory.
+                chunk_stream = _LimitedFileReader(file_stream, current_part_size)
+
+                response = httpx.put(upload_url, content=chunk_stream, headers=headers)
                 if response.status_code not in (200, 201):
                     raise ToolkitAPIError(
                         message=f"Upload of part {i + 1} failed with status code {response.status_code}: {response.text}",

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -284,15 +284,26 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
         return to_check, elapsed_time
 
     def upload_file(self, filepath: Path, upload_url: str, mime_type: str | None = None) -> SuccessResponse:
+        """Upload a file to CDF using streaming to avoid loading entire file into memory.
+
+        Args:
+            filepath: The local path to the file to upload.
+            upload_url: The URL to upload the file to.
+            mime_type: MIME type of the file. Defaults to "application/octet-stream".
+
+        Returns:
+            SuccessResponse object containing the upload response details.
+        """
         # Todo: If file size is above 5000 MB - 5,000,000,000 bytes, do a multipart file upload.
-        fileupoad = RequestMessage(
-            endpoint_url=upload_url,
-            method="PUT",
-            content_type=mime_type or "application/octet-stream",
-            data_content=filepath.read_bytes(),
-        )
-        upload_response = self._http_client.request_single_retries(fileupoad)
-        return upload_response.get_success_or_raise(fileupoad)
+        content_type = mime_type or "application/octet-stream"
+        with filepath.open("rb") as file_stream:
+            response = httpx.put(upload_url, content=file_stream, headers={"Content-Type": content_type})
+            if response.status_code not in (200, 201):
+                raise ToolkitAPIError(
+                    message=f"Upload failed with status code {response.status_code}: {response.text}",
+                    code=response.status_code,
+                )
+            return SuccessResponse(status_code=response.status_code, body=response.text, content=response.content)
 
     def get_upload_url(self, items: Sequence[ExternalId | InstanceId]) -> builtins.list[FileMetadataResponse]:
         """Get a URL to upload a file to CDF for one or more file metadata entries."""

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -1,9 +1,8 @@
 import builtins
-import io
 import time
 from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
-from typing import Any, Literal
+from typing import IO, Any, Literal
 
 import httpx
 
@@ -37,7 +36,7 @@ class _LimitedFileReader(Iterable[bytes]):
 
     _CHUNK_SIZE = 64 * 1024  # 64 KB chunks
 
-    def __init__(self, file_stream: io.IOBase, limit: int) -> None:
+    def __init__(self, file_stream: IO[bytes], limit: int) -> None:
         self._file_stream = file_stream
         self._limit = limit
         self._remaining = limit
@@ -310,26 +309,19 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
         Returns:
             SuccessResponse object containing the upload response details.
         """
-        # Todo: If file size is above 5000 MB - 5,000,000,000 bytes, do a multipart file upload.
-        content_type = mime_type or "application/octet-stream"
-
         if isinstance(filepath, bytes):
-            file_stream: io.IOBase = io.BytesIO(filepath)
+            content: Iterable[bytes] = (filepath,)
         elif isinstance(filepath, str):
-            file_stream = io.StringIO(filepath)
+            content = (filepath.encode("utf-8"),)
         else:
-            file_stream = filepath.open("rb")
+            content = _LimitedFileReader(filepath.open("rb"), filepath.stat().st_size)
 
-        try:
-            response = httpx.put(upload_url, content=file_stream, headers={"Content-Type": content_type})
-            if response.status_code not in (200, 201):
-                raise ToolkitAPIError(
-                    message=f"Upload failed with status code {response.status_code}: {response.text}",
-                    code=response.status_code,
-                )
-            return SuccessResponse(status_code=response.status_code, body=response.text, content=response.content)
-        finally:
-            file_stream.close()
+        return self._http_client.request_raw_retries(
+            method="PUT",
+            url=upload_url,
+            content=content,
+            headers={"Content-Type": mime_type} if mime_type else None,
+        )
 
     def upload_file_multiparts(
         self, filepath: Path, upload_urls: builtins.list[str], mime_type: str | None = None
@@ -370,15 +362,13 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
                 # allowing httpx to stream directly from disk without loading the entire chunk into memory.
                 chunk_stream = _LimitedFileReader(file_stream, current_part_size)
 
-                response = httpx.put(upload_url, content=chunk_stream, headers=headers)
-                if response.status_code not in (200, 201):
-                    raise ToolkitAPIError(
-                        message=f"Upload of part {i + 1} failed with status code {response.status_code}: {response.text}",
-                        code=response.status_code,
-                    )
-                results.append(
-                    SuccessResponse(status_code=response.status_code, body=response.text, content=response.content)
+                response = self._http_client.request_raw_retries(
+                    method="PUT",
+                    url=upload_url,
+                    content=chunk_stream,
+                    headers=headers,
                 )
+                results.append(response)
 
         return results
 

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -306,6 +306,48 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
         finally:
             file_stream.close()
 
+    def upload_file_multiparts(
+        self, filepath: Path, upload_urls: builtins.list[str], mime_type: str | None = None
+    ) -> builtins.list[SuccessResponse]:
+        """Upload a file to CDF in multiple parts using the provided upload URLs.
+
+        The file is split uniformly across all upload URLs, with each part uploaded
+        to its corresponding URL.
+
+        Args:
+            filepath: The local path to the file to upload.
+            upload_urls: List of URLs to upload file parts to.
+            mime_type: MIME type of the file. Defaults to "application/octet-stream".
+
+        Returns:
+            List of SuccessResponse objects containing the upload response details for each part.
+        """
+        content_type = mime_type or "application/octet-stream"
+        file_size = filepath.stat().st_size
+        num_parts = len(upload_urls)
+        part_size = file_size // num_parts
+
+        results: builtins.list[SuccessResponse] = []
+        with filepath.open("rb") as file_stream:
+            for i, upload_url in enumerate(upload_urls):
+                # Last part gets any remaining bytes
+                if i == num_parts - 1:
+                    chunk = file_stream.read()
+                else:
+                    chunk = file_stream.read(part_size)
+
+                response = httpx.put(upload_url, content=chunk, headers={"Content-Type": content_type})
+                if response.status_code not in (200, 201):
+                    raise ToolkitAPIError(
+                        message=f"Upload of part {i + 1} failed with status code {response.status_code}: {response.text}",
+                        code=response.status_code,
+                    )
+                results.append(
+                    SuccessResponse(status_code=response.status_code, body=response.text, content=response.content)
+                )
+
+        return results
+
     def get_upload_url(
         self, items: Sequence[ExternalId | InstanceId], ignore_unknown_ids: bool = False
     ) -> builtins.list[FileMetadataResponse]:

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -1,4 +1,5 @@
 import builtins
+import io
 import time
 from collections.abc import Iterable, Sequence
 from pathlib import Path
@@ -245,11 +246,13 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             sleep_time *= 2
         return to_check, elapsed_time
 
-    def upload_file(self, filepath: Path, upload_url: str, mime_type: str | None = None) -> SuccessResponse:
+    def upload_file(
+        self, filepath: Path | str | bytes, upload_url: str, mime_type: str | None = None
+    ) -> SuccessResponse:
         """Upload a file to CDF using streaming to avoid loading entire file into memory.
 
         Args:
-            filepath: The local path to the file to upload.
+            filepath: The local path to the file to upload, or raw bytes content.
             upload_url: The URL to upload the file to.
             mime_type: MIME type of the file. Defaults to "application/octet-stream".
 
@@ -258,7 +261,15 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
         """
         # Todo: If file size is above 5000 MB - 5,000,000,000 bytes, do a multipart file upload.
         content_type = mime_type or "application/octet-stream"
-        with filepath.open("rb") as file_stream:
+
+        if isinstance(filepath, bytes):
+            file_stream: io.BufferedIOBase = io.BytesIO(filepath)
+        elif isinstance(filepath, str):
+            file_stream = Path(filepath).open("rb")
+        else:
+            file_stream = filepath.open("rb")
+
+        try:
             response = httpx.put(upload_url, content=file_stream, headers={"Content-Type": content_type})
             if response.status_code not in (200, 201):
                 raise ToolkitAPIError(
@@ -266,6 +277,8 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
                     code=response.status_code,
                 )
             return SuccessResponse(status_code=response.status_code, body=response.text, content=response.content)
+        finally:
+            file_stream.close()
 
     def get_upload_url(
         self, items: Sequence[ExternalId | InstanceId], ignore_unknown_ids: bool = False

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -40,8 +40,9 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             },
             api_version="alpha",
         )
+        self._create_multipart = Endpoint(method="POST", path="/files", item_limit=1, concurrency_max_workers=1)
         self._download_link = Endpoint(method="POST", path="/files/downloadlink", item_limit=10)
-        self._multipart_file_upload_link = Endpoint(method="POST", path="/files/multiuploadlink", item_limit=1)
+        self._multipart_file_upload_link = Endpoint(method="POST", path="/files/initmultipartupload", item_limit=1)
 
     def _validate_page_response(
         self, response: SuccessResponse | ItemsSuccessResponse
@@ -79,6 +80,30 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             file_response.filepath = item.filepath
             results.append(file_response)
         return results
+
+    def upload_multi_parts(self, item: FileMetadataResponse, overwrite: bool, parts: int) -> FileMetadataResponse:
+        """Upload file metadata to CDF and return mutiple URLs for uploading"""
+        self._validate_parts_parameter(parts)
+        endpoint = self._multipart_file_upload_link
+        request = RequestMessage(
+            endpoint_url=self._make_url(endpoint.path),
+            method=endpoint.method,
+            body_content=item.dump(),
+            parameters={"overwrite": overwrite, "parts": parts},
+        )
+        response = self._http_client.request_single_retries(request)
+        result = response.get_success_or_raise(request)
+        items = ResponseItems[FileMetadataResponse].model_validate_json(result.body).items
+        if len(items) != 1:
+            raise ToolkitAPIError(
+                message=f"Expected exactly one item in response, got {len(items)}", code=result.status_code
+            )
+        items[0].filepath = item.filepath
+        return items[0]
+
+    def _validate_parts_parameter(self, parts: int) -> None:
+        if not (1 <= parts <= 250):
+            raise ValueError("Parts parameter must be between 1 and 250")
 
     def retrieve(
         self, items: Sequence[InternalId | ExternalId | InstanceId], ignore_unknown_ids: bool = False
@@ -313,8 +338,7 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
 
     def get_multipart_upload_urls(self, item: ExternalId | InstanceId, parts: int) -> FileMetadataResponse:
         """Get URLs to upload a file in multiple parts to CDF for one file metadata entry."""
-        if not (1 <= parts <= 250):
-            raise ValueError("Parts must be between 1 and 250")
+        self._validate_parts_parameter(parts)
         endpoint = self._multipart_file_upload_link
         request = RequestMessage(
             endpoint_url=self._http_client.config.create_api_url(endpoint.path),

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -10,7 +10,6 @@ from cognite_toolkit._cdf_tk.client.cdf_client import CDFResourceAPI, PagedRespo
 from cognite_toolkit._cdf_tk.client.cdf_client.api import Endpoint
 from cognite_toolkit._cdf_tk.client.http_client import (
     HTTPClient,
-    HTTPResult,
     ItemsSuccessResponse,
     RequestMessage,
     SuccessResponse,
@@ -245,23 +244,6 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             time.sleep(max(0, to_sleep))
             sleep_time *= 2
         return to_check, elapsed_time
-
-    def upload_content(self, data_content: bytes, upload_url: str, mime_type: str | None = None) -> HTTPResult:
-        """Uploads file content to CDF.
-
-        Args:
-            data_content: Content to be uploaded.
-            upload_url: Upload URL.
-            mime_type: MIME type to upload. None for no MIME type.
-        """
-        return self._http_client.request_single_retries(
-            RequestMessage(
-                endpoint_url=upload_url,
-                method="PUT",
-                content_type=mime_type or "application/octet-stream",
-                data_content=data_content,
-            )
-        )
 
     def upload_file(self, filepath: Path, upload_url: str, mime_type: str | None = None) -> SuccessResponse:
         """Upload a file to CDF using streaming to avoid loading entire file into memory.

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -81,7 +81,7 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             results.append(file_response)
         return results
 
-    def upload_multi_parts(self, item: FileMetadataResponse, overwrite: bool, parts: int) -> FileMetadataResponse:
+    def upload_multi_parts(self, item: FileMetadataRequest, overwrite: bool, parts: int) -> FileMetadataResponse:
         """Upload file metadata to CDF and return mutiple URLs for uploading"""
         self._validate_parts_parameter(parts)
         endpoint = self._multipart_file_upload_link
@@ -93,13 +93,9 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
         )
         response = self._http_client.request_single_retries(request)
         result = response.get_success_or_raise(request)
-        items = ResponseItems[FileMetadataResponse].model_validate_json(result.body).items
-        if len(items) != 1:
-            raise ToolkitAPIError(
-                message=f"Expected exactly one item in response, got {len(items)}", code=result.status_code
-            )
-        items[0].filepath = item.filepath
-        return items[0]
+        result_item = FileMetadataResponse.model_validate_json(result.body)
+        result_item.filepath = item.filepath
+        return result_item
 
     def _validate_parts_parameter(self, parts: int) -> None:
         if not (1 <= parts <= 250):
@@ -317,15 +313,20 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
         Args:
             filepath: The local path to the file to upload.
             upload_urls: List of URLs to upload file parts to.
-            mime_type: MIME type of the file. Defaults to "application/octet-stream".
+            mime_type: MIME type of the file. If None, no Content-Type header is sent
+                (required for GCS signed URLs that were generated without a Content-Type).
 
         Returns:
             List of SuccessResponse objects containing the upload response details for each part.
         """
-        content_type = mime_type or "application/octet-stream"
         file_size = filepath.stat().st_size
         num_parts = len(upload_urls)
         part_size = file_size // num_parts
+
+        # Only include Content-Type header if explicitly provided.
+        # GCS signed URLs embed the expected Content-Type in the signature,
+        # so sending a different Content-Type (or any when none was signed) causes SignatureDoesNotMatch.
+        headers = {"Content-Type": mime_type} if mime_type else {}
 
         results: builtins.list[SuccessResponse] = []
         with filepath.open("rb") as file_stream:
@@ -336,7 +337,7 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
                 else:
                     chunk = file_stream.read(part_size)
 
-                response = httpx.put(upload_url, content=chunk, headers={"Content-Type": content_type})
+                response = httpx.put(upload_url, content=chunk, headers=headers)
                 if response.status_code not in (200, 201):
                     raise ToolkitAPIError(
                         message=f"Upload of part {i + 1} failed with status code {response.status_code}: {response.text}",

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -263,9 +263,9 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
         content_type = mime_type or "application/octet-stream"
 
         if isinstance(filepath, bytes):
-            file_stream: io.BufferedIOBase = io.BytesIO(filepath)
+            file_stream: io.IOBase = io.BytesIO(filepath)
         elif isinstance(filepath, str):
-            file_stream = Path(filepath).open("rb")
+            file_stream = io.StringIO(filepath)
         else:
             file_stream = filepath.open("rb")
 

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -111,7 +111,7 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
         return results
 
     def upload_multi_parts(self, item: FileMetadataRequest, overwrite: bool, parts: int) -> FileMetadataResponse:
-        """Upload file metadata to CDF and return mutiple URLs for uploading"""
+        """Upload file metadata to CDF and return multiple URLs for uploading"""
         self._validate_parts_parameter(parts)
         endpoint = self._multipart_file_upload_link
         request = RequestMessage(

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -41,6 +41,7 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             api_version="alpha",
         )
         self._download_link = Endpoint(method="POST", path="/files/downloadlink", item_limit=10)
+        self._multipart_file_upload_link = Endpoint(method="POST", path="/files/multiuploadlink", item_limit=1)
 
     def _validate_page_response(
         self, response: SuccessResponse | ItemsSuccessResponse
@@ -310,6 +311,26 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
                 _ = response.get_success_or_raise(request)
         return results
 
+    def get_multipart_upload_urls(self, item: ExternalId | InstanceId, parts: int) -> FileMetadataResponse:
+        """Get URLs to upload a file in multiple parts to CDF for one file metadata entry."""
+        if not (1 <= parts <= 250):
+            raise ValueError("Parts must be between 1 and 250")
+        endpoint = self._multipart_file_upload_link
+        request = RequestMessage(
+            endpoint_url=self._http_client.config.create_api_url(endpoint.path),
+            method="POST",
+            parameters={"parts": parts},
+            body_content={"items": [item.dump()]},
+        )
+        success = self._http_client.request_single_retries(request).get_success_or_raise(request)
+        items = ResponseItems[FileMetadataResponse].model_validate_json(success.body).items
+        if len(items) != 1:
+            raise ToolkitAPIError(
+                message=f"Expected exactly one item in response, got {len(items)}",
+                code=success.status_code,
+            )
+        return items[0]
+
     def get_download_url(
         self, items: Sequence[InternalId], extended_expiration: bool = False
     ) -> builtins.list[DownloadResponse]:
@@ -351,3 +372,14 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             with destination.open(mode="wb") as file_stream:
                 for chunk in response.iter_bytes(chunk_size=8192):
                     file_stream.write(chunk)
+
+    def complete_multipart_upload(self, item: InternalId | ExternalId | InstanceId, upload_id: str) -> SuccessResponse:
+        """Complete a multipart upload for one or more file metadata entries."""
+        body = item.dump()
+        body["uploadId"] = upload_id
+        request = RequestMessage(
+            endpoint_url=self._http_client.config.create_api_url("/files/completemultipartupload"),
+            method="POST",
+            body_content=body,
+        )
+        return self._http_client.request_single_retries(request).get_success_or_raise(request)

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -192,26 +192,6 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
         """
         return self._list(limit=limit)
 
-    def upload_file_link(
-        self, items: Sequence[ExternalId | InstanceId], ignore_unknown_ids: bool = False
-    ) -> builtins.list[FileMetadataResponse]:
-        """Upload file link to CDF."""
-        results: list[FileMetadataResponse] = []
-        for item in items:
-            request = RequestMessage(
-                endpoint_url=self._http_client.config.create_api_url("/files/uploadlink"),
-                method="POST",
-                body_content={"items": [item.dump()]},
-            )
-            response = self._http_client.request_single_retries(request)
-            if isinstance(response, SuccessResponse):
-                results.extend(ResponseItems[FileMetadataResponse].model_validate_json(response.body).items)
-            elif ignore_unknown_ids:
-                continue
-            else:
-                _ = response.get_success_or_raise(request)
-        return results
-
     def upload_content(self, data_content: bytes, upload_url: str, mime_type: str | None = None) -> HTTPResult:
         """Uploads file content to CDF.
 

--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -9,6 +9,7 @@ import httpx
 from cognite_toolkit._cdf_tk.client.cdf_client import CDFResourceAPI, PagedResponse, ResponseItems
 from cognite_toolkit._cdf_tk.client.cdf_client.api import Endpoint
 from cognite_toolkit._cdf_tk.client.http_client import (
+    FailedResponse,
     HTTPClient,
     ItemsSuccessResponse,
     RequestMessage,
@@ -316,12 +317,16 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
         else:
             content = _LimitedFileReader(filepath.open("rb"), filepath.stat().st_size)
 
-        return self._http_client.request_raw_retries(
+        response = self._http_client.request_raw_retries(
             method="PUT",
             url=upload_url,
             content=content,
             headers={"Content-Type": mime_type} if mime_type else None,
         )
+        if isinstance(response, FailedResponse):
+            raise ToolkitAPIError(message=response.body, code=response.status_code)
+
+        return response
 
     def upload_file_multiparts(
         self, filepath: Path, upload_urls: builtins.list[str], mime_type: str | None = None
@@ -368,6 +373,8 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
                     content=chunk_stream,
                     headers=headers,
                 )
+                if isinstance(response, FailedResponse):
+                    raise ToolkitAPIError(message=response.body, code=response.status_code)
                 results.append(response)
 
         return results

--- a/cognite_toolkit/_cdf_tk/client/http_client/_client.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_client.py
@@ -2,7 +2,7 @@ import random
 import sys
 import time
 from collections import deque
-from collections.abc import MutableMapping, Sequence, Set
+from collections.abc import Iterable, MutableMapping, Sequence, Set
 from typing import Literal, TypeVar
 
 import httpx
@@ -18,6 +18,7 @@ from cognite_toolkit._cdf_tk.client.http_client._data_classes import (
     RequestMessage,
     SuccessResponse,
 )
+from cognite_toolkit._cdf_tk.client.http_client._exception import ToolkitAPIError
 from cognite_toolkit._cdf_tk.client.http_client._item_classes import (
     ItemsFailedRequest,
     ItemsFailedResponse,
@@ -258,6 +259,91 @@ class HTTPClient:
             error_msg = f"RequestException after {request.total_attempts - 1} attempts ({error_type} error): {e!s}"
 
             return FailedRequest(error=error_msg)
+
+    def request_raw_retries(
+        self,
+        method: Literal["GET", "POST", "PUT", "DELETE"],
+        url: str,
+        content: bytes | Iterable[bytes],
+        headers: dict[str, str] | None = None,
+        max_retries: int | None = None,
+    ) -> SuccessResponse:
+        """Send a raw HTTP request with retry logic but without authentication headers.
+
+        This is useful for uploading to signed URLs (e.g., GCS signed URLs) where
+        authentication is embedded in the URL and adding auth headers would cause errors.
+
+        Args:
+            method: HTTP method to use.
+            url: The URL to send the request to.
+            content: The content to send. Can be bytes or an iterable of bytes for streaming.
+            headers: Optional headers to include in the request.
+            max_retries: Maximum number of retries. Defaults to the client's max_retries setting.
+
+        Returns:
+            SuccessResponse object containing the response details.
+
+        Raises:
+            ToolkitAPIError: If the request fails after all retries.
+        """
+        retries = max_retries if max_retries is not None else self._max_retries
+        attempt = 0
+        last_error: Exception | None = None
+
+        while attempt <= retries:
+            try:
+                response = self.session.request(
+                    method=method,
+                    url=url,
+                    content=content,
+                    headers=headers or {},
+                    follow_redirects=False,
+                )
+                if 200 <= response.status_code < 300:
+                    return SuccessResponse(
+                        status_code=response.status_code,
+                        body=response.text,
+                        content=response.content,
+                    )
+
+                # Check if we should retry based on status code
+                if response.status_code in self._retry_status_codes:
+                    retry_after = self._get_retry_after_in_header(response)
+                    if retry_after is not None:
+                        time.sleep(retry_after)
+                    else:
+                        time.sleep(self._backoff_time(attempt))
+                    attempt += 1
+                    continue
+
+                # Non-retryable error
+                raise ToolkitAPIError(
+                    message=f"Request failed with status code {response.status_code}: {response.text}",
+                    code=response.status_code,
+                )
+
+            except (
+                httpx.ReadTimeout,
+                httpx.TimeoutException,
+                ConnectionError,
+                httpx.ConnectError,
+                httpx.ConnectTimeout,
+            ) as e:
+                last_error = e
+                attempt += 1
+                if attempt <= retries:
+                    time.sleep(self._backoff_time(attempt))
+                    continue
+                raise ToolkitAPIError(
+                    message=f"Request failed after {attempt} attempts: {e!s}",
+                    code=-1,
+                ) from e
+
+        # Should not reach here, but just in case
+        raise ToolkitAPIError(
+            message=f"Request failed after {attempt} attempts: {last_error!s}",
+            code=-1,
+        )
 
     def request_items(self, message: ItemsRequest) -> Sequence[ItemsRequest | ItemsResultMessage]:
         """Send an HTTP request with multiple items and return the response.

--- a/cognite_toolkit/_cdf_tk/client/http_client/_client.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_client.py
@@ -18,7 +18,6 @@ from cognite_toolkit._cdf_tk.client.http_client._data_classes import (
     RequestMessage,
     SuccessResponse,
 )
-from cognite_toolkit._cdf_tk.client.http_client._exception import ToolkitAPIError
 from cognite_toolkit._cdf_tk.client.http_client._item_classes import (
     ItemsFailedRequest,
     ItemsFailedResponse,
@@ -267,7 +266,7 @@ class HTTPClient:
         content: bytes | Iterable[bytes],
         headers: dict[str, str] | None = None,
         max_retries: int | None = None,
-    ) -> SuccessResponse:
+    ) -> SuccessResponse | FailedResponse:
         """Send a raw HTTP request with retry logic but without authentication headers.
 
         This is useful for uploading to signed URLs (e.g., GCS signed URLs) where
@@ -281,15 +280,11 @@ class HTTPClient:
             max_retries: Maximum number of retries. Defaults to the client's max_retries setting.
 
         Returns:
-            SuccessResponse object containing the response details.
-
-        Raises:
-            ToolkitAPIError: If the request fails after all retries.
+            HTTPResult: The result of the HTTP request, either SuccessResponse or FailedResponse.
         """
         retries = max_retries if max_retries is not None else self._max_retries
         attempt = 0
-        last_error: Exception | None = None
-
+        last_error_code: int = -1
         while attempt <= retries:
             try:
                 response = self.session.request(
@@ -305,7 +300,7 @@ class HTTPClient:
                         body=response.text,
                         content=response.content,
                     )
-
+                last_error_code = response.status_code
                 # Check if we should retry based on status code
                 if response.status_code in self._retry_status_codes:
                     retry_after = self._get_retry_after_in_header(response)
@@ -315,11 +310,11 @@ class HTTPClient:
                         time.sleep(self._backoff_time(attempt))
                     attempt += 1
                     continue
-
                 # Non-retryable error
-                raise ToolkitAPIError(
-                    message=f"Request failed with status code {response.status_code}: {response.text}",
-                    code=response.status_code,
+                return FailedResponse(
+                    status_code=response.status_code,
+                    body=response.text,
+                    error=ErrorDetails(code=response.status_code, message=response.text),
                 )
 
             except (
@@ -329,20 +324,21 @@ class HTTPClient:
                 httpx.ConnectError,
                 httpx.ConnectTimeout,
             ) as e:
-                last_error = e
                 attempt += 1
                 if attempt <= retries:
                     time.sleep(self._backoff_time(attempt))
                     continue
-                raise ToolkitAPIError(
-                    message=f"Request failed after {attempt} attempts: {e!s}",
-                    code=-1,
-                ) from e
+                return FailedResponse(
+                    status_code=last_error_code,
+                    body=f"Request failed after {attempt} attempts: {e!s}",
+                    error=ErrorDetails(code=last_error_code, message=f"Request failed after {attempt} attempts: {e!s}"),
+                )
 
         # Should not reach here, but just in case
-        raise ToolkitAPIError(
-            message=f"Request failed after {attempt} attempts: {last_error!s}",
-            code=-1,
+        return FailedResponse(
+            status_code=last_error_code,
+            body=f"Request failed after {attempt} attempts.",
+            error=ErrorDetails(code=last_error_code, message=f"Request failed after {attempt} attempts."),
         )
 
     def request_items(self, message: ItemsRequest) -> Sequence[ItemsRequest | ItemsResultMessage]:

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/filemetadata.py
@@ -58,6 +58,9 @@ class FileMetadataResponse(FileMetadata, ResponseResource[FileMetadataRequest]):
     pending_instance_id: NodeUntypedId | None = None
     # This field is required in the upload endpoint response, but not in any other file metadata response
     upload_url: str | None = None
+    # These fields are required in the multipart upload response
+    upload_id: str | None = None
+    upload_urls: list[str] | None = None
 
     @classmethod
     def request_cls(cls) -> type[FileMetadataRequest]:

--- a/tests/test_integration/test_commands/test_migrate_command.py
+++ b/tests/test_integration/test_commands/test_migrate_command.py
@@ -289,7 +289,7 @@ def cdm_file(
 
     _ = client.tool.cognite_files.create([node])
 
-    file = client.tool.filemetadata.upload_file_link([node.as_instance_id()])[0]
+    file = client.tool.filemetadata.get_upload_url([node.as_instance_id()])[0]
     _ = client.tool.filemetadata.upload_content(
         b"This is the CDM file content", file.upload_url, mime_type="text/plain"
     )

--- a/tests/test_integration/test_commands/test_migrate_command.py
+++ b/tests/test_integration/test_commands/test_migrate_command.py
@@ -290,7 +290,7 @@ def cdm_file(
     _ = client.tool.cognite_files.create([node])
 
     file = client.tool.filemetadata.get_upload_url([node.as_instance_id()])[0]
-    _ = client.tool.filemetadata.upload_file(b"This is the CDM file content", file.upload_url, mime_type="text/plain")
+    _ = client.tool.filemetadata.upload_file("This is the CDM file content", file.upload_url, mime_type="text/plain")
     request = RequestMessage(
         endpoint_url=client.config.create_api_url("/files/update"),
         method="POST",

--- a/tests/test_integration/test_commands/test_migrate_command.py
+++ b/tests/test_integration/test_commands/test_migrate_command.py
@@ -290,9 +290,7 @@ def cdm_file(
     _ = client.tool.cognite_files.create([node])
 
     file = client.tool.filemetadata.get_upload_url([node.as_instance_id()])[0]
-    _ = client.tool.filemetadata.upload_content(
-        b"This is the CDM file content", file.upload_url, mime_type="text/plain"
-    )
+    _ = client.tool.filemetadata.upload_file(b"This is the CDM file content", file.upload_url, mime_type="text/plain")
     request = RequestMessage(
         endpoint_url=client.config.create_api_url("/files/update"),
         method="POST",

--- a/tests_smoke/test_client/test_cdf_resource_api.py
+++ b/tests_smoke/test_client/test_cdf_resource_api.py
@@ -2,6 +2,7 @@ import io
 import types
 import zipfile
 from collections.abc import Callable, Hashable, Iterable, Set
+from pathlib import Path
 from typing import Annotated, Any, cast, get_args, get_origin
 
 import pytest
@@ -2478,3 +2479,62 @@ class TestCDFResourceAPI:
             client.charts.folders.create([request])
         except ToolkitAPIError as e:
             raise EndpointAssertionError(endpoints["create"].path, f"Failed to create chart folder: {e!s}")
+
+    def test_upload_large_file(
+        self, toolkit_client: ToolkitClient, smoke_dataset: DataSetResponse, tmp_path: Path
+    ) -> None:
+        api = toolkit_client.tool.filemetadata
+
+        # Create a 10 MB file (each part must be at least 5MB for multipart upload)
+        content_to_repeat = b"This is a smoke test"
+        file_size = 12 * 1024 * 1024  # 10 MB
+        repetitions = file_size // len(content_to_repeat) + 1
+
+        file_path = tmp_path / "large_test_file.txt"
+        file_path.write_bytes(content_to_repeat * repetitions)
+
+        request = FileMetadataRequest(
+            external_id="Smoke test large file",
+            name="Smoke test large file",
+            data_set_id=smoke_dataset.id,
+            mime_type="text/plain",
+        )
+        try:
+            result = api.upload_multi_parts(request, overwrite=True, parts=2)
+        except ToolkitAPIError as e:
+            raise EndpointAssertionError(
+                api._multipart_file_upload_link.path,
+                f"Failed to initiate multipart upload: {e!s}",
+            ) from e
+
+        if not result.upload_urls or len(result.upload_urls) != 2:
+            raise EndpointAssertionError(
+                api._multipart_file_upload_link.path,
+                f"Expected 2 upload URLs, got {len(result.upload_urls) if result.upload_urls else 0}",
+            )
+        if not result.upload_id:
+            raise EndpointAssertionError(
+                api._multipart_file_upload_link.path,
+                "Expected upload_id in response, got None",
+            )
+
+        try:
+            api.upload_file_multiparts(file_path, result.upload_urls)
+        except ToolkitAPIError as e:
+            raise EndpointAssertionError(
+                api._multipart_file_upload_link.path,
+                f"Failed to upload file parts: {e!s}",
+            ) from e
+
+        try:
+            api.complete_multipart_upload(result.as_internal_id(), result.upload_id)
+        except ToolkitAPIError as e:
+            raise EndpointAssertionError(
+                "/files/completemultipartupload",
+                f"Failed to complete multipart upload: {e!s}",
+            ) from e
+
+        try:
+            api.delete([result.as_id()], ignore_unknown_ids=True)
+        except ToolkitAPIError:
+            pass


### PR DESCRIPTION
# Description

* Avoid reading files into memory on upload.
* Remove duplicated `upload_file_link` and `upload_content` methods in the filemetadata api.
* Added the multi part endpoints, such that we can support multipart upload in the the data plugin (will be an upcoming PR)

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Improved

- When uploading file blobs (either in `cdf deploy` or `cdf data upload`), no longer reads the entire file into memory. 
