### PR TITLE
[CDF-27793] 😀 Download cognite file

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -643,7 +643,6 @@ class DownloadApp(typer.Typer):
                 choices=[Choice(title=format_.value, value=format_) for format_ in AssetCentricFormats],
                 default=file_format,
             ).unsafe_ask()
-            download_dir_name = "asset_centric-files-with-content"
             output_dir = Path(
                 questionary.path(
                     "Where to download the file metadata and contents:", default=str(output_dir), only_directories=True
@@ -651,6 +650,7 @@ class DownloadApp(typer.Typer):
             )
             selected = selector.select_documents()
             if selected.selection.file_type == "dms":
+                download_dir_name = "cognite-file-with-content"
                 io = CogniteFileContentIO(
                     client,
                     config_directory=output_dir / download_dir_name,
@@ -671,6 +671,7 @@ class DownloadApp(typer.Typer):
                     )
                 ]
             else:
+                download_dir_name = "asset_centric-files-with-content"
                 io = FileMetadataContentIO(
                     client,
                     config_directory=output_dir / download_dir_name,

--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -671,7 +671,7 @@ class DownloadApp(typer.Typer):
                     )
                 ]
             else:
-                download_dir_name = "asset_centric-files-with-content"
+                download_dir_name = "asset-centric-files-with-content"
                 io = FileMetadataContentIO(
                     client,
                     config_directory=output_dir / download_dir_name,

--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -646,20 +646,24 @@ class DownloadApp(typer.Typer):
                     "Where to download the file metadata and contents:", default=str(output_dir), only_directories=True
                 ).unsafe_ask()
             )
