### PR TITLE
[CDF-27794] 🪟🫂dev create Function 

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/functions.py
+++ b/cognite_toolkit/_cdf_tk/commands/functions.py
@@ -240,5 +240,5 @@ class FunctionsCommand(ToolkitCommand):
         if path.exists() and not questionary.confirm(f"{path.name} already exists. Overwrite?").unsafe_ask():
             print(f"[yellow]Skipping {path.as_posix()}[/yellow]")
             return
-        path.write_text(content)
+        path.write_text(content, encoding="utf-8")
         print(f"[green]Created {path.as_posix()}[/green]")

--- a/tests/test_integration/test_commands/test_deploy.py
+++ b/tests/test_integration/test_commands/test_deploy.py
@@ -159,7 +159,9 @@ def get_changed_resources(env_vars: EnvironmentVariables, build_dir: Path) -> di
         if loader_cls in {DataProductIO, DataProductVersionIO, RuleSetIO, RuleSetVersionIO}:
             # Data Products and Rule Sets APIs are not yet available on the test server.
             continue
-
+        if loader_cls in {CogniteFileCRUD}:
+            # This is running the legacy deploy command that does not hash the file blob like deploy v2
+            continue
         loader = create_loader(loader_cls, client, build_dir)
 
         worker = ResourceWorker(loader, "deploy")
@@ -196,6 +198,8 @@ def get_changed_source_files(
             or loader_cls is SearchConfigIO
             # Data Products and Rule Sets APIs are not yet available on the test server.
             or loader_cls in {DataProductIO, DataProductVersionIO, RuleSetIO, RuleSetVersionIO}
+            # This is running the legacy deploy command that does not hash the file blob like deploy v2
+            or loader_cls in {CogniteFileCRUD}
         ):
             continue
 


### PR DESCRIPTION
# Description

I thought this was a bad unit test, but it was a Windows specific bug.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- [alpha] Running `cdf dev create Function` and selecting FunctionApp no longer raise a `UnicodeEncodeError` on Windows.
