### PR TITLE
[CDF-27760] 👌Function requirements.txt

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -698,6 +698,7 @@ class BuildV2Command(ToolkitCommand):
                         crud_cls=file.resource_type.crud_cls,
                         dependencies=dependencies,
                         extra_files=resource.extra_files,
+                        has_syntax_errors=file.syntax_warning is not None,
                     )
                 )
         return built_resources

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -697,6 +697,7 @@ class BuildV2Command(ToolkitCommand):
                         build_path=destination_path,
                         crud_cls=file.resource_type.crud_cls,
                         dependencies=dependencies,
+                        extra_files=resource.extra_files,
                     )
                 )
         return built_resources

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -744,7 +744,9 @@ class BuildV2Command(ToolkitCommand):
         table.add_column("Status", style="dim")
         table.add_column("Message", style="dim")
         for step in plan:
-            status_style = {"ready": "green", "skip": "yellow", "unavailable": "yellow"}[step.status.code]
+            status_style = {"ready": "green", "reduced": "yellow", "skip": "yellow", "unavailable": "red"}[
+                step.status.code
+            ]
             status_display = f"[{status_style}]{step.status.code}[/]"
             message = step.status.message or "-"
             table.add_row(step.rule.DISPLAY_NAME, status_display, message)

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
@@ -79,6 +79,7 @@ class BuiltResource(BaseModel):
     crud_cls: builtins.type[ResourceIO]
     dependencies: set[tuple[builtins.type[ResourceIO], Identifier]] = Field(default_factory=set)
     extra_files: list[ReadExtra] = Field(default_factory=list)
+    has_syntax_errors: bool
 
 
 class BuiltModule(BaseModel):

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
 from cognite_toolkit._cdf_tk.client._resource_base import Identifier
 from cognite_toolkit._cdf_tk.constants import MODULES
-from cognite_toolkit._cdf_tk.resource_ios._base_ios import ResourceIO
+from cognite_toolkit._cdf_tk.resource_ios._base_ios import ReadExtra, ResourceIO
 
 from ._insights import Insight, InsightList, ModelSyntaxWarning
 from ._module import BuildVariable, FailedReadYAMLFile, IgnoredFile, ModuleId, ResourceType
@@ -78,6 +78,7 @@ class BuiltResource(BaseModel):
     build_path: AbsoluteFilePath
     crud_cls: builtins.type[ResourceIO]
     dependencies: set[tuple[builtins.type[ResourceIO], Identifier]] = Field(default_factory=set)
+    extra_files: list[ReadExtra] = Field(default_factory=list)
 
 
 class BuiltModule(BaseModel):

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
@@ -185,8 +185,12 @@ class FunctionIO(ResourceIO[ExternalId, FunctionRequest, FunctionResponse]):
         return raw_list
 
     @classmethod
+    def get_function_code_implicitly(cls, filepath: Path, identifier: ExternalId) -> Path:
+        return filepath.parent / identifier.external_id
+
+    @classmethod
     def get_extra_files(cls, filepath: Path, identifier: ExternalId, item: dict[str, Any]) -> Iterable[ReadExtra]:
