### PR TITLE
[CDF-27700] Replace container update warning with structured diff and remediation hints

### DIFF
--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -145,7 +145,9 @@ class URL:
     plugins = "https://docs.cognite.com/cdf/deploy/cdf_toolkit/guides/plugins/"
     libyaml = "https://pyyaml.org/wiki/PyYAMLDocumentation"
     build_variables = "https://docs.cognite.com/cdf/deploy/cdf_toolkit/api/config_yaml#the-variables-section"
-    container_changes_docs = "https://docs.cognite.com/cdf/dm/dm_concepts/dm_containers_views_datamodels#container-changes"
+    container_changes_docs = (
+        "https://docs.cognite.com/cdf/dm/dm_concepts/dm_containers_views_datamodels#container-changes"
+    )
 
 
 # The number of instances that should be left as a margin when Toolkit writes to CDF through the DMS API.

--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -145,6 +145,7 @@ class URL:
     plugins = "https://docs.cognite.com/cdf/deploy/cdf_toolkit/guides/plugins/"
     libyaml = "https://pyyaml.org/wiki/PyYAMLDocumentation"
     build_variables = "https://docs.cognite.com/cdf/deploy/cdf_toolkit/api/config_yaml#the-variables-section"
+    container_changes_docs = "https://docs.cognite.com/cdf/dm/dm_concepts/dm_containers_views_datamodels#container-changes"
 
 
 # The number of instances that should be left as a margin when Toolkit writes to CDF through the DMS API.

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
@@ -438,7 +438,7 @@ class ContainerCRUD(ResourceContainerIO[ContainerId, ContainerRequest, Container
 
         lines = [
             f"Container {item_id} has differing config in your local YAML as opposed to CDF.",
-            "This may occur if you have tried to remove previously deployed properties, constraints or indexes from a container in your local container YAML file.",
+            "This may occur if you have tried to remove previously deployed properties, constraints or indexes from a container in your local YAML file.",
             "Please note that CDF containers do not support removing existing property definitions and CDF toolkit currently does not support removing constraints or indexes.",
             "This warning will persist until the discrepancies are resolved.",
         ]

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
@@ -91,6 +91,8 @@ from cognite_toolkit._cdf_tk.client.resource_classes.group import (
 from cognite_toolkit._cdf_tk.constants import (
     BUILD_FOLDER_ENCODING,
     HAS_DATA_FILTER_LIMIT,
+    HINT_LEAD_TEXT,
+    URL,
     VIEW_UPSERT_BATCH_LIMIT,
 )
 from cognite_toolkit._cdf_tk.exceptions import GraphQLParseError, ToolkitCycleError, ToolkitFileNotFoundError
@@ -409,32 +411,64 @@ class ContainerCRUD(ResourceContainerIO[ContainerId, ContainerRequest, Container
 
     def update(self, items: Sequence[ContainerRequest]) -> list[ContainerResponse]:
         updated = self.create(items)
-        # The API might silently fail to update a container.
+        # The API might silently fail to apply some changes.
         updated_by_id = {item.as_id(): item for item in updated}
         for local in items:
             item_id = local.as_id()
             local_dict = local.dump()
             if item_id not in updated_by_id:
                 raise ToolkitAPIError(
-                    f"The container {item_id} was not updated. You might need to delete and recreate it.",
+                    f"The container {item_id} was not updated due to an unknown error.",
                     code=500,
                 )
             cdf_dict = self.dump_resource(updated_by_id[item_id], local_dict)
             if cdf_dict != local_dict:
-                is_verbose = "-v" in sys.argv or "--verbose" in sys.argv
-                if is_verbose:
-                    print(
-                        Panel(
-                            "\n".join(to_diff(cdf_dict, local_dict)),
-                            title=f"{self.display_name}: {item_id}",
-                            expand=False,
-                        )
-                    )
-                suffix = "" if is_verbose else " (use -v for more info)"
-                HighSeverityWarning(
-                    f"The container {item_id} was not updated. You might need to delete and recreate it{suffix}."
-                ).print_warning()
+                self._print_container_diff_warning(item_id, local_dict, cdf_dict)
         return updated
+
+    def _print_container_diff_warning(
+        self,
+        item_id: ContainerId,
+        local_dict: dict[str, Any],
+        cdf_dict: dict[str, Any],
+    ) -> None:
+        only_in_cdf_props = sorted(set(cdf_dict.get("properties", {})) - set(local_dict.get("properties", {})))
+        only_in_cdf_constraints = sorted(set(cdf_dict.get("constraints", {})) - set(local_dict.get("constraints", {})))
+        only_in_cdf_indexes = sorted(set(cdf_dict.get("indexes", {})) - set(local_dict.get("indexes", {})))
+
+        lines = [
+            f"Container {item_id} has differing config in your local YAML as opposed to CDF.",
+            "This may occur if you have tried to remove previously deployed properties, constraints or indexes from a container in your local container YAML file.",
+            "Please note that CDF containers do not support removing existing property definitions and CDF toolkit currently does not support removing constraints or indexes.",
+            "This warning will persist until the discrepancies are resolved.",
+        ]
+        if only_in_cdf_props:
+            lines.append(f"• Properties missing in your local YAML: [bold]{', '.join(only_in_cdf_props)}[/bold]")
+        if only_in_cdf_constraints:
+            lines.append(f"• Constraints missing in your local YAML: [bold]{', '.join(only_in_cdf_constraints)}[/bold]")
+        if only_in_cdf_indexes:
+            lines.append(f"• Indexes missing in your local YAML: [bold]{', '.join(only_in_cdf_indexes)}[/bold]")
+
+        HighSeverityWarning("\n".join(lines)).print_warning(console=self.console)
+
+        self.console.print(
+            f"{HINT_LEAD_TEXT}To remove this warning, you can run [bold]cdf modules pull[/bold] to retrieve the missing container config from CDF. This will overwrite your local YAML file(s)."
+        )
+        self.console.print(
+            f"{HINT_LEAD_TEXT}For more details on allowed container changes, see: {URL.container_changes_docs}"
+        )
+
+        is_verbose = "-v" in sys.argv or "--verbose" in sys.argv
+        if is_verbose:
+            self.console.print(
+                Panel(
+                    "\n".join(to_diff(cdf_dict, local_dict)),
+                    title=f"{self.display_name}: {item_id}",
+                    expand=False,
+                )
+            )
+        else:
+            self.console.print("    Use -v/--verbose for a full diff.")
 
     def delete(self, ids: Sequence[ContainerId]) -> int:
         self.client.tool.containers.delete(list(ids))

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_container.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_container.py
@@ -1,6 +1,7 @@
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from cognite_toolkit._cdf_tk.client.identifiers import ContainerId
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     ContainerPropertyDefinition,
     ContainerResponse,
@@ -63,3 +64,24 @@ indexes: {}
 
         dumped_no_local = crud.dump_resource(cdf_container)
         assert "usedFor" in dumped_no_local
+
+    def test_only_in_cdf_properties_listed(self, toolkit_client_approval: ApprovalToolkitClient) -> None:
+        crud = ContainerCRUD.create_loader(toolkit_client_approval.mock_client)
+        item_id = ContainerId(space="my_space", external_id="MyContainer")
+
+        local_dict = {"properties": {"name": {"type": {"type": "text"}}}}
+        cdf_dict = {
+            "properties": {
+                "name": {"type": {"type": "text"}},
+                "attempted_deleted_field": {"type": {"type": "int32"}},
+            }
+        }
+
+        with patch(
+            "cognite_toolkit._cdf_tk.resource_ios._resource_ios.datamodel.HighSeverityWarning"
+        ) as mock_warning_cls:
+            mock_warning_cls.return_value.print_warning = MagicMock()
+            crud._print_container_diff_warning(item_id, local_dict, cdf_dict)
+
+        message = mock_warning_cls.call_args[0][0]
+        assert "attempted_deleted_field" in message


### PR DESCRIPTION
# Description

Replace the potentially harmful "You might need to delete and recreate it" container warning with a structured diff that lists specific properties, constraints, and indexes that differ between a local container YAML and CDF. Adds remediation hints pointing users to `cdf modules pull` and the container changes documentation.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Improved

- When running `cdf deploy` with a container that has properties, constraints, or indexes that have been removed locally in your YAML file, toolkit will now list the diff against the deployed container clearly with actionable remediation steps instead of suggesting full container recreation.
