### PR TITLE
[CDF-27379] Fix spurious container diff and crash when constraints/indexes are null

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
@@ -371,9 +371,18 @@ class ContainerCRUD(ResourceContainerIO[ContainerId, ContainerRequest, Container
                 dumped.pop(key, None)
 
         for key in ["constraints", "indexes"]:
-            if not dumped.get(key) and key not in local:
-                # Set to empty dict by server.
-                dumped.pop(key, None)
+            cdf_value = dumped.get(key)
+            local_value = local.get(key)
+            if not cdf_value and not local_value:
+                # Both sides represent "no constraints/indexes". The API and
+                # the local YAML can each express this by not including the
+                # keys, or setting them to null, or {}.
+                # This normalizes the CDF side to match the shape used locally so the
+                # diff doesn't flag a purely cosmetic mismatch.
+                if key in local:
+                    dumped[key] = local_value
+                else:
+                    dumped.pop(key, None)
                 continue
             if isinstance((cdf_value := dumped.get(key)), dict) and isinstance((local_value := local.get(key)), dict):
                 for cdf_id, cdf_item in cdf_value.items():
@@ -433,8 +442,10 @@ class ContainerCRUD(ResourceContainerIO[ContainerId, ContainerRequest, Container
         cdf_dict: dict[str, Any],
     ) -> None:
         only_in_cdf_props = sorted(set(cdf_dict.get("properties", {})) - set(local_dict.get("properties", {})))
-        only_in_cdf_constraints = sorted(set(cdf_dict.get("constraints", {})) - set(local_dict.get("constraints", {})))
-        only_in_cdf_indexes = sorted(set(cdf_dict.get("indexes", {})) - set(local_dict.get("indexes", {})))
+        only_in_cdf_constraints = sorted(
+            set(cdf_dict.get("constraints") or {}) - set(local_dict.get("constraints") or {})
+        )
+        only_in_cdf_indexes = sorted(set(cdf_dict.get("indexes") or {}) - set(local_dict.get("indexes") or {}))
 
         lines = [
             f"Container {item_id} has differing config in your local YAML as opposed to CDF.",

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_container.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_container.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from cognite_toolkit._cdf_tk.client.identifiers import ContainerId
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     ContainerPropertyDefinition,
@@ -11,8 +13,34 @@ from cognite_toolkit._cdf_tk.resource_ios import ContainerCRUD, ResourceWorker
 from tests.test_unit.approval_client import ApprovalToolkitClient
 
 
+@pytest.fixture
+def cdf_container() -> ContainerResponse:
+    return ContainerResponse(
+        space="sp_enterprise_process_industry_full",
+        external_id="Toolkit360Image",
+        last_updated_time=1739469813633,
+        created_time=1739469813633,
+        description=None,
+        name=None,
+        used_for="node",
+        is_global=False,
+        properties={
+            "UUID": ContainerPropertyDefinition(
+                type=TextProperty(list=False, collation="ucs_basic"),
+                immutable=False,
+                nullable=True,
+                auto_increment=False,
+            )
+        },
+        indexes={},
+        constraints={},
+    )
+
+
 class TestContainerCRUD:
-    def test_unchanged_used_for_not_set(self, toolkit_client_approval: ApprovalToolkitClient) -> None:
+    def test_unchanged_used_for_not_set(
+        self, toolkit_client_approval: ApprovalToolkitClient, cdf_container: ContainerResponse
+    ) -> None:
         crud = ContainerCRUD.create_loader(toolkit_client_approval.mock_client)
         raw_file = """space: sp_enterprise_process_industry_full
 externalId: Toolkit360Image
@@ -30,26 +58,6 @@ indexes: {}
 """
         file = MagicMock(spec=Path)
         file.read_text.return_value = raw_file
-        cdf_container = ContainerResponse(
-            space="sp_enterprise_process_industry_full",
-            external_id="Toolkit360Image",
-            last_updated_time=1739469813633,
-            created_time=1739469813633,
-            description=None,
-            name=None,
-            used_for="node",
-            is_global=False,
-            properties={
-                "UUID": ContainerPropertyDefinition(
-                    type=TextProperty(list=False, collation="ucs_basic"),
-                    immutable=False,
-                    nullable=True,
-                    auto_increment=False,
-                )
-            },
-            indexes={},
-            constraints={},
-        )
 
         toolkit_client_approval.append(ContainerResponse, [cdf_container])
 
@@ -85,3 +93,23 @@ indexes: {}
 
         message = mock_warning_cls.call_args[0][0]
         assert "attempted_deleted_field" in message
+
+    def test_dump_resource_normalizes_empty_constraints_and_indexes_to_local_shape(
+        self, toolkit_client_approval: ApprovalToolkitClient, cdf_container: ContainerResponse
+    ) -> None:
+        crud = ContainerCRUD.create_loader(toolkit_client_approval.mock_client)
+
+        local_with_null = {"constraints": None, "indexes": None}
+        dumped = crud.dump_resource(cdf_container, local_with_null)
+        assert dumped.get("constraints") is None
+        assert dumped.get("indexes") is None
+
+        local_with_empty_dict = {"constraints": {}, "indexes": {}}
+        dumped = crud.dump_resource(cdf_container, local_with_empty_dict)
+        assert dumped.get("constraints") == {}
+        assert dumped.get("indexes") == {}
+
+        local_absent: dict = {}
+        dumped = crud.dump_resource(cdf_container, local_absent)
+        assert "constraints" not in dumped
+        assert "indexes" not in dumped


### PR DESCRIPTION
# Description

Container `constraints` and `indexes` are optional and may be expressed as missing, `null`, or `{}` in either the local YAML or the CDF response. This caused two issues during deploy: (1) a `TypeError: 'NoneType' object is not iterable` in `_print_container_diff_warning` when either `constraints` or `indexes` was explicitly set to `null`, and (2) cosmetic `null` =/= `{}` diffs that also caused unchanged containers as being flagged as updated (since the API seems to always return `{}`). `ContainerCRUD.dump_resource` now normalizes the CDF dump to match whichever empty shape the local YAML used.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fix `cdf deploy` crashing with `TypeError: 'NoneType' object is not iterable` when a container's `constraints` or `indexes` were set to `null`.
- Fix containers being flagged as changed during `cdf deploy` when `constraints` or `indexes` in containers were set to `null` even though they were unchanged since last deploy.