-        function_rootdir = filepath.parent / identifier.external_id
+        function_rootdir = cls.get_function_code_implicitly(filepath, identifier)
         if not function_rootdir.is_dir():
             yield FailedReadExtra(
                 code="NOT-EXISTING",

--- a/cognite_toolkit/_cdf_tk/rules/__init__.py
+++ b/cognite_toolkit/_cdf_tk/rules/__init__.py
@@ -1,14 +1,14 @@
 from ._auth import CheckDataSetMissing
 from ._base import ToolkitGlobalRulSet, ToolkitLocalRule
 from ._dependencies import DependencyRuleSet
-from ._functions import FunctionLimitsRule
+from ._functions import FunctionRules
 from ._neat import NeatRuleSet
 from ._orchestrator import LocalRulesOrchestrator, get_global_rules_registry
 
 __all__ = [
     "CheckDataSetMissing",
     "DependencyRuleSet",
-    "FunctionLimitsRule",
+    "FunctionRules",
     "LocalRulesOrchestrator",
     "NeatRuleSet",
     "ToolkitGlobalRulSet",

--- a/cognite_toolkit/_cdf_tk/rules/_base.py
+++ b/cognite_toolkit/_cdf_tk/rules/_base.py
@@ -40,7 +40,7 @@ class ToolkitLocalRule(ABC):
 
 
 class RuleSetStatus(BaseModel):
-    code: Literal["ready", "skip", "unavailable"]
+    code: Literal["ready", "reduced", "skip", "unavailable"]
     message: str | None = None
 
 

--- a/cognite_toolkit/_cdf_tk/rules/_functions.py
+++ b/cognite_toolkit/_cdf_tk/rules/_functions.py
@@ -23,6 +23,7 @@ class FunctionLimitsRule(ToolkitGlobalRulSet):
                 message=(
                     "Function limits validation requires a client. "
                     "Provide client credentials to validate function CPU and MEMORY limits."
+                    "Will only validate the requirement txt."
                 ),
             )
 

--- a/cognite_toolkit/_cdf_tk/rules/_functions.py
+++ b/cognite_toolkit/_cdf_tk/rules/_functions.py
@@ -12,7 +12,7 @@ from cognite_toolkit._cdf_tk.utils.file import read_yaml_file
 from cognite_toolkit._cdf_tk.yaml_classes.functions import FunctionsYAML
 
 
-class FunctionLimitsRule(ToolkitGlobalRulSet):
+class FunctionRules(ToolkitGlobalRulSet):
     CODE_PREFIX = "FUNCTION"
     DISPLAY_NAME = "Functions checks"
 

--- a/cognite_toolkit/_cdf_tk/rules/_functions.py
+++ b/cognite_toolkit/_cdf_tk/rules/_functions.py
@@ -95,11 +95,12 @@ class FunctionRules(ToolkitGlobalRulSet):
             pip_result = validate_requirements_with_pip(
                 requirement_txt, function_def.index_url, function_def.extra_index_urls
             )
-            yield ConsistencyError(
-                message=pip_result.create_message("Function", function_def.external_id),
-                code=f"{self.CODE_PREFIX}-REQUIREMENTS-TXT",
-                fix="Ensure that requirements.txt is valid.",
-            )
+            if not pip_result.success:
+                yield ConsistencyError(
+                    message=pip_result.create_message("Function", function_def.external_id),
+                    code=f"{self.CODE_PREFIX}-REQUIREMENTS-TXT",
+                    fix="Ensure that requirements.txt is valid.",
+                )
 
     @cached_property
     def limits(self) -> FunctionLimits | None:

--- a/cognite_toolkit/_cdf_tk/rules/_functions.py
+++ b/cognite_toolkit/_cdf_tk/rules/_functions.py
@@ -14,21 +14,21 @@ from cognite_toolkit._cdf_tk.yaml_classes.functions import FunctionsYAML
 
 class FunctionLimitsRule(ToolkitGlobalRulSet):
     CODE_PREFIX = "FUNCTION"
-    DISPLAY_NAME = "Function limits"
+    DISPLAY_NAME = "Functions checks"
 
     def get_status(self) -> RuleSetStatus:
         if not self.client:
             return RuleSetStatus(
-                code="unavailable",
+                code="reduced",
                 message=(
                     "Function limits validation requires a client. "
-                    "Provide client credentials to use Neat for validation."
+                    "Provide client credentials to validate function CPU and MEMORY limits."
                 ),
             )
 
         return RuleSetStatus(
             code="ready",
-            message="Will validate function definitions against CDF Project limits.",
+            message="Will validate function limits and requirement txt.",
         )
 
     def validate(self) -> Iterable[ConsistencyError | FailedValidation]:
@@ -66,7 +66,7 @@ class FunctionLimitsRule(ToolkitGlobalRulSet):
             function_def = FunctionsYAML.model_validate(function_def_data)
 
             # Validate CPU cores
-            if function_def.cpu is not None:
+            if function_def.cpu is not None and limits:
                 if function_def.cpu < limits.cpu_cores.min or function_def.cpu > limits.cpu_cores.max:
                     yield ConsistencyError(
                         message=(
@@ -78,7 +78,7 @@ class FunctionLimitsRule(ToolkitGlobalRulSet):
                     )
 
             # Validate memory
-            if function_def.memory is not None:
+            if function_def.memory is not None and limits:
                 if function_def.memory < limits.memory_gb.min or function_def.memory > limits.memory_gb.max:
                     yield ConsistencyError(
                         message=(
@@ -90,7 +90,7 @@ class FunctionLimitsRule(ToolkitGlobalRulSet):
                     )
 
     @cached_property
-    def limits(self) -> FunctionLimits:
+    def limits(self) -> FunctionLimits | None:
         if not self.client:
-            raise ValueError("Client is required to fetch function limits.")
+            return None
         return self.client.tool.functions.limits()

--- a/cognite_toolkit/_cdf_tk/rules/_functions.py
+++ b/cognite_toolkit/_cdf_tk/rules/_functions.py
@@ -1,13 +1,14 @@
 from collections.abc import Iterable
 from functools import cached_property
-from pathlib import Path
 
 from cognite_toolkit._cdf_tk.client.resource_classes.function import FunctionLimits
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import ResourceType
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import FailedValidation
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltResource, FailedValidation
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import ConsistencyError
+from cognite_toolkit._cdf_tk.constants import HINT_LEAD_TEXT
 from cognite_toolkit._cdf_tk.resource_ios import FunctionIO
 from cognite_toolkit._cdf_tk.rules._base import RuleSetStatus, ToolkitGlobalRulSet
+from cognite_toolkit._cdf_tk.utils import validate_requirements_with_pip
 from cognite_toolkit._cdf_tk.utils.file import read_yaml_file
 from cognite_toolkit._cdf_tk.yaml_classes.functions import FunctionsYAML
 
@@ -35,16 +36,19 @@ class FunctionLimitsRule(ToolkitGlobalRulSet):
         function_type = ResourceType(resource_folder=FunctionIO.folder_name, kind=FunctionIO.kind)
         for module in self.modules:
             for resource in module.resources:
+                if resource.has_syntax_errors:
+                    # We do not do further validation if there are syntax errrors.
+                    continue
                 if resource.type == function_type:
                     try:
-                        yield from self._validate_function(resource.build_path)
+                        yield from self._validate_function(resource)
                     except Exception as e:
                         yield FailedValidation(
                             message=f"Function limits validation failed for function definition {resource.build_path.name!r}: {e}",
                             source=str(resource.identifier),
                         )
 
-    def _validate_function(self, function_file: Path) -> Iterable[ConsistencyError]:
+    def _validate_function(self, resource: BuiltResource) -> Iterable[ConsistencyError]:
         """Validate function definitions against CDF project limits.
 
         Args:
@@ -54,40 +58,58 @@ class FunctionLimitsRule(ToolkitGlobalRulSet):
             ConsistencyError for any violations of function limits.
         """
         # Parse function_file (YAML) to dict/list, then create FunctionsYAML objects to validate and extract definitions
-        raw_data = read_yaml_file(function_file, expected_output="dict")
+        raw_data = read_yaml_file(resource.build_path, expected_output="dict")
 
         # Ensure we always work with a list of function definitions
-        function_defs = [raw_data] if isinstance(raw_data, dict) else (raw_data or [])
-
         limits = self.limits
 
-        for function_def_data in function_defs:
-            # Validate against schema
-            function_def = FunctionsYAML.model_validate(function_def_data)
+        # Validate against schema
+        function_def = FunctionsYAML.model_validate(raw_data)
 
-            # Validate CPU cores
-            if function_def.cpu is not None and limits:
-                if function_def.cpu < limits.cpu_cores.min or function_def.cpu > limits.cpu_cores.max:
-                    yield ConsistencyError(
-                        message=(
-                            f"Function '{function_def.external_id}' CPU cores ({function_def.cpu}) "
-                            f"must be between {limits.cpu_cores.min} and {limits.cpu_cores.max}."
-                        ),
-                        code=f"{self.CODE_PREFIX}-CPU",
-                        fix=f"Ensure that CPU cores is between {limits.cpu_cores.min} and {limits.cpu_cores.max}.",
-                    )
+        # Validate CPU cores
+        if function_def.cpu is not None and limits:
+            if function_def.cpu < limits.cpu_cores.min or function_def.cpu > limits.cpu_cores.max:
+                yield ConsistencyError(
+                    message=(
+                        f"Function '{function_def.external_id}' CPU cores ({function_def.cpu}) "
+                        f"must be between {limits.cpu_cores.min} and {limits.cpu_cores.max}."
+                    ),
+                    code=f"{self.CODE_PREFIX}-CPU",
+                    fix=f"Ensure that CPU cores is between {limits.cpu_cores.min} and {limits.cpu_cores.max}.",
+                )
 
-            # Validate memory
-            if function_def.memory is not None and limits:
-                if function_def.memory < limits.memory_gb.min or function_def.memory > limits.memory_gb.max:
-                    yield ConsistencyError(
-                        message=(
-                            f"Function '{function_def.external_id}' memory ({function_def.memory} GB) "
-                            f"must be between {limits.memory_gb.min} and {limits.memory_gb.max} GB."
-                        ),
-                        code=f"{self.CODE_PREFIX}-MEMORY",
-                        fix=f"Ensure that memory is between {limits.memory_gb.min} and {limits.memory_gb.max} GB.",
-                    )
+        # Validate memory
+        if function_def.memory is not None and limits:
+            if function_def.memory < limits.memory_gb.min or function_def.memory > limits.memory_gb.max:
+                yield ConsistencyError(
+                    message=(
+                        f"Function '{function_def.external_id}' memory ({function_def.memory} GB) "
+                        f"must be between {limits.memory_gb.min} and {limits.memory_gb.max} GB."
+                    ),
+                    code=f"{self.CODE_PREFIX}-MEMORY",
+                    fix=f"Ensure that memory is between {limits.memory_gb.min} and {limits.memory_gb.max} GB.",
+                )
+
+        if requirement_txt := next(
+            (extra for extra in resource.extra_files if extra.source_path.name == "requirements.txt"), None
+        ):
+            pip_result = validate_requirements_with_pip(
+                requirement_txt.source_path, function_def.index_url, function_def.extra_index_urls
+            )
+            message = (
+                f"Function [bold]{function_def.external_id}[/bold] requirements.txt validation failed. "
+                f"Packages could not be resolved: {pip_result.error_message}"
+            )
+            if pip_result.is_credential_error:
+                message += (
+                    f"\n{HINT_LEAD_TEXT}This appears to be a credential/authentication issue. "
+                    "Check if the Personal Access Token (PAT) or credentials in indexUrl are valid and not expired."
+                )
+            yield ConsistencyError(
+                message=message,
+                code=f"{self.CODE_PREFIX}-REQUIREMENTS-TXT",
+                fix="Ensure that requirements.txt is valid.",
+            )
 
     @cached_property
     def limits(self) -> FunctionLimits | None:

--- a/cognite_toolkit/_cdf_tk/rules/_functions.py
+++ b/cognite_toolkit/_cdf_tk/rules/_functions.py
@@ -5,7 +5,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.function import FunctionLim
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import ResourceType
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltResource, FailedValidation
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import ConsistencyError
-from cognite_toolkit._cdf_tk.constants import HINT_LEAD_TEXT
 from cognite_toolkit._cdf_tk.resource_ios import FunctionIO
 from cognite_toolkit._cdf_tk.rules._base import RuleSetStatus, ToolkitGlobalRulSet
 from cognite_toolkit._cdf_tk.utils import validate_requirements_with_pip
@@ -90,23 +89,13 @@ class FunctionLimitsRule(ToolkitGlobalRulSet):
                     fix=f"Ensure that memory is between {limits.memory_gb.min} and {limits.memory_gb.max} GB.",
                 )
 
-        if requirement_txt := next(
-            (extra for extra in resource.extra_files if extra.source_path.name == "requirements.txt"), None
-        ):
+        function_folder = FunctionIO.get_function_code_implicitly(resource.source_path, function_def.as_id())
+        if function_folder.is_dir() and (requirement_txt := next(function_folder.rglob("requirements.txt"), None)):
             pip_result = validate_requirements_with_pip(
-                requirement_txt.source_path, function_def.index_url, function_def.extra_index_urls
+                requirement_txt, function_def.index_url, function_def.extra_index_urls
             )
-            message = (
-                f"Function [bold]{function_def.external_id}[/bold] requirements.txt validation failed. "
-                f"Packages could not be resolved: {pip_result.error_message}"
-            )
-            if pip_result.is_credential_error:
-                message += (
-                    f"\n{HINT_LEAD_TEXT}This appears to be a credential/authentication issue. "
-                    "Check if the Personal Access Token (PAT) or credentials in indexUrl are valid and not expired."
-                )
             yield ConsistencyError(
-                message=message,
+                message=pip_result.create_message("Function", function_def.external_id),
                 code=f"{self.CODE_PREFIX}-REQUIREMENTS-TXT",
                 fix="Ensure that requirements.txt is valid.",
             )

--- a/cognite_toolkit/_cdf_tk/utils/pip_validator.py
+++ b/cognite_toolkit/_cdf_tk/utils/pip_validator.py
@@ -5,6 +5,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from cognite_toolkit._cdf_tk.constants import HINT_LEAD_TEXT
+
 
 @dataclass
 class PipValidationResult:
@@ -44,6 +46,18 @@ class PipValidationResult:
         relevant_lines = [line for line in error_detail.strip().split("\n") if line.strip()][-self.max_error_lines :]
         error_detail = "\n      ".join(relevant_lines)
         return error_detail
+
+    def create_message(self, resource_type: str, identifier: str) -> str:
+        message = (
+            f"{resource_type} [bold]{identifier}[/bold] requirements.txt validation failed."
+            f"Packages could not be resolved: {self.error_message}"
+        )
+        if self.is_credential_error:
+            message += (
+                f"\n{HINT_LEAD_TEXT}This appears to be a credential/authentication issue. "
+                "Check if the Personal Access Token (PAT) or credentials in indexUrl are valid and not expired."
+            )
+        return message
 
 
 def validate_requirements_with_pip(

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
@@ -226,6 +226,7 @@ class TestDependencyValidationSearchConfig:
                 build_path=AbsoluteFilePath(build_file.resolve()),
                 crud_cls=ViewIO,
                 dependencies=set(),
+                has_syntax_errors=False,
             )
         )
         module.resources.append(
@@ -240,6 +241,7 @@ class TestDependencyValidationSearchConfig:
                 build_path=AbsoluteFilePath(build_file.resolve()),
                 crud_cls=SearchConfigIO,
                 dependencies={(ViewIO, view_ref)},
+                has_syntax_errors=False,
             )
         )
         result = list(DependencyRuleSet([module]).validate())

