### PR TITLE
[CDF-27752] 🦐Selection of config.yaml from defaults

### DIFF
--- a/cdf.toml
+++ b/cdf.toml
@@ -1,6 +1,7 @@
 [cdf]
 default_organization_dir = "cognite_toolkit"
 #default_env = "dev"
+#default_config_yaml = "my_sim/config.dev2.yaml"
 file_encoding = "utf-8"
 file_upload_timeout_seconds = 90
 

--- a/cognite_toolkit/_cdf_tk/apps/_core_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_core_app.py
@@ -341,8 +341,9 @@ class CoreApp(typer.Typer):
 
         if build_env_name is not None and config_yaml is None:
             ToolkitDeprecationWarning(
-                feature="the --env / -e option in cdf build",
-                alternative="--config-yaml / -c with the path to your config file (for example <organization-dir>/config.<env>.yaml)",
+                feature="the --env / -e option in cdf build or default_env in cdf.toml",
+                alternative="--config-yaml / -c or config_yaml in cdf.toml with the path to your config file "
+                "(for example <organization-dir>/config.<env>.yaml)",
             ).print_warning()
             if config_yaml is None:
                 config_yaml = organization_dir / ConfigYAML.get_filename(build_env_name)

--- a/cognite_toolkit/_cdf_tk/apps/_core_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_core_app.py
@@ -339,7 +339,7 @@ class CoreApp(typer.Typer):
 
         cmd = BuildV2Command(print_warning=True, client=client)
 
-        if build_env_name is not None:
+        if build_env_name is not None and config_yaml is None:
             ToolkitDeprecationWarning(
                 feature="the --env / -e option in cdf build",
                 alternative="--config-yaml / -c with the path to your config file (for example <organization-dir>/config.<env>.yaml)",

--- a/cognite_toolkit/_cdf_tk/apps/_core_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_core_app.py
@@ -312,7 +312,7 @@ class CoreApp(typer.Typer):
                 "-e",
                 help="Deprecated. Prefer --config-yaml. If set and --config-yaml is omitted, uses <organization-dir>/config.<env>.yaml.",
             ),
-        ] = None,
+        ] = CDF_TOML.cdf.default_env,
         insight_format: Annotated[
             InsightFormat,
             typer.Option(

--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -47,6 +47,7 @@ class CLIConfig:
         return cls(
             default_organization_dir=default_organization_dir,
             default_env=raw.get("default_env", "dev"),
+            default_config_yaml=raw.get("default_config_yaml"),
             file_encoding=raw.get("file_encoding"),
             has_user_set_default_org=has_user_set_default_org,
             has_user_set_default_env=has_user_set_default_env,

--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -46,7 +46,7 @@ class CLIConfig:
 
         return cls(
             default_organization_dir=default_organization_dir,
-            default_env=raw.get("default_env", "dev"),
+            default_env=raw.get("default_env"),
             default_config_yaml=raw.get("default_config_yaml"),
             file_encoding=raw.get("file_encoding"),
             has_user_set_default_org=has_user_set_default_org,


### PR DESCRIPTION
# Description

## No default set
User have to select
<img width="938" height="118" alt="image" src="https://github.com/user-attachments/assets/1e2352aa-0c50-480a-9baa-ab5227e46e18" />

## Default config yaml is set <code>default_config_yaml = "my_sim/config.dev.yaml"</code> in <code>cdf.toml</code>
Runs without issues
<img width="1125" height="371" alt="image" src="https://github.com/user-attachments/assets/35febbc8-24ad-4a94-b78b-4f037450c5b7" />

## Default env set <code>env=dev</code>, but not default config yaml set in <code>cdf.toml</code>
Runs with a deprecation warning

<img width="1110" height="339" alt="image" src="https://github.com/user-attachments/assets/518ac904-e7f5-415e-9657-5c99fe5762fe" />


## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- When running `cdf build`, Toolkit now correctly selects the `config.[name].yaml` file based on the defaults in the `cdf.toml`.
