### PR TITLE
[CDF-27524] 🦛Avoid using discriminators in request/response classes

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/__init__.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/__init__.py
@@ -66,6 +66,8 @@ from ._instance import (
     InstanceResponseDefinition,
     InstanceSlimDefinition,
     InstanceSource,
+    NodeOrEdgeRequest,
+    NodeOrEdgeResponse,
     NodeRequest,
     NodeResponse,
 )
@@ -174,6 +176,8 @@ __all__ = [
     "MultiReverseDirectRelationPropertyRequest",
     "MultiReverseDirectRelationPropertyResponse",
     "NodeId",
+    "NodeOrEdgeRequest",
+    "NodeOrEdgeResponse",
     "NodeRequest",
     "NodeResponse",
     "PropertyTypeDefinition",

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_constraints.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_constraints.py
@@ -1,11 +1,12 @@
 from abc import ABC
 from typing import Annotated, Any, Literal
 
-from pydantic import Field, TypeAdapter, field_serializer
+from pydantic import BeforeValidator, ConfigDict, TypeAdapter, field_serializer
 from pydantic_core.core_schema import FieldSerializationInfo
 
 from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject
 from cognite_toolkit._cdf_tk.client.identifiers import ContainerId
+from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
 
 
 class ConstraintDefinition(BaseModelObject, ABC):
@@ -28,9 +29,30 @@ class RequiresConstraintDefinition(ConstraintDefinition):
         return {**require.model_dump(**vars(info)), "type": "container"}
 
 
+class UnknownConstraintDefinition(ConstraintDefinition):
+    model_config = ConfigDict(extra="allow")
+    constraint_type: str
+
+
+def _handle_unknown_constraint(value: Any) -> Any:
+    if isinstance(value, dict):
+        constraint_type = dict_discriminator_value(value, "constraint_type")
+        if constraint_type not in _CONSTRAINT_BY_TYPE:
+            return UnknownConstraintDefinition.model_validate(value)
+        return _CONSTRAINT_BY_TYPE[constraint_type].model_validate(value)
+    return value
+
+
+_CONSTRAINT_BY_TYPE = registry_from_subclasses_with_type_field(
+    ConstraintDefinition,
+    type_field="constraint_type",
+    exclude=(UnknownConstraintDefinition,),
+)
+
+
 Constraint = Annotated[
-    UniquenessConstraintDefinition | RequiresConstraintDefinition,
-    Field(discriminator="constraint_type"),
+    UniquenessConstraintDefinition | RequiresConstraintDefinition | UnknownConstraintDefinition,
+    BeforeValidator(_handle_unknown_constraint),
 ]
 
 ConstraintAdapter: TypeAdapter[Constraint] = TypeAdapter(Constraint)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_constraints.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_constraints.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from typing import Annotated, Any, Literal
 
-from pydantic import BeforeValidator, ConfigDict, TypeAdapter, field_serializer
+from pydantic import BeforeValidator, TypeAdapter, field_serializer
 from pydantic_core.core_schema import FieldSerializationInfo
 
 from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_constraints.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_constraints.py
@@ -30,7 +30,6 @@ class RequiresConstraintDefinition(ConstraintDefinition):
 
 
 class UnknownConstraintDefinition(ConstraintDefinition):
-    model_config = ConfigDict(extra="allow")
     constraint_type: str
 
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_constraints.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_constraints.py
@@ -6,7 +6,7 @@ from pydantic_core.core_schema import FieldSerializationInfo
 
 from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject
 from cognite_toolkit._cdf_tk.client.identifiers import ContainerId
-from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
+from cognite_toolkit._cdf_tk.utils._auxiliary import registry_from_subclasses_with_type_field
 
 
 class ConstraintDefinition(BaseModelObject, ABC):
@@ -36,7 +36,7 @@ class UnknownConstraintDefinition(ConstraintDefinition):
 
 def _handle_unknown_constraint(value: Any) -> Any:
     if isinstance(value, dict):
-        constraint_type = dict_discriminator_value(value, "constraint_type")
+        constraint_type = value.get("constraintType")
         if constraint_type not in _CONSTRAINT_BY_TYPE:
             return UnknownConstraintDefinition.model_validate(value)
         return _CONSTRAINT_BY_TYPE[constraint_type].model_validate(value)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_data_types.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_data_types.py
@@ -1,11 +1,12 @@
 from abc import ABC
 from typing import Annotated, Any, Literal
 
-from pydantic import Field, TypeAdapter, field_serializer
+from pydantic import BeforeValidator, ConfigDict, Field, TypeAdapter, field_serializer
 from pydantic_core.core_schema import FieldSerializationInfo
 
 from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject
 from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, ViewId
+from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
 
 
 class PropertyTypeDefinition(BaseModelObject, ABC):
@@ -100,6 +101,27 @@ class EnumProperty(PropertyTypeDefinition):
     values: dict[str, EnumValue]
 
 
+class UnknownPropertyType(PropertyTypeDefinition):
+    model_config = ConfigDict(extra="allow")
+    type: str
+
+
+def _handle_unknown_property_type(value: Any) -> Any:
+    if isinstance(value, dict):
+        prop_type = dict_discriminator_value(value, "type")
+        if prop_type not in _PROPERTY_TYPE_BY_TYPE:
+            return UnknownPropertyType.model_validate(value)
+        return _PROPERTY_TYPE_BY_TYPE[prop_type].model_validate(value)
+    return value
+
+
+_PROPERTY_TYPE_BY_TYPE = registry_from_subclasses_with_type_field(
+    PropertyTypeDefinition,
+    type_field="type",
+    exclude=(UnknownPropertyType,),
+)
+
+
 DataType = Annotated[
     TextProperty
     | Float32Property
@@ -114,8 +136,9 @@ DataType = Annotated[
     | FileCDFExternalIdReference
     | SequenceCDFExternalIdReference
     | EnumProperty
-    | DirectNodeRelation,
-    Field(discriminator="type"),
+    | DirectNodeRelation
+    | UnknownPropertyType,
+    BeforeValidator(_handle_unknown_property_type),
 ]
 
 DataTypeAdapter: TypeAdapter[DataType] = TypeAdapter(DataType)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_data_types.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_data_types.py
@@ -6,7 +6,7 @@ from pydantic_core.core_schema import FieldSerializationInfo
 
 from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject
 from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, ViewId
-from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
+from cognite_toolkit._cdf_tk.utils._auxiliary import registry_from_subclasses_with_type_field
 
 
 class PropertyTypeDefinition(BaseModelObject, ABC):
@@ -108,7 +108,7 @@ class UnknownPropertyType(PropertyTypeDefinition):
 
 def _handle_unknown_property_type(value: Any) -> Any:
     if isinstance(value, dict):
-        prop_type = dict_discriminator_value(value, "type")
+        prop_type = value.get("type")
         if prop_type not in _PROPERTY_TYPE_BY_TYPE:
             return UnknownPropertyType.model_validate(value)
         return _PROPERTY_TYPE_BY_TYPE[prop_type].model_validate(value)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_data_types.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_data_types.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from typing import Annotated, Any, Literal
 
-from pydantic import BeforeValidator, ConfigDict, Field, TypeAdapter, field_serializer
+from pydantic import BeforeValidator, Field, TypeAdapter, field_serializer
 from pydantic_core.core_schema import FieldSerializationInfo
 
 from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_data_types.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_data_types.py
@@ -102,7 +102,6 @@ class EnumProperty(PropertyTypeDefinition):
 
 
 class UnknownPropertyType(PropertyTypeDefinition):
-    model_config = ConfigDict(extra="allow")
     type: str
 
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_indexes.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_indexes.py
@@ -1,9 +1,10 @@
 from abc import ABC
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import Field, TypeAdapter
+from pydantic import BeforeValidator, ConfigDict, TypeAdapter
 
 from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject
+from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
 
 
 class IndexDefinition(BaseModelObject, ABC):
@@ -21,6 +22,27 @@ class InvertedIndex(IndexDefinition):
     index_type: Literal["inverted"] = "inverted"
 
 
-Index = Annotated[BtreeIndex | InvertedIndex, Field(discriminator="index_type")]
+class UnknownIndexDefinition(IndexDefinition):
+    model_config = ConfigDict(extra="allow")
+    index_type: str
+
+
+def _handle_unknown_index(value: Any) -> Any:
+    if isinstance(value, dict):
+        index_type = dict_discriminator_value(value, "index_type")
+        if index_type not in _INDEX_BY_TYPE:
+            return UnknownIndexDefinition.model_validate(value)
+        return _INDEX_BY_TYPE[index_type].model_validate(value)
+    return value
+
+
+_INDEX_BY_TYPE = registry_from_subclasses_with_type_field(
+    IndexDefinition,
+    type_field="index_type",
+    exclude=(UnknownIndexDefinition,),
+)
+
+
+Index = Annotated[BtreeIndex | InvertedIndex | UnknownIndexDefinition, BeforeValidator(_handle_unknown_index)]
 
 IndexAdapter: TypeAdapter[Index] = TypeAdapter(Index)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_indexes.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_indexes.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any, Literal
 from pydantic import BeforeValidator, ConfigDict, TypeAdapter
 
 from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject
-from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
+from cognite_toolkit._cdf_tk.utils._auxiliary import registry_from_subclasses_with_type_field
 
 
 class IndexDefinition(BaseModelObject, ABC):
@@ -29,7 +29,7 @@ class UnknownIndexDefinition(IndexDefinition):
 
 def _handle_unknown_index(value: Any) -> Any:
     if isinstance(value, dict):
-        index_type = dict_discriminator_value(value, "index_type")
+        index_type = value.get("indexType")
         if index_type not in _INDEX_BY_TYPE:
             return UnknownIndexDefinition.model_validate(value)
         return _INDEX_BY_TYPE[index_type].model_validate(value)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_indexes.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_indexes.py
@@ -23,7 +23,6 @@ class InvertedIndex(IndexDefinition):
 
 
 class UnknownIndexDefinition(IndexDefinition):
-    model_config = ConfigDict(extra="allow")
     index_type: str
 
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_indexes.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_indexes.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from typing import Annotated, Any, Literal
 
-from pydantic import BeforeValidator, ConfigDict, TypeAdapter
+from pydantic import BeforeValidator, TypeAdapter
 
 from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject
 from cognite_toolkit._cdf_tk.utils._auxiliary import registry_from_subclasses_with_type_field

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_instance.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_instance.py
@@ -2,7 +2,7 @@ import builtins
 from abc import ABC
 from typing import Annotated, Any, Generic, Literal, TypeAlias
 
-from pydantic import BeforeValidator, ConfigDict, JsonValue, TypeAdapter, field_serializer, field_validator
+from pydantic import BeforeValidator, JsonValue, TypeAdapter, field_serializer, field_validator
 
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_instance.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_instance.py
@@ -2,7 +2,7 @@ import builtins
 from abc import ABC
 from typing import Annotated, Any, Generic, Literal, TypeAlias
 
-from pydantic import BeforeValidator, JsonValue, TypeAdapter, field_serializer, field_validator
+from pydantic import BeforeValidator, Field, JsonValue, TypeAdapter, field_serializer, field_validator
 
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,
@@ -197,6 +197,10 @@ class UnknownInstanceRequest(InstanceRequestDefinition):
 class UnknownInstanceResponse(InstanceResponseDefinition[UnknownInstanceRequest]):
     instance_type: str
 
+    def as_id(self) -> NodeId:
+        """Address unknown kinds by node external id until a typed instance model exists."""
+        return NodeId(space=self.space, external_id=self.external_id)
+
     @classmethod
     def request_cls(cls) -> builtins.type[UnknownInstanceRequest]:
         return UnknownInstanceRequest
@@ -249,5 +253,12 @@ InstanceResponse: TypeAlias = Annotated[
     NodeResponse | EdgeResponse | UnknownInstanceResponse,
     BeforeValidator(_handle_unknown_instance_response),
 ]
+
+# We are not using discriminator in general for request/response classes,
+# however, this is an exception for the cases that we want exactly a Node or Edge.
+NodeOrEdgeRequest: TypeAlias = Annotated[NodeRequest | EdgeRequest, Field(discriminator="instance_type")]
+NodeOrEdgeResponse: TypeAlias = Annotated[NodeResponse | EdgeResponse, Field(discriminator="instance_type")]
+
+NodeOrEdgeRequestAdapter: TypeAdapter[NodeOrEdgeRequest] = TypeAdapter(NodeOrEdgeRequest)
 
 InstanceRequestAdapter: TypeAdapter[InstanceRequest] = TypeAdapter(InstanceRequest)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_instance.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_instance.py
@@ -18,7 +18,7 @@ from cognite_toolkit._cdf_tk.client.identifiers import (
     NodeUntypedId,
     ViewId,
 )
-from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
+from cognite_toolkit._cdf_tk.utils._auxiliary import registry_from_subclasses_with_type_field
 
 
 class InstanceDefinition(BaseModelObject, ABC):
@@ -215,7 +215,7 @@ class UnknownInstanceResponse(InstanceResponseDefinition[UnknownInstanceRequest]
 
 def _handle_unknown_instance_request(value: Any) -> Any:
     if isinstance(value, dict):
-        instance_type = dict_discriminator_value(value, "instance_type")
+        instance_type = value.get("instanceType")
         if instance_type not in _INSTANCE_REQUEST_BY_TYPE:
             return UnknownInstanceRequest.model_validate(value)
         return _INSTANCE_REQUEST_BY_TYPE[instance_type].model_validate(value)
@@ -224,7 +224,7 @@ def _handle_unknown_instance_request(value: Any) -> Any:
 
 def _handle_unknown_instance_response(value: Any) -> Any:
     if isinstance(value, dict):
-        instance_type = dict_discriminator_value(value, "instance_type")
+        instance_type = value.get("instanceType")
         if instance_type not in _INSTANCE_RESPONSE_BY_TYPE:
             return UnknownInstanceResponse.model_validate(value)
         return _INSTANCE_RESPONSE_BY_TYPE[instance_type].model_validate(value)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_instance.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_instance.py
@@ -190,6 +190,10 @@ class UnknownInstanceRequest(InstanceRequestDefinition):
     model_config = ConfigDict(extra="allow")
     instance_type: str
 
+    def as_id(self) -> NodeId:
+        """Address unknown kinds by node external id until a typed instance model exists."""
+        return NodeId(space=self.space, external_id=self.external_id)
+
 
 class UnknownInstanceResponse(InstanceResponseDefinition[UnknownInstanceRequest]):
     model_config = ConfigDict(extra="allow")

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_instance.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_instance.py
@@ -2,7 +2,7 @@ import builtins
 from abc import ABC
 from typing import Annotated, Any, Generic, Literal, TypeAlias
 
-from pydantic import Field, JsonValue, TypeAdapter, field_serializer, field_validator
+from pydantic import BeforeValidator, ConfigDict, JsonValue, TypeAdapter, field_serializer, field_validator
 
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,
@@ -18,6 +18,7 @@ from cognite_toolkit._cdf_tk.client.identifiers import (
     NodeUntypedId,
     ViewId,
 )
+from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
 
 
 class InstanceDefinition(BaseModelObject, ABC):
@@ -185,13 +186,66 @@ class InstanceSlimDefinition(BaseModelObject):
         return InstanceId(instance_id=node_id)
 
 
+class UnknownInstanceRequest(InstanceRequestDefinition):
+    model_config = ConfigDict(extra="allow")
+    instance_type: str
+
+
+class UnknownInstanceResponse(InstanceResponseDefinition[UnknownInstanceRequest]):
+    model_config = ConfigDict(extra="allow")
+    instance_type: str
+
+    @classmethod
+    def request_cls(cls) -> builtins.type[UnknownInstanceRequest]:
+        return UnknownInstanceRequest
+
+    def as_request_resource(self) -> UnknownInstanceRequest:
+        dumped = self.dump()
+        if self.properties:
+            dumped["sources"] = [
+                InstanceSource(source=source_ref, properties=props) for source_ref, props in self.properties.items()
+            ]
+        dumped["existingVersion"] = dumped.pop("version", None)
+        return UnknownInstanceRequest.model_validate(dumped, extra="ignore")
+
+
+def _handle_unknown_instance_request(value: Any) -> Any:
+    if isinstance(value, dict):
+        instance_type = dict_discriminator_value(value, "instance_type")
+        if instance_type not in _INSTANCE_REQUEST_BY_TYPE:
+            return UnknownInstanceRequest.model_validate(value)
+        return _INSTANCE_REQUEST_BY_TYPE[instance_type].model_validate(value)
+    return value
+
+
+def _handle_unknown_instance_response(value: Any) -> Any:
+    if isinstance(value, dict):
+        instance_type = dict_discriminator_value(value, "instance_type")
+        if instance_type not in _INSTANCE_RESPONSE_BY_TYPE:
+            return UnknownInstanceResponse.model_validate(value)
+        return _INSTANCE_RESPONSE_BY_TYPE[instance_type].model_validate(value)
+    return value
+
+
+_INSTANCE_REQUEST_BY_TYPE = registry_from_subclasses_with_type_field(
+    InstanceRequestDefinition,
+    type_field="instance_type",
+    exclude=(UnknownInstanceRequest,),
+)
+_INSTANCE_RESPONSE_BY_TYPE = registry_from_subclasses_with_type_field(
+    InstanceResponseDefinition,
+    type_field="instance_type",
+    exclude=(UnknownInstanceResponse,),
+)
+
+
 InstanceRequest: TypeAlias = Annotated[
-    NodeRequest | EdgeRequest,
-    Field(discriminator="instance_type"),
+    NodeRequest | EdgeRequest | UnknownInstanceRequest,
+    BeforeValidator(_handle_unknown_instance_request),
 ]
 InstanceResponse: TypeAlias = Annotated[
-    NodeResponse | EdgeResponse,
-    Field(discriminator="instance_type"),
+    NodeResponse | EdgeResponse | UnknownInstanceResponse,
+    BeforeValidator(_handle_unknown_instance_response),
 ]
 
 InstanceRequestAdapter: TypeAdapter[InstanceRequest] = TypeAdapter(InstanceRequest)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_instance.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_instance.py
@@ -187,7 +187,6 @@ class InstanceSlimDefinition(BaseModelObject):
 
 
 class UnknownInstanceRequest(InstanceRequestDefinition):
-    model_config = ConfigDict(extra="allow")
     instance_type: str
 
     def as_id(self) -> NodeId:
@@ -196,7 +195,6 @@ class UnknownInstanceRequest(InstanceRequestDefinition):
 
 
 class UnknownInstanceResponse(InstanceResponseDefinition[UnknownInstanceRequest]):
-    model_config = ConfigDict(extra="allow")
     instance_type: str
 
     @classmethod

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_view_property.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_view_property.py
@@ -142,7 +142,6 @@ class UnknownViewPropertyRequest(ViewPropertyDefinition):
 
 
 class UnknownViewPropertyResponse(ViewPropertyDefinition):
-    model_config = ConfigDict(extra="allow")
     connection_type: str
 
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_view_property.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_view_property.py
@@ -13,7 +13,7 @@ from cognite_toolkit._cdf_tk.client.identifiers import (
     ViewDirectId,
     ViewId,
 )
-from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_model_classes
+from cognite_toolkit._cdf_tk.utils._auxiliary import registry_from_model_classes
 
 from ._data_types import DataType
 
@@ -148,7 +148,7 @@ class UnknownViewPropertyResponse(ViewPropertyDefinition):
 
 def _handle_view_request_property(value: Any) -> Any:
     if isinstance(value, dict):
-        connection_type = dict_discriminator_value(value, "connection_type") or "primary_property"
+        connection_type = value.get("connectionType") or "primary_property"
         if connection_type not in _VIEW_REQUEST_PROPERTY_BY_CT:
             return UnknownViewPropertyRequest.model_validate(value)
         return _VIEW_REQUEST_PROPERTY_BY_CT[connection_type].model_validate(value)
@@ -157,7 +157,7 @@ def _handle_view_request_property(value: Any) -> Any:
 
 def _handle_view_response_property(value: Any) -> Any:
     if isinstance(value, dict):
-        connection_type = dict_discriminator_value(value, "connection_type") or "primary_property"
+        connection_type = value.get("connectionType") or "primary_property"
         if connection_type not in _VIEW_RESPONSE_PROPERTY_BY_CT:
             return UnknownViewPropertyResponse.model_validate(value)
         return _VIEW_RESPONSE_PROPERTY_BY_CT[connection_type].model_validate(value)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_view_property.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_view_property.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from typing import Annotated, Any, Literal
 
-from pydantic import Field, JsonValue, TypeAdapter, field_serializer
+from pydantic import BeforeValidator, ConfigDict, Field, JsonValue, TypeAdapter, field_serializer
 from pydantic_core.core_schema import FieldSerializationInfo
 
 from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject
@@ -13,6 +13,7 @@ from cognite_toolkit._cdf_tk.client.identifiers import (
     ViewDirectId,
     ViewId,
 )
+from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_model_classes
 
 from ._data_types import DataType
 
@@ -135,21 +136,73 @@ class MultiReverseDirectRelationPropertyResponse(ReverseDirectRelationProperty):
         return MultiReverseDirectRelationPropertyRequest.model_validate(self.model_dump(by_alias=True))
 
 
+class UnknownViewPropertyRequest(ViewPropertyDefinition):
+    model_config = ConfigDict(extra="allow")
+    connection_type: str
+
+
+class UnknownViewPropertyResponse(ViewPropertyDefinition):
+    model_config = ConfigDict(extra="allow")
+    connection_type: str
+
+
+def _handle_view_request_property(value: Any) -> Any:
+    if isinstance(value, dict):
+        connection_type = dict_discriminator_value(value, "connection_type") or "primary_property"
+        if connection_type not in _VIEW_REQUEST_PROPERTY_BY_CT:
+            return UnknownViewPropertyRequest.model_validate(value)
+        return _VIEW_REQUEST_PROPERTY_BY_CT[connection_type].model_validate(value)
+    return value
+
+
+def _handle_view_response_property(value: Any) -> Any:
+    if isinstance(value, dict):
+        connection_type = dict_discriminator_value(value, "connection_type") or "primary_property"
+        if connection_type not in _VIEW_RESPONSE_PROPERTY_BY_CT:
+            return UnknownViewPropertyResponse.model_validate(value)
+        return _VIEW_RESPONSE_PROPERTY_BY_CT[connection_type].model_validate(value)
+    return value
+
+
+_VIEW_REQUEST_PROPERTY_BY_CT = registry_from_model_classes(
+    (
+        SingleEdgeProperty,
+        MultiEdgeProperty,
+        SingleReverseDirectRelationPropertyRequest,
+        MultiReverseDirectRelationPropertyRequest,
+        ViewCorePropertyRequest,
+    ),
+    type_field="connection_type",
+)
+_VIEW_RESPONSE_PROPERTY_BY_CT = registry_from_model_classes(
+    (
+        SingleEdgeProperty,
+        MultiEdgeProperty,
+        SingleReverseDirectRelationPropertyResponse,
+        MultiReverseDirectRelationPropertyResponse,
+        ViewCorePropertyResponse,
+    ),
+    type_field="connection_type",
+)
+
+
 ViewRequestProperty = Annotated[
     SingleEdgeProperty
     | MultiEdgeProperty
     | SingleReverseDirectRelationPropertyRequest
     | MultiReverseDirectRelationPropertyRequest
-    | ViewCorePropertyRequest,
-    Field(discriminator="connection_type"),
+    | ViewCorePropertyRequest
+    | UnknownViewPropertyRequest,
+    BeforeValidator(_handle_view_request_property),
 ]
 ViewResponseProperty = Annotated[
     SingleEdgeProperty
     | MultiEdgeProperty
     | SingleReverseDirectRelationPropertyResponse
     | MultiReverseDirectRelationPropertyResponse
-    | ViewCorePropertyResponse,
-    Field(discriminator="connection_type"),
+    | ViewCorePropertyResponse
+    | UnknownViewPropertyResponse,
+    BeforeValidator(_handle_view_response_property),
 ]
 
 ViewRequestPropertyAdapter: TypeAdapter[ViewRequestProperty] = TypeAdapter(ViewRequestProperty)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_view_property.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_view_property.py
@@ -64,7 +64,7 @@ class ViewCorePropertyResponse(ViewCoreProperty):
     type: DataType
 
     def as_request(self) -> ViewCorePropertyRequest:
-        return ViewCorePropertyRequest.model_validate(self.model_dump(by_alias=True))
+        return ViewCorePropertyRequest.model_validate(self.model_dump(by_alias=True), extra="ignore")
 
 
 class ConnectionPropertyDefinition(ViewPropertyDefinition, ABC):

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_job.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_job.py
@@ -8,7 +8,7 @@ from cognite_toolkit._cdf_tk.client._resource_base import (
     UpdatableRequestResource,
 )
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
-from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
+from cognite_toolkit._cdf_tk.utils._auxiliary import registry_from_subclasses_with_type_field
 
 
 class JobFormatDefinition(BaseModelObject):
@@ -62,7 +62,7 @@ class UnknownJobFormat(JobFormatDefinition):
 
 def _handle_unknown_job_format(value: Any) -> Any:
     if isinstance(value, dict):
-        fmt_type = dict_discriminator_value(value, "type")
+        fmt_type = value.get("type")
         if fmt_type not in _JOB_FORMAT_BY_TYPE:
             return UnknownJobFormat.model_validate(value)
         return _JOB_FORMAT_BY_TYPE[fmt_type].model_validate(value)
@@ -115,7 +115,7 @@ class UnknownIncrementalLoad(IncrementalLoadDefinition):
 
 def _handle_unknown_incremental_load(value: Any) -> Any:
     if isinstance(value, dict):
-        load_type = dict_discriminator_value(value, "type")
+        load_type = value.get("type")
         if load_type not in _INCREMENTAL_LOAD_BY_TYPE:
             return UnknownIncrementalLoad.model_validate(value)
         return _INCREMENTAL_LOAD_BY_TYPE[load_type].model_validate(value)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_job.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_job.py
@@ -56,7 +56,6 @@ class ValueFormat(JobFormatDefinition):
 
 
 class UnknownJobFormat(JobFormatDefinition):
-    model_config = ConfigDict(extra="allow")
     type: str
 
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_job.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_job.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal
 
-from pydantic import Field, JsonValue, field_validator
+from pydantic import BeforeValidator, ConfigDict, JsonValue, field_validator
 
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,
@@ -8,6 +8,7 @@ from cognite_toolkit._cdf_tk.client._resource_base import (
     UpdatableRequestResource,
 )
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
 
 
 class JobFormatDefinition(BaseModelObject):
@@ -54,9 +55,30 @@ class ValueFormat(JobFormatDefinition):
     data_models: list[SpaceRef] | None = None
 
 
+class UnknownJobFormat(JobFormatDefinition):
+    model_config = ConfigDict(extra="allow")
+    type: str
+
+
+def _handle_unknown_job_format(value: Any) -> Any:
+    if isinstance(value, dict):
+        fmt_type = dict_discriminator_value(value, "type")
+        if fmt_type not in _JOB_FORMAT_BY_TYPE:
+            return UnknownJobFormat.model_validate(value)
+        return _JOB_FORMAT_BY_TYPE[fmt_type].model_validate(value)
+    return value
+
+
+_JOB_FORMAT_BY_TYPE = registry_from_subclasses_with_type_field(
+    JobFormatDefinition,
+    type_field="type",
+    exclude=(UnknownJobFormat,),
+)
+
+
 JobFormat = Annotated[
-    CogniteFormat | CustomFormat | RockwellFormat | ValueFormat,
-    Field(discriminator="type"),
+    CogniteFormat | CustomFormat | RockwellFormat | ValueFormat | UnknownJobFormat,
+    BeforeValidator(_handle_unknown_job_format),
 ]
 
 
@@ -86,6 +108,37 @@ class QueryParamIncrementalLoad(IncrementalLoadDefinition):
     value: str
 
 
+class UnknownIncrementalLoad(IncrementalLoadDefinition):
+    model_config = ConfigDict(extra="allow")
+    type: str
+
+
+def _handle_unknown_incremental_load(value: Any) -> Any:
+    if isinstance(value, dict):
+        load_type = dict_discriminator_value(value, "type")
+        if load_type not in _INCREMENTAL_LOAD_BY_TYPE:
+            return UnknownIncrementalLoad.model_validate(value)
+        return _INCREMENTAL_LOAD_BY_TYPE[load_type].model_validate(value)
+    return value
+
+
+_INCREMENTAL_LOAD_BY_TYPE = registry_from_subclasses_with_type_field(
+    IncrementalLoadDefinition,
+    type_field="type",
+    exclude=(UnknownIncrementalLoad,),
+)
+
+
+IncrementalLoad = Annotated[
+    BodyIncrementalLoad
+    | NextUrlIncrementalLoad
+    | HeaderIncrementalLoad
+    | QueryParamIncrementalLoad
+    | UnknownIncrementalLoad,
+    BeforeValidator(_handle_unknown_incremental_load),
+]
+
+
 class MQTTConfig(BaseModelObject):
     topic_filter: str
 
@@ -102,12 +155,8 @@ class RestConfig(BaseModelObject):
     body: JsonValue | None = None
     query: dict[str, str] | None = None
     headers: dict[str, str] | None = None
-    incremental_load: BodyIncrementalLoad | HeaderIncrementalLoad | QueryParamIncrementalLoad | None = Field(
-        None, discriminator="type"
-    )
-    pagination: (
-        BodyIncrementalLoad | NextUrlIncrementalLoad | HeaderIncrementalLoad | QueryParamIncrementalLoad | None
-    ) = Field(None, discriminator="type")
+    incremental_load: IncrementalLoad | None = None
+    pagination: IncrementalLoad | None = None
 
 
 class HostedExtractorJob(BaseModelObject):

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_mapping.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_mapping.py
@@ -1,6 +1,6 @@
-from typing import Annotated, ClassVar, Literal
+from typing import Annotated, Any, ClassVar, Literal
 
-from pydantic import Field
+from pydantic import BeforeValidator, ConfigDict
 
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,
@@ -8,6 +8,7 @@ from cognite_toolkit._cdf_tk.client._resource_base import (
     UpdatableRequestResource,
 )
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_model_classes
 
 
 class Mapping(BaseModelObject):
@@ -43,9 +44,29 @@ class JSONInput(BaseModelObject):
     type: Literal["json"] = "json"
 
 
+class UnknownMappingInput(MappingInputDefinition):
+    model_config = ConfigDict(extra="allow")
+    type: str
+
+
+def _handle_unknown_mapping_input(value: Any) -> Any:
+    if isinstance(value, dict):
+        input_type = dict_discriminator_value(value, "type")
+        if input_type not in _MAPPING_INPUT_BY_TYPE:
+            return UnknownMappingInput.model_validate(value)
+        return _MAPPING_INPUT_BY_TYPE[input_type].model_validate(value)
+    return value
+
+
+_MAPPING_INPUT_BY_TYPE = registry_from_model_classes(
+    (ProtobufInput, CSVInput, XMLInput, JSONInput),
+    type_field="type",
+)
+
+
 MappingInput = Annotated[
-    ProtobufInput | CSVInput | XMLInput | JSONInput,
-    Field(discriminator="type"),
+    ProtobufInput | CSVInput | XMLInput | JSONInput | UnknownMappingInput,
+    BeforeValidator(_handle_unknown_mapping_input),
 ]
 
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_mapping.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_mapping.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, ClassVar, Literal
 
-from pydantic import BeforeValidator, ConfigDict
+from pydantic import BeforeValidator
 
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,
@@ -45,7 +45,6 @@ class JSONInput(BaseModelObject):
 
 
 class UnknownMappingInput(MappingInputDefinition):
-    model_config = ConfigDict(extra="allow")
     type: str
 
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_mapping.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_mapping.py
@@ -8,7 +8,7 @@ from cognite_toolkit._cdf_tk.client._resource_base import (
     UpdatableRequestResource,
 )
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
-from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_model_classes
+from cognite_toolkit._cdf_tk.utils._auxiliary import registry_from_model_classes
 
 
 class Mapping(BaseModelObject):
@@ -51,7 +51,7 @@ class UnknownMappingInput(MappingInputDefinition):
 
 def _handle_unknown_mapping_input(value: Any) -> Any:
     if isinstance(value, dict):
-        input_type = dict_discriminator_value(value, "type")
+        input_type = value.get("type")
         if input_type not in _MAPPING_INPUT_BY_TYPE:
             return UnknownMappingInput.model_validate(value)
         return _MAPPING_INPUT_BY_TYPE[input_type].model_validate(value)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/__init__.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/__init__.py
@@ -13,6 +13,7 @@ from ._auth import (
     HTTPBasicAuthenticationResponse,
     ScramShaAuthenticationRequest,
     ScramShaAuthenticationResponse,
+    UnknownAuthenticationRequest,
 )
 from ._base import SourceRequestDefinition, SourceResponseDefinition, UnknownSourceRequest, UnknownSourceResponse
 from ._certificate import AuthCertificateRequest, CACertificateRequest, CertificateResponse
@@ -94,6 +95,7 @@ __all__ = [
     "RESTSourceResponse",
     "ScramShaAuthenticationRequest",
     "ScramShaAuthenticationResponse",
+    "UnknownAuthenticationRequest",
     "UnknownSourceRequest",
     "UnknownSourceResponse",
 ]

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/__init__.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/__init__.py
@@ -2,7 +2,7 @@ from typing import Annotated, Any
 
 from pydantic import BeforeValidator, TypeAdapter
 
-from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
+from cognite_toolkit._cdf_tk.utils._auxiliary import registry_from_subclasses_with_type_field
 
 from ._auth import (
     BasicAuthenticationRequest,
@@ -24,7 +24,7 @@ from ._rest import RESTSourceRequest, RESTSourceResponse
 
 def _handle_source_request_union(value: Any) -> Any:
     if isinstance(value, dict):
-        source_type = dict_discriminator_value(value, "type")
+        source_type = value.get("type")
         if source_type not in _SOURCE_REQUEST_BY_TYPE:
             return UnknownSourceRequest.model_validate(value)
         return _SOURCE_REQUEST_BY_TYPE[source_type].model_validate(value)
@@ -33,7 +33,7 @@ def _handle_source_request_union(value: Any) -> Any:
 
 def _handle_source_response_union(value: Any) -> Any:
     if isinstance(value, dict):
-        source_type = dict_discriminator_value(value, "type")
+        source_type = value.get("type")
         if source_type not in _SOURCE_RESPONSE_BY_TYPE:
             return UnknownSourceResponse.model_validate(value)
         return _SOURCE_RESPONSE_BY_TYPE[source_type].model_validate(value)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/__init__.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/__init__.py
@@ -1,6 +1,8 @@
-from typing import Annotated
+from typing import Annotated, Any
 
-from pydantic import Field, TypeAdapter
+from pydantic import BeforeValidator, TypeAdapter
+
+from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
 
 from ._auth import (
     BasicAuthenticationRequest,
@@ -12,15 +14,47 @@ from ._auth import (
     ScramShaAuthenticationRequest,
     ScramShaAuthenticationResponse,
 )
+from ._base import SourceRequestDefinition, SourceResponseDefinition, UnknownSourceRequest, UnknownSourceResponse
 from ._certificate import AuthCertificateRequest, CACertificateRequest, CertificateResponse
 from ._eventhub import EventHubSourceRequest, EventHubSourceResponse
 from ._kafka import KafkaBroker, KafkaSourceRequest, KafkaSourceResponse
 from ._mqtt import MQTTSourceRequest, MQTTSourceResponse
 from ._rest import RESTSourceRequest, RESTSourceResponse
 
+
+def _handle_source_request_union(value: Any) -> Any:
+    if isinstance(value, dict):
+        source_type = dict_discriminator_value(value, "type")
+        if source_type not in _SOURCE_REQUEST_BY_TYPE:
+            return UnknownSourceRequest.model_validate(value)
+        return _SOURCE_REQUEST_BY_TYPE[source_type].model_validate(value)
+    return value
+
+
+def _handle_source_response_union(value: Any) -> Any:
+    if isinstance(value, dict):
+        source_type = dict_discriminator_value(value, "type")
+        if source_type not in _SOURCE_RESPONSE_BY_TYPE:
+            return UnknownSourceResponse.model_validate(value)
+        return _SOURCE_RESPONSE_BY_TYPE[source_type].model_validate(value)
+    return value
+
+
+_SOURCE_REQUEST_BY_TYPE = registry_from_subclasses_with_type_field(
+    SourceRequestDefinition,
+    type_field="type",
+    exclude=(UnknownSourceRequest,),
+)
+_SOURCE_RESPONSE_BY_TYPE = registry_from_subclasses_with_type_field(
+    SourceResponseDefinition,
+    type_field="type",
+    exclude=(UnknownSourceResponse,),
+)
+
+
 HostedExtractorSourceRequestUnion = Annotated[
-    KafkaSourceRequest | EventHubSourceRequest | MQTTSourceRequest | RESTSourceRequest,
-    Field(discriminator="type"),
+    KafkaSourceRequest | EventHubSourceRequest | MQTTSourceRequest | RESTSourceRequest | UnknownSourceRequest,
+    BeforeValidator(_handle_source_request_union),
 ]
 
 HostedExtractorSourceRequest: TypeAdapter[HostedExtractorSourceRequestUnion] = TypeAdapter(
@@ -28,8 +62,8 @@ HostedExtractorSourceRequest: TypeAdapter[HostedExtractorSourceRequestUnion] = T
 )
 
 HostedExtractorSourceResponseUnion = Annotated[
-    KafkaSourceResponse | EventHubSourceResponse | MQTTSourceResponse | RESTSourceResponse,
-    Field(discriminator="type"),
+    KafkaSourceResponse | EventHubSourceResponse | MQTTSourceResponse | RESTSourceResponse | UnknownSourceResponse,
+    BeforeValidator(_handle_source_response_union),
 ]
 
 HostedExtractorSourceResponse: TypeAdapter[HostedExtractorSourceResponseUnion] = TypeAdapter(
@@ -60,4 +94,6 @@ __all__ = [
     "RESTSourceResponse",
     "ScramShaAuthenticationRequest",
     "ScramShaAuthenticationResponse",
+    "UnknownSourceRequest",
+    "UnknownSourceResponse",
 ]

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_auth.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_auth.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal
 
-from pydantic import BeforeValidator, ConfigDict
+from pydantic import BeforeValidator
 
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,
@@ -67,12 +67,10 @@ class HTTPBasicAuthenticationResponse(AuthenticationResponseDefinition):
 
 
 class UnknownAuthenticationRequest(AuthenticationRequestDefinition):
-    model_config = ConfigDict(extra="allow")
     type: str
 
 
 class UnknownAuthenticationResponse(AuthenticationResponseDefinition):
-    model_config = ConfigDict(extra="allow")
     type: str
 
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_auth.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_auth.py
@@ -5,7 +5,7 @@ from pydantic import BeforeValidator, ConfigDict
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,
 )
-from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
+from cognite_toolkit._cdf_tk.utils._auxiliary import registry_from_subclasses_with_type_field
 
 
 class AuthenticationRequestDefinition(BaseModelObject):
@@ -78,7 +78,7 @@ class UnknownAuthenticationResponse(AuthenticationResponseDefinition):
 
 def _handle_authentication_request(value: Any) -> Any:
     if isinstance(value, dict):
-        auth_type = dict_discriminator_value(value, "type")
+        auth_type = value.get("type")
         if auth_type not in _AUTHENTICATION_REQUEST_BY_TYPE:
             return UnknownAuthenticationRequest.model_validate(value)
         return _AUTHENTICATION_REQUEST_BY_TYPE[auth_type].model_validate(value)
@@ -87,7 +87,7 @@ def _handle_authentication_request(value: Any) -> Any:
 
 def _handle_authentication_response(value: Any) -> Any:
     if isinstance(value, dict):
-        auth_type = dict_discriminator_value(value, "type")
+        auth_type = value.get("type")
         if auth_type not in _AUTHENTICATION_RESPONSE_BY_TYPE:
             return UnknownAuthenticationResponse.model_validate(value)
         return _AUTHENTICATION_RESPONSE_BY_TYPE[auth_type].model_validate(value)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_auth.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_auth.py
@@ -1,8 +1,11 @@
-from typing import Literal
+from typing import Annotated, Any, Literal
+
+from pydantic import BeforeValidator, ConfigDict
 
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,
 )
+from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
 
 
 class AuthenticationRequestDefinition(BaseModelObject):
@@ -61,3 +64,62 @@ class HTTPBasicAuthenticationRequest(AuthenticationRequestDefinition):
 class HTTPBasicAuthenticationResponse(AuthenticationResponseDefinition):
     type: Literal["header", "query"]
     key: str
+
+
+class UnknownAuthenticationRequest(AuthenticationRequestDefinition):
+    model_config = ConfigDict(extra="allow")
+    type: str
+
+
+class UnknownAuthenticationResponse(AuthenticationResponseDefinition):
+    model_config = ConfigDict(extra="allow")
+    type: str
+
+
+def _handle_authentication_request(value: Any) -> Any:
+    if isinstance(value, dict):
+        auth_type = dict_discriminator_value(value, "type")
+        if auth_type not in _AUTHENTICATION_REQUEST_BY_TYPE:
+            return UnknownAuthenticationRequest.model_validate(value)
+        return _AUTHENTICATION_REQUEST_BY_TYPE[auth_type].model_validate(value)
+    return value
+
+
+def _handle_authentication_response(value: Any) -> Any:
+    if isinstance(value, dict):
+        auth_type = dict_discriminator_value(value, "type")
+        if auth_type not in _AUTHENTICATION_RESPONSE_BY_TYPE:
+            return UnknownAuthenticationResponse.model_validate(value)
+        return _AUTHENTICATION_RESPONSE_BY_TYPE[auth_type].model_validate(value)
+    return value
+
+
+_AUTHENTICATION_REQUEST_BY_TYPE = registry_from_subclasses_with_type_field(
+    AuthenticationRequestDefinition,
+    type_field="type",
+    exclude=(UnknownAuthenticationRequest,),
+)
+_AUTHENTICATION_RESPONSE_BY_TYPE = registry_from_subclasses_with_type_field(
+    AuthenticationResponseDefinition,
+    type_field="type",
+    exclude=(UnknownAuthenticationResponse,),
+)
+
+
+AuthenticationRequestUnion = Annotated[
+    BasicAuthenticationRequest
+    | ClientCredentialAuthenticationRequest
+    | ScramShaAuthenticationRequest
+    | HTTPBasicAuthenticationRequest
+    | UnknownAuthenticationRequest,
+    BeforeValidator(_handle_authentication_request),
+]
+
+AuthenticationResponseUnion = Annotated[
+    BasicAuthenticationResponse
+    | ClientCredentialAuthenticationResponse
+    | ScramShaAuthenticationResponse
+    | HTTPBasicAuthenticationResponse
+    | UnknownAuthenticationResponse,
+    BeforeValidator(_handle_authentication_response),
+]

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_base.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_base.py
@@ -1,7 +1,5 @@
 from typing import Any, Literal
 
-from pydantic import ConfigDict
-
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,
     UpdatableRequestResource,
@@ -31,10 +29,8 @@ class SourceResponseDefinition(BaseModelObject):
 
 
 class UnknownSourceRequest(SourceRequestDefinition):
-    model_config = ConfigDict(extra="allow")
     type: str
 
 
 class UnknownSourceResponse(SourceResponseDefinition):
-    model_config = ConfigDict(extra="allow")
     type: str

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_base.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_base.py
@@ -1,5 +1,7 @@
 from typing import Any, Literal
 
+from pydantic import ConfigDict
+
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,
     UpdatableRequestResource,
@@ -26,3 +28,13 @@ class SourceResponseDefinition(BaseModelObject):
     external_id: str
     created_time: int
     last_updated_time: int
+
+
+class UnknownSourceRequest(SourceRequestDefinition):
+    model_config = ConfigDict(extra="allow")
+    type: str
+
+
+class UnknownSourceResponse(SourceResponseDefinition):
+    model_config = ConfigDict(extra="allow")
+    type: str

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_base.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_base.py
@@ -1,7 +1,9 @@
+import builtins
 from typing import Any, Literal
 
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,
+    ResponseResource,
     UpdatableRequestResource,
 )
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
@@ -32,5 +34,12 @@ class UnknownSourceRequest(SourceRequestDefinition):
     type: str
 
 
-class UnknownSourceResponse(SourceResponseDefinition):
+class UnknownSourceResponse(SourceResponseDefinition, ResponseResource[UnknownSourceRequest]):
     type: str
+
+    @classmethod
+    def request_cls(cls) -> builtins.type[UnknownSourceRequest]:
+        return UnknownSourceRequest
+
+    def as_request_resource(self) -> UnknownSourceRequest:
+        return UnknownSourceRequest.model_validate(self.dump(), extra="allow")

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_kafka.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_kafka.py
@@ -1,20 +1,14 @@
 import builtins
 from typing import ClassVar, Literal
 
-from pydantic import Field
-
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,
     ResponseResource,
 )
 
 from ._auth import (
-    BasicAuthenticationRequest,
-    BasicAuthenticationResponse,
-    ClientCredentialAuthenticationRequest,
-    ClientCredentialAuthenticationResponse,
-    ScramShaAuthenticationRequest,
-    ScramShaAuthenticationResponse,
+    AuthenticationRequestUnion,
+    AuthenticationResponseUnion,
 )
 from ._base import SourceRequestDefinition, SourceResponseDefinition
 from ._certificate import AuthCertificateRequest, CACertificateRequest, CertificateResponse
@@ -33,9 +27,7 @@ class KafkaSource(BaseModelObject):
 
 class KafkaSourceRequest(KafkaSource, SourceRequestDefinition):
     non_nullable_fields: ClassVar[frozenset[str]] = frozenset({"use_tls"})
-    authentication: (
-        BasicAuthenticationRequest | ClientCredentialAuthenticationRequest | ScramShaAuthenticationRequest | None
-    ) = Field(None, discriminator="type")
+    authentication: AuthenticationRequestUnion | None = None
     ca_certificate: CACertificateRequest | None = None
     auth_certificate: AuthCertificateRequest | None = None
 
@@ -45,9 +37,7 @@ class KafkaSourceResponse(
     KafkaSource,
     ResponseResource[KafkaSourceRequest],
 ):
-    authentication: (
-        BasicAuthenticationResponse | ClientCredentialAuthenticationResponse | ScramShaAuthenticationResponse | None
-    ) = Field(None, discriminator="type")
+    authentication: AuthenticationResponseUnion | None = None
     ca_certificate: CertificateResponse | None = None
     auth_certificate: CertificateResponse | None = None
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_rest.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_source/_rest.py
@@ -1,20 +1,14 @@
 import builtins
 from typing import ClassVar, Literal
 
-from pydantic import Field
-
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,
     ResponseResource,
 )
 
 from ._auth import (
-    BasicAuthenticationRequest,
-    BasicAuthenticationResponse,
-    ClientCredentialAuthenticationRequest,
-    ClientCredentialAuthenticationResponse,
-    HTTPBasicAuthenticationRequest,
-    HTTPBasicAuthenticationResponse,
+    AuthenticationRequestUnion,
+    AuthenticationResponseUnion,
 )
 from ._base import SourceRequestDefinition, SourceResponseDefinition
 from ._certificate import AuthCertificateRequest, CACertificateRequest, CertificateResponse
@@ -29,9 +23,7 @@ class RESTSource(BaseModelObject):
 class RESTSourceRequest(RESTSource, SourceRequestDefinition):
     non_nullable_fields: ClassVar[frozenset[str]] = frozenset({"scheme", "port"})
     scheme: Literal["https", "http"] | None = None
-    authentication: (
-        BasicAuthenticationRequest | HTTPBasicAuthenticationRequest | ClientCredentialAuthenticationRequest | None
-    ) = Field(None, discriminator="type")
+    authentication: AuthenticationRequestUnion | None = None
     ca_certificate: CACertificateRequest | None = None
     auth_certificate: AuthCertificateRequest | None = None
 
@@ -41,9 +33,7 @@ class RESTSourceResponse(
     RESTSource,
     ResponseResource[RESTSourceRequest],
 ):
-    authentication: (
-        BasicAuthenticationResponse | HTTPBasicAuthenticationResponse | ClientCredentialAuthenticationResponse | None
-    ) = Field(None, discriminator="type")
+    authentication: AuthenticationResponseUnion | None = None
     ca_certificate: CertificateResponse | None = None
     auth_certificate: CertificateResponse | None = None
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/principal.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/principal.py
@@ -7,11 +7,11 @@ https://api-docs.cognite.com/20230101/tag/Principals
 from abc import ABC
 from typing import Annotated, Any, Literal, TypeAlias
 
-from pydantic import BeforeValidator, ConfigDict, Field
+from pydantic import BeforeValidator, Field
 
 from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject
 from cognite_toolkit._cdf_tk.client.identifiers import PrincipalId
-from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
+from cognite_toolkit._cdf_tk.utils._auxiliary import registry_from_subclasses_with_type_field
 
 PrincipalType: TypeAlias = Literal["SERVICE_ACCOUNT", "USER"]
 
@@ -50,13 +50,12 @@ class UserPrincipal(PrincipalDefinition):
 
 
 class UnknownPrincipal(PrincipalDefinition):
-    model_config = ConfigDict(extra="allow")
     type: str
 
 
 def _handle_unknown_principal(value: Any) -> Any:
     if isinstance(value, dict):
-        principal_type = dict_discriminator_value(value, "type")
+        principal_type = value.get("type")
         if principal_type not in _PRINCIPAL_BY_TYPE:
             return UnknownPrincipal.model_validate(value)
         return _PRINCIPAL_BY_TYPE[principal_type].model_validate(value)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/principal.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/principal.py
@@ -5,12 +5,13 @@ https://api-docs.cognite.com/20230101/tag/Principals
 """
 
 from abc import ABC
-from typing import Annotated, Literal, TypeAlias
+from typing import Annotated, Any, Literal, TypeAlias
 
-from pydantic import Field
+from pydantic import BeforeValidator, ConfigDict, Field
 
 from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject
 from cognite_toolkit._cdf_tk.client.identifiers import PrincipalId
+from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
 
 PrincipalType: TypeAlias = Literal["SERVICE_ACCOUNT", "USER"]
 
@@ -22,7 +23,7 @@ class CreatedBy(BaseModelObject):
 
 class PrincipalDefinition(BaseModelObject, ABC):
     id: str
-    type: Literal["SERVICE_ACCOUNT", "USER"]
+    type: str
     name: str
     picture_url: str
 
@@ -48,9 +49,30 @@ class UserPrincipal(PrincipalDefinition):
     family_name: str | None = None
 
 
+class UnknownPrincipal(PrincipalDefinition):
+    model_config = ConfigDict(extra="allow")
+    type: str
+
+
+def _handle_unknown_principal(value: Any) -> Any:
+    if isinstance(value, dict):
+        principal_type = dict_discriminator_value(value, "type")
+        if principal_type not in _PRINCIPAL_BY_TYPE:
+            return UnknownPrincipal.model_validate(value)
+        return _PRINCIPAL_BY_TYPE[principal_type].model_validate(value)
+    return value
+
+
+_PRINCIPAL_BY_TYPE = registry_from_subclasses_with_type_field(
+    PrincipalDefinition,
+    type_field="type",
+    exclude=(UnknownPrincipal,),
+)
+
+
 Principal = Annotated[
-    ServiceAccountPrincipal | UserPrincipal,
-    Field(discriminator="type"),
+    ServiceAccountPrincipal | UserPrincipal | UnknownPrincipal,
+    BeforeValidator(_handle_unknown_principal),
 ]
 
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/signal_subscription.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/signal_subscription.py
@@ -18,7 +18,6 @@ class CurrentUserSinkRef(BaseModelObject):
 
 
 class UnknownSinkRef(BaseModelObject):
-    model_config = ConfigDict(extra="allow")
     type: str
 
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/signal_subscription.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/signal_subscription.py
@@ -1,11 +1,11 @@
 import builtins
 from typing import Annotated, Any, ClassVar, Literal
 
-from pydantic import BeforeValidator, ConfigDict, Field
+from pydantic import BeforeValidator, ConfigDict
 
 from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject, ResponseResource, UpdatableRequestResource
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
-from cognite_toolkit._cdf_tk.utils._auxiliary import get_concrete_subclasses
+from cognite_toolkit._cdf_tk.utils._auxiliary import get_concrete_subclasses, registry_from_model_classes
 
 
 class SinkRefWithExternalId(BaseModelObject):
@@ -17,9 +17,29 @@ class CurrentUserSinkRef(BaseModelObject):
     type: Literal["current_user"] = "current_user"
 
 
+class UnknownSinkRef(BaseModelObject):
+    model_config = ConfigDict(extra="allow")
+    type: str
+
+
+def _handle_unknown_sink_ref(value: Any) -> Any:
+    if isinstance(value, dict):
+        sink_type = value.get("type")
+        if sink_type not in _SINK_REF_BY_TYPE:
+            return UnknownSinkRef.model_validate(value)
+        return _SINK_REF_BY_TYPE[sink_type].model_validate(value)
+    return value
+
+
+_SINK_REF_BY_TYPE = registry_from_model_classes(
+    (SinkRefWithExternalId, CurrentUserSinkRef),
+    type_field="type",
+)
+
+
 SinkRef = Annotated[
-    SinkRefWithExternalId | CurrentUserSinkRef,
-    Field(discriminator="type"),
+    SinkRefWithExternalId | CurrentUserSinkRef | UnknownSinkRef,
+    BeforeValidator(_handle_unknown_sink_ref),
 ]
 
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/transformation.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/transformation.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, ClassVar, Literal
 
-from pydantic import Field, JsonValue, field_validator
+from pydantic import BeforeValidator, ConfigDict, Field, JsonValue, field_validator
 
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,
@@ -8,6 +8,7 @@ from cognite_toolkit._cdf_tk.client._resource_base import (
     UpdatableRequestResource,
 )
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
 
 
 class NonceCredentials(BaseModelObject):
@@ -80,9 +81,35 @@ class SequenceRowDataSource(DestinationDefinition):
     external_id: str
 
 
+class UnknownDestinationDefinition(DestinationDefinition):
+    model_config = ConfigDict(extra="allow")
+    type: str
+
+
+def _handle_unknown_destination(value: Any) -> Any:
+    if isinstance(value, dict):
+        dest_type = dict_discriminator_value(value, "type")
+        if dest_type not in _DESTINATION_BY_TYPE:
+            return UnknownDestinationDefinition.model_validate(value)
+        return _DESTINATION_BY_TYPE[dest_type].model_validate(value)
+    return value
+
+
+_DESTINATION_BY_TYPE = registry_from_subclasses_with_type_field(
+    DestinationDefinition,
+    type_field="type",
+    exclude=(UnknownDestinationDefinition,),
+)
+
+
 Destination = Annotated[
-    AssetCentricDataSource | DataModelSource | ViewDataSource | RawDataSource | SequenceRowDataSource,
-    Field(discriminator="type"),
+    AssetCentricDataSource
+    | DataModelSource
+    | ViewDataSource
+    | RawDataSource
+    | SequenceRowDataSource
+    | UnknownDestinationDefinition,
+    BeforeValidator(_handle_unknown_destination),
 ]
 
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/transformation.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/transformation.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, ClassVar, Literal
 
-from pydantic import BeforeValidator, ConfigDict, Field, JsonValue, field_validator
+from pydantic import BeforeValidator, Field, JsonValue, field_validator
 
 from cognite_toolkit._cdf_tk.client._resource_base import (
     BaseModelObject,
@@ -8,7 +8,7 @@ from cognite_toolkit._cdf_tk.client._resource_base import (
     UpdatableRequestResource,
 )
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
-from cognite_toolkit._cdf_tk.utils._auxiliary import dict_discriminator_value, registry_from_subclasses_with_type_field
+from cognite_toolkit._cdf_tk.utils._auxiliary import registry_from_subclasses_with_type_field
 
 
 class NonceCredentials(BaseModelObject):
@@ -82,14 +82,13 @@ class SequenceRowDataSource(DestinationDefinition):
 
 
 class UnknownDestinationDefinition(DestinationDefinition):
-    model_config = ConfigDict(extra="allow")
     type: str
 
 
 def _handle_unknown_destination(value: Any) -> Any:
     if isinstance(value, dict):
-        dest_type = dict_discriminator_value(value, "type")
-        if dest_type not in _DESTINATION_BY_TYPE:
+        dest_type = value.get("type")
+        if dest_type not in _DESTINATION_BY_TYPE or dest_type is None:
             return UnknownDestinationDefinition.model_validate(value)
         return _DESTINATION_BY_TYPE[dest_type].model_validate(value)
     return value

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/workflow_version.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/workflow_version.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, TypeAlias
 
-from pydantic import ConfigDict, Field, JsonValue, field_serializer, field_validator
+from pydantic import BeforeValidator, ConfigDict, Field, JsonValue, field_serializer, field_validator
 from pydantic_core.core_schema import ValidationInfo
 
 from cognite_toolkit._cdf_tk.client._resource_base import (
@@ -10,6 +10,7 @@ from cognite_toolkit._cdf_tk.client._resource_base import (
     ResponseResource,
 )
 from cognite_toolkit._cdf_tk.client.identifiers import WorkflowVersionId
+from cognite_toolkit._cdf_tk.utils._auxiliary import get_concrete_subclasses
 
 TaskType: TypeAlias = Literal[
     "function", "transformation", "cdf", "dynamic", "subworkflow", "simulation", "functionApp"
@@ -120,6 +121,27 @@ class FunctionAppTaskParameters(TaskParameterDefinition):
     function_app: FunctionAppRef
 
 
+class UnknownTaskParameters(TaskParameterDefinition):
+    model_config = ConfigDict(extra="allow")
+    type: str
+
+
+def _handle_unknown_parameter(value: Any) -> Any:
+    if isinstance(value, dict):
+        param_type = value.get("type")
+        if param_type not in _PARAMETER_BY_TYPE:
+            return UnknownTaskParameters.model_validate(value)
+        return _PARAMETER_BY_TYPE[param_type].model_validate(value)
+    return value
+
+
+_PARAMETER_BY_TYPE = {
+    cls_.model_fields["type"].default: cls_
+    for cls_ in get_concrete_subclasses(TaskParameterDefinition)
+    if cls_ is not UnknownTaskParameters
+}
+
+
 Parameter = Annotated[
     FunctionTaskParameters
     | TransformationTaskParameters
@@ -127,8 +149,9 @@ Parameter = Annotated[
     | DynamicTaskParameters
     | SubworkflowTaskParameters
     | SimulationTaskParameters
-    | FunctionAppTaskParameters,
-    Field(discriminator="type"),
+    | FunctionAppTaskParameters
+    | UnknownTaskParameters,
+    BeforeValidator(_handle_unknown_parameter),
 ]
 
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -45,10 +45,10 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     DirectNodeRelation,
     EdgeRequest,
     EdgeResponse,
-    InstanceRequest,
-    InstanceResponse,
     InstanceSource,
     NodeId,
+    NodeOrEdgeRequest,
+    NodeOrEdgeResponse,
     NodeRequest,
     NodeResponse,
     ViewCorePropertyResponse,
@@ -299,7 +299,7 @@ class AssetCentricMapper(
         return output
 
 
-class AssetCentricToInstanceMapper(AssetCentricMapper[T_AssetCentricResourceExtended, InstanceRequest]):
+class AssetCentricToInstanceMapper(AssetCentricMapper[T_AssetCentricResourceExtended, NodeOrEdgeRequest]):
     def __init__(self, client: ToolkitClient) -> None:
         super().__init__(client)
         self._ingestion_view_by_id: dict[ViewId, ViewResponse] = {}
@@ -1254,7 +1254,7 @@ class ThreeDAssetMapper(DataMapper[ThreeDSelector, AssetMappingClassicResponse, 
         return mapped_request, issue
 
 
-class FDMtoCDMMapper(DataMapper[InstanceSelector, InstanceResponse, InstanceRequest]):
+class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdgeRequest]):
     """This mapper maps instances to instances accounting for the difference between older data models
     (back when they were called Flexible Data Models) and newer data models (backed by Cognite Core Data Model).
 
@@ -1282,7 +1282,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, InstanceResponse, InstanceRequ
         mappings: Sequence[ViewToViewMapping],
         connection_creator: ConnectionCreator,
         custom_properties_mappings: Sequence[CustomContainerPropertiesMapping] | None = None,
-        custom_instance_mappings: Mapping[ViewId, DataMapper[InstanceSelector, InstanceResponse, InstanceRequest]]
+        custom_instance_mappings: Mapping[ViewId, DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdgeRequest]]
         | None = None,
     ) -> None:
         super().__init__(client)