-            documents = selector.select_documents()
-            io = FileMetadataContentIO(
-                client,
-                config_directory=output_dir / download_dir_name,
-                file_directory=output_dir / download_dir_name / "files",
-            )
-            selectors = [
-                FileMetadataFilesSelectorV2(
-                    ids=tuple(
-                        InternalWithNameId(id=document.id, name=document.source_file.name) for document in documents
-                    ),
-                    download_dir_name=download_dir_name,
+            selected = selector.select_documents()
+            if selected.selection.file_type == "dms":
+                raise NotImplementedError()
+            else:
+                io = FileMetadataContentIO(
+                    client,
+                    config_directory=output_dir / download_dir_name,
+                    file_directory=output_dir / download_dir_name / "files",
                 )
-            ]
+                selectors = [
+                    FileMetadataFilesSelectorV2(
+                        ids=tuple(
+                            InternalWithNameId(id=document.id, name=document.source_file.name)
+                            for document in selected.documents
+                        ),
+                        download_dir_name=download_dir_name,
+                    )
+                ]
         elif data_sets is not None:
             selectors = [
                 DataSetSelector(

--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -15,6 +15,7 @@ from cognite_toolkit._cdf_tk.dataio import (
     AssetDataIO,
     CanvasIO,
     ChartIO,
+    CogniteFileContentIO,
     DataIO,
     DatapointsIO,
     DataSelector,
@@ -33,6 +34,7 @@ from cognite_toolkit._cdf_tk.dataio.selectors import (
     CanvasSelector,
     ChartExternalIdSelector,
     ChartSelector,
+    CogniteFileFilesSelectorV2,
     DataPointsDataSetSelector,
     DataSetSelector,
     FileMetadataFilesSelectorV2,
@@ -40,6 +42,7 @@ from cognite_toolkit._cdf_tk.dataio.selectors import (
     InstanceSpaceSelector,
     InstanceViewSelector,
     InternalWithNameId,
+    NodeWithNameId,
     RawTableSelector,
     SelectedTable,
     SelectedView,
@@ -648,7 +651,25 @@ class DownloadApp(typer.Typer):
             )
             selected = selector.select_documents()
             if selected.selection.file_type == "dms":
-                raise NotImplementedError()
+                io = CogniteFileContentIO(
+                    client,
+                    config_directory=output_dir / download_dir_name,
+                    file_directory=output_dir / download_dir_name / "files",
+                )
+                selectors = [
+                    CogniteFileFilesSelectorV2(
+                        download_dir_name=download_dir_name,
+                        ids=tuple(
+                            NodeWithNameId(
+                                space=doc.instance_id.space,
+                                external_id=doc.instance_id.external_id,
+                                name=doc.source_file.name,
+                            )
+                            for doc in selected.documents
+                            if doc.instance_id
+                        ),
+                    )
+                ]
             else:
                 io = FileMetadataContentIO(
                     client,

--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -7,6 +7,8 @@ from typing import Literal, TypeAlias
 
 from cognite.client import data_modeling as dm
 
+from cognite_toolkit._cdf_tk.client.identifiers import ContainerId
+
 try:
     from pyodide.ffi import IN_BROWSER
 except ModuleNotFoundError:
@@ -171,7 +173,7 @@ MAX_RUN_QUERY_FREQUENCY_MIN = 10
 COGNITE_MIGRATION_SPACE = "cognite_migration"
 
 COGNITE_TIME_SERIES_CONTAINER = dm.ContainerId("cdf_cdm", "CogniteTimeSeries")
-COGNITE_FILE_CONTAINER = dm.ContainerId("cdf_cdm", "CogniteFile")
+COGNITE_FILE_CONTAINER = ContainerId(space="cdf_cdm", external_id="CogniteFile")
 CDF_UNIT_SPACE = "cdf_cdm_units"
 
 

--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -171,7 +171,7 @@ MAX_RUN_QUERY_FREQUENCY_MIN = 10
 COGNITE_MIGRATION_SPACE = "cognite_migration"
 
 COGNITE_TIME_SERIES_CONTAINER = dm.ContainerId("cdf_cdm", "CogniteTimeSeries")
-COGNITE_FILE_CONTAINER = dict(space="cdf_cdm", external_id="CogniteFile")
+COGNITE_FILE_CONTAINER = dm.ContainerId("cdf_cdm", "CogniteFile")
 CDF_UNIT_SPACE = "cdf_cdm_units"
 
 

--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -7,8 +7,6 @@ from typing import Literal, TypeAlias
 
 from cognite.client import data_modeling as dm
 
-from cognite_toolkit._cdf_tk.client.identifiers import ContainerId
-
 try:
     from pyodide.ffi import IN_BROWSER
 except ModuleNotFoundError:
@@ -173,7 +171,7 @@ MAX_RUN_QUERY_FREQUENCY_MIN = 10
 COGNITE_MIGRATION_SPACE = "cognite_migration"
 
 COGNITE_TIME_SERIES_CONTAINER = dm.ContainerId("cdf_cdm", "CogniteTimeSeries")
-COGNITE_FILE_CONTAINER = ContainerId(space="cdf_cdm", external_id="CogniteFile")
+COGNITE_FILE_CONTAINER = dict(space="cdf_cdm", external_id="CogniteFile")
 CDF_UNIT_SPACE = "cdf_cdm_units"
 
 

--- a/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
@@ -641,7 +641,7 @@ class CogniteFileContentIO(
             if subkeys:
                 json_item[key] = {subkey: json_item.pop(f"{key}.{subkey}") for subkey in subkeys}
 
-        return self.json_to_resource(dict(row))
+        return self.json_to_resource(json_item)
 
     def json_to_resource(self, item_json: dict[str, JsonVal]) -> CogniteFileRequest:
         # CogniteFileCRUD.load_resource only restores filepath from YAML-side cache; table/template

--- a/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
@@ -661,7 +661,7 @@ class CogniteFileContentIO(
     ) -> dict[str, JsonVal]:
         row = dict(item_json)
         for key in ["category", "type"]:
-            value = item_json.pop(key, None)
+            value = row.pop(key, None)
             if value is not None and isinstance(value, dict):
                 for subkey, subvalue in value.items():
                     row[f"{key}.{subkey}"] = subvalue

--- a/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
@@ -539,8 +539,10 @@ class CogniteFileContentIO(
             SchemaColumn(name="assets", type="json"),
             SchemaColumn(name="mimeType", type="string"),
             SchemaColumn(name="directory", type="string"),
-            SchemaColumn(name="category", type="json"),
-            SchemaColumn(name="type", type="json"),
+            SchemaColumn(name="category.space", type="string"),
+            SchemaColumn(name="category.externalId", type="string"),
+            SchemaColumn(name="type.space", type="string"),
+            SchemaColumn(name="type.externalId", type="string"),
             SchemaColumn(name="existingVersion", type="integer"),
             SchemaColumn(name=FILEPATH, type="string"),
         ]
@@ -633,7 +635,12 @@ class CogniteFileContentIO(
     def row_to_resource(
         self, source_id: str, row: dict[str, JsonVal], selector: CogniteFileContentSelectorV2 | None = None
     ) -> CogniteFileRequest:
-        _ = source_id, selector
+        json_item = dict(row)
+        for key in ["category", "type"]:
+            subkeys = {subkey[len(key) + 1 :] for subkey in json_item if subkey.startswith(f"{key}.")}
+            if subkeys:
+                json_item[key] = {subkey: json_item.pop(f"{key}.{subkey}") for subkey in subkeys}
+
         return self.json_to_resource(dict(row))
 
     def json_to_resource(self, item_json: dict[str, JsonVal]) -> CogniteFileRequest:
@@ -652,8 +659,13 @@ class CogniteFileContentIO(
     def json_to_row(
         self, item_json: dict[str, JsonVal], selector: CogniteFileContentSelectorV2 | None = None
     ) -> dict[str, JsonVal]:
-        _ = selector
-        return dict(item_json)
+        row = dict(item_json)
+        for key in ["category", "type"]:
+            value = item_json.pop(key, None)
+            if value is not None and isinstance(value, dict):
+                for subkey, subvalue in value.items():
+                    row[f"{key}.{subkey}"] = subvalue
+        return row
 
     def data_to_json_chunk(
         self, data_chunk: Page[CogniteFileResponse], selector: CogniteFileContentSelectorV2 | None = None
@@ -670,7 +682,6 @@ class CogniteFileContentIO(
         return data_chunk.create_from(dumped)
 
     def configurations(self, selector: CogniteFileContentSelectorV2) -> Iterable[StorageIOConfig]:
-        _ = selector
         yield from ()
 
     def upload_items(

--- a/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
@@ -515,7 +515,6 @@ class CogniteFileContentIO(
         self._config_directory = config_directory
         self._file_directory = file_directory
         self._crud = CogniteFileCRUD(client, None, None, support_upload=False)
-        self._dump_keys_by_selector: dict[CogniteFileContentSelectorV2 | None, set[str]] = {}
 
     def _verify_download_selector(self, selector: CogniteFileContentSelectorV2) -> tuple[NodeWithNameId, ...]:
         if isinstance(selector, CogniteFileFilesSelectorV2) and selector.ids:
@@ -523,12 +522,7 @@ class CogniteFileContentIO(
         raise NotImplementedError(f"{selector.type} does not support download")
 
     def get_schema(self, selector: CogniteFileContentSelectorV2) -> list[SchemaColumn] | None:
-        if selector not in self._dump_keys_by_selector:
-            self._dump_keys_by_selector[selector] = set()
-            return None
-        extra_keys = sorted(self._dump_keys_by_selector.get(selector, set()) - _COGNITE_FILE_BASE_SCHEMA_KEYS)
-        extra_schema = [SchemaColumn(name=key, type="string", is_array=False) for key in extra_keys]
-        base_schema = [
+        return [
             SchemaColumn(name="space", type="string"),
             SchemaColumn(name="externalId", type="string"),
             SchemaColumn(name="name", type="string"),
@@ -542,7 +536,7 @@ class CogniteFileContentIO(
             SchemaColumn(name="sourceUpdatedTime", type="timestamp"),
             SchemaColumn(name="sourceCreatedUser", type="string"),
             SchemaColumn(name="sourceUpdatedUser", type="string"),
-            SchemaColumn(name="assets", type="json", is_array=True),
+            SchemaColumn(name="assets", type="json"),
             SchemaColumn(name="mimeType", type="string"),
             SchemaColumn(name="directory", type="string"),
             SchemaColumn(name="category", type="json"),
@@ -550,7 +544,6 @@ class CogniteFileContentIO(
             SchemaColumn(name="existingVersion", type="integer"),
             SchemaColumn(name=FILEPATH, type="string"),
         ]
-        return base_schema + extra_schema
 
     def stream_data(
         self, selector: CogniteFileContentSelectorV2, limit: int | None = None, bookmark: Bookmark | None = None
@@ -665,9 +658,6 @@ class CogniteFileContentIO(
     def data_to_json_chunk(
         self, data_chunk: Page[CogniteFileResponse], selector: CogniteFileContentSelectorV2 | None = None
     ) -> Page[dict[str, JsonVal]]:
-        if selector in self._dump_keys_by_selector:
-            for di in data_chunk.items:
-                self._dump_keys_by_selector[selector].update(self._crud.dump_resource(di.item).keys())
         dumped: list[DataItem[dict[str, JsonVal]]] = []
         for item in data_chunk.items:
             dumped_item = self._crud.dump_resource(item.item)

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -45,7 +45,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.group.acls import ChartsAdm
 from cognite_toolkit._cdf_tk.client.resource_classes.resource_view_mapping import ResourceViewMappingResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.streams import StreamResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.three_d import ThreeDModelClassicResponse
-from cognite_toolkit._cdf_tk.constants import COGNITE_FILE_CONTAINER
 from cognite_toolkit._cdf_tk.exceptions import ToolkitMissingResourceError, ToolkitValueError
 
 from . import humanize_collection
@@ -1117,12 +1116,12 @@ class DocumentSelectStatus:
     document_filter: dict[DocumentPropertyPath, Any] = field(default_factory=dict)
     metadata_filter: dict[DocumentPropertyPath, Any] = field(default_factory=dict)
     attempted_options: set[DocumentPropertyPath] = field(default_factory=set)
-    view_id: ViewId | None = None
+    is_cognite_file: bool = False
     data_set_id: int | None = None
 
     @property
     def file_type(self) -> Literal["asset-centric", "dms", "ambiguous"]:
-        if self.view_id is not None:
+        if self.is_cognite_file:
             return "dms"
         if (
             self.data_set_id is not None
@@ -1186,8 +1185,8 @@ class DocumentsInteractiveSelect:
                 )
             elif action == "select-data-sets":
                 self._select_dataset()
-            elif action == "select-view":
-                self._select_view()
+            elif action == "is-cognite-file":
+                self._set_cognite_file()
             elif action == "search":
                 self._prompt_search_query()
             elif action == "name":
@@ -1206,7 +1205,7 @@ class DocumentsInteractiveSelect:
             choices.append(Choice(title="Filter metadata properties", value="filter-metadata-properties"))
             choices.append(Choice(title="Select data sets", value="select-data-sets"))
         if selected_file_type != "asset-centric":
-            choices.append(Choice(title="Select view", value="select-view"))
+            choices.append(Choice(title="Is CogniteFile", value="is-cognite-file"))
         if self.max_selected <= self.MAX_SEARCH_RESULTS:
             choices.append(
                 Choice(title="Search documents (full-text query)", value="search"),
@@ -1287,17 +1286,8 @@ class DocumentsInteractiveSelect:
         ).unsafe_ask()
         self.status.data_set_id = selected_data_set_id
 
-    def _select_view(self) -> None:
-        res = self.client.tool.containers.inspect(
-            [ContainerId(**COGNITE_FILE_CONTAINER)],  # type: ignore[arg-type]
-            all_versions=False,
-            include_unavailable_views=False,
-        )[0]
-        view_id = questionary.select(
-            message="Select view to retrieve through",
-            choices=[Choice(title=repr(view_id), value=view_id) for view_id in res.inspection_results.involved_views],
-        ).unsafe_ask()
-        self.status.view_id = view_id
+    def _set_cognite_file(self) -> None:
+        self.status.is_cognite_file = True
 
     def _prompt_search_query(self) -> None:
         answer = questionary.text(

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -1202,7 +1202,7 @@ class DocumentsInteractiveSelect:
         ]
         selected_file_type = self.status.file_type
         if selected_file_type != "dms":
-            choices.append(Choice(title="Filter metadata properties", value="filter-metadata-properties"))
+            choices.append(Choice(title="Filter by metadata properties", value="filter-metadata-properties"))
             choices.append(Choice(title="Select data sets", value="select-data-sets"))
         if selected_file_type != "asset-centric":
             choices.append(Choice(title="Is CogniteFile", value="is-cognite-file"))

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -1225,7 +1225,7 @@ class DocumentsInteractiveSelect:
         if selected_file_type == "dms":
             caveat = " (approximate)"
         return questionary.select(
-            f"{count} documents found{caveat}. What do you want to do?{query_note}{suffix}",
+            f"{count} documents found{caveat}. How would you like to proceed?{query_note}{suffix}",
             choices=choices,
         ).unsafe_ask()
 

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -1267,22 +1267,22 @@ class DocumentsInteractiveSelect:
         buckets = self.client.tool.documents.unique(
             property=("sourceFile", "dataSetId"), filter=self.status.current_filter, query=self.status.search_query
         )
-        internal_ids = [int(bucket.value) for bucket in buckets if isinstance(bucket.value, int | float)]
+        internal_ids = {int(bucket.value): bucket.count for bucket in buckets if isinstance(bucket.value, int | float)}
         if len(internal_ids) == 0:
             self.client.console.print("No documents found for filtering on data set ID.", style="bold red")
             return
-        external_ids = self.client.lookup.data_sets.external_id(internal_ids)
+        external_ids = self.client.lookup.data_sets.external_id(list(internal_ids))
         if len(external_ids) == 1:
             self.client.console.print(
                 f"Only one data set found: {external_ids[0]!r}. Automatically applying this filter."
             )
-            self.status.data_set_id = internal_ids[0]
+            self.status.data_set_id = next(iter(internal_ids.keys()))
             return
         selected_data_set_id = questionary.select(
             message="Select data set:",
             choices=[
-                Choice(title=external_id, value=internal_id)
-                for internal_id, external_id in zip(internal_ids, external_ids)
+                Choice(title=f"{external_id} ({count})", value=internal_id)
+                for (internal_id, count), external_id in zip(internal_ids.items(), external_ids)
             ],
         ).unsafe_ask()
         self.status.data_set_id = selected_data_set_id

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property, lru_cache, partial
 from typing import Any, ClassVar, Literal, TypeVar, get_args, overload
 
@@ -45,6 +45,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.group.acls import ChartsAdm
 from cognite_toolkit._cdf_tk.client.resource_classes.resource_view_mapping import ResourceViewMappingResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.streams import StreamResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.three_d import ThreeDModelClassicResponse
+from cognite_toolkit._cdf_tk.constants import COGNITE_FILE_CONTAINER
 from cognite_toolkit._cdf_tk.exceptions import ToolkitMissingResourceError, ToolkitValueError
 
 from . import humanize_collection
@@ -1104,6 +1105,49 @@ class RecordInteractiveSelect:
         return selected_spaces
 
 
+@dataclass
+class DocumentSelectStatus:
+    ASSET_CENTRIC_PROPERTIES: ClassVar[set[DocumentPropertyPath]] = {
+        ("labels",),
+        ("sourceFile", "source"),
+        ("sourceFile", "metadata"),
+        ("sourceFile", "labels"),
+    }
+    search_query: str | None = None
+    document_filter: dict[DocumentPropertyPath, Any] = field(default_factory=dict)
+    metadata_filter: dict[DocumentPropertyPath, Any] = field(default_factory=dict)
+    attempted_options: set[DocumentPropertyPath] = field(default_factory=set)
+    view_id: ViewId | None = None
+    data_set_id: int | None = None
+
+    @property
+    def file_type(self) -> Literal["asset-centric", "dms", "ambiguous"]:
+        if self.view_id is not None:
+            return "dms"
+        if (
+            self.data_set_id is not None
+            or self.metadata_filter is not None
+            or (self.ASSET_CENTRIC_PROPERTIES.intersection(self.document_filter.keys()))
+        ):
+            return "asset-centric"
+        return "ambiguous"
+
+    @property
+    def current_filter(self) -> dict[str, Any] | None:
+        if not self.document_filter and not self.metadata_filter and self.data_set_id is not None:
+            return None
+        leaf_filter = list(*self.document_filter.values(), *self.metadata_filter.values())
+        if self.data_set_id is not None:
+            leaf_filter.append({"equals": {"property": ["sourceFile", "dataSetId"], "value": self.data_set_id}})
+        return {"and": leaf_filter}
+
+
+@dataclass
+class SelectedDocuments:
+    documents: list[DocumentResponse]
+    selection: DocumentSelectStatus
+
+
 class DocumentsInteractiveSelect:
     MAX_TERMINAL_CHOICES = 100
     # This can be increased by implementing pagination for the /documents/search endpoint
@@ -1112,35 +1156,40 @@ class DocumentsInteractiveSelect:
     def __init__(self, client: ToolkitClient, max_selected: int = 100) -> None:
         self.client = client
         self.max_selected = max_selected
-        self._filter: dict[DocumentPropertyPath, Any] = {}
-        self._search_query: str | None = None
-        self._attempted_options: set[DocumentPropertyPath] = set()
+        self.status = DocumentSelectStatus()
 
     @cached_property
-    def _all_filter_options(self) -> set[DocumentPropertyPath]:
+    def _all_document_properties(self) -> set[DocumentPropertyPath]:
+        # Dataset is treated specially.
+        return set(DOCUMENT_PROPERTY_OPTIONS) - {("sourceFile", "dataSetId")}
+
+    @cached_property
+    def _all_metadata_keys(self) -> set[DocumentPropertyPath]:
         metadata_keys = self.client.tool.documents.unique(("sourceFile", "metadata"))
-        return set(DOCUMENT_PROPERTY_OPTIONS) | {("sourceFile", "metadata", str(key.value)) for key in metadata_keys}
+        return {("sourceFile", "metadata", str(key.value)) for key in metadata_keys}
 
-    @property
-    def _current_filter(self) -> dict[str, Any] | None:
-        if not self._filter:
-            return None
-        return {"and": list(self._filter.values())}
-
-    def select_documents(self) -> list[DocumentResponse]:
+    def select_documents(self) -> SelectedDocuments:
         while True:
-            count = self.client.tool.documents.count(filter=self._current_filter, query=self._search_query)
+            count = self.client.tool.documents.count(filter=self.status.current_filter, query=self._search_query)
             action = self._action(count)
             if action == "abort":
                 raise ToolkitValueError("Aborted document selection.")
             elif action == "finished":
                 break
-            elif action == "filter":
-                self._update_filter()
-                continue
+            elif action == "filter-document-properties":
+                self._update_filter(
+                    self._all_document_properties - self.status.attempted_options, self.status.document_filter
+                )
+            elif action == "filter-metadata-properties":
+                self._update_filter(
+                    self._all_metadata_keys - self.status.attempted_options, self.status.metadata_filter
+                )
+            elif action == "select-data-sets":
+                self._select_dataset()
+            elif action == "select-view":
+                self._select_view()
             elif action == "search":
                 self._prompt_search_query()
-                continue
             elif action == "name":
                 return self._select_by_name()
             else:
@@ -1150,8 +1199,14 @@ class DocumentsInteractiveSelect:
 
     def _action(self, count: int) -> str:
         choices = [
-            Choice(title="Filter documents", value="filter"),
+            Choice(title="Filter document properties", value="filter-document-properties"),
         ]
+        selected_file_type = self.status.file_type
+        if selected_file_type != "dms":
+            choices.append(Choice(title="Filter metadata properties", value="filter-metadata-properties"))
+            choices.append(Choice(title="Select data sets", value="select-data-sets"))
+        if selected_file_type != "asset-centric":
+            choices.append(Choice(title="Select view", value="select-view"))
         if self.max_selected <= self.MAX_SEARCH_RESULTS:
             choices.append(
                 Choice(title="Search documents (full-text query)", value="search"),
@@ -1167,14 +1222,17 @@ class DocumentsInteractiveSelect:
         query_note = ""
         if self._search_query is not None:
             query_note = f' Active full-text query: "{self._search_query}".'
-
+        caveat = ""
+        if selected_file_type == "dms":
+            caveat = " (approximate)"
         return questionary.select(
-            f"{count} documents found. What do you want to do?{query_note}{suffix}",
+            f"{count} documents found{caveat}. What do you want to do?{query_note}{suffix}",
             choices=choices,
         ).unsafe_ask()
 
-    def _update_filter(self) -> None:
-        available_options = self._all_filter_options - self._attempted_options
+    def _update_filter(
+        self, available_options: set[DocumentPropertyPath], filter: dict[DocumentPropertyPath, Any]
+    ) -> None:
         if len(available_options) == 0:
             self.client.console.print("No more filtering options available.", style="bold red")
             return
@@ -1184,9 +1242,9 @@ class DocumentsInteractiveSelect:
         ).unsafe_ask()
 
         buckets = self.client.tool.documents.unique(
-            property=filter_type, filter=self._current_filter, query=self._search_query
+            property=filter_type, filter=self.status.current_filter, query=self._search_query
         )
-        self._attempted_options.add(filter_type)
+        self.status.attempted_options.add(filter_type)
         if len(buckets) == 0:
             self.client.console.print(f"No documents found for filtering on {filter_type!r}.", style="bold red")
             return
@@ -1194,7 +1252,7 @@ class DocumentsInteractiveSelect:
             self.client.console.print(
                 f"Only one value found for {filter_type!r}: {buckets[0].value!r}. Automatically applying this filter."
             )
-            selected_values = [buckets[0].value]
+            filter[filter_type] = {"equals": {"property": list(filter_type), "value": buckets[0].value}}
         else:
             selected_values = questionary.checkbox(
                 f"Select values for {filter_type!r}:",
@@ -1203,37 +1261,74 @@ class DocumentsInteractiveSelect:
                 ],
                 validator=lambda choices: True if choices else "You must select at least one value.",
             ).unsafe_ask()
-        self._filter[filter_type] = {"in": {"property": list(filter_type), "values": list(selected_values)}}
+            filter[filter_type] = {"in": {"property": list(filter_type), "values": list(selected_values)}}
+
+    def _select_dataset(self) -> None:
+        buckets = self.client.tool.documents.unique(
+            property=("sourceFile", "dataSetId"), filter=self.status.current_filter, query=self._search_query
+        )
+        internal_ids = [int(bucket.value) for bucket in buckets if isinstance(bucket.value, int | float)]
+        if len(internal_ids) == 0:
+            self.client.console.print("No documents found for filtering on data set ID.", style="bold red")
+            return
+        external_ids = self.client.lookup.data_sets.external_id(internal_ids)
+        if len(external_ids) == 1:
+            self.client.console.print(
+                f"Only one data set found: {external_ids[0]!r}. Automatically applying this filter."
+            )
+            self.status.data_set_id = internal_ids[0]
+            return
+        selected_data_set_id = questionary.select(
+            message="Select data set:",
+            choices=[
+                Choice(title=external_id, value=internal_id)
+                for internal_id, external_id in zip(internal_ids, external_ids)
+            ],
+        ).unsafe_ask()
+        self.status.data_set_id = selected_data_set_id
+
+    def _select_view(self) -> None:
+        res = self.client.tool.containers.inspect(
+            [COGNITE_FILE_CONTAINER], all_versions=False, include_unavailable_views=False
+        )[0]
+        view_id = questionary.select(
+            message="Select view to retrieve through",
+            choices=[Choice(title=repr(view_id), value=view_id) for view_id in res.inspection_results.involved_views],
+        ).unsafe_ask()
+        self.status.view_id = view_id
 
     def _prompt_search_query(self) -> None:
         answer = questionary.text(
             "Full-text search query (empty clears search and uses list/filter only):",
-            default=self._search_query or "",
+            default=self.status.search_query or "",
         ).unsafe_ask()
         stripped = (answer or "").strip()
         self._search_query = stripped or None
-        count = self.client.tool.documents.count(filter=self._current_filter, query=self._search_query)
+        count = self.client.tool.documents.count(filter=self.status.current_filter, query=self._search_query)
         if count == 0:
             self.client.console.print("No documents found. Clearing search query.", style="bold red")
             self._search_query = None
 
-    def _documents_list_or_search(self, *, limit: int) -> list[DocumentResponse]:
+    def _documents_list_or_search(self, *, limit: int) -> SelectedDocuments:
         if self._search_query is None:
-            return self.client.tool.documents.list(filter=self._current_filter, limit=limit)
+            return SelectedDocuments(
+                self.client.tool.documents.list(filter=self.status.current_filter, limit=limit), self.status
+            )
         page = self.client.tool.documents.search(
             query=self._search_query,
-            filter=self._current_filter,
+            filter=self.status.current_filter,
             limit=limit,
         )
-        return [hit.item for hit in page.items]
+        return SelectedDocuments([hit.item for hit in page.items], self.status)
 
-    def _select_by_name(self) -> list[DocumentResponse]:
-        documents = self._documents_list_or_search(limit=self.max_selected)
+    def _select_by_name(self) -> SelectedDocuments:
+        docs = self._documents_list_or_search(limit=self.max_selected)
         choices = [
-            Choice(title=f"{doc.source_file.name} ({doc.mime_type}, {doc.id!r})", value=doc) for doc in documents
+            Choice(title=f"{doc.source_file.name} ({doc.mime_type}, {doc.id!r})", value=doc) for doc in docs.documents
         ]
-        return questionary.checkbox(
+        documents = questionary.checkbox(
             "Select documents:",
             choices=choices,
             validator=lambda choices: True if choices else "You must select at least one document.",
         ).unsafe_ask()
+        return SelectedDocuments(documents, self.status)

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -1126,7 +1126,7 @@ class DocumentSelectStatus:
             return "dms"
         if (
             self.data_set_id is not None
-            or self.metadata_filter is not None
+            or self.metadata_filter
             or (self.ASSET_CENTRIC_PROPERTIES.intersection(self.document_filter.keys()))
         ):
             return "asset-centric"
@@ -1134,9 +1134,9 @@ class DocumentSelectStatus:
 
     @property
     def current_filter(self) -> dict[str, Any] | None:
-        if not self.document_filter and not self.metadata_filter and self.data_set_id is not None:
+        if not self.document_filter and not self.metadata_filter and self.data_set_id is None:
             return None
-        leaf_filter = list(*self.document_filter.values(), *self.metadata_filter.values())
+        leaf_filter = [*self.document_filter.values(), *self.metadata_filter.values()]
         if self.data_set_id is not None:
             leaf_filter.append({"equals": {"property": ["sourceFile", "dataSetId"], "value": self.data_set_id}})
         return {"and": leaf_filter}
@@ -1170,7 +1170,7 @@ class DocumentsInteractiveSelect:
 
     def select_documents(self) -> SelectedDocuments:
         while True:
-            count = self.client.tool.documents.count(filter=self.status.current_filter, query=self._search_query)
+            count = self.client.tool.documents.count(filter=self.status.current_filter, query=self.status.search_query)
             action = self._action(count)
             if action == "abort":
                 raise ToolkitValueError("Aborted document selection.")
@@ -1220,8 +1220,8 @@ class DocumentsInteractiveSelect:
         else:
             suffix = f" You have to filter down to below {self.max_selected} documents to continue."
         query_note = ""
-        if self._search_query is not None:
-            query_note = f' Active full-text query: "{self._search_query}".'
+        if self.status.search_query is not None:
+            query_note = f' Active full-text query: "{self.status.search_query}".'
         caveat = ""
         if selected_file_type == "dms":
             caveat = " (approximate)"
@@ -1242,7 +1242,7 @@ class DocumentsInteractiveSelect:
         ).unsafe_ask()
 
         buckets = self.client.tool.documents.unique(
-            property=filter_type, filter=self.status.current_filter, query=self._search_query
+            property=filter_type, filter=self.status.current_filter, query=self.status.search_query
         )
         self.status.attempted_options.add(filter_type)
         if len(buckets) == 0:
@@ -1265,7 +1265,7 @@ class DocumentsInteractiveSelect:
 
     def _select_dataset(self) -> None:
         buckets = self.client.tool.documents.unique(
-            property=("sourceFile", "dataSetId"), filter=self.status.current_filter, query=self._search_query
+            property=("sourceFile", "dataSetId"), filter=self.status.current_filter, query=self.status.search_query
         )
         internal_ids = [int(bucket.value) for bucket in buckets if isinstance(bucket.value, int | float)]
         if len(internal_ids) == 0:
@@ -1289,7 +1289,9 @@ class DocumentsInteractiveSelect:
 
     def _select_view(self) -> None:
         res = self.client.tool.containers.inspect(
-            [COGNITE_FILE_CONTAINER], all_versions=False, include_unavailable_views=False
+            [ContainerId(**COGNITE_FILE_CONTAINER)],  # type: ignore[arg-type]
+            all_versions=False,
+            include_unavailable_views=False,
         )[0]
         view_id = questionary.select(
             message="Select view to retrieve through",
@@ -1303,19 +1305,19 @@ class DocumentsInteractiveSelect:
             default=self.status.search_query or "",
         ).unsafe_ask()
         stripped = (answer or "").strip()
-        self._search_query = stripped or None
-        count = self.client.tool.documents.count(filter=self.status.current_filter, query=self._search_query)
+        self.status.search_query = stripped or None
+        count = self.client.tool.documents.count(filter=self.status.current_filter, query=self.status.search_query)
         if count == 0:
             self.client.console.print("No documents found. Clearing search query.", style="bold red")
-            self._search_query = None
+            self.status.search_query = None
 
     def _documents_list_or_search(self, *, limit: int) -> SelectedDocuments:
-        if self._search_query is None:
+        if self.status.search_query is None:
             return SelectedDocuments(
                 self.client.tool.documents.list(filter=self.status.current_filter, limit=limit), self.status
             )
         page = self.client.tool.documents.search(
-            query=self._search_query,
+            query=self.status.search_query,
             filter=self.status.current_filter,
             limit=limit,
         )

--- a/tests/test_unit/test_cdf_tk/test_utils/test_interactive_select.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_interactive_select.py
@@ -55,6 +55,7 @@ from cognite_toolkit._cdf_tk.utils.interactive_select import (
     InteractiveChartSelect,
     RawTableInteractiveSelect,
     ResourceViewMappingInteractiveSelect,
+    SelectedDocuments,
     ThreeDInteractiveSelect,
     TimeSeriesInteractiveSelect,
     ViewSelectFilter,
@@ -1284,7 +1285,8 @@ class TestDocumentsInteractiveSelect:
             result = selector.select_documents()
 
         client.tool.documents.list.assert_called_once_with(filter=None, limit=100)
-        assert result == docs
+        assert isinstance(result, SelectedDocuments)
+        assert result.documents == docs
 
     def test_select_documents_abort(self, monkeypatch) -> None:
         answers = ["abort"]
@@ -1319,7 +1321,8 @@ class TestDocumentsInteractiveSelect:
             result = selector.select_documents()
 
         client.tool.documents.list.assert_called_once_with(filter=None, limit=100)
-        assert result == [docs[0]]
+        assert isinstance(result, SelectedDocuments)
+        assert result.documents == [docs[0]]
 
     def test_select_documents_filter_single_bucket_then_finished(self, monkeypatch) -> None:
         docs = self._sample_documents()
@@ -1328,7 +1331,7 @@ class TestDocumentsInteractiveSelect:
             mime_choice = next(c for c in choices if c.value == ("mimeType",))
             return mime_choice.value
 
-        answers = ["filter", pick_mime_type, "finished"]
+        answers = ["filter-document-properties", pick_mime_type, "finished"]
 
         def unique_side_effect(
             property: tuple[str, ...] | tuple[str, str] | tuple[str, str, str],
@@ -1337,7 +1340,7 @@ class TestDocumentsInteractiveSelect:
             if property == ("sourceFile", "metadata"):
                 return []
             if property == ("mimeType",):
-                return [DocumentUniqueBucket(count=4, values=["application/pdf"])]
+                return [DocumentUniqueBucket(count=4, value="application/pdf")]
             raise AssertionError(f"unexpected unique property: {property!r}")
 
         with (
@@ -1352,10 +1355,11 @@ class TestDocumentsInteractiveSelect:
             result = selector.select_documents()
 
         expected_filter = {
-            "and": [{"in": {"property": ["mimeType"], "values": ["application/pdf"]}}],
+            "and": [{"equals": {"property": ["mimeType"], "value": "application/pdf"}}],
         }
         client.tool.documents.list.assert_called_once_with(filter=expected_filter, limit=100)
-        assert result == docs
+        assert isinstance(result, SelectedDocuments)
+        assert result.documents == docs
 
     def test_select_documents_search_then_finished(self, monkeypatch) -> None:
         docs = self._sample_documents()
@@ -1376,4 +1380,5 @@ class TestDocumentsInteractiveSelect:
 
         client.tool.documents.search.assert_called_once_with(query="turbine", filter=None, limit=100)
         client.tool.documents.list.assert_not_called()
-        assert result == docs
+        assert isinstance(result, SelectedDocuments)
+        assert result.documents == docs


### PR DESCRIPTION
# Description

Adds option for downloading to Cognite file

## Running command
<img width="1118" height="443" alt="image" src="https://github.com/user-attachments/assets/da5c094b-9f34-4c9d-9305-e23a6cda0357" />

## Result
<img width="400" height="177" alt="image" src="https://github.com/user-attachments/assets/aa5154ed-63cf-4048-bcad-36856649711d" />

## Caveat
For now, we do not support any extensions of CogniteFile. 

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- [alpha] When running `cdf data download files`, you can now select CogniteFiles.
