### PR TITLE
[CDF-27670] 	🐛InField config migration

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -440,10 +440,13 @@ class InfieldV2ConfigCreator(MigrationCreator):
         ]:
             view_mappings[key] = default_view.dump()
 
+        original_external_id = config.external_id or config.asset_external_id or str(uuid.uuid4())
+        external_id = f"infield_config_{original_external_id}"
+        name = config.display_name or config.asset_external_id or external_id
         return InFieldCDMLocationConfigRequest(
             space=config.source_data_instance_space or "<Please fill in the source data instance space>",
             external_id=external_id,
-            name="InField Location Config",
+            name=name,
             description="Migrated InField Location Configuration",
             feature_toggles=feature_toggles,
             access_management=access_management or None,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -440,8 +440,6 @@ class InfieldV2ConfigCreator(MigrationCreator):
         ]:
             view_mappings[key] = default_view.dump()
 
-        original_external_id = config.external_id or config.asset_external_id or str(uuid.uuid4())
-        external_id = f"infield_config_{original_external_id}"
         name = config.display_name or config.asset_external_id or external_id
         return InFieldCDMLocationConfigRequest(
             space=config.source_data_instance_space or "<Please fill in the source data instance space>",

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator/test_create_infield_config.yml
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator/test_create_infield_config.yml
@@ -33,7 +33,7 @@ InField CDM Location Configs:
   disciplines: null
   externalId: WMT:VAL_0
   featureToggles: null
-  name: InField Location Config
+  name: WMT:VAL
   space: sp_asset_oid_source
   viewMappings:
     asset:


### PR DESCRIPTION
# Description

## Before
<img width="696" height="298" alt="image" src="https://github.com/user-attachments/assets/3c3e9e49-8244-4d8a-a86d-f2e34000ba89" />


## After
<img width="596" height="483" alt="image" src="https://github.com/user-attachments/assets/74f901c6-8a8c-4d2c-b9b8-2c28fa304e77" />


## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- When running `cdf migrate infield-configs`, Toolkit now produces one template configuration for each location.