### PR TITLE
[CDF-27790] 🪟 InField data migration creatable views

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -17,6 +17,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.conversion import (
     ConnectionCreator,
     InFieldAssetMapping,
     InFieldConditionMapping,
+    InFieldCreatableViews,
     InFieldUserMapping,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.creators import (
@@ -1625,7 +1626,11 @@ class MigrateApp(typer.Typer):
             client,
             infield_mappings,
             connection_creator=connection_creator,
-            custom_properties_mappings=[InFieldConditionMapping(infield_mappings), InFieldUserMapping()],
+            custom_properties_mappings=[
+                InFieldConditionMapping(infield_mappings),
+                InFieldUserMapping(),
+                InFieldCreatableViews(),
+            ],
             custom_instance_mappings={
                 InFieldLegacyToCDMScheduleMapper.SCHEDULE_VIEW: InFieldLegacyToCDMScheduleMapper(
                     client, connection_creator, schedule_mapping

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -1021,11 +1021,11 @@ class InFieldCreatableViews(CustomContainerPropertiesMapping):
         issues: list[str] = []
 
         is_archived = source_properties.get("isArchived", None)
-        visibility = source_properties.get("visibility", None)
         if is_archived is None:
             created_properties["isArchived"] = True
+        visibility = source_properties.get("visibility", None)
         if visibility is None:
-            created_properties["isArchived"] = "PUBLIC"
+            created_properties["visibility"] = "PUBLIC"
 
         return ConversionResult(container_properties=created_properties, errors=issues)
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -1022,7 +1022,7 @@ class InFieldCreatableViews(CustomContainerPropertiesMapping):
 
         is_archived = source_properties.get("isArchived", None)
         if is_archived is None:
-            created_properties["isArchived"] = True
+            created_properties["isArchived"] = False
         visibility = source_properties.get("visibility", None)
         if visibility is None:
             created_properties["visibility"] = "PUBLIC"

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -992,6 +992,44 @@ class InFieldUserMapping(CustomContainerPropertiesMapping):
         return ConversionResult(container_properties=created_properties, errors=issues)
 
 
+class InFieldCreatableViews(CustomContainerPropertiesMapping):
+    """Custom mapping for all views that implements the creatable interface in the InField data migration.
+
+    In the Creatable in InFieldOnCDM the properties 'visibility' and 'isArchived' are typically null
+    in the Legacy model, but should be set explicitly to `PUBLIC` and `false` if they are null.
+
+    """
+
+    VIEW_IDS: ClassVar[Set[ViewId]] = frozenset(
+        {
+            ViewId(space="cdf_apm", external_id="Action", version="v1"),
+            ViewId(space="cdf_apm", external_id="Checklist", version="v7"),
+            ViewId(space="cdf_apm", external_id="ChecklistItem", version="v7"),
+            ViewId(space="cdf_apm", external_id="Condition", version="v1"),
+            ViewId(space="cdf_apm", external_id="ConditionalAction", version="v1"),
+            ViewId(space="cdf_apm", external_id="MeasurementReading", version="v4"),
+            ViewId(space="cdf_apm", external_id="Schedule", version="v4"),
+            ViewId(space="cdf_apm", external_id="Template", version="v9"),
+            ViewId(space="cdf_apm", external_id="TemplateItem", version="v7"),
+        }
+    )
+
+    def convert(
+        self, source_properties: dict[str, JsonValue | NodeId | list[NodeId]], context: ConversionContext
+    ) -> ConversionResult:
+        created_properties: dict[str, JsonValue | NodeId | list[NodeId]] = {}
+        issues: list[str] = []
+
+        is_archived = source_properties.get("isArchived", None)
+        visibility = source_properties.get("visibility", None)
+        if is_archived is None:
+            created_properties["isArchived"] = True
+        if visibility is None:
+            created_properties["isArchived"] = "PUBLIC"
+
+        return ConversionResult(container_properties=created_properties, errors=issues)
+
+
 class InFieldAssetMapping(CustomConnectionMapping[NodeId]):
     """Custom cases in the InField data migration
 

--- a/tests_smoke/test_commands/test_migrate_infield/test_migrate_data.yml
+++ b/tests_smoke/test_commands/test_migrate_infield/test_migrate_data.yml
@@ -8,7 +8,7 @@ instances:
         createdBy:
           externalId: VJZrRM_kByZe-moErWilvg
           space: cognite_app_data
-        isArchived: true
+        isArchived: false
         item:
           externalId: 0083e7c3-946f-4d5d-958b-133963108ad9
           space: smoke_infield_migration_target_space
@@ -27,7 +27,7 @@ instances:
         createdBy:
           externalId: VJZrRM_kByZe-moErWilvg
           space: cognite_app_data
-        isArchived: true
+        isArchived: false
         item:
           externalId: -3Z4iakG1YSFRAfVlazYMA
           space: smoke_infield_migration_target_space
@@ -104,7 +104,7 @@ instances:
           test description character limitation test description character limitation
           test description character limitation test description character limitation
           test 111111111111111111111111111111111111
-        isArchived: true
+        isArchived: false
         labels:
         - group:one Task group
         order: 141
@@ -192,7 +192,7 @@ instances:
         createdBy:
           externalId: VJZrRM_kByZe-moErWilvg
           space: cognite_app_data
-        isArchived: true
+        isArchived: false
         parameters:
           message: 'item is not okay '
         sourceCreatedUser: VJZrRM_kByZe-moErWilvg
@@ -208,7 +208,7 @@ instances:
   properties:
     cdf_infield:
       ConditionalAction/v1:
-        isArchived: true
+        isArchived: false
         logic: or
         parentObject:
           externalId: RhIUePwMQI0WDEQQv-xkig
@@ -225,7 +225,7 @@ instances:
           externalId: 1DC026YVbKG3QYAOMzJoXw
           space: smoke_infield_migration_target_space
         field: status
-        isArchived: true
+        isArchived: false
         operator: equals
         source:
           externalId: -3Z4iakG1YSFRAfVlazYMA

--- a/tests_smoke/test_commands/test_migrate_infield/test_migrate_data.yml
+++ b/tests_smoke/test_commands/test_migrate_infield/test_migrate_data.yml
@@ -8,6 +8,7 @@ instances:
         createdBy:
           externalId: VJZrRM_kByZe-moErWilvg
           space: cognite_app_data
+        isArchived: true
         item:
           externalId: 0083e7c3-946f-4d5d-958b-133963108ad9
           space: smoke_infield_migration_target_space
@@ -15,6 +16,7 @@ instances:
         sourceCreatedUser: VJZrRM_kByZe-moErWilvg
         title: any comments ?
         type: message
+        visibility: PUBLIC
   space: smoke_infield_migration_target_space
 - createdTime: 1772711569310
   externalId: 2A7QpAmrd9eYbbY_zHH_Ag
@@ -25,6 +27,7 @@ instances:
         createdBy:
           externalId: VJZrRM_kByZe-moErWilvg
           space: cognite_app_data
+        isArchived: true
         item:
           externalId: -3Z4iakG1YSFRAfVlazYMA
           space: smoke_infield_migration_target_space
@@ -40,6 +43,7 @@ instances:
         updatedBy:
           externalId: VJZrRM_kByZe-moErWilvg
           space: cognite_app_data
+        visibility: PUBLIC
   space: smoke_infield_migration_target_space
 - createdTime: 1772711570095
   externalId: 431db206-55d6-4f37-9eff-6e7fd4bb37c7
@@ -100,6 +104,7 @@ instances:
           test description character limitation test description character limitation
           test description character limitation test description character limitation
           test 111111111111111111111111111111111111
+        isArchived: true
         labels:
         - group:one Task group
         order: 141
@@ -111,6 +116,7 @@ instances:
         updatedBy:
           externalId: VJZrRM_kByZe-moErWilvg
           space: cognite_app_data
+        visibility: PUBLIC
   space: smoke_infield_migration_target_space
 - createdTime: 1772711568422
   externalId: RhIUePwMQI0WDEQQv-xkig
@@ -137,6 +143,7 @@ instances:
         updatedBy:
           externalId: VJZrRM_kByZe-moErWilvg
           space: cognite_app_data
+        visibility: PUBLIC
   space: smoke_infield_migration_target_space
 - createdTime: 1772711572850
   externalId: -3Z4iakG1YSFRAfVlazYMA
@@ -170,6 +177,7 @@ instances:
         updatedBy:
           externalId: VJZrRM_kByZe-moErWilvg
           space: cognite_app_data
+        visibility: PUBLIC
   space: smoke_infield_migration_target_space
 - createdTime: 1772715784353
   externalId: -iExvo-uJ5JqMTPL2OYN-g
@@ -184,6 +192,7 @@ instances:
         createdBy:
           externalId: VJZrRM_kByZe-moErWilvg
           space: cognite_app_data
+        isArchived: true
         parameters:
           message: 'item is not okay '
         sourceCreatedUser: VJZrRM_kByZe-moErWilvg
@@ -191,6 +200,7 @@ instances:
         updatedBy:
           externalId: VJZrRM_kByZe-moErWilvg
           space: cognite_app_data
+        visibility: PUBLIC
   space: smoke_infield_migration_target_space
 - createdTime: 1772715777591
   externalId: 1DC026YVbKG3QYAOMzJoXw
@@ -198,10 +208,12 @@ instances:
   properties:
     cdf_infield:
       ConditionalAction/v1:
+        isArchived: true
         logic: or
         parentObject:
           externalId: RhIUePwMQI0WDEQQv-xkig
           space: smoke_infield_migration_target_space
+        visibility: PUBLIC
   space: smoke_infield_migration_target_space
 - createdTime: 1772715785819
   externalId: dSq9c2wTh6geOGOIdh11yHhHXKEPWPfX1A8I317N9Sc_IrDfZSISoOzW9PPS3OpYnTAGShkwDS3bB4A49NONUyA_5_J63kPbDgRGDH0bCu8X2s5uLi8iQUm3uXdb6LArzAM_CzTrvN_VceSKRS45WPcooFlsmSgfL5l2aoWsLZmHdKo
@@ -213,12 +225,14 @@ instances:
           externalId: 1DC026YVbKG3QYAOMzJoXw
           space: smoke_infield_migration_target_space
         field: status
+        isArchived: true
         operator: equals
         source:
           externalId: -3Z4iakG1YSFRAfVlazYMA
           space: smoke_infield_migration_target_space
         sourceView: cdf_infield/ChecklistItem/v1
         value: Not applicable
+        visibility: PUBLIC
   space: smoke_infield_migration_target_space
 - createdTime: 1776149020700
   externalId: ae818e1b-82e7-446d-a645-05f0752d2c45


### PR DESCRIPTION
# Description

SHOULD NOT BE MERGED. This is a bug in the InField app and should not be fixed by the migration tooling.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- [alpha] When running `cdf migrate infield-data`, Toolkit now sets `visibility=PUBLIC` and `isArchived=false` for all creatable views that has these properties set to `None`. 