@@ -1308,7 +1308,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, InstanceResponse, InstanceRequ
         views = self.client.tool.views.retrieve(list(view_ids))
         self._connection_creator.update_view_cache(views)
 
-    def map(self, source: Sequence[InstanceResponse]) -> Sequence[InstanceRequest | None]:
+    def map(self, source: Sequence[NodeOrEdgeResponse]) -> Sequence[NodeOrEdgeRequest | None]:
         if self._custom_instance_mappings and (
             intersecting_view_ids := (self._get_view_ids(source) & set(self._custom_instance_mappings))
         ):
@@ -1323,7 +1323,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, InstanceResponse, InstanceRequ
                 )
         self._connection_creator.update_cache(source)
         nodes, other_side_by_edge_type_and_direction_by_source = self._as_nodes_and_edges(source)
-        mapped_instances: list[InstanceRequest | None] = []
+        mapped_instances: list[NodeOrEdgeRequest | None] = []
         issue_by_node_id: dict[NodeId, InstanceConversionIssue] = {}
         target_view_ids: set[ViewId] = set()
         for node in nodes:
@@ -1362,7 +1362,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, InstanceResponse, InstanceRequ
             )
         return mapped_instances
 
-    def _get_view_ids(self, source: Sequence[InstanceResponse]) -> set[ViewId]:
+    def _get_view_ids(self, source: Sequence[NodeOrEdgeResponse]) -> set[ViewId]:
         return {
             view_or_container_id
             for item in source
@@ -1501,7 +1501,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, InstanceResponse, InstanceRequ
             new_id=new_id,
         )
 
