### PR TITLE
[CDF-27751] 🐛 Space pattern check

### DIFF
--- a/cognite_toolkit/_cdf_tk/yaml_classes/cognitefile.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/cognitefile.py
@@ -13,7 +13,12 @@ from .view_field_definitions import DirectRelationReference
 
 
 class CogniteFileYAML(ToolkitResource):
-    space: str = Field(description="The space where the file is located.", max_length=43, pattern=SPACE_FORMAT_PATTERN)
+    space: str = Field(
+        description="The space where the file is located.",
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
+    )
     external_id: str = Field(
         description="External-id of the file.", max_length=255, pattern=INSTANCE_EXTERNAL_ID_PATTERN
     )

--- a/cognite_toolkit/_cdf_tk/yaml_classes/data_product.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/data_product.py
@@ -1,6 +1,7 @@
 from pydantic import Field
 
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 
 from .base import ToolkitResource
 
@@ -20,6 +21,9 @@ class DataProductYAML(ToolkitResource):
     schema_space: str | None = Field(
         default=None,
         description="The schema space where the data product's data model and views are located. Defaults to the data product's externalId.",
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
     )
     description: str | None = Field(
         default=None,

--- a/cognite_toolkit/_cdf_tk/yaml_classes/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/data_product_version.py
@@ -7,7 +7,7 @@ from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 
 from .base import BaseModelResource, ToolkitResource
 
-SpaceId = Annotated[str, Field(pattern=SPACE_FORMAT_PATTERN, max_length=43)]
+SpaceId = Annotated[str, Field(pattern=SPACE_FORMAT_PATTERN, min_length=1, max_length=43)]
 
 
 class ViewInstanceSpaces(BaseModelResource):

--- a/cognite_toolkit/_cdf_tk/yaml_classes/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/filemetadata.py
@@ -3,13 +3,14 @@ from typing import Any, Literal
 from pydantic import Field
 
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 
 from .base import BaseModelResource, ToolkitResource
 
 
 class NodeId(BaseModelResource):
     external_id: str
-    space: str
+    space: str = Field(min_length=1, max_length=43, pattern=SPACE_FORMAT_PATTERN)
 
 
 class FileMetadataYAML(ToolkitResource):

--- a/cognite_toolkit/_cdf_tk/yaml_classes/hosted_extractor_job.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/hosted_extractor_job.py
@@ -7,6 +7,7 @@ from pydantic import Field, JsonValue, ModelWrapValidatorHandler, field_validato
 from pydantic_core.core_schema import SerializationInfo, SerializerFunctionWrapHandler
 
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 from cognite_toolkit._cdf_tk.utils import humanize_collection
 from cognite_toolkit._cdf_tk.utils._auxiliary import get_concrete_subclasses
 
@@ -72,7 +73,12 @@ class PrefixConfig(BaseModelResource):
 
 
 class SpaceRef(BaseModelResource):
-    space: str = Field(description="The data models space where time series will be created.")
+    space: str = Field(
+        description="The data models space where time series will be created.",
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
+    )
 
 
 class DataModelFormat(JobFormat, ABC):

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
@@ -1,6 +1,9 @@
 from typing import Any
 
+from pydantic import Field
+
 from cognite_toolkit._cdf_tk.client.identifiers import NodeId
+from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 
 from .base import BaseModelResource, ToolkitResource
 
@@ -27,7 +30,7 @@ class AccessManagement(BaseModelResource):
 class DataFilterPath(BaseModelResource):
     """Path reference for data filters."""
 
-    space: str
+    space: str = Field(min_length=1, max_length=43, pattern=SPACE_FORMAT_PATTERN)
     external_id: str
 
 
@@ -59,7 +62,7 @@ class DataStorage(BaseModelResource):
 class ViewMapping(BaseModelResource):
     """View mapping configuration."""
 
-    space: str
+    space: str = Field(min_length=1, max_length=43, pattern=SPACE_FORMAT_PATTERN)
     version: str
     external_id: str
 
@@ -98,7 +101,7 @@ class InFieldCDMLocationConfigYAML(ToolkitResource):
     - data_exploration_config: Data exploration configuration
     """
 
-    space: str
+    space: str = Field(min_length=1, max_length=43, pattern=SPACE_FORMAT_PATTERN)
     external_id: str
 
     name: str | None = None

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
@@ -56,7 +56,7 @@ class DataStorage(BaseModelResource):
     """Data storage configuration."""
 
     root_location: DataFilterPath | None = None
-    app_instance_space: str | None = None
+    app_instance_space: str | None = Field(None, min_length=1, max_length=43, pattern=SPACE_FORMAT_PATTERN)
 
 
 class ViewMapping(BaseModelResource):

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_location_config.py
@@ -98,7 +98,7 @@ class InfieldLocationConfigYAML(ToolkitResource):
 
     root_location_external_id: str | None = None
     feature_toggles: FeatureToggles | None = None
-    app_instance_space: str | None = None
+    app_instance_space: str | None = Field(None, min_length=1, max_length=43, pattern=SPACE_FORMAT_PATTERN)
     access_management: AccessManagement | None = None
     data_filters: RootLocationDataFilters | None = None
     data_exploration_config: DataExplorationConfig | None = None

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_location_config.py
@@ -1,6 +1,9 @@
 from typing import Any
 
+from pydantic import Field
+
 from cognite_toolkit._cdf_tk.client.identifiers import NodeId
+from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 
 from .base import BaseModelResource, ToolkitResource
 
@@ -61,7 +64,12 @@ class DataExplorationConfig(BaseModelResource):
     - assets: Asset page configuration
     """
 
-    space: str | None = None
+    space: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
+    )
     external_id: str | None = None
 
     observations: dict[str, Any] | None = None  # ObservationsConfigFeature