--- a/tests/test_unit/test_cdf_tk/test_rules/test_functions.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_functions.py
@@ -1,12 +1,18 @@
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
 
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.function import FunctionLimits, ResourceLimit
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltResource
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import ConsistencyError
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._module import ResourceType
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._types import AbsoluteFilePath
+from cognite_toolkit._cdf_tk.resource_ios import FunctionIO
 from cognite_toolkit._cdf_tk.rules._functions import FunctionRules
+from cognite_toolkit._cdf_tk.utils import PipValidationResult
 
 
 class TestFunctionLimitsRule:
@@ -31,6 +37,20 @@ class TestFunctionLimitsRule:
             yaml.safe_dump(content, f)
 
     @staticmethod
+    def _create_built_resource(source_path: Path, build_path: Path, external_id: str = "my_function") -> BuiltResource:
+        """Create a BuiltResource for testing."""
+        return BuiltResource(
+            identifier=ExternalId(external_id=external_id),
+            source_hash="test-hash",
+            type=ResourceType(resource_folder=FunctionIO.folder_name, kind=FunctionIO.kind),
+            source_path=AbsoluteFilePath(source_path.resolve()),
+            build_path=AbsoluteFilePath(build_path.resolve()),
+            crud_cls=FunctionIO,
+            dependencies=set(),
+            has_syntax_errors=False,
+        )
+
+    @staticmethod
     def _create_rule_with_client(function_limits: FunctionLimits) -> FunctionRules:
         """Create a FunctionLimitsRule with mocked client."""
         mock_client = MagicMock()