-    def _update_existing_node_cache(self, mapped_instances: Sequence[InstanceRequest | EdgeRequest | None]) -> None:
+    def _update_existing_node_cache(self, mapped_instances: Sequence[NodeOrEdgeRequest | EdgeRequest | None]) -> None:
         """Updates the existing nodes cache for all direct relations properties that have
         constraints on the target node.
         """
@@ -1544,7 +1544,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, InstanceResponse, InstanceRequ
         this with the DMS API as you cannot retrieve node with properties in a given container only given view.
 
         Args:
-            mapped_instances: Iterable of InstanceRequest or EdgeRequest or None. CAVEAT: The node request are
+            mapped_instances: Iterable of NodeOrEdgeRequest or EdgeRequest or None. CAVEAT: The node request are
                 mutated by this function
             issue_by_node_id: The issues by node id. CAVEAT: The collection is mutated if any property value
                 is removed.
@@ -1586,7 +1586,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, InstanceResponse, InstanceRequ
                     source.properties[prop_id] = keep  # type: ignore[assignment]
 
     def _iterate_constrained_direct_relation_properties(
-        self, instances: Sequence[InstanceRequest | EdgeRequest | None]
+        self, instances: Sequence[NodeOrEdgeRequest | EdgeRequest | None]
     ) -> Iterable[tuple[NodeId, dict[str, ContainerId], InstanceSource]]:
         for node in instances:
             if node is None or isinstance(node, EdgeRequest):
