### PR TITLE
[CDF-27798] Fix false 'source files changed' error for files with special characters (°, %)

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_lineage.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_lineage.py
@@ -25,7 +25,7 @@ from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import (
 )
 from cognite_toolkit._cdf_tk.constants import BUILD_FOLDER_ENCODING
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValidationError, ToolkitYAMLFormatError
-from cognite_toolkit._cdf_tk.utils import calculate_hash, read_yaml_content, safe_read
+from cognite_toolkit._cdf_tk.utils import calculate_hash, read_yaml_content
 from cognite_toolkit._cdf_tk.validation import humanize_validation_error
 
 from ._module import ResourceType
@@ -208,7 +208,7 @@ class BuildLineage(_BaseLineageModel):
 
         Reads each source file tracked in the lineage and compares its current hash
         with the stored hash from build time. Uses the same hashing method as
-        BuildV2Command (calculate_hash with shorten=True on file content read via safe_read).
+        BuildV2Command (calculate_hash with shorten=True on the raw file Path).
 
         Raises:
             ToolkitValidationError: If any source file has changed or is missing.
@@ -224,12 +224,10 @@ class BuildLineage(_BaseLineageModel):
                     continue
 
                 try:
-                    content = safe_read(source_file)
+                    current_hash = calculate_hash(source_file, shorten=True)
                 except Exception:
                     missing_files.append(source_file.as_posix())
                     continue
-
-                current_hash = calculate_hash(content, shorten=True)
 
                 if current_hash != resource.source_hash:
                     changed_files.append(source_file.as_posix())

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_data_classes.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_data_classes.py
@@ -7,7 +7,12 @@ from pydantic import TypeAdapter
 
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import BuildVariable, RelativeDirPath
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._lineage import ResourceLineageItem
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._lineage import (
+    BuildLineage,
+    ModuleLineageItem,
+    ResourceLineageItem,
+)
+from cognite_toolkit._cdf_tk.utils import calculate_hash
 
 
 @pytest.fixture(scope="session")
@@ -250,3 +255,49 @@ class TestBuildLinage:
         }
         linage = ResourceLineageItem.model_validate(data)
         assert isinstance(linage.identifier, ExternalId)
+
+    @pytest.mark.parametrize(
+        "special_content",
+        [
+            pytest.param("description: Temperature in °C\nname: My View °", id="degree_symbol"),
+            pytest.param("description: Completion is 50% done\nname: Progress %", id="percent_symbol"),
+        ],
+    )
+    def test_validate_source_files_unchanged_special_chars(self, tmp_path: Path, special_content: str) -> None:
+        """Regression test: files with special characters must not trigger false hash mismatches.
+
+        The build-time hash uses raw bytes (calculate_hash with a Path).
+        The validation-time hash must use the same method, not safe_read which
+        can produce different bytes when file_encoding != UTF-8.
+        """
+        source_file = tmp_path / "my_view.view.yaml"
+        source_file.write_bytes(special_content.encode("utf-8"))
+        built_file = tmp_path / "1-my_view.view.yaml"
+        built_file.touch()
+
+        build_hash = calculate_hash(source_file, shorten=True)
+
+        lineage = BuildLineage(
+            organization_dir=tmp_path,
+            build_dir=tmp_path,
+            modules_summary={"processed": 1, "succeeded": 1, "failed": 0},
+            insights_summary={},
+            module_lineage=[
+                ModuleLineageItem(
+                    module_id="modules/my_module",
+                    module_path=tmp_path,
+                    insights_summary={},
+                    resource_lineage=[
+                        ResourceLineageItem(
+                            source_file=source_file,
+                            source_hash=build_hash,
+                            type={"resource_folder": "data_models", "kind": "View"},
+                            built_file=built_file,
+                            identifier={"space": "my_space", "externalId": "MyView", "version": "1"},
+                        )
+                    ],
+                )
+            ],
+        )
+
+        lineage.validate_source_files_unchanged()


### PR DESCRIPTION
# Description

In v0.8.x, data model YAML files containing multi-byte UTF-8 characters
(e.g. degree symbol `°` or percent `%`) in description/name fields
incorrectly triggered a `ToolkitValidationError: Source files have changed
since the build` during deployment, even when no changes were made.

**Root cause:** `validate_source_files_unchanged` computed the current
file hash by reading the file as text via `safe_read` (which respects
`file_encoding` from `cdf.toml`, defaulting to the system encoding), then
re-encoding the string to UTF-8. The build-time hash is computed from raw
bytes via `calculate_hash(path, shorten=True)`. When `file_encoding` is
non-UTF-8 (e.g. `cp1252` on Windows), multi-byte characters decode to
different code points and re-encode to different UTF-8 bytes, producing a
hash mismatch.

**Fix:** Pass the `Path` object directly to `calculate_hash` in
`validate_source_files_unchanged`, exactly matching what the build does.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- `ToolkitValidationError: Source files have changed since the build` was
  incorrectly raised when source YAML files for data models contained
  special characters such as `°` or `%` and the system or configured file
  encoding was not UTF-8.