@@ -43,14 +63,14 @@ class TestFunctionLimitsRule:
         rule = self._create_rule_with_client(function_limits)
         status = rule.get_status()
         assert status.code == "ready"
-        assert "validate function definitions" in status.message.lower()
+        assert "validate function limits" in status.message.lower()
 
     def test_get_status_without_client(self) -> None:
-        """Test get_status returns unavailable when no client is provided."""
+        """Test get_status returns reduced when no client is provided."""
         rule = FunctionRules(modules=[])
         status = rule.get_status()
-        assert status.code == "unavailable"
-        assert "client" in status.message.lower()
+        assert status.code == "reduced"
+        assert "requirement" in status.message.lower()
 
     def test_validate_function_cpu_exceeds_max(self, tmp_path: Path, function_limits: FunctionLimits) -> None:
         """Test validation error when CPU cores exceed maximum limit."""
@@ -63,8 +83,9 @@ class TestFunctionLimitsRule:
                 "cpu": 3.0,
             },
         )
+        resource = self._create_built_resource(yaml_file, yaml_file)
         rule = self._create_rule_with_client(function_limits)
-        errors = list(rule._validate_function(yaml_file))
+        errors = list(rule._validate_function(resource))
         assert len(errors) == 1
         assert isinstance(errors[0], ConsistencyError)
         assert "CPU cores" in errors[0].message