@@ -1619,7 +1619,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, InstanceResponse, InstanceRequ
                     yield node.as_id(), constraint_by_prop_id, source
 
 
-class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, InstanceResponse, InstanceRequest]):
+class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdgeRequest]):
     """This is a custom case for mapping InField legacy to InField on CDM.
 
     In legacy, the schedules are modeled with edge connections as follows:
@@ -1634,7 +1634,7 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, InstanceResp
     Template <- Schedule.template
     TemplateItems <- Schedule.templateItems (many).
 
-    This mapper assumes that the sequence of InstanceResponses are all schedules connected to a single template,
+    This mapper assumes that the sequence of NodeOrEdgeResponses are all schedules connected to a single template,
     along with all the edges between the template and template items, as well as the template items and schedules.
     Note there should be no template or template items in the source, only schedules and edges.
 
@@ -1675,9 +1675,9 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, InstanceResp
         retrieved = self.client.tool.views.retrieve([self._mapping.destination_view])
         self._connection_creator.update_view_cache(retrieved)
 
-    def map(self, source: Sequence[InstanceResponse]) -> Sequence[InstanceRequest | None]:
+    def map(self, source: Sequence[NodeOrEdgeResponse]) -> Sequence[NodeOrEdgeRequest | None]:
         schedules, template_edges, template_id_edges, issues = self._as_schedules_and_edges(source)
-        output: list[InstanceRequest | None] = []
+        output: list[NodeOrEdgeRequest | None] = []
         for duplicated_schedules in schedules.values():
             # Sort for deterministic output.
             duplicated_schedules.sort(key=lambda item: item.external_id)
@@ -1699,7 +1699,7 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, InstanceResp
         return output
 
     def _as_schedules_and_edges(
-        self, source: Sequence[InstanceResponse]
+        self, source: Sequence[NodeOrEdgeResponse]
     ) -> tuple[
         dict[str, list[NodeResponse]],
         dict[NodeId, list[EdgeOtherSide]],
@@ -1764,7 +1764,7 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, InstanceResp
         duplicated_schedules: list[NodeResponse],
         template_edges_by_item_id: dict[NodeId, list[EdgeOtherSide]],
         template_item_edges_by_schedule_id: dict[NodeId, list[EdgeOtherSide]],
-    ) -> tuple[InstanceRequest | None, InstanceConversionIssue]:
+    ) -> tuple[NodeOrEdgeRequest | None, InstanceConversionIssue]:
         if not duplicated_schedules:
             raise ValueError("At least one schedule is required to create a schedule mapping.")
         first = duplicated_schedules[0]

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
@@ -16,7 +16,7 @@ from cognite_toolkit._cdf_tk.client.http_client._item_classes import (
 )
 from cognite_toolkit._cdf_tk.client.identifiers import InternalId, SpaceId
 from cognite_toolkit._cdf_tk.client.resource_classes.annotation import AnnotationResponse
-from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import EdgeId, InstanceRequest, NodeId
+from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import EdgeId, NodeId, NodeOrEdgeRequest
 from cognite_toolkit._cdf_tk.client.resource_classes.migration import SpaceSource
 from cognite_toolkit._cdf_tk.client.resource_classes.pending_instance_id import PendingInstanceId
 from cognite_toolkit._cdf_tk.client.resource_classes.records import RecordRequest
@@ -66,7 +66,7 @@ from .selectors import AssetCentricMigrationSelector, MigrateDataSetSelector, Mi
 
 
 class AssetCentricMigrationIO(
-    UploadableDataIO[AssetCentricMigrationSelector, AssetCentricMapping[T_AssetCentricResource], InstanceRequest]
+    UploadableDataIO[AssetCentricMigrationSelector, AssetCentricMapping[T_AssetCentricResource], NodeOrEdgeRequest]
 ):
     KIND = "AssetCentricMigration"
     CHUNK_SIZE = 1000
@@ -195,12 +195,12 @@ class AssetCentricMigrationIO(
             [DataItem(tracking_id=item.tracking_id, item=item.item.dump()) for item in data_chunk.items]
         )
 
-    def json_to_resource(self, item_json: dict[str, JsonVal]) -> InstanceRequest:
+    def json_to_resource(self, item_json: dict[str, JsonVal]) -> NodeOrEdgeRequest:
         raise NotImplementedError()
 
     def upload_items(
         self,
-        data_chunk: Page[InstanceRequest],
+        data_chunk: Page[NodeOrEdgeRequest],
         http_client: HTTPClient,
         selector: AssetCentricMigrationSelector | None = None,
     ) -> ItemsResultList:
@@ -224,11 +224,11 @@ class AssetCentricMigrationIO(
             results.extend(super().upload_items(to_upload, http_client, None))
         return results
 
-    def _remove_existing(self, data_chunk: Page[InstanceRequest]) -> Page[InstanceRequest]:
+    def _remove_existing(self, data_chunk: Page[NodeOrEdgeRequest]) -> Page[NodeOrEdgeRequest]:
         """Remove items from the chunk that already exist in CDF to avoid upload failures."""
         data_by_instance_id = {item.item.as_id(): item for item in data_chunk.items}
         existing_ids = {item.as_id() for item in self.client.tool.instances.retrieve(list(data_by_instance_id.keys()))}
-        to_create: list[DataItem[InstanceRequest]] = []
+        to_create: list[DataItem[NodeOrEdgeRequest]] = []
         skipped_entries: list[MigrationEntryV2] = []
         for instance_id, data in data_by_instance_id.items():
             if instance_id in existing_ids:
@@ -251,10 +251,10 @@ class AssetCentricMigrationIO(
 
     def link_asset_centric(
         self,
-        data_chunk: Page[InstanceRequest],
+        data_chunk: Page[NodeOrEdgeRequest],
         http_client: HTTPClient,
         pending_instance_id_endpoint: str,
-    ) -> Page[InstanceRequest]:
+    ) -> Page[NodeOrEdgeRequest]:
         """Links asset-centric resources to their (uncreated) instances using the pending-instance-ids endpoint."""
         config = http_client.config
         successful_linked: set[str] = set()
@@ -295,7 +295,7 @@ class AssetCentricMigrationIO(
         return data_chunk.create_from(to_upload)
 
     @staticmethod
-    def as_pending_instance_id(item: InstanceRequest) -> PendingInstanceId:
+    def as_pending_instance_id(item: NodeOrEdgeRequest) -> PendingInstanceId:
         """Convert an InstanceApply to a PendingInstanceId for linking."""
         source = next((source for source in item.sources or [] if source.source == INSTANCE_SOURCE_VIEW_ID), None)
         if source is None:
@@ -396,7 +396,7 @@ class RecordsMigrationIO(AssetCentricMigrationIO):
 
 
 class AnnotationMigrationIO(
-    UploadableDataIO[AssetCentricMigrationSelector, AssetCentricMapping[AnnotationResponse], InstanceRequest]
+    UploadableDataIO[AssetCentricMigrationSelector, AssetCentricMapping[AnnotationResponse], NodeOrEdgeRequest]
 ):
     """IO class for migrating Annotations.
 
