### PR TITLE
Fix crash bugs in DeployV2Command error handling

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -10,6 +10,7 @@ from typing import Any, Generic, Literal, TypeAlias
 
 import questionary
 from rich.console import Console
+from rich.markup import escape
 from rich.panel import Panel
 from rich.progress import Progress
 from rich.table import Table
@@ -772,6 +773,7 @@ class DeployV2Command(ToolkitCommand):
 
         suffix = ""
         if deploy_dir:
+            deploy_dir.mkdir(parents=True, exist_ok=True)
             filepath = deploy_dir / f"{sanitize_filename(datetime.now(timezone.utc).isoformat())}.json"
             suffix = (
                 f"\nThe request body and response has been written to {filepath.as_posix()} for debugging purposes."
@@ -780,7 +782,6 @@ class DeployV2Command(ToolkitCommand):
             for item in resources.to_create + resources.to_update:
                 for string in crud.sensitive_strings(item):
                     json_str = json_str.replace(string, "********")
-            filepath.parent.mkdir(parents=True, exist_ok=True)
             filepath.write_text(json_str, encoding="utf-8")
 
         if skipped_cruds:
@@ -804,7 +805,7 @@ class DeployV2Command(ToolkitCommand):
         missing_variables = [variable for id in match for variable in resources.missing_env_vars_by_id[id]]
         if not missing_variables:
             return None
-        variables_str = humanize_collection(missing_variables)
+        variables_str = escape(humanize_collection(missing_variables))
         suffix = "s" if len(missing_variables) > 1 else ""
         return f"\n  {HINT_LEAD_TEXT}This is likely due to missing environment variable{suffix}: {variables_str}"
 

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -780,6 +780,7 @@ class DeployV2Command(ToolkitCommand):
             for item in resources.to_create + resources.to_update:
                 for string in crud.sensitive_strings(item):
                     json_str = json_str.replace(string, "********")
+            filepath.parent.mkdir(parents=True, exist_ok=True)
             filepath.write_text(json_str, encoding="utf-8")
 
         if skipped_cruds:
@@ -801,6 +802,8 @@ class DeployV2Command(ToolkitCommand):
         if not match:
             return None
         missing_variables = [variable for id in match for variable in resources.missing_env_vars_by_id[id]]
+        if not missing_variables:
+            return None
         variables_str = humanize_collection(missing_variables)
         suffix = "s" if len(missing_variables) > 1 else ""
         return f"\n  {HINT_LEAD_TEXT}This is likely due to missing environment variable{suffix}: {variables_str}"


### PR DESCRIPTION
# Description

Fix two bugs in `DeployV2Command` error handling:
- `_handle_deploy_error` can crash with `FileNotFoundError` when writing the deploy debug log, because the log directory (defaulting to `deploy_logs_<date>`) doesn't exist yet on the first API error of the day. The `--log-dir` help text already promises "If the directory does not exist, it will be created" — the code just wasn't doing it yet.
- `_missing_environment_variables` returns a misleading hint string with a blank variable name when a resource ID is tracked in `missing_env_vars_by_id` but has an empty variable set, triggering a confusing `ResourceUpdateError` which would end up shadowing real API error responses.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fixes a crashing issue when writing deploy error debug log.
- Fixes a misleading error hint about missing environment variables that could show up in place of CDF API errors.