@@ -81,8 +102,9 @@ class TestFunctionLimitsRule:
                 "cpu": 0.05,
             },
         )
+        resource = self._create_built_resource(yaml_file, yaml_file)
         rule = self._create_rule_with_client(function_limits)
-        errors = list(rule._validate_function(yaml_file))
+        errors = list(rule._validate_function(resource))
         assert len(errors) == 1
         assert "CPU cores" in errors[0].message
 
@@ -97,8 +119,9 @@ class TestFunctionLimitsRule:
                 "memory": 5.0,
             },
         )
+        resource = self._create_built_resource(yaml_file, yaml_file)
         rule = self._create_rule_with_client(function_limits)
-        errors = list(rule._validate_function(yaml_file))
+        errors = list(rule._validate_function(resource))
         assert len(errors) == 1
         assert "memory" in errors[0].message
 
@@ -113,8 +136,9 @@ class TestFunctionLimitsRule:
                 "memory": 0.1,
             },
         )
+        resource = self._create_built_resource(yaml_file, yaml_file)
         rule = self._create_rule_with_client(function_limits)
-        errors = list(rule._validate_function(yaml_file))
+        errors = list(rule._validate_function(resource))
         assert len(errors) == 1
 
     def test_validate_function_valid_resources(self, tmp_path: Path, function_limits: FunctionLimits) -> None:
@@ -129,8 +153,9 @@ class TestFunctionLimitsRule:
                 "memory": 2.0,
             },
         )
+        resource = self._create_built_resource(yaml_file, yaml_file)
         rule = self._create_rule_with_client(function_limits)
-        errors = list(rule._validate_function(yaml_file))
+        errors = list(rule._validate_function(resource))
         assert len(errors) == 0
 
     def test_validate_function_none_resources(self, tmp_path: Path, function_limits: FunctionLimits) -> None:
@@ -143,8 +168,9 @@ class TestFunctionLimitsRule:
                 "name": "My Function",
             },
         )
+        resource = self._create_built_resource(yaml_file, yaml_file)
         rule = self._create_rule_with_client(function_limits)
-        errors = list(rule._validate_function(yaml_file))
+        errors = list(rule._validate_function(resource))
         assert len(errors) == 0
 
     def test_validate_function_multiple_violations(self, tmp_path: Path, function_limits: FunctionLimits) -> None:
@@ -159,8 +185,9 @@ class TestFunctionLimitsRule:
                 "memory": 5.0,
             },
         )
+        resource = self._create_built_resource(yaml_file, yaml_file)
         rule = self._create_rule_with_client(function_limits)
-        errors = list(rule._validate_function(yaml_file))
+        errors = list(rule._validate_function(resource))
         assert len(errors) == 2
 
     def test_validate_function_consistency_error_attributes(
@@ -176,16 +203,98 @@ class TestFunctionLimitsRule:
                 "cpu": 5.0,
             },
         )
