### PR TITLE
Fix Neat data model validation crashing with NameError

### DIFF
--- a/cognite_toolkit/_cdf_tk/rules/_neat.py
+++ b/cognite_toolkit/_cdf_tk/rules/_neat.py
@@ -106,6 +106,8 @@ class NeatRuleSet(ToolkitGlobalRulSet):
 
     @cached_property
     def _neat_client(self) -> "NeatClient":
+        from cognite.neat._toolkit_adapter import NeatClient
+
         if self.client is None:
             raise RuntimeError(
                 "NeatRules requires a client to be provided to fetch CDF snapshot and limits for validation. Please provide client credentials."


### PR DESCRIPTION
# Description

`NeatRuleSet._neat_client` referenced `NeatClient` at runtime but only imported it under `TYPE_CHECKING`, causing every Neat data model validation to fail with `NameError: name 'NeatClient' is not defined`. Adds a lazy import inside the property, matching the existing pattern for optional `cognite.neat` dependencies in this file.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fixed an issue causing data model validation to crash when Neat is installed alongside Toolkit.