@@ -85,7 +93,7 @@ class InfieldLocationConfigYAML(ToolkitResource):
     - data_exploration_config: Direct relation to the DataExplorationConfig node (shared across all locations)
     """
 
-    space: str
+    space: str = Field(min_length=1, max_length=43, pattern=SPACE_FORMAT_PATTERN)
     external_id: str
 
     root_location_external_id: str | None = None

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_v1.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_v1.py
@@ -1,6 +1,7 @@
-from pydantic import JsonValue
+from pydantic import Field, JsonValue
 
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 
 from .base import BaseModelResource, ToolkitResource
 
@@ -91,8 +92,8 @@ class RootLocationConfiguration(BaseModelResource):
     data_set_external_id: str | None = None
     template_admins: list[str] | None = None  # list of Group Names
     checklist_admins: list[str] | None = None  # list of Group Names
-    app_data_instance_space: str | None = None
-    source_data_instance_space: str | None = None
+    app_data_instance_space: str | None = Field(None, min_length=1, max_length=43, pattern=SPACE_FORMAT_PATTERN)
+    source_data_instance_space: str | None = Field(None, min_length=1, max_length=43, pattern=SPACE_FORMAT_PATTERN)
     data_filters: RootLocationDataFilters | None = None
     feature_toggles: RootLocationFeatureToggles | None = None
     observations: ObservationsConfig | None = None

--- a/cognite_toolkit/_cdf_tk/yaml_classes/location.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/location.py
@@ -3,24 +3,40 @@ from typing import Literal
 from pydantic import Field
 
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 
 from .base import BaseModelResource, ToolkitResource
 
 
 class Scenes(BaseModelResource):
     external_id: str = Field(description="External ID of the scene.")
-    space: str = Field(description="The space that the scene is in")
+    space: str = Field(
+        description="The space that the scene is in",
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
+    )
 
 
 class DataModelID(BaseModelResource):
     external_id: str = Field(description="The external ID of the data model.")
-    space: str = Field(description="The space of the data model.")
+    space: str = Field(
+        description="The space of the data model.",
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
+    )
     version: str = Field(description="The version of the data model.")
 
 
 class LocationFilterViewId(BaseModelResource):
     external_id: str = Field(description="The external ID of the view.")
-    space: str = Field(description="The space of the view.")
+    space: str = Field(
+        description="The space of the view.",
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
+    )
     version: str = Field(description="The version of the view.")
     represents_entity: Literal["MAINTENANCE_ORDER", "OPERATION", "NOTIFICATION", "ASSET"] = Field(
         description="Represents entity type"

--- a/cognite_toolkit/_cdf_tk/yaml_classes/search_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/search_config.py
@@ -1,12 +1,13 @@
 from pydantic import Field
 
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import ViewNoVersionId
+from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 
 from .base import BaseModelResource, ToolkitResource
 
 
 class ViewId(BaseModelResource):
-    space: str
+    space: str = Field(min_length=1, max_length=43, pattern=SPACE_FORMAT_PATTERN)
     external_id: str
 
 

--- a/cognite_toolkit/_cdf_tk/yaml_classes/transformation_destination.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/transformation_destination.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar, Literal, cast
 from pydantic import Field, ModelWrapValidatorHandler, model_serializer, model_validator
 from pydantic_core.core_schema import SerializerFunctionWrapHandler
 
+from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 from cognite_toolkit._cdf_tk.utils.collection import humanize_collection
 
 from .base import BaseModelResource
@@ -16,7 +17,12 @@ else:
 
 
 class DataModelInfo(BaseModelResource):
-    space: str = Field(description="Space of the Data Model.")
+    space: str = Field(
+        description="Space of the Data Model.",
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
+    )
     external_id: str = Field(description="External ID of the Data Model.")
     version: str = Field(description="Version of the Data Model.")
     destination_type: str = Field(description="External ID of the type(view) in the data model.")
@@ -26,13 +32,23 @@ class DataModelInfo(BaseModelResource):
 
 
 class ViewInfo(BaseModelResource):
-    space: str = Field(description="Space of the view.")
+    space: str = Field(
+        description="Space of the view.",
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
+    )
     external_id: str = Field(description="External ID of the view.")
     version: str = Field(description="Version of the view.")
 
 
 class EdgeType(BaseModelResource):
-    space: str = Field(description="Space of the type.")
+    space: str = Field(
+        description="Space of the type.",
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
+    )
     external_id: str = Field(description="External ID of the type.")
 
 

--- a/cognite_toolkit/_cdf_tk/yaml_classes/transformation_destination.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/transformation_destination.py
@@ -159,7 +159,13 @@ class DataModelSource(Destination):
     _destination_type = "instances"
     type: Literal["instances"] = "instances"
     data_model: DataModelInfo = Field(description="Target data model info.")
-    instance_space: str | None = Field(None, description="The space where the instances will be created.")
+    instance_space: str | None = Field(
+        None,
+        description="The space where the instances will be created.",
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
+    )
 
 
 class ViewDataSource(Destination):
@@ -168,7 +174,11 @@ class ViewDataSource(Destination):
     view: ViewInfo | None = Field(default=None, description="Target view info.")
     edge_type: EdgeType | None = Field(default=None, description="Target type of the connection definition.")
     instance_space: str | None = Field(
-        default=None, description="The space where the instances(nodes/edges) will be created."
+        default=None,
+        description="The space where the instances(nodes/edges) will be created.",
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
     )
 
 


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- When running `cdf build`, Toolkit will no longer try to check `space` dependencies that have an invalid space name resulting in the error: `cognite_toolkit._cdf_tk.client.http_client._exception.ToolkitAPIError: Request failed with status code 400: Request had 1 constraint violations. Please fix the request and try again. [space must match "^[a-zA-Z][a-zA-Z0-9_-]{0,41}[a-zA-Z0-9]?$"]`. 