### PR TITLE
[🪼]  Fix no access

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -430,7 +430,12 @@ class AuthCommand(ToolkitCommand):
                 continue
 
             crud = crud_cls.create_loader(client)
-            if crud.prerequisite_warning() is not None:
+            try:
+                warning_str = crud.prerequisite_warning()
+            except ToolkitAPIError:
+                # Requires access we do not have.
+                continue
+            if warning_str is not None:
                 continue
             for acl in crud.create_acl({"READ", "WRITE"}, AllScope()):
                 required_acls.append(acl)

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -432,7 +432,7 @@ class AuthCommand(ToolkitCommand):
             crud = crud_cls.create_loader(client)
             try:
                 warning_str = crud.prerequisite_warning()
-            except ToolkitAPIError:
+            except (ToolkitAPIError, CogniteAPIError):
                 # Requires access we do not have.
                 continue
             if warning_str is not None:


### PR DESCRIPTION
# Description

Found when setting up a new CDF porject

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- When calling `cdf auth verify`, Toolkit no longer fails with `You are not allowed to access this resource endpoint | code: 403` if you lack access.
