### PR TITLE
[CDF-27764] 📉 Chart migration skip DM-only charts

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -455,6 +455,20 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
         chart_dest = "Charts (data modeling)"
         for item in source:
             identifier = item.external_id
+
+            if not item.data.time_series_collection:
+                self.logger.log(
+                    MigrationEntryV2(
+                        id=identifier,
+                        label="No asset-centric timeseries in Chart.",
+                        severity=Severity.skipped,
+                        message=f"There are only {len(item.data.core_timeseries_collection or [])} CogniteTimesSeries in the chart.",
+                        source=chart_src,
+                        destination=chart_dest,
+                    )
+                )
+                output.append(None)
+                continue
             mapped_item, issue = self._map_single_item(
                 item, event_ids_by_chart_external_id.get(item.external_id, set())
             )

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -473,6 +473,7 @@ class TestChartMapper:
         with monkeypatch_toolkit_client() as client:
             mapper = ChartMapper(client)
             logger = FileWithAggregationLogger(MagicMock())
+            logger.register([chart.external_id])
             mapper.logger = logger
             result = mapper.map([chart])
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -71,7 +71,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.data_mapper import (
 )
 from cognite_toolkit._cdf_tk.commands._migrate.issues import MigrationEntryV2
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import MigrationCSVFileSelector
-from cognite_toolkit._cdf_tk.dataio.logger import DataLogger, FileWithAggregationLogger
+from cognite_toolkit._cdf_tk.dataio.logger import DataLogger, FileWithAggregationLogger, Severity
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 from tests.data import MIGRATION_DIR
 
@@ -459,7 +459,7 @@ class TestChartMapper:
 
         data_regression.check(dumped, fullpath=output_chart_path)
 
-    def test_skip_dms_chart(self) -> None:
+    def test_skip_dms_chart(self, tmp_path: Path) -> None:
         dms_chart = MIGRATION_DIR / "charts" / "dms.Chart.yaml"
         request_format = yaml.safe_load(dms_chart.read_text(encoding="utf-8"))
         # Make this into response
@@ -474,9 +474,13 @@ class TestChartMapper:
             mapper = ChartMapper(client)
             logger = FileWithAggregationLogger(MagicMock())
             mapper.logger = logger
-            result = ChartMapper(client).map([chart])
+            result = mapper.map([chart])
 
         assert result == [None]
+
+        aggregations = logger.aggregations_by_ids[chart.external_id]
+        assert len(aggregations) == 1
+        assert aggregations[0].severity == Severity.skipped
 
 
 class TestFDMtoCDMMapper:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -71,7 +71,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.data_mapper import (
 )
 from cognite_toolkit._cdf_tk.commands._migrate.issues import MigrationEntryV2
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import MigrationCSVFileSelector
-from cognite_toolkit._cdf_tk.dataio.logger import DataLogger
+from cognite_toolkit._cdf_tk.dataio.logger import DataLogger, FileWithAggregationLogger
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 from tests.data import MIGRATION_DIR
 
@@ -458,6 +458,25 @@ class TestChartMapper:
         ] or None
 
         data_regression.check(dumped, fullpath=output_chart_path)
+
+    def test_skip_dms_chart(self) -> None:
+        dms_chart = MIGRATION_DIR / "charts" / "dms.Chart.yaml"
+        request_format = yaml.safe_load(dms_chart.read_text(encoding="utf-8"))
+        # Make this into response
+        request_format["createdTime"] = 0
+        request_format["lastUpdatedTime"] = 0
+        request_format["ownerId"] = "me"
+        request_format["monitoringJobs"][0]["id"] = -1
+
+        chart = ChartResponse.model_validate(request_format)
+
+        with monkeypatch_toolkit_client() as client:
+            mapper = ChartMapper(client)
+            logger = FileWithAggregationLogger(MagicMock())
+            mapper.logger = logger
+            result = ChartMapper(client).map([chart])
+
+        assert result == [None]
 
 
 class TestFDMtoCDMMapper:


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- [alpha] When running `cdf migrate charts`, Toolkit skips all charts that does not contain any asset-centric timeseries (DM-only Charts).
