### PR TITLE
[CDF-27762] 🪠Added $FILEPATH to FileMetadata and CogniteFile spec

### DIFF
--- a/cognite_toolkit/_cdf_tk/yaml_classes/cognitefile.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/cognitefile.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pydantic import Field
 
 from cognite_toolkit._cdf_tk.client.identifiers import NodeId
+from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FILEPATH
 from cognite_toolkit._cdf_tk.constants import (
     INSTANCE_EXTERNAL_ID_PATTERN,
     SPACE_FORMAT_PATTERN,
@@ -51,6 +52,7 @@ class CogniteFileYAML(ToolkitResource):
     )
     existing_version: int | None = Field(default=None, description="Existing version of the file.")
     type: DirectRelationReference | None = Field(default=None, description="Direct relation to the type of the file.")
+    filepath: str | None = Field(None, alias=FILEPATH)
 
     def as_id(self) -> NodeId:
         return NodeId(space=self.space, external_id=self.external_id)

--- a/cognite_toolkit/_cdf_tk/yaml_classes/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/filemetadata.py
@@ -3,6 +3,7 @@ from typing import Any, Literal
 from pydantic import Field
 
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FILEPATH
 from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 
 from .base import BaseModelResource, ToolkitResource
@@ -64,6 +65,7 @@ class FileMetadataYAML(ToolkitResource):
     security_categories: list[str] | None = Field(
         default=None, description="The security category IDs required to access this file.", max_length=100
     )
+    filepath: str | None = Field(None, alias=FILEPATH, description="The path to the file content")
 
     def as_id(self) -> ExternalId:
         return ExternalId(external_id=self.external_id)


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Toolkit no longer warns if you build a file metadata or CogniteFile with file content in the `cdf build` command.
