### PR TITLE
fix: correct spelling ToolkitGlobalRulSet → ToolkitGlobalRuleSet

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -62,7 +62,7 @@ from cognite_toolkit._cdf_tk.resource_ios import (
     ResourceIO,
 )
 from cognite_toolkit._cdf_tk.resource_ios._base_ios import FailedReadExtra, ReadExtra, SuccessExtra
-from cognite_toolkit._cdf_tk.rules import LocalRulesOrchestrator, ToolkitGlobalRulSet, get_global_rules_registry
+from cognite_toolkit._cdf_tk.rules import LocalRulesOrchestrator, ToolkitGlobalRuleSet, get_global_rules_registry
 from cognite_toolkit._cdf_tk.rules._base import FailedValidation, RuleSetStatus
 from cognite_toolkit._cdf_tk.utils import calculate_hash, humanize_collection, safe_write
 from cognite_toolkit._cdf_tk.utils.file import (
@@ -78,7 +78,7 @@ from cognite_toolkit._cdf_tk.yaml_classes import ToolkitResource
 @dataclass
 class ValidationStep:
     status: RuleSetStatus
-    rule: ToolkitGlobalRulSet
+    rule: ToolkitGlobalRuleSet
 
 
 class BuildV2Command(ToolkitCommand):

--- a/cognite_toolkit/_cdf_tk/rules/__init__.py
+++ b/cognite_toolkit/_cdf_tk/rules/__init__.py
@@ -1,5 +1,5 @@
 from ._auth import CheckDataSetMissing
-from ._base import ToolkitGlobalRulSet, ToolkitLocalRule
+from ._base import ToolkitGlobalRuleSet, ToolkitLocalRule
 from ._dependencies import DependencyRuleSet
 from ._functions import FunctionRules
 from ._neat import NeatRuleSet
@@ -11,8 +11,8 @@ __all__ = [
     "FunctionRules",
     "LocalRulesOrchestrator",
     "NeatRuleSet",
-    "ToolkitGlobalRulSet",
-    "ToolkitGlobalRulSet",
+    "ToolkitGlobalRuleSet",
+    "ToolkitGlobalRuleSet",
     "ToolkitLocalRule",
     "get_global_rules_registry",
 ]

--- a/cognite_toolkit/_cdf_tk/rules/_base.py
+++ b/cognite_toolkit/_cdf_tk/rules/_base.py
@@ -44,7 +44,7 @@ class RuleSetStatus(BaseModel):
     message: str | None = None
 
 
-class ToolkitGlobalRulSet(ABC):
+class ToolkitGlobalRuleSet(ABC):
     """Validation of all modules as a whole.
 
     This can output different

--- a/cognite_toolkit/_cdf_tk/rules/_dependencies.py
+++ b/cognite_toolkit/_cdf_tk/rules/_dependencies.py
@@ -7,10 +7,10 @@ from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import Con
 from cognite_toolkit._cdf_tk.resource_ios import ResourceIO
 from cognite_toolkit._cdf_tk.utils.file import relative_to_if_possible
 
-from ._base import FailedValidation, RuleSetStatus, ToolkitGlobalRulSet
+from ._base import FailedValidation, RuleSetStatus, ToolkitGlobalRuleSet
 
 
-class DependencyRuleSet(ToolkitGlobalRulSet):
+class DependencyRuleSet(ToolkitGlobalRuleSet):
     CODE_PREFIX = "MISSING-DEPENDENCY"
     DISPLAY_NAME = "dependencies"
 

--- a/cognite_toolkit/_cdf_tk/rules/_functions.py
+++ b/cognite_toolkit/_cdf_tk/rules/_functions.py
@@ -6,13 +6,13 @@ from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import ResourceType
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltResource, FailedValidation
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import ConsistencyError
 from cognite_toolkit._cdf_tk.resource_ios import FunctionIO
-from cognite_toolkit._cdf_tk.rules._base import RuleSetStatus, ToolkitGlobalRulSet
+from cognite_toolkit._cdf_tk.rules._base import RuleSetStatus, ToolkitGlobalRuleSet
 from cognite_toolkit._cdf_tk.utils import validate_requirements_with_pip
 from cognite_toolkit._cdf_tk.utils.file import read_yaml_file
 from cognite_toolkit._cdf_tk.yaml_classes.functions import FunctionsYAML
 
 
-class FunctionRules(ToolkitGlobalRulSet):
+class FunctionRules(ToolkitGlobalRuleSet):
     CODE_PREFIX = "FUNCTION"
     DISPLAY_NAME = "Functions checks"
 

--- a/cognite_toolkit/_cdf_tk/rules/_neat.py
+++ b/cognite_toolkit/_cdf_tk/rules/_neat.py
@@ -13,13 +13,13 @@ from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import (
 )
 from cognite_toolkit._cdf_tk.resource_ios import DataModelIO
 
-from ._base import FailedValidation, RuleSetStatus, ToolkitGlobalRulSet
+from ._base import FailedValidation, RuleSetStatus, ToolkitGlobalRuleSet
 
 if TYPE_CHECKING:
     from cognite.neat._toolkit_adapter import NeatClient, NeatIssueList, SchemaLimits, SchemaSnapshot
 
 
-class NeatRuleSet(ToolkitGlobalRulSet):
+class NeatRuleSet(ToolkitGlobalRuleSet):
     CODE_PREFIX = "NEAT"
     DISPLAY_NAME = "Neat (data modeling)"
 

--- a/cognite_toolkit/_cdf_tk/rules/_orchestrator.py
+++ b/cognite_toolkit/_cdf_tk/rules/_orchestrator.py
@@ -2,11 +2,11 @@ from collections.abc import Set
 
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import Insight
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._module import Module
-from cognite_toolkit._cdf_tk.rules._base import ToolkitGlobalRulSet, ToolkitLocalRule
+from cognite_toolkit._cdf_tk.rules._base import ToolkitGlobalRuleSet, ToolkitLocalRule
 from cognite_toolkit._cdf_tk.utils._auxiliary import get_concrete_subclasses
 
 _LOCAL_RULES_REGISTRY: list[type[ToolkitLocalRule]] | None = None
-_GLOBAL_RULES_REGISTRY: list[type[ToolkitGlobalRulSet]] | None = None
+_GLOBAL_RULES_REGISTRY: list[type[ToolkitGlobalRuleSet]] | None = None
 
 
 def get_local_rules_registry(force_reload: bool = False) -> list[type[ToolkitLocalRule]]:
@@ -24,11 +24,11 @@ def get_local_rules_registry(force_reload: bool = False) -> list[type[ToolkitLoc
     return _LOCAL_RULES_REGISTRY
 
 
-def get_global_rules_registry(force_reload: bool = False) -> list[type[ToolkitGlobalRulSet]]:
+def get_global_rules_registry(force_reload: bool = False) -> list[type[ToolkitGlobalRuleSet]]:
     """Get the registry of rules, optionally forcing a reload."""
     global _GLOBAL_RULES_REGISTRY
     if _GLOBAL_RULES_REGISTRY is None or force_reload:
-        _GLOBAL_RULES_REGISTRY = list(get_concrete_subclasses(ToolkitGlobalRulSet))  # type: ignore[type-abstract]
+        _GLOBAL_RULES_REGISTRY = list(get_concrete_subclasses(ToolkitGlobalRuleSet))  # type: ignore[type-abstract]
     return _GLOBAL_RULES_REGISTRY
 
 


### PR DESCRIPTION
# Description

Fixes a typo in the class name `ToolkitGlobalRulSet` → `ToolkitGlobalRuleSet` across 7 files.

## Bump

- [ ] Patch
- [x] Skip

## Changelog

### Fixed

- Corrected spelling of `ToolkitGlobalRulSet` to `ToolkitGlobalRuleSet`