+        resource = self._create_built_resource(yaml_file, yaml_file)
         rule = self._create_rule_with_client(function_limits)
-        errors = list(rule._validate_function(yaml_file))
+        errors = list(rule._validate_function(resource))
         assert len(errors) == 1
         error = errors[0]
         assert error.code == "FUNCTION-CPU"
         assert error.message is not None
         assert error.fix is not None
 
-    def test_limits_property_raises_without_client(self) -> None:
-        """Test that limits property raises when no client is available."""
+    def test_limits_property_returns_none_without_client(self) -> None:
+        """Test that limits property returns None when no client is available."""
         rule = FunctionRules(modules=[])
-        with pytest.raises(ValueError, match="Client is required"):
-            _ = rule.limits
+        assert rule.limits is None
+
+    @patch("cognite_toolkit._cdf_tk.rules._functions.validate_requirements_with_pip")
+    def test_validate_function_with_invalid_requirements_txt(
+        self, mock_validate_pip: MagicMock, tmp_path: Path, function_limits: FunctionLimits
+    ) -> None:
+        """Test validation error when requirements.txt has invalid packages."""
+        yaml_file = tmp_path / "functions" / "func.yaml"
+        self._write_function_yaml(
+            yaml_file,
+            {
+                "externalId": "my_function",
+                "name": "My Function",
+            },
+        )
+        # Create the function code directory with requirements.txt
+        function_dir = tmp_path / "functions" / "my_function"
+        function_dir.mkdir(parents=True, exist_ok=True)
+        requirements_file = function_dir / "requirements.txt"
+        requirements_file.write_text("nonexistent-package==99.99.99\n")
+
+        mock_validate_pip.return_value = PipValidationResult(error_message="Package not found: nonexistent-package")
+
+        resource = self._create_built_resource(yaml_file, yaml_file)
+        rule = self._create_rule_with_client(function_limits)
+        errors = list(rule._validate_function(resource))
+
+        assert len(errors) == 1
+        assert errors[0].code == "FUNCTION-REQUIREMENTS-TXT"
+        mock_validate_pip.assert_called_once()
+
+    @patch("cognite_toolkit._cdf_tk.rules._functions.validate_requirements_with_pip")
+    def test_validate_function_without_requirements_txt(
+        self, mock_validate_pip: MagicMock, tmp_path: Path, function_limits: FunctionLimits
+    ) -> None:
+        """Test no requirements.txt error when function has no requirements.txt."""
+        yaml_file = tmp_path / "functions" / "func.yaml"
+        self._write_function_yaml(
+            yaml_file,
+            {
+                "externalId": "my_function",
+                "name": "My Function",
+            },
+        )
+        # Don't create the function directory or requirements.txt
+
+        resource = self._create_built_resource(yaml_file, yaml_file)
+        rule = self._create_rule_with_client(function_limits)
+        errors = list(rule._validate_function(resource))
+
+        assert len(errors) == 0
+        mock_validate_pip.assert_not_called()
+
+    @patch("cognite_toolkit._cdf_tk.rules._functions.validate_requirements_with_pip")
+    def test_validate_function_with_valid_requirements_txt(
+        self, mock_validate_pip: MagicMock, tmp_path: Path, function_limits: FunctionLimits
+    ) -> None:
+        """Test validation passes when requirements.txt is valid."""
+        yaml_file = tmp_path / "functions" / "func.yaml"
+        self._write_function_yaml(
+            yaml_file,
+            {
+                "externalId": "my_function",
+                "name": "My Function",
+            },
+        )
+        # Create the function code directory with requirements.txt
+        function_dir = tmp_path / "functions" / "my_function"
+        function_dir.mkdir(parents=True, exist_ok=True)
+        requirements_file = function_dir / "requirements.txt"
+        requirements_file.write_text("requests>=2.0.0\n")
+
+        mock_validate_pip.return_value = PipValidationResult()
+
+        resource = self._create_built_resource(yaml_file, yaml_file)
+        rule = self._create_rule_with_client(function_limits)
+        errors = list(rule._validate_function(resource))
+
+        # Valid requirements should still yield an error due to unconditional yield in the code
+        # Let's check this behavior
+        assert len(errors) == 1
+        assert errors[0].code == "FUNCTION-REQUIREMENTS-TXT"
+        mock_validate_pip.assert_called_once()

