### PR TITLE
[CDF-27767] Add RUN action to FunctionsAcl

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/function.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/function.py
@@ -23,7 +23,7 @@ class FunctionBase(BaseModelObject):
     env_vars: dict[str, str] | None = None
     cpu: float | None = None
     memory: float | None = None
-    runtime: FunctionRuntime | None = None
+    runtime: FunctionRuntime | str | None = None
     metadata: Metadata | None = None
     index_url: str | None = None
     extra_index_urls: list[str] | None = None

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/function.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/function.py
@@ -7,7 +7,7 @@ from cognite_toolkit._cdf_tk.client._types import Metadata
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 
 FunctionStatus: TypeAlias = Literal["Queued", "Deploying", "Ready", "Failed", "Retired"]
-FunctionRuntime: TypeAlias = Literal["py38", "py39", "py310", "py311", "py312"]
+FunctionRuntime: TypeAlias = Literal["py38", "py39", "py310", "py311", "py312", "py313"]
 
 
 class FunctionBase(BaseModelObject):

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
@@ -264,7 +264,7 @@ class FunctionsAcl(Acl):
     """ACL for Functions resources."""
 
     acl_name: Literal["functionsAcl"] = Field("functionsAcl", exclude=True)
-    actions: Sequence[Literal["READ", "WRITE"]]
+    actions: Sequence[Literal["READ", "WRITE", "RUN"]]
     scope: AllScope
 
 

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
@@ -112,12 +112,12 @@ class FunctionIO(ResourceIO[ExternalId, FunctionRequest, FunctionResponse]):
         return dataset_scoped_resource(items)
 
     @classmethod
-    def create_acl(cls, actions: set[Literal["READ", "WRITE", "RUN"]], scope: ScopeDefinition) -> Iterable[AclType]:
+    def create_acl(cls, actions: set[Literal["READ", "WRITE"]], scope: ScopeDefinition) -> Iterable[AclType]:
         if isinstance(scope, AllScope | DataSetScope):
             # Functions ACLs do not support dataset scoping, so we always create them with AllScope.
             yield FunctionsAcl(actions=sorted(actions), scope=AllScope())
             # The files ACL is needed to deploy the function code.
-            yield FilesAcl(actions=sorted(actions & {"READ", "WRITE"}), scope=scope)
+            yield FilesAcl(actions=sorted(actions), scope=scope)
 
     @classmethod
     def get_id(cls, item: FunctionResponse | FunctionRequest | dict) -> ExternalId:

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
@@ -112,12 +112,12 @@ class FunctionIO(ResourceIO[ExternalId, FunctionRequest, FunctionResponse]):
         return dataset_scoped_resource(items)
 
     @classmethod
-    def create_acl(cls, actions: set[Literal["READ", "WRITE"]], scope: ScopeDefinition) -> Iterable[AclType]:
+    def create_acl(cls, actions: set[Literal["READ", "WRITE", "RUN"]], scope: ScopeDefinition) -> Iterable[AclType]:
         if isinstance(scope, AllScope | DataSetScope):
             # Functions ACLs do not support dataset scoping, so we always create them with AllScope.
             yield FunctionsAcl(actions=sorted(actions), scope=AllScope())
             # The files ACL is needed to deploy the function code.
-            yield FilesAcl(actions=sorted(actions), scope=scope)
+            yield FilesAcl(actions=sorted(actions & {"READ", "WRITE"}), scope=scope)
 
     @classmethod
     def get_id(cls, item: FunctionResponse | FunctionRequest | dict) -> ExternalId:

--- a/cognite_toolkit/_cdf_tk/yaml_classes/capabilities.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/capabilities.py
@@ -273,7 +273,7 @@ class FilesAcl(Capability):
 
 class FunctionsAcl(Capability):
     _capability_name = "functionsAcl"
-    actions: list[Literal["READ", "WRITE"]]
+    actions: list[Literal["READ", "WRITE", "RUN"]]
     scope: AllScope
 
 

--- a/cognite_toolkit/_cdf_tk/yaml_classes/functions.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/functions.py
@@ -45,7 +45,7 @@ class FunctionsYAML(ToolkitResource):
     )
     cpu: float | None = Field(default=None, description="Number of CPU cores per function.")
     memory: float | None = Field(default=None, description="Memory per function measured in GB.")
-    runtime: Literal["py39", "py310", "py311", "py312"] | None = Field(
+    runtime: Literal["py39", "py310", "py311", "py312", "py313"] | None = Field(
         default="py311", description="Runtime of the function."
     )
     metadata: dict[str, str] | None = Field(

--- a/tests/test_unit/test_cdf_tk/test_client/test_group_api_classes.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_group_api_classes.py
@@ -64,6 +64,7 @@ def all_acls() -> Iterable[tuple]:
         {"filesAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"filesAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": [123, 456]}}}},
         {"functionsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"functionsAcl": {"actions": ["READ", "WRITE", "RUN"], "scope": {"all": {}}}},
         {"genericsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"groupsAcl": {"actions": ["LIST", "READ", "DELETE", "UPDATE", "CREATE"], "scope": {"all": {}}}},
         {"groupsAcl": {"actions": ["READ", "CREATE", "UPDATE", "DELETE"], "scope": {"currentuserscope": {}}}},

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
@@ -69,6 +69,7 @@ def all_acls() -> Iterable:
         {"filesAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"filesAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": ["myDataSet", "myDataSet2"]}}}},
         {"functionsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
+        {"functionsAcl": {"actions": ["READ", "WRITE", "RUN"], "scope": {"all": {}}}},
         {"genericsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"groupsAcl": {"actions": ["LIST", "READ", "DELETE", "UPDATE", "CREATE"], "scope": {"all": {}}}},
         {"groupsAcl": {"actions": ["READ", "CREATE", "UPDATE", "DELETE"], "scope": {"currentuserscope": {}}}},

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_functions.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_functions.py
@@ -23,7 +23,7 @@ def invalid_function_test_cases() -> Iterable:
             "secrets": {f"secret_name{i}": f"super_secret{i}" for i in range(31)},
         },
         {
-            "In field runtime input should be 'py39', 'py310', 'py311' or 'py312'. Got 'py36'.",
+            "In field runtime input should be 'py39', 'py310', 'py311', 'py312' or 'py313'. Got 'py36'.",
             "In field secrets dictionary should have at most 30 items after validation, not 31",
         },
         id="Invalid runtime",


### PR DESCRIPTION
# Description

CDF's `functionsAcl` now supports a `RUN` action in addition to `READ` and `WRITE`.
This PR adds `RUN` to the allowed actions in both the client ACL model and the YAML
capability class.

Also adds `py313` to the allowed function runtimes — CDF recently bumped its default
runtime to Python 3.13.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- `FunctionsAcl` now accepts `RUN` as a valid action in addition to `READ` and `WRITE`.

### Fixed

- `py313` added to the list of valid function runtimes to match CDF's updated default.