### PR TITLE
[CDF-27797] Fix Streamlit app code not re-uploaded on deploy

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/file.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/file.py
@@ -220,21 +220,22 @@ class FileMetadataCRUD(ResourceContainerIO[ExternalId, FileMetadataRequest, File
         return self.client.tool.filemetadata.retrieve(list(ids), ignore_unknown_ids=True)
 
     def update(self, items: Sequence[FileMetadataRequest]) -> list[FileMetadataResponse]:
+        pre_update_hash_by_id: dict[str, str | None] = {}
+        if self.support_upload:
+            # Read hashes before updating — the update payload overwrites them, making
+            # a post-update comparison always equal and preventing re-upload.
+            ids_to_retrieve = [ExternalId(external_id=item.external_id) for item in items if item.external_id]
+            for r in self.retrieve(ids_to_retrieve):
+                if r.external_id is not None:
+                    pre_update_hash_by_id[r.external_id] = (r.metadata or {}).get(self._MetadataKey.FILECONTENT_HASH)
+
         responses = self.client.tool.filemetadata.update(items, mode="replace")
         if self.support_upload:
-            response_by_external_id = {
-                response.external_id: response for response in responses if response.external_id is not None
-            }
             for item in items:
-                if not (item.external_id and item.external_id in response_by_external_id):
+                if not item.external_id:
                     continue
-                response = response_by_external_id[item.external_id]
-                if (
-                    item.filepath
-                    and (response.metadata or {}).get(self._MetadataKey.FILECONTENT_HASH)
-                    != (item.metadata or {})[self._MetadataKey.FILECONTENT_HASH]
-                ):
-                    # Need to reupload the file content
+                local_hash = (item.metadata or {}).get(self._MetadataKey.FILECONTENT_HASH)
+                if item.filepath and local_hash != pre_update_hash_by_id.get(item.external_id):
                     responses_with_url = self.client.tool.filemetadata.get_upload_url([item.as_id()])
                     if len(responses_with_url) != 1:
                         raise RuntimeError(

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/industrial_tool.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/industrial_tool.py
@@ -318,6 +318,14 @@ class StreamlitIO(ResourceIO[ExternalId, StreamlitRequest, StreamlitResponse]):
         file_request_by_external_id = {
             cast(str, file.external_id): file for file in fileio.load_resource_files(filepaths)
         }
+        # Read hashes before updating — the update payload overwrites them, making
+        # a post-update comparison always equal and preventing re-upload.
+        current_cdf = fileio.retrieve([ExternalId(external_id=eid) for eid in file_request_by_external_id])
+        pre_update_hash_by_id: dict[str, str | None] = {
+            r.external_id: (r.metadata or {}).get(self._metadata_hash_key)
+            for r in current_cdf
+            if r.external_id is not None
+        }
         file_responses = fileio.update(list(file_request_by_external_id.values()))
         response_by_external_id = {
             response.external_id: StreamlitResponse.model_validate(response.dump()) for response in file_responses
@@ -325,14 +333,12 @@ class StreamlitIO(ResourceIO[ExternalId, StreamlitRequest, StreamlitResponse]):
         for item in items:
             if item.external_id not in response_by_external_id or item.external_id not in file_request_by_external_id:
                 continue
-            response = response_by_external_id[item.external_id]
             request = file_request_by_external_id[item.external_id]
-            if item.cognite_toolkit_app_hash == response.cognite_toolkit_app_hash:
+            if item.cognite_toolkit_app_hash == pre_update_hash_by_id.get(item.external_id):
                 # Unchanged App
                 continue
             if request.filepath is None:
                 raise ResourceUpdateError(f"Cannot update streamlit app {item.external_id}. Missing source file")
-            # Need to reupload the file content
             responses_with_url = self.client.tool.filemetadata.get_upload_url([request.as_id()])
             if len(responses_with_url) != 1:
                 raise RuntimeError(

--- a/tests/test_unit/approval_client/client.py
+++ b/tests/test_unit/approval_client/client.py
@@ -199,6 +199,10 @@ class ApprovalToolkitClient:
 
         # All files are uploaded successfully
         self.mock_client.tool.filemetadata.await_file_uploaded.return_value = set(), 0.0
+        # Return a single (no-op) upload URL response so the update-upload path doesn't raise
+        self.mock_client.tool.filemetadata.get_upload_url.return_value = [
+            FileMetadataResponse(id=1, uploaded=False, created_time=0, last_updated_time=0, name="file")
+        ]
 
         # Use Hybrid project
         return_list = ProjectStatusList([ProjectStatus(url_name=project, data_modeling_status="HYBRID")])

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_file_metadata.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_file_metadata.py
@@ -111,3 +111,42 @@ class TestLoadResources:
             "name": "my_file.txt",
             "mimeType": "text/plain",
         }
+
+
+class TestFileMetadataCRUDUpdate:
+    @pytest.mark.parametrize(
+        "cdf_hash, local_hash, expect_upload",
+        [
+            pytest.param("old", "new", True, id="hash_changed_triggers_reupload"),
+            pytest.param("same", "same", False, id="hash_unchanged_skips_reupload"),
+        ],
+    )
+    def test_reupload_based_on_hash(self, cdf_hash: str, local_hash: str, expect_upload: bool) -> None:
+        mock_client = MagicMock()
+        fileio = FileMetadataCRUD(mock_client, None, None, support_upload=True)
+
+        def _response(h: str) -> FileMetadataResponse:
+            return FileMetadataResponse(
+                external_id="f",
+                name="f.txt",
+                id=1,
+                created_time=0,
+                last_updated_time=0,
+                uploaded=True,
+                metadata={FileMetadataCRUD._MetadataKey.FILECONTENT_HASH: h},
+            )
+
+        mock_client.tool.filemetadata.retrieve.return_value = [_response(cdf_hash)]
+        mock_client.tool.filemetadata.update.return_value = [_response(local_hash)]
+        upload_resp = MagicMock(filepath=MagicMock(spec=Path), upload_url="https://upload.example.com", mime_type=None)
+        mock_client.tool.filemetadata.get_upload_url.return_value = [upload_resp]
+
+        item = FileMetadataRequest(
+            external_id="f",
+            name="f.txt",
+            metadata={FileMetadataCRUD._MetadataKey.FILECONTENT_HASH: local_hash},
+            filepath=MagicMock(spec=Path),
+        )
+        fileio.update([item])
+
+        assert mock_client.tool.filemetadata.upload_file.called == expect_upload

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_industrial_tool.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_industrial_tool.py
@@ -1,7 +1,12 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 import pytest
 from cognite.client import _version as CogniteSDKVersion
 from packaging.requirements import Requirement
 
+from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.streamlit_ import StreamlitRequest
 from cognite_toolkit._cdf_tk.resource_ios._resource_ios.industrial_tool import StreamlitIO
 from cognite_toolkit._cdf_tk.tk_warnings import StreamlitRequirementsWarning
 
@@ -37,3 +42,57 @@ class TestStreamlitLoader:
     def test_requirements_file_missing_packages(self, mock_content, expected_result) -> None:
         actual = StreamlitIO._missing_recommended_requirements(mock_content)
         assert set(actual) == set(expected_result)
+
+
+class TestStreamlitUpdateWithFileio:
+    def _file_response(self, external_id: str, app_hash: str | None) -> FileMetadataResponse:
+        return FileMetadataResponse(
+            external_id=external_id,
+            name=f"{external_id}-source.json",
+            id=1,
+            created_time=0,
+            last_updated_time=0,
+            uploaded=True,
+            metadata={
+                "creator": "tester",
+                "entrypoint": "app.py",
+                **({StreamlitIO._metadata_hash_key: app_hash} if app_hash else {}),
+            },
+        )
+
+    @pytest.mark.parametrize(
+        "cdf_hash, local_hash, expect_upload",
+        [
+            pytest.param("old", "new", True, id="hash_changed_triggers_reupload"),
+            pytest.param("same", "same", False, id="hash_unchanged_skips_reupload"),
+        ],
+    )
+    def test_reupload_based_on_hash(self, cdf_hash: str, local_hash: str, expect_upload: bool) -> None:
+        mock_client = MagicMock()
+        loader = StreamlitIO(mock_client, None, None, use_fileio=True)
+        ext_id = "stapp-test"
+        loader.filemetadata_by_external_id[ext_id] = MagicMock(spec=Path)
+
+        item = StreamlitRequest(
+            external_id=ext_id,
+            name="Test App",
+            creator="tester",
+            entrypoint="app.py",
+            cognite_toolkit_app_hash=local_hash,
+        )
+        source_file = MagicMock(spec=Path)
+        file_request = MagicMock(external_id=ext_id, filepath=source_file)
+        file_request.as_id.return_value = MagicMock(external_id=ext_id)
+
+        with patch("cognite_toolkit._cdf_tk.resource_ios._resource_ios.industrial_tool.FileMetadataCRUD") as MockCRUD:
+            mock_fileio = MagicMock()
+            MockCRUD.return_value = mock_fileio
+            mock_fileio.load_resource_files.return_value = [file_request]
+            mock_fileio.retrieve.return_value = [self._file_response(ext_id, cdf_hash)]
+            mock_fileio.update.return_value = [self._file_response(ext_id, local_hash)]
+            mock_client.tool.filemetadata.get_upload_url.return_value = [
+                MagicMock(upload_url="https://upload.example.com")
+            ]
+            loader._update_with_fileio([item])
+
+        assert mock_client.tool.filemetadata.upload_file.called == expect_upload

--- a/tests/test_unit/utils.py
+++ b/tests/test_unit/utils.py
@@ -81,7 +81,8 @@ def mock_read_yaml_file(
         if file_content := file_content_by_name.get(filepath.name):
             if modify:
                 source = read_yaml_file(filepath, expected_output)
-                source.update(file_content)
+                if isinstance(source, dict):
+                    source.update(file_content)
                 file_content = source
             return file_content
         return read_yaml_file(filepath, expected_output)
@@ -102,7 +103,8 @@ def mock_read_yaml_file(
                 source = load_yaml_inject_variables(
                     filepath, environment_variables, required_return_type, validate, original_filepath
                 )
-                source.update(file_content)
+                if isinstance(source, dict):
+                    source.update(file_content)
                 file_content = source
             return file_content
         return load_yaml_inject_variables(
@@ -132,8 +134,8 @@ class PrintCapture:
     # Find all text within square brackets
     _pattern = re.compile(r"\[([^]]+)\]")
 
-    def __init__(self):
-        self.messages = []
+    def __init__(self) -> None:
+        self.messages: list[str] = []
 
     def __call__(
         self,
@@ -142,7 +144,7 @@ class PrintCapture:
         end: str = "\n",
         file: IO[str] | None = None,
         flush: bool = False,
-    ):
+    ) -> None:
         for obj in objects:
             if isinstance(obj, str) and (clean := self._pattern.sub("", obj).strip()):
                 # Remove square brackets and whitespace. This is to take
@@ -197,8 +199,8 @@ class FakeCogniteResourceGenerator:
         self._max_string_length = max_string_length
 
     def create_instances(self, list_cls: type[T_Object], skip_defaulted_args: bool = False) -> T_Object:
-        return list_cls(
-            [self.create_instance(list_cls._RESOURCE, skip_defaulted_args) for _ in range(self._max_list_dict_items)]
+        return list_cls(  # type: ignore[call-arg]
+            [self.create_instance(list_cls._RESOURCE, skip_defaulted_args) for _ in range(self._max_list_dict_items)]  # type: ignore[attr-defined]
         )
 
     def create_instance(self, resource_cls: type[T_Object], skip_defaulted_args: bool = False) -> T_Object:
@@ -211,7 +213,7 @@ class FakeCogniteResourceGenerator:
             return self.create_instance(first_not_none, skip_defaulted_args)
 
         if issubclass(resource_cls, BaseModel):
-            return self.create_pydantic_instance(resource_cls, skip_defaulted_args)
+            return self.create_pydantic_instance(resource_cls, skip_defaulted_args)  # type: ignore[return-value]
 
         is_abstract = any(base is abc.ABC for base in resource_cls.__bases__)
         if is_abstract:
@@ -347,7 +349,7 @@ class FakeCogniteResourceGenerator:
                 keyword_arguments["is_list"] = True
         elif resource_cls is ZoneInfo:
             # ZoneInfo does not allow setting any parameters
-            return ZoneInfo("UTC")
+            return ZoneInfo("UTC")  # type: ignore[return-value]
         return resource_cls(*positional_arguments, **keyword_arguments)
 
     def create_pydantic_instance(self, model_cls: type[BaseModel], skip_defaulted_args: bool = False) -> BaseModel:
@@ -379,7 +381,7 @@ class FakeCogniteResourceGenerator:
         import numpy as np
 
         if isinstance(type_, typing.ForwardRef):
-            type_ = type_._evaluate(globals(), self._type_checking())
+            type_ = type_._evaluate(globals(), self._type_checking(), ())  # type: ignore[call-arg]
         if inspect.isclass(type_) and issubclass(type_, BaseModel):
             return self.create_pydantic_instance(type_)
 
@@ -486,7 +488,7 @@ class FakeCogniteResourceGenerator:
                     implementations.remove(LegacyCapability)
             if type_ is WorkflowTaskOutput:
                 # For Workflow Output has to match the input type
-                selected = FunctionTaskOutput
+                selected: Any = FunctionTaskOutput
             elif type_ is WorkflowTaskParameters:
                 selected = FunctionTaskParameters
             else:
@@ -594,7 +596,7 @@ class MockQuestion:
         self.choices = choices
 
     def unsafe_ask(self) -> Any:
-        if isinstance(self.answer, Callable):
+        if callable(self.answer):
             return self.answer(self.choices)
         return self.answer
 
@@ -612,25 +614,25 @@ class MockQuestionary:
         self.answers = answers
         self.monkeypatch = monkeypatch
 
-    def select(self, _: str, choices: list[Choice] | None = None, **__) -> MockQuestion:
+    def select(self, _: str, choices: list[Choice] | None = None, **__: Any) -> MockQuestion:
         return MockQuestion(self.answers.pop(0), choices)
 
-    def confirm(self, *_, **__) -> MockQuestion:
+    def confirm(self, *_: Any, **__: Any) -> MockQuestion:
         return MockQuestion(self.answers.pop(0))
 
-    def checkbox(self, *_, choices: list[Choice], **__) -> MockQuestion:
+    def checkbox(self, *_: Any, choices: list[Choice], **__: Any) -> MockQuestion:
         return MockQuestion(self.answers.pop(0), choices)
 
-    def text(self, *_, **__) -> MockQuestion:
+    def text(self, *_: Any, **__: Any) -> MockQuestion:
         return MockQuestion(self.answers.pop(0))
 
-    def __enter__(self):
+    def __enter__(self) -> MockQuestionary:
         for method in [self.select, self.confirm, self.checkbox, self.text]:
             for module_target in self.module_targets:
                 self.monkeypatch.setattr(f"{module_target}.questionary.{method.__name__}", method)
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any) -> Literal[False]:
         self.monkeypatch.undo()
         return False
 
@@ -638,10 +640,10 @@ class MockQuestionary:
     def select_all(choices: list[Choice]) -> list[str]:
         if not choices:
             return []
-        return [choice.value for choice in choices]
+        return [choice.value for choice in choices if choice.value is not None]
 
 
-def find_resources(resource: str, resource_dir: str | None = None, base: Path = COMPLETE_ORG / MODULES):
+def find_resources(resource: str, resource_dir: str | None = None, base: Path = COMPLETE_ORG / MODULES) -> Any:
     for path in base.rglob(f"*{resource}.yaml"):
         if resource_dir and resource_dir not in path.parts:
             continue


### PR DESCRIPTION
# Description

Fixes a regression introduced in v0.8.33 where Streamlit app code changes were not reflected after `cdf deploy`. First run reported "1 updated" but code was unchanged; second run reported "1 unchanged".

**Root cause:** `StreamlitIO._update_with_fileio` and `FileMetadataCRUD.update` both compared the file hash against the CDF response *after* the metadata update. Since the update payload includes the new hash, the response always reflected the new hash — making the comparison always equal and skipping the blob re-upload.

**Fix:** Retrieve the current CDF state before calling `update()` in both methods, and compare local hashes against those pre-update values.

Also fixes pre-existing mypy errors in `tests/test_unit/utils.py` and adds a `get_upload_url` mock to `ApprovalToolkitClient`.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Streamlit app code changes are now correctly re-uploaded when the app hash has changed during `cdf deploy` (regression in v0.8.33).
- File content is no longer skipped on update in `FileMetadataCRUD` when the file hash changed.