--- a/tests/test_unit/test_cdf_tk/test_rules/test_functions.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_functions.py
@@ -293,8 +293,4 @@ class TestFunctionLimitsRule:
         rule = self._create_rule_with_client(function_limits)
         errors = list(rule._validate_function(resource))
 
-        # Valid requirements should still yield an error due to unconditional yield in the code
-        # Let's check this behavior
-        assert len(errors) == 1
-        assert errors[0].code == "FUNCTION-REQUIREMENTS-TXT"
-        mock_validate_pip.assert_called_once()
+        assert len(errors) == 0

--- a/tests/test_unit/test_cdf_tk/test_rules/test_functions.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_functions.py
@@ -6,7 +6,7 @@ import yaml
 
 from cognite_toolkit._cdf_tk.client.resource_classes.function import FunctionLimits, ResourceLimit
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import ConsistencyError
-from cognite_toolkit._cdf_tk.rules._functions import FunctionLimitsRule
+from cognite_toolkit._cdf_tk.rules._functions import FunctionRules
 
 
 class TestFunctionLimitsRule:
@@ -31,11 +31,11 @@ class TestFunctionLimitsRule:
             yaml.safe_dump(content, f)
 
     @staticmethod
-    def _create_rule_with_client(function_limits: FunctionLimits) -> FunctionLimitsRule:
+    def _create_rule_with_client(function_limits: FunctionLimits) -> FunctionRules:
         """Create a FunctionLimitsRule with mocked client."""
         mock_client = MagicMock()
         mock_client.tool.functions.limits.return_value = function_limits
-        rule = FunctionLimitsRule(modules=[], client=mock_client)
+        rule = FunctionRules(modules=[], client=mock_client)
         return rule
 
     def test_get_status_with_client(self, function_limits: FunctionLimits) -> None:
@@ -47,7 +47,7 @@ class TestFunctionLimitsRule:
 
     def test_get_status_without_client(self) -> None:
         """Test get_status returns unavailable when no client is provided."""
-        rule = FunctionLimitsRule(modules=[])
+        rule = FunctionRules(modules=[])
         status = rule.get_status()
         assert status.code == "unavailable"
         assert "client" in status.message.lower()
@@ -186,6 +186,6 @@ class TestFunctionLimitsRule:
 
     def test_limits_property_raises_without_client(self) -> None:
         """Test that limits property raises when no client is available."""
-        rule = FunctionLimitsRule(modules=[])
+        rule = FunctionRules(modules=[])
         with pytest.raises(ValueError, match="Client is required"):
             _ = rule.limits


### PR DESCRIPTION
# Description

When moving from v0.7 to v0.8 these checks was lost (they were placed inside the old builder classes which we do not use any more)

Adding them back in

<img width="2115" height="675" alt="image" src="https://github.com/user-attachments/assets/db059665-1de6-4ed0-a9f7-d10aa4fe49f0" />




## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- When running `cdf build` with Cognite Functions, Toolkit now validates the `requirement.txt`.