@@ -533,7 +533,7 @@ class AnnotationMigrationIO(
                 "Please specify the ingestion view explicitly in the CSV file."
             ) from e
 
-    def json_to_resource(self, item_json: dict[str, JsonVal]) -> InstanceRequest:
+    def json_to_resource(self, item_json: dict[str, JsonVal]) -> NodeOrEdgeRequest:
         raise NotImplementedError("Deserializing Annotation Migrations from JSON is not supported.")
 
     def data_to_json_chunk(

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -16,8 +16,8 @@ from cognite_toolkit._cdf_tk.client.identifiers import (
 from cognite_toolkit._cdf_tk.client.request_classes.filters import InstanceFilter
 from cognite_toolkit._cdf_tk.client.resource_classes import data_modeling as dm
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
-    InstanceRequest,
-    InstanceResponse,
+    NodeOrEdgeRequest,
+    NodeOrEdgeResponse,
     QueryEdgeExpression,
     QueryEdgeTableExpression,
     QueryNodeExpression,
@@ -27,7 +27,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     QuerySelectSource,
     QuerySortSpec,
 )
-from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._instance import InstanceRequestAdapter
+from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._instance import NodeOrEdgeRequestAdapter
 from cognite_toolkit._cdf_tk.constants import SUBSELECTION_LIMIT_QUERY_ENDPOINT
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 from cognite_toolkit._cdf_tk.resource_ios import ContainerCRUD, SpaceCRUD, ViewIO
@@ -45,9 +45,9 @@ from .selectors._instances import InstanceQuerySelector
 
 
 class InstanceIO(
-    ConfigurableDataIO[InstanceSelector, InstanceResponse],
-    TableDataIO[InstanceSelector, InstanceResponse],
-    TableUploadableDataIO[InstanceSelector, InstanceResponse, InstanceRequest],
+    ConfigurableDataIO[InstanceSelector, NodeOrEdgeResponse],
+    TableDataIO[InstanceSelector, NodeOrEdgeResponse],
+    TableUploadableDataIO[InstanceSelector, NodeOrEdgeResponse, NodeOrEdgeRequest],
 ):
     """This class provides functionality to interact with instances in Cognite Data Fusion (CDF).
 
@@ -135,7 +135,7 @@ class InstanceIO(
             return leaf_filters[0]
         return {"and": leaf_filters}
 
-    def _filter_readonly_properties(self, instance: InstanceRequest) -> None:
+    def _filter_readonly_properties(self, instance: NodeOrEdgeRequest) -> None:
         """Filter out read-only properties from the instance.
 
         Warnings: This mutates the instance in-place.
@@ -425,7 +425,7 @@ class InstanceIO(
         raise NotImplementedError()
 
     def data_to_json_chunk(
-        self, data_chunk: Page[InstanceResponse], selector: InstanceSelector | None = None
+        self, data_chunk: Page[NodeOrEdgeResponse], selector: InstanceSelector | None = None
     ) -> Page[dict[str, JsonVal]]:
         result = [
             DataItem(tracking_id=item.tracking_id, item=item.item.as_request_resource().dump())
@@ -433,11 +433,11 @@ class InstanceIO(
         ]
         return data_chunk.create_from(result)
 
-    def json_to_resource(self, item_json: dict[str, JsonVal]) -> InstanceRequest:
+    def json_to_resource(self, item_json: dict[str, JsonVal]) -> NodeOrEdgeRequest:
         item_to_load = item_json.copy()
         if self._remove_existing_version and "existingVersion" in item_to_load:
             del item_to_load["existingVersion"]
-        instance = InstanceRequestAdapter.validate_python(item_to_load)
+        instance = NodeOrEdgeRequestAdapter.validate_python(item_to_load)
         self._filter_readonly_properties(instance)
         return instance
 
@@ -463,8 +463,8 @@ class InstanceIO(
 
     def row_to_resource(
         self, source_id: str, row: dict[str, JsonVal], selector: InstanceSelector | None = None
-    ) -> InstanceRequest:
-        """Convert a row-based dictionary back to an InstanceRequest.
+    ) -> NodeOrEdgeRequest:
+        """Convert a row-based dictionary back to an NodeOrEdgeRequest.
 
         The row format is the inverse of json_to_row:
         - Instance-level fields: `space`, `externalId`, `existingVersion`
@@ -477,7 +477,7 @@ class InstanceIO(
             selector: The selector used to identify the view for source properties.
 
         Returns:
-            An InstanceRequest representing the data.
+            An NodeOrEdgeRequest representing the data.
         """
         # Known instance-level fields and nested field prefixes
         instance_scalar_fields = {"space", "externalId", "existingVersion"}

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/hosted_extractors.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/hosted_extractors.py
@@ -38,6 +38,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.hosted_extractor_source imp
     MQTTSourceRequest,
     RESTSourceRequest,
     ScramShaAuthenticationRequest,
+    UnknownAuthenticationRequest,
 )
 from cognite_toolkit._cdf_tk.exceptions import ToolkitNotSupported
 from cognite_toolkit._cdf_tk.resource_ios._base_ios import ResourceIO
@@ -148,7 +149,8 @@ class HostedExtractorSourceIO(
         auth: BasicAuthenticationRequest
         | ClientCredentialAuthenticationRequest
         | ScramShaAuthenticationRequest
-        | HTTPBasicAuthenticationRequest,
+        | HTTPBasicAuthenticationRequest
+        | UnknownAuthenticationRequest,
     ) -> Iterable[str]:
         if isinstance(auth, BasicAuthenticationRequest | ScramShaAuthenticationRequest) and auth.password:
             yield auth.password
@@ -156,6 +158,9 @@ class HostedExtractorSourceIO(
             yield auth.client_secret
         elif isinstance(auth, HTTPBasicAuthenticationRequest):
             yield auth.value
+        elif isinstance(auth, UnknownAuthenticationRequest):
+            # Assume all keys are sensitive. Ensuring that we do not expose secrets.
+            yield from set(auth.dump().keys()) - {"type"}
 
 
 @final

--- a/cognite_toolkit/_cdf_tk/utils/_auxiliary.py
+++ b/cognite_toolkit/_cdf_tk/utils/_auxiliary.py
@@ -1,10 +1,72 @@
 import inspect
+import types
 from abc import ABC
-from typing import TypeVar
+from collections.abc import Iterable
+from typing import Annotated, Any, Literal, TypeVar, Union, get_args, get_origin
+
+from pydantic.alias_generators import to_camel
+from pydantic_core import PydanticUndefined
 
 from cognite_toolkit import _version
 
 T_Cls = TypeVar("T_Cls")
+
+
+def dict_discriminator_value(value: dict[str, Any], field_name: str) -> Any:
+    """Read discriminator from an API dict (snake_case or camelCase alias)."""
+    if field_name in value:
+        return value[field_name]
+    camel = to_camel(field_name)
+    if camel in value:
+        return value[camel]
+    return None
+
+
+def literal_string_values_from_annotation(annotation: Any) -> list[str]:
+    """Collect string literal values from a typing annotation (Literal, unions, Annotated)."""
+    if annotation is None:
+        return []
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin is Literal:
+        return [str(a) for a in args]
+    if origin is Annotated:
+        return literal_string_values_from_annotation(args[0])
+    if origin is Union or origin is types.UnionType:
+        result: list[str] = []
+        for arg in args:
+            if arg is type(None):
+                continue
+            result.extend(literal_string_values_from_annotation(arg))
+        return result
+    return []
+
+
+def registry_from_model_classes(classes: Iterable[type[Any]], *, type_field: str) -> dict[str, type[Any]]:
+    """Map discriminator string to concrete model class for BeforeValidator routing."""
+    registry: dict[str, type[Any]] = {}
+    for cls_ in classes:
+        field_info = cls_.model_fields.get(type_field)
+        if field_info is None:
+            continue
+        default = field_info.default
+        if default is not PydanticUndefined:
+            registry[str(default)] = cls_
+            continue
+        for lit in literal_string_values_from_annotation(field_info.annotation):
+            registry[lit] = cls_
+    return registry
+
+
+def registry_from_subclasses_with_type_field(
+    base_cls: type[Any],
+    *,
+    type_field: str,
+    exclude: tuple[type[Any], ...] = (),
+) -> dict[str, type[Any]]:
+    excluded = set(exclude)
+    classes: list[type[Any]] = [c for c in get_concrete_subclasses(base_cls) if c not in excluded]
+    return registry_from_model_classes(classes, type_field=type_field)
 
 
 def get_concrete_subclasses(base_cls: type[T_Cls], exclude_ABC_base: bool = True) -> list[type[T_Cls]]:

--- a/cognite_toolkit/_cdf_tk/utils/_auxiliary.py
+++ b/cognite_toolkit/_cdf_tk/utils/_auxiliary.py
@@ -4,22 +4,11 @@ from abc import ABC
 from collections.abc import Iterable
 from typing import Annotated, Any, Literal, TypeVar, Union, get_args, get_origin
 
-from pydantic.alias_generators import to_camel
 from pydantic_core import PydanticUndefined
 
 from cognite_toolkit import _version
 
 T_Cls = TypeVar("T_Cls")
-
-
-def dict_discriminator_value(value: dict[str, Any], field_name: str) -> Any:
-    """Read discriminator from an API dict (snake_case or camelCase alias)."""
-    if field_name in value:
-        return value[field_name]
-    camel = to_camel(field_name)
-    if camel in value:
-        return value[camel]
-    return None
 
 
 def literal_string_values_from_annotation(annotation: Any) -> list[str]:

--- a/cognite_toolkit/_cdf_tk/yaml_classes/hosted_extractor_mapping.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/hosted_extractor_mapping.py
@@ -70,6 +70,7 @@ class CSVMappingInput(MappingInput):
         max_length=1,
         default=",",
     )
+    skip: int = Field(0, description="Undocumented, but is returned in the response form the API.")
     custom_keys: list[str] | None = Field(
         None,
         description="List of headers. If this is not set, the headers will be retrieved from the CSV file.",

--- a/tests/data/complete_org/modules/my_example_module/hosted_extractors/mapping.Mapping.yaml
+++ b/tests/data/complete_org/modules/my_example_module/hosted_extractors/mapping.Mapping.yaml
@@ -6,4 +6,5 @@ mapping:
 input:
   type: csv
   delimiter: ','
+  skip: 0
 published: true

--- a/tests/test_integration/test_commands/test_deploy.py
+++ b/tests/test_integration/test_commands/test_deploy.py
@@ -168,6 +168,7 @@ def get_changed_resources(env_vars: EnvironmentVariables, build_dir: Path) -> di
         if changed := (set(loader.get_ids(resources.to_update)) - {dm.NodeId("sp_nodes", "MyExtendedFile")}):
             # We do not have a way to get CogniteFile extensions. This is a workaround to avoid the test failing.
             changed_resources[loader.display_name] = changed
+            worker.prepare_resources(files, environment_variables=env_vars.dump(), verbose=True)
 
     return changed_resources
 

--- a/tests/test_unit/test_cdf_tk/test_client/test_api_data_classes.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_api_data_classes.py
@@ -50,7 +50,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.streamlit_ import Streamlit
 from cognite_toolkit._cdf_tk.client.resource_classes.streams import StreamRequest, StreamResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.transformation import TransformationRequest
 from cognite_toolkit._cdf_tk.client.resource_classes.workflow_trigger import WorkflowTriggerRequest
-from cognite_toolkit._cdf_tk.client.resource_classes.workflow_version import Parameter
 from tests.test_unit.test_cdf_tk.test_client.data import (
     CDFResource,
     get_example_minimum_responses,
@@ -814,15 +813,3 @@ class TestUnknownInstanceUnions:
             "opaqueApiFields": {"replicated": True},
         }
         assert TypeAdapter(InstanceResponse).validate_python(data).dump() == data
-
-
-class TestUnknownWorkflowParameterUnion:
-    """Unknown parameters.type maps to UnknownTaskParameters (same idea as WorkflowTrigger triggerRule)."""
-
-    def test_unknown_task_parameter_type(self) -> None:
-        data = {
-            "type": "pipelineStageNotInToolkitYet",
-            "runnerRef": {"name": "gpu-pool"},
-            "inputs": [{"key": "model", "uri": "s3://bucket/m.pt"}],
-        }
-        assert TypeAdapter(Parameter).validate_python(data).dump() == data

--- a/tests/test_unit/test_cdf_tk/test_client/test_api_data_classes.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_api_data_classes.py
@@ -2,24 +2,44 @@ from collections.abc import Mapping
 from typing import Any, Literal
 
 import pytest
+from pydantic import TypeAdapter
 
 from cognite_toolkit._cdf_tk.client._resource_base import UpdatableRequestResource, _get_annotation_origin
 from cognite_toolkit._cdf_tk.client._types import Metadata
 from cognite_toolkit._cdf_tk.client.identifiers import NodeId, PrincipalId, ViewId
 from cognite_toolkit._cdf_tk.client.resource_classes.agent import KNOWN_TOOLS, AgentRequest, AgentResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.asset import AssetRequest
-from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import InstanceSource, NodeRequest
+from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
+    ContainerRequest,
+    InstanceRequest,
+    InstanceResponse,
+    InstanceSource,
+    NodeRequest,
+    ViewRequest,
+)
 from cognite_toolkit._cdf_tk.client.resource_classes.datapoint_subscription import (
     DatapointSubscriptionRequest,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.dataset import DataSetRequest
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.group import GroupResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.hosted_extractor_job import HostedExtractorJobRequest
+from cognite_toolkit._cdf_tk.client.resource_classes.hosted_extractor_mapping import HostedExtractorMappingRequest
+from cognite_toolkit._cdf_tk.client.resource_classes.hosted_extractor_source import (
+    HostedExtractorSourceRequest,
+    HostedExtractorSourceResponse,
+)
+from cognite_toolkit._cdf_tk.client.resource_classes.hosted_extractor_source._kafka import (
+    KafkaSourceRequest,
+    KafkaSourceResponse,
+)
 from cognite_toolkit._cdf_tk.client.resource_classes.principal import (
     LoginSession,
+    Principal,
     ServiceAccountPrincipal,
     UserPrincipal,
 )
+from cognite_toolkit._cdf_tk.client.resource_classes.signal_subscription import SignalSubscriptionRequest
 from cognite_toolkit._cdf_tk.client.resource_classes.simulator_routine_revision import (
     Disabled,
     ScheduleConfig,
@@ -28,7 +48,9 @@ from cognite_toolkit._cdf_tk.client.resource_classes.simulator_routine_revision 
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.streamlit_ import StreamlitResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.streams import StreamRequest, StreamResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.transformation import TransformationRequest
 from cognite_toolkit._cdf_tk.client.resource_classes.workflow_trigger import WorkflowTriggerRequest
+from cognite_toolkit._cdf_tk.client.resource_classes.workflow_version import Parameter
 from tests.test_unit.test_cdf_tk.test_client.data import (
     CDFResource,
     get_example_minimum_responses,
@@ -584,3 +606,223 @@ class TestWorkflowTriggers:
             "authentication": {"nonce": "123"},
         }
         assert WorkflowTriggerRequest._load(data).dump() == data
+
+
+class TestUnknownPrincipalUnion:
+    """Principal union routes unknown type strings to UnknownPrincipal."""
+
+    def test_unknown_principal_type(self) -> None:
+        data = {
+            "id": "principal_unknown_1",
+            "type": "NOT_YET_IN_SDK",
+            "name": "Future principal",
+            "pictureUrl": "https://example.com/p.png",
+            "extraFromApi": {"tier": "preview"},
+        }
+        assert TypeAdapter(Principal).validate_python(data).dump() == data
+
+
+class TestUnknownTransformationDestinationUnion:
+    """Destination union accepts unknown transformation destination kinds."""
+
+    def test_unknown_destination_type(self) -> None:
+        data = {
+            "externalId": "tf_unknown_dest",
+            "name": "Transformation",
+            "ignoreNullFields": False,
+            "destination": {"type": "futureWarehouse", "catalog": "iceberg", "table": "events"},
+        }
+        assert TransformationRequest._load(data).dump() == data
+
+
+class TestUnknownHostedExtractorMappingInputUnion:
+    def test_unknown_mapping_input_type(self) -> None:
+        data = {
+            "externalId": "mapping_1",
+            "mapping": {"expression": "true"},
+            "published": False,
+            "input": {"type": "avro", "schemaRegistryUrl": "https://registry.example.com", "subject": "topic-value"},
+        }
+        assert HostedExtractorMappingRequest._load(data).dump() == data
+
+
+class TestUnknownSinkRefUnion:
+    def test_unknown_sink_type(self) -> None:
+        data = {
+            "externalId": "sub_unknown_sink",
+            "sink": {"type": "webhook_sink", "url": "https://example.com/hooks/cdf", "secretHeader": "abc"},
+            "filter": {"topic": "cognite_workflows"},
+        }
+        assert SignalSubscriptionRequest._load(data).dump() == data
+
+
+class TestUnknownSubscriptionFilterUnion:
+    def test_unknown_filter_topic(self) -> None:
+        data = {
+            "externalId": "sub_unknown_filter",
+            "sink": {"type": "current_user"},
+            "filter": {"topic": "cognite_futureSignals", "routingHint": "priority-high"},
+        }
+        assert SignalSubscriptionRequest._load(data).dump() == data
+
+
+class TestUnknownHostedExtractorJobUnions:
+    def test_unknown_job_format(self) -> None:
+        data = {
+            "externalId": "job_unknown_format",
+            "destinationId": "dest_1",
+            "sourceId": "src_1",
+            "format": {"type": "futureBinaryFormat", "endianness": "little", "blockSize": 4096},
+        }
+        assert HostedExtractorJobRequest._load(data).dump() == data
+
+    def test_unknown_incremental_load_in_rest_config(self) -> None:
+        data = {
+            "externalId": "job_unknown_incremental",
+            "destinationId": "dest_1",
+            "sourceId": "src_1",
+            "format": {"type": "cognite"},
+            "config": {
+                "interval": "5m",
+                "path": "/ingest",
+                "incrementalLoad": {
+                    "type": "futureCursor",
+                    "opaqueState": {"token": "abc", "seq": 42},
+                },
+            },
+        }
+        assert HostedExtractorJobRequest._load(data).dump() == data
+
+
+class TestUnknownHostedExtractorSourceUnions:
+    def test_unknown_source_request_type(self) -> None:
+        data = {
+            "externalId": "source_future",
+            "type": "quantumBridge",
+            "endpoint": "https://edge.example.com/v1",
+            "handshake": {"protocol": "v2"},
+        }
+        assert HostedExtractorSourceRequest.validate_python(data).dump() == data
+
+    def test_unknown_source_response_type(self) -> None:
+        data = {
+            "externalId": "source_future_resp",
+            "type": "quantumBridge",
+            "createdTime": 1700000000000,
+            "lastUpdatedTime": 1700000001000,
+            "health": "nominal",
+        }
+        assert HostedExtractorSourceResponse.validate_python(data).dump() == data
+
+
+class TestUnknownHostedExtractorAuthenticationUnion:
+    def test_unknown_authentication_request_on_kafka_source(self) -> None:
+        data = {
+            "externalId": "kafka_auth_unknown",
+            "type": "kafka",
+            "bootstrapBrokers": [{"host": "broker.example.com", "port": 9092}],
+            "authentication": {
+                "type": "oauthDeviceCode",
+                "deviceUri": "https://idp.example.com/device",
+                "userCode": "ABCD",
+            },
+        }
+        assert KafkaSourceRequest._load(data).dump() == data
+
+    def test_unknown_authentication_response_on_kafka_source(self) -> None:
+        data = {
+            "externalId": "kafka_auth_unknown_resp",
+            "type": "kafka",
+            "bootstrapBrokers": [{"host": "broker.example.com", "port": 9092}],
+            "createdTime": 1700000000000,
+            "lastUpdatedTime": 1700000001000,
+            "authentication": {"type": "futureTokenExchange", "expiresIn": 3600},
+        }
+        assert KafkaSourceResponse._load(data).dump() == data
+
+
+class TestUnknownDataModelingContainerUnions:
+    """Container embeds Constraint, Index, and DataType unions on properties/constraints/indexes."""
+
+    def test_unknown_constraint_index_and_property_data_type(self) -> None:
+        data = {
+            "space": "dm_space",
+            "externalId": "container_future",
+            "properties": {
+                "propA": {
+                    "type": {
+                        "type": "hypotheticalGeometry",
+                        "srid": 4326,
+                        "coordinatesDimension": 3,
+                    },
+                }
+            },
+            "constraints": {
+                "c_future": {
+                    "constraintType": "futureBusinessRule",
+                    "expression": "volume > 0",
+                    "severity": "warn",
+                }
+            },
+            "indexes": {
+                "idx_future": {
+                    "indexType": "vectorApproximate",
+                    "properties": ["propA"],
+                    "dimensions": 128,
+                    "metric": "cosine",
+                }
+            },
+        }
+        assert ContainerRequest._load(data).dump() == data
+
+
+class TestUnknownViewPropertyUnion:
+    def test_unknown_view_request_property_connection_type(self) -> None:
+        data = {
+            "space": "view_space",
+            "externalId": "view_future",
+            "version": "v1",
+            "properties": {
+                "edge_like": {
+                    "connectionType": "future_graph_connector",
+                    "opaqueConfig": {"apiVersion": "2026-01"},
+                    "name": "External graph",
+                }
+            },
+        }
+        assert ViewRequest._load(data).dump() == data
+
+
+class TestUnknownInstanceUnions:
+    def test_unknown_instance_request(self) -> None:
+        data = {
+            "instanceType": "future_instance_kind",
+            "space": "instance_space",
+            "externalId": "inst_unknown",
+            "opaquePayload": {"routing": "shard-7"},
+        }
+        assert TypeAdapter(InstanceRequest).validate_python(data).dump() == data
+
+    def test_unknown_instance_response(self) -> None:
+        data = {
+            "instanceType": "future_instance_kind",
+            "space": "instance_space",
+            "externalId": "inst_unknown_resp",
+            "version": 3,
+            "createdTime": 1700000000000,
+            "lastUpdatedTime": 1700000001000,
+            "opaqueApiFields": {"replicated": True},
+        }
+        assert TypeAdapter(InstanceResponse).validate_python(data).dump() == data
+
+
+class TestUnknownWorkflowParameterUnion:
+    """Unknown parameters.type maps to UnknownTaskParameters (same idea as WorkflowTrigger triggerRule)."""
+
+    def test_unknown_task_parameter_type(self) -> None:
+        data = {
+            "type": "pipelineStageNotInToolkitYet",
+            "runnerRef": {"name": "gpu-pool"},
+            "inputs": [{"key": "model", "uri": "s3://bucket/m.pt"}],
+        }
+        assert TypeAdapter(Parameter).validate_python(data).dump() == data

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org.yaml
@@ -429,6 +429,7 @@ HostedExtractorMappingRequest:
 - externalId: MyMapping
   input:
     delimiter: ','
+    skip: 0
     type: csv
   mapping:
     expression: '[{ "type": "datapoint", "timestamp": to_unix_timestamp(input.timestamp,

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_v2.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_v2.yaml
@@ -424,6 +424,7 @@ HostedExtractorMappingRequest:
 - externalId: MyMapping
   input:
     delimiter: ','
+    skip: 0
     type: csv
   mapping:
     expression: '[{ "type": "datapoint", "timestamp": to_unix_timestamp(input.timestamp,


### PR DESCRIPTION
# Description

Avoid using discriminators in the request/response objects such that we can deal with unknown types.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- When running `cdf deploy`, Toolkit now handles unknown destinations in transformations,  hosted extractor mapping input, source, and jobs, container constraints, indexes, and data types. 
