### PR TITLE
[CDF-27783] 🚩Traceback flag

### DIFF
--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -126,11 +126,16 @@ def about() -> None:
 
 def app() -> NoReturn:
     # --- Main entry point ---
+    # Strip --traceback from sys.argv before Typer processes it (hidden debug flag)
+    show_traceback = "--traceback" in sys.argv
+    if show_traceback:
+        sys.argv.remove("--traceback")
+
     # Users run 'app()' directly, but that doesn't allow us to control excepton handling:
     try:
         _app()
     except ToolkitError as err:
-        if "--verbose" in sys.argv:
+        if show_traceback:
             print(Panel(traceback.format_exc(), title="Traceback", expand=False))
 
         print(f"  [bold red]ERROR ([/][red]{type(err).__name__}[/][bold red]):[/] {err}")


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Improved

- When running any command and hitting an error, Toolkit no longer prints traceback. That is only done if the user passes in `--traceback`. 