### PR TITLE
[CDF-27811] 😀Purge logging tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -321,3 +321,4 @@ deploy_logs*/
 tests/data/**/__pycache__/
 build_info.dev.yaml
 tests/data/run_data/function_local_venvs*/**
+purge_logs*/

--- a/cognite_toolkit/_cdf_tk/apps/_purge.py
+++ b/cognite_toolkit/_cdf_tk/apps/_purge.py
@@ -319,7 +319,6 @@ class PurgeApp(typer.Typer):
             Path,
             typer.Option(
                 "--log-dir",
-                "-l",
                 help="Path to the directory where logs will be stored. If the directory does not exist, it will be created.",
             ),
         ] = Path(f"purge_logs_{TODAY!s}"),

--- a/cognite_toolkit/_cdf_tk/apps/_purge.py
+++ b/cognite_toolkit/_cdf_tk/apps/_purge.py
@@ -1,3 +1,4 @@
+from datetime import date
 from enum import Enum
 from pathlib import Path
 from typing import Annotated, Any
@@ -23,6 +24,8 @@ from cognite_toolkit._cdf_tk.utils.interactive_select import (
     ViewSelectFilter,
 )
 from cognite_toolkit._cdf_tk.utils.validate_access import ValidateAccess
+
+TODAY = date.today()
 
 
 class InstanceTypeEnum(str, Enum):
@@ -312,6 +315,14 @@ class PurgeApp(typer.Typer):
                 "themselves, not the links to their parent nodes.",
             ),
         ] = True,
+        log_dir: Annotated[
+            Path,
+            typer.Option(
+                "--log-dir",
+                "-l",
+                help="Path to the directory where logs will be stored. If the directory does not exist, it will be created.",
+            ),
+        ] = Path(f"purge_logs_{TODAY!s}"),
         auto_yes: Annotated[
             bool,
             typer.Option(
@@ -381,6 +392,7 @@ class PurgeApp(typer.Typer):
                 selector=selector,
                 unlink=unlink,
                 dry_run=dry_run,
+                log_dir=log_dir,
                 verbose=verbose,
             )
         )

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -911,6 +911,7 @@ class PurgeCommand(ToolkitCommand):
         logger: FileWithAggregationLogger,
     ) -> None:
         if dry_run:
+            logger.apply_to_all_unprocessed("Ready to delete", Severity.info)
             return
 
         responses = delete_client.request_items_retries(

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -2,7 +2,9 @@ import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
+from datetime import date
 from functools import partial
+from pathlib import Path
 from typing import Any, Literal, cast
 
 import questionary
@@ -34,7 +36,7 @@ from cognite_toolkit._cdf_tk.client.request_classes.filters import ContainerFilt
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import NodeId, NodeResponse, SpaceId
 from cognite_toolkit._cdf_tk.constants import DMS_SOFT_DELETED_INSTANCE_LIMIT_MARGIN
 from cognite_toolkit._cdf_tk.data_classes import DeployResults, ResourceDeployResult
-from cognite_toolkit._cdf_tk.dataio import InstanceIO
+from cognite_toolkit._cdf_tk.dataio import InstanceIO, Page
 from cognite_toolkit._cdf_tk.dataio.selectors import InstanceSelector
 from cognite_toolkit._cdf_tk.exceptions import (
     AuthorizationError,
@@ -80,6 +82,8 @@ from cognite_toolkit._cdf_tk.utils.producer_worker import ProducerWorkerExecutor
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 from cognite_toolkit._cdf_tk.utils.validate_access import ValidateAccess
 
+from ..dataio.logger import FileWithAggregationLogger, LogEntryV2, Severity, display_item_results
+from ..utils.fileio import NDJsonWriter, Uncompressed
 from ._base import ToolkitCommand
 
 
@@ -727,6 +731,7 @@ class PurgeCommand(ToolkitCommand):
         self,
         client: ToolkitClient,
         selector: InstanceSelector,
+        log_dir: Path,
         dry_run: bool = False,
         unlink: bool = True,
         verbose: bool = False,
@@ -764,18 +769,34 @@ class PurgeCommand(ToolkitCommand):
             if not confirm_purge:
                 return DeleteResults()
 
-        process: Callable[[Sequence[InstanceDefinitionId]], list[dict[str, JsonVal]]] = self._prepare
-        if unlink:
-            process = partial(self._unlink_prepare, client=client, dry_run=dry_run, console=console, verbose=verbose)
+        log_filestem = f"purge_{date.today().strftime('%Y%m%d')}"
+        with (
+            HTTPClient(config=client.config) as delete_client,
+            NDJsonWriter(
+                log_dir, kind="PurgeLogs", default_filestem=log_filestem, compression=Uncompressed
+            ) as log_writer,
+        ):
+            logger = FileWithAggregationLogger(log_writer)
+            io.logger = logger
 
-        with HTTPClient(config=client.config) as delete_client:
+            process: Callable[[Page[InstanceDefinitionId]], Page[InstanceDefinitionId]] = self._no_op
+            if unlink:
+                process = partial(
+                    self._unlink_prepare,
+                    client=client,
+                    dry_run=dry_run,
+                    console=console,
+                    logger=logger,
+                    verbose=verbose,
+                )
+
             process_str = "Would be unlinking" if dry_run else "Unlinking"
             write_str = "Would be deleting" if dry_run else "Deleting"
-            results = DeleteResults()
-            executor = ProducerWorkerExecutor[Sequence[InstanceDefinitionId], list[dict[str, JsonVal]]](
+
+            executor = ProducerWorkerExecutor[Page[InstanceDefinitionId], Page[InstanceDefinitionId]](
                 download_iterable=io.download_ids(selector),
                 process=process,
-                write=partial(self._delete_instance_ids, dry_run=dry_run, delete_client=delete_client, results=results),
+                write=partial(self._delete_instance_ids, dry_run=dry_run, delete_client=delete_client),
                 total_item_count=total,
                 max_queue_size=10,
                 download_description=f"Retrieving instances from {selector!s}",
@@ -783,18 +804,13 @@ class PurgeCommand(ToolkitCommand):
                 write_description=f"{write_str} instances",
                 console=console,
             )
-
             executor.run()
+            items_results = logger.finalize(is_dry_run=False)
+            display_item_results(items_results, title=f"Finished {selector.display_name}", console=console)
+
             executor.raise_on_error()
 
-        prefix = "Would have purged" if dry_run else "Purged"
-        if results.failed == 0:
-            console.print(f"{prefix} {results.deleted:,} instances in {selector!s}")
-        else:
-            console.print(
-                f"{prefix} {results.deleted:,} instances in {selector!s}, but failed to purge {results.failed:,} instances"
-            )
-        return results
+        return
 
     def _confirm_purge(self, message: str, client: ToolkitClient) -> bool:
         client_project = client.config.project
@@ -860,29 +876,23 @@ class PurgeCommand(ToolkitCommand):
         self.warn(LimitedAccessWarning(f"You can only unlink files in the following scopes: {scope_str}."))
 
     @staticmethod
-    def _prepare(instance_ids: Sequence[InstanceDefinitionId]) -> list[dict[str, JsonVal]]:
-        output: list[dict[str, JsonVal]] = []
-        for instance_id in instance_ids:
-            dumped = instance_id.dump(include_instance_type=True)
-            output.append(dumped)
-
-        return output
+    def _no_op(instance_ids: Page[InstanceDefinitionId]) -> Page[InstanceDefinitionId]:
+        return instance_ids
 
     def _unlink_prepare(
         self,
-        instance_ids: Sequence[InstanceDefinitionId],
+        instance_ids: Page[InstanceDefinitionId],
         client: ToolkitClient,
         dry_run: bool,
-        console: Console,
-        verbose: bool = False,
-    ) -> list[dict[str, JsonVal]]:
-        self._unlink_timeseries(instance_ids, client, dry_run, console, verbose)
-        self._unlink_files(instance_ids, client, dry_run, console, verbose)
-        return self._prepare(instance_ids)
+        logger: FileWithAggregationLogger,
+    ) -> Page[InstanceDefinitionId]:
+        self._unlink_timeseries(instance_ids, client, dry_run, logger)
+        self._unlink_files(instance_ids, client, dry_run, logger)
+        return instance_ids
 
     @staticmethod
     def _delete_instance_ids(
-        items: list[dict[str, JsonVal]], dry_run: bool, delete_client: HTTPClient, results: DeleteResults
+        items: Page[InstanceDefinitionId], dry_run: bool, delete_client: HTTPClient, results: DeleteResults
     ) -> None:
         if dry_run:
             results.deleted += len(items)
@@ -903,29 +913,46 @@ class PurgeCommand(ToolkitCommand):
 
     @staticmethod
     def _unlink_timeseries(
-        instances: Sequence[InstanceDefinitionId], client: ToolkitClient, dry_run: bool, console: Console, verbose: bool
-    ) -> list[InstanceDefinitionId]:
-        node_ids = [instance for instance in instances if isinstance(instance, NodeId)]
-        if node_ids:
-            timeseries = client.tool.timeseries.retrieve(
-                [InstanceId(instance_id=NodeId(space=node.space, external_id=node.external_id)) for node in node_ids],
-                ignore_unknown_ids=True,
-            )
-            migrated_timeseries_ids = [
-                InternalId(id=ts.id) for ts in timeseries if ts.instance_id and ts.pending_instance_id
-            ]
+        page: Page[InstanceDefinitionId],
+        client: ToolkitClient,
+        dry_run: bool,
+        logger: FileWithAggregationLogger,
+    ) -> None:
+        node_items = {InstanceId(instance_id=item.item): item for item in page.items if isinstance(item.item, NodeId)}
+        if node_items:
+            timeseries = client.tool.timeseries.retrieve(list(node_items.keys()), ignore_unknown_ids=True)
+            migrated_timeseries_ids = {
+                InternalId(id=ts.id): ts.instance_id for ts in timeseries if ts.instance_id and ts.pending_instance_id
+            }
             if not dry_run and timeseries:
-                client.tool.timeseries.unlink_instance_ids(migrated_timeseries_ids)
-                if verbose:
-                    console.print(f"Unlinked {len(migrated_timeseries_ids)} timeseries from datapoints.")
-            elif verbose and migrated_timeseries_ids:
-                console.print(f"Would have unlinked {len(timeseries)} timeseries from datapoints.")
-        return list(instances)
+                client.tool.timeseries.unlink_instance_ids(list(migrated_timeseries_ids.keys()))
+                for value in migrated_timeseries_ids.values():
+                    data_item = node_items[value]
+                    logger.log(
+                        LogEntryV2(
+                            id=data_item.tracking_id,
+                            label="Unlinked timeseries",
+                            severity=Severity.info,
+                            message=f"Unlinked TimeSeries with internal ID {value.id} from Node {data_item.item!r}",
+                        )
+                    )
+            elif migrated_timeseries_ids:
+                for value in migrated_timeseries_ids.values():
+                    data_item = node_items[value]
+                    logger.log(
+                        LogEntryV2(
+                            id=data_item.tracking_id,
+                            label="Ready to unlink timeseries",
+                            severity=Severity.info,
+                            message=f"Ready to unlink TimeSeries with internal ID {value.id} from Node {data_item.item!r}",
+                        )
+                    )
+        return None
 
     @staticmethod
     def _unlink_files(
-        instances: Sequence[InstanceDefinitionId], client: ToolkitClient, dry_run: bool, console: Console, verbose: bool
-    ) -> list[InstanceDefinitionId]:
+        instances: Page[InstanceDefinitionId], client: ToolkitClient, dry_run: bool, console: Console, verbose: bool
+    ) -> None:
         file_ids = [instance for instance in instances if isinstance(instance, NodeId)]
         if file_ids:
             files = client.tool.filemetadata.retrieve(

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -809,7 +809,7 @@ class PurgeCommand(ToolkitCommand):
             executor = ProducerWorkerExecutor[Page[InstanceDefinitionId], Page[InstanceDefinitionId]](
                 download_iterable=io.download_ids(selector),
                 process=process,
-                write=partial(self._delete_instance_ids, dry_run=dry_run, delete_client=delete_client),
+                write=partial(self._delete_instance_ids, dry_run=dry_run, delete_client=delete_client, logger=logger),
                 total_item_count=total,
                 max_queue_size=10,
                 download_description=f"Retrieving instances from {selector!s}",

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -819,7 +819,7 @@ class PurgeCommand(ToolkitCommand):
                 console=console,
             )
             executor.run()
-            items_results = logger.finalize(is_dry_run=False)
+            items_results = logger.finalize(is_dry_run=dry_run)
             display_item_results(items_results, title=f"Finished {selector.display_name}", console=console)
             self.tracker.track(DataTracking.from_item_results("PurgeResult", io.KIND, items_results), client)
             executor.raise_on_error()

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -82,7 +82,7 @@ from cognite_toolkit._cdf_tk.utils.producer_worker import ProducerWorkerExecutor
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 from cognite_toolkit._cdf_tk.utils.validate_access import ValidateAccess
 
-from ..dataio.logger import FileWithAggregationLogger, LogEntryV2, Severity, display_item_results
+from ..dataio.logger import FileWithAggregationLogger, ItemsResult, LogEntryV2, Severity, display_item_results
 from ..utils.fileio import NDJsonWriter, Uncompressed
 from ._base import ToolkitCommand
 
@@ -120,6 +120,18 @@ def validate_soft_delete_purge_headroom(
 class DeleteResults:
     deleted: int = 0
     failed: int = 0
+
+    @classmethod
+    def from_item_results(cls, items_results: list[ItemsResult]) -> "DeleteResults":
+        deleted = 0
+        failed = 0
+        for result in items_results:
+            if result.status in ("success", "success-with-warning", "pending", "pending-with-warning"):
+                deleted += result.count
+            elif result.status == "failure":
+                failed += result.count
+            # "skipped" items are neither deleted nor failed
+        return cls(deleted=deleted, failed=failed)
 
 
 class DeleteItem(RequestItem):
@@ -781,14 +793,7 @@ class PurgeCommand(ToolkitCommand):
 
             process: Callable[[Page[InstanceDefinitionId]], Page[InstanceDefinitionId]] = self._no_op
             if unlink:
-                process = partial(
-                    self._unlink_prepare,
-                    client=client,
-                    dry_run=dry_run,
-                    console=console,
-                    logger=logger,
-                    verbose=verbose,
-                )
+                process = partial(self._unlink_prepare, client=client, dry_run=dry_run, logger=logger)
 
             process_str = "Would be unlinking" if dry_run else "Unlinking"
             write_str = "Would be deleting" if dry_run else "Deleting"
@@ -810,7 +815,7 @@ class PurgeCommand(ToolkitCommand):
 
             executor.raise_on_error()
 
-        return
+        return DeleteResults.from_item_results(items_results)
 
     def _confirm_purge(self, message: str, client: ToolkitClient) -> bool:
         client_project = client.config.project
@@ -892,24 +897,22 @@ class PurgeCommand(ToolkitCommand):
 
     @staticmethod
     def _delete_instance_ids(
-        items: Page[InstanceDefinitionId], dry_run: bool, delete_client: HTTPClient, results: DeleteResults
+        items: Page[InstanceDefinitionId], dry_run: bool, delete_client: HTTPClient, logger: FileWithAggregationLogger,
     ) -> None:
         if dry_run:
-            results.deleted += len(items)
+            ...
             return
 
         responses = delete_client.request_items_retries(
             ItemsRequest(
                 endpoint_url=delete_client.config.create_api_url("/models/instances/delete"),
                 method="POST",
-                items=[InstanceDefinitionId._load(item) for item in items],
+                items=items,
             )
         )
         for response in responses:
-            if isinstance(response, ItemsSuccessResponse):
-                results.deleted += len(response.ids)
-            else:
-                results.failed += len(response.ids)
+            if not isinstance(response, ItemsSuccessResponse):
+
 
     @staticmethod
     def _unlink_timeseries(
@@ -951,21 +954,38 @@ class PurgeCommand(ToolkitCommand):
 
     @staticmethod
     def _unlink_files(
-        instances: Page[InstanceDefinitionId], client: ToolkitClient, dry_run: bool, console: Console, verbose: bool
+        page: Page[InstanceDefinitionId],
+        client: ToolkitClient,
+        dry_run: bool,
+        logger: FileWithAggregationLogger,
     ) -> None:
-        file_ids = [instance for instance in instances if isinstance(instance, NodeId)]
-        if file_ids:
-            files = client.tool.filemetadata.retrieve(
-                [InstanceId(instance_id=NodeId(space=node.space, external_id=node.external_id)) for node in file_ids],
-                ignore_unknown_ids=True,
-            )
-            migrated_file_ids = [
-                InternalId(id=file.id) for file in files if file.instance_id and file.pending_instance_id
-            ]
+        node_items = {InstanceId(instance_id=item.item): item for item in page.items if isinstance(item.item, NodeId)}
+        if node_items:
+            files = client.tool.filemetadata.retrieve(list(node_items.keys()), ignore_unknown_ids=True)
+            migrated_file_ids = {
+                InternalId(id=file.id): file.instance_id for file in files if file.instance_id and file.pending_instance_id
+            }
             if not dry_run and files:
-                client.tool.filemetadata.unlink_instance_ids(migrated_file_ids)
-                if verbose:
-                    console.print(f"Unlinked {len(migrated_file_ids)} files from nodes.")
-            elif verbose and files:
-                console.print(f"Would have unlinked {len(migrated_file_ids)} files from their blob content.")
-        return list(instances)
+                client.tool.filemetadata.unlink_instance_ids(list(migrated_file_ids.keys()))
+                for value in migrated_file_ids.values():
+                    data_item = node_items[value]
+                    logger.log(
+                        LogEntryV2(
+                            id=data_item.tracking_id,
+                            label="Unlinked file",
+                            severity=Severity.info,
+                            message=f"Unlinked File with internal ID {value.id} from Node {data_item.item!r}",
+                        )
+                    )
+            elif migrated_file_ids:
+                for value in migrated_file_ids.values():
+                    data_item = node_items[value]
+                    logger.log(
+                        LogEntryV2(
+                            id=data_item.tracking_id,
+                            label="Ready to unlink file",
+                            severity=Severity.info,
+                            message=f"Ready to unlink File with internal ID {value.id} from Node {data_item.item!r}",
+                        )
+                    )
+        return None

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -38,6 +38,7 @@ from cognite_toolkit._cdf_tk.client.request_classes.filters import ContainerFilt
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import NodeId, NodeResponse, SpaceId
 from cognite_toolkit._cdf_tk.constants import DMS_SOFT_DELETED_INSTANCE_LIMIT_MARGIN
 from cognite_toolkit._cdf_tk.data_classes import DeployResults, ResourceDeployResult
+from cognite_toolkit._cdf_tk.data_classes._tracking_info import DataTracking
 from cognite_toolkit._cdf_tk.dataio import InstanceIO, Page
 from cognite_toolkit._cdf_tk.dataio.logger import (
     FileWithAggregationLogger,
@@ -820,7 +821,7 @@ class PurgeCommand(ToolkitCommand):
             executor.run()
             items_results = logger.finalize(is_dry_run=False)
             display_item_results(items_results, title=f"Finished {selector.display_name}", console=console)
-
+            self.tracker.track(DataTracking.from_item_results("PurgeResult", io.KIND, items_results), client)
             executor.raise_on_error()
 
         return DeleteResults.from_item_results(items_results)

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -22,6 +22,8 @@ from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client._resource_base import RequestItem
 from cognite_toolkit._cdf_tk.client.http_client import (
     HTTPClient,
+    ItemsFailedRequest,
+    ItemsFailedResponse,
     ItemsRequest,
     ItemsSuccessResponse,
 )
@@ -37,6 +39,13 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import NodeId
 from cognite_toolkit._cdf_tk.constants import DMS_SOFT_DELETED_INSTANCE_LIMIT_MARGIN
 from cognite_toolkit._cdf_tk.data_classes import DeployResults, ResourceDeployResult
 from cognite_toolkit._cdf_tk.dataio import InstanceIO, Page
+from cognite_toolkit._cdf_tk.dataio.logger import (
+    FileWithAggregationLogger,
+    ItemsResult,
+    LogEntryV2,
+    Severity,
+    display_item_results,
+)
 from cognite_toolkit._cdf_tk.dataio.selectors import InstanceSelector
 from cognite_toolkit._cdf_tk.exceptions import (
     AuthorizationError,
@@ -78,12 +87,11 @@ from cognite_toolkit._cdf_tk.utils.aggregators import (
     SequenceAggregator,
     TimeSeriesAggregator,
 )
+from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter, Uncompressed
 from cognite_toolkit._cdf_tk.utils.producer_worker import ProducerWorkerExecutor
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 from cognite_toolkit._cdf_tk.utils.validate_access import ValidateAccess
 
-from ..dataio.logger import FileWithAggregationLogger, ItemsResult, LogEntryV2, Severity, display_item_results
-from ..utils.fileio import NDJsonWriter, Uncompressed
 from ._base import ToolkitCommand
 
 
@@ -897,22 +905,39 @@ class PurgeCommand(ToolkitCommand):
 
     @staticmethod
     def _delete_instance_ids(
-        items: Page[InstanceDefinitionId], dry_run: bool, delete_client: HTTPClient, logger: FileWithAggregationLogger,
+        page: Page[InstanceDefinitionId],
+        dry_run: bool,
+        delete_client: HTTPClient,
+        logger: FileWithAggregationLogger,
     ) -> None:
         if dry_run:
-            ...
             return
 
         responses = delete_client.request_items_retries(
             ItemsRequest(
                 endpoint_url=delete_client.config.create_api_url("/models/instances/delete"),
                 method="POST",
-                items=items,
+                items=page.items,
             )
         )
         for response in responses:
-            if not isinstance(response, ItemsSuccessResponse):
-
+            if isinstance(response, ItemsFailedRequest):
+                for id in response.ids:
+                    logger.log(
+                        LogEntryV2(
+                            id=id, severity=Severity.failure, label="Failed request", message=response.error_message
+                        )
+                    )
+            elif isinstance(response, ItemsFailedResponse):
+                for id in response.ids:
+                    logger.log(
+                        LogEntryV2(
+                            id=id,
+                            severity=Severity.failure,
+                            label=f"Failed response {response.status_code}",
+                            message=response.error_message,
+                        )
+                    )
 
     @staticmethod
     def _unlink_timeseries(
@@ -925,29 +950,31 @@ class PurgeCommand(ToolkitCommand):
         if node_items:
             timeseries = client.tool.timeseries.retrieve(list(node_items.keys()), ignore_unknown_ids=True)
             migrated_timeseries_ids = {
-                InternalId(id=ts.id): ts.instance_id for ts in timeseries if ts.instance_id and ts.pending_instance_id
+                InternalId(id=ts.id): InstanceId(instance_id=ts.instance_id)
+                for ts in timeseries
+                if ts.instance_id and ts.pending_instance_id
             }
             if not dry_run and timeseries:
                 client.tool.timeseries.unlink_instance_ids(list(migrated_timeseries_ids.keys()))
-                for value in migrated_timeseries_ids.values():
+                for internal_id, value in migrated_timeseries_ids.items():
                     data_item = node_items[value]
                     logger.log(
                         LogEntryV2(
                             id=data_item.tracking_id,
                             label="Unlinked timeseries",
                             severity=Severity.info,
-                            message=f"Unlinked TimeSeries with internal ID {value.id} from Node {data_item.item!r}",
+                            message=f"Unlinked TimeSeries with internal ID {internal_id!s} from Node {data_item.item!r}",
                         )
                     )
             elif migrated_timeseries_ids:
-                for value in migrated_timeseries_ids.values():
+                for internal_id, value in migrated_timeseries_ids.items():
                     data_item = node_items[value]
                     logger.log(
                         LogEntryV2(
                             id=data_item.tracking_id,
                             label="Ready to unlink timeseries",
                             severity=Severity.info,
-                            message=f"Ready to unlink TimeSeries with internal ID {value.id} from Node {data_item.item!r}",
+                            message=f"Ready to unlink TimeSeries with internal ID {internal_id!s} from Node {data_item.item!r}",
                         )
                     )
         return None
@@ -963,29 +990,31 @@ class PurgeCommand(ToolkitCommand):
         if node_items:
             files = client.tool.filemetadata.retrieve(list(node_items.keys()), ignore_unknown_ids=True)
             migrated_file_ids = {
-                InternalId(id=file.id): file.instance_id for file in files if file.instance_id and file.pending_instance_id
+                InternalId(id=file.id): InstanceId(instance_id=file.instance_id)
+                for file in files
+                if file.instance_id and file.pending_instance_id
             }
             if not dry_run and files:
                 client.tool.filemetadata.unlink_instance_ids(list(migrated_file_ids.keys()))
-                for value in migrated_file_ids.values():
+                for internal_id, value in migrated_file_ids.items():
                     data_item = node_items[value]
                     logger.log(
                         LogEntryV2(
                             id=data_item.tracking_id,
                             label="Unlinked file",
                             severity=Severity.info,
-                            message=f"Unlinked File with internal ID {value.id} from Node {data_item.item!r}",
+                            message=f"Unlinked File with internal ID {internal_id!s} from Node {data_item.item!r}",
                         )
                     )
             elif migrated_file_ids:
-                for value in migrated_file_ids.values():
+                for internal_id, value in migrated_file_ids.items():
                     data_item = node_items[value]
                     logger.log(
                         LogEntryV2(
                             id=data_item.tracking_id,
                             label="Ready to unlink file",
                             severity=Severity.info,
-                            message=f"Ready to unlink File with internal ID {value.id} from Node {data_item.item!r}",
+                            message=f"Ready to unlink File with internal ID {internal_id!s} from Node {data_item.item!r}",
                         )
                     )
         return None

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -255,12 +255,12 @@ class InstanceIO(
             for chunk in chunker_sequence(selector.ids, self.CHUNK_SIZE):
                 ids = [f"{item.space}:{item.external_id}" for item in chunk]
                 self.logger.register(ids)
-                items = [
-                    DataItem(tracking_id=f"{item.space}:{item.external_id}", item=item)
-                    for item in self.client.tool.instances.retrieve(chunk)
-                ]
-                if missing_ids := (set(ids) - {item.tracking_id for item in items}):
-                    for item_id in missing_ids:
+                retrieved_by_id = {
+                    f"{item.space}:{item.external_id}": item for item in self.client.tool.instances.retrieve(chunk)
+                }
+                items: list[DataItem[NodeOrEdgeResponse]] = []
+                for item_id in ids:
+                    if item_id not in retrieved_by_id:
                         self.logger.log(
                             LogEntryV2(
                                 id=item_id,
@@ -269,6 +269,20 @@ class InstanceIO(
                                 message=f"The {item_id} was not found in CDF",
                             )
                         )
+                        continue
+                    value = retrieved_by_id[item_id]
+                    if not isinstance(value, NodeOrEdgeResponse):
+                        self.logger.log(
+                            LogEntryV2(
+                                id=item_id,
+                                label="Unknown format",
+                                severity=Severity.failure,
+                                message=f"The {item_id} was found in CDF but is not in the expected format. Expected NodeOrEdgeResponse, got {type(value).__name__}",
+                            )
+                        )
+                        continue
+                    items.append(DataItem(tracking_id=item_id, item=value))
+
                 yield Page(worker_id="main", items=items, bookmark=NoBookmark())
             return
         elif isinstance(selector, InstanceQuerySelector):
@@ -400,7 +414,8 @@ class InstanceIO(
         else:
             for page in self.stream_data(selector, limit):
                 ids = [DataItem(tracking_id=item.tracking_id, item=item.item.as_id()) for item in page.items]
-                yield page.create_from(items=ids)
+                # NodeId | EdgeId are InstanceDefinitionId
+                yield page.create_from(items=ids)  # type: ignore[arg-type]
 
     def count(self, selector: InstanceSelector) -> int | None:
         if isinstance(selector, InstanceViewSelector) or (

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -27,7 +27,11 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     QuerySelectSource,
     QuerySortSpec,
 )
-from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._instance import NodeOrEdgeRequestAdapter
+from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._instance import (
+    EdgeResponse,
+    NodeOrEdgeRequestAdapter,
+    NodeResponse,
+)
 from cognite_toolkit._cdf_tk.constants import SUBSELECTION_LIMIT_QUERY_ENDPOINT
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 from cognite_toolkit._cdf_tk.resource_ios import ContainerCRUD, SpaceCRUD, ViewIO
@@ -271,7 +275,7 @@ class InstanceIO(
                         )
                         continue
                     value = retrieved_by_id[item_id]
-                    if not isinstance(value, NodeOrEdgeResponse):
+                    if not isinstance(value, NodeResponse | EdgeResponse):
                         self.logger.log(
                             LogEntryV2(
                                 id=item_id,

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping
 from types import MappingProxyType
 from typing import Any, ClassVar, Literal, cast
 
@@ -245,7 +245,7 @@ class InstanceIO(
         selector: InstanceSelector,
         limit: int | None = None,
         bookmark: Bookmark | None = None,
-    ) -> Iterable[Page]:
+    ) -> Iterable[Page[NodeOrEdgeResponse]]:
         init_cursor = bookmark.cursor if isinstance(bookmark, CursorBookmark) else None
         if isinstance(selector, InstanceViewSelector) and selector.edge_types and selector.instance_type == "node":
             pages = self._instances_with_container_and_edge_properties(selector, limit, init_cursor)
@@ -385,16 +385,22 @@ class InstanceIO(
 
     def download_ids(
         self, selector: InstanceSelector, limit: int | None = None
-    ) -> Iterable[Sequence[InstanceDefinitionId]]:
+    ) -> Iterable[Page[InstanceDefinitionId]]:
         if isinstance(selector, InstanceFileSelector) and selector.validate_instance is False:
             instances_to_yield = selector.instance_ids
             if limit is not None:
                 instances_to_yield = instances_to_yield[:limit]
-            yield from chunker_sequence(instances_to_yield, self.CHUNK_SIZE)
-        else:
             yield from (
-                [data_item.item.as_id() for data_item in chunk.items] for chunk in self.stream_data(selector, limit)
+                Page(
+                    worker_id="main",
+                    items=[DataItem(tracking_id=f"{item.space}:{item.external_id}", item=item) for item in chunk],
+                )
+                for chunk in chunker_sequence(instances_to_yield, self.CHUNK_SIZE)
             )
+        else:
+            for page in self.stream_data(selector, limit):
+                ids = [DataItem(tracking_id=item.tracking_id, item=item.item.as_id()) for item in page.items]
+                yield page.create_from(items=ids)
 
     def count(self, selector: InstanceSelector) -> int | None:
         if isinstance(selector, InstanceViewSelector) or (

--- a/cognite_toolkit/_cdf_tk/dataio/logger.py
+++ b/cognite_toolkit/_cdf_tk/dataio/logger.py
@@ -17,6 +17,7 @@ from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter
 
 
 class Severity(Enum):
+    info = 0
     warning = 1
     skipped = 2
     failure = 3

--- a/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
@@ -1,6 +1,7 @@
 import itertools
 import json
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -172,6 +173,7 @@ def purge_client(toolkit_config: ToolkitClientConfig) -> Iterator[ToolkitClient]
 
 
 class TestPurgeInstances:
+    @pytest.mark.usefixtures("disable_gzip")
     @pytest.mark.parametrize(
         "dry_run,unlink,instance_type",
         [
@@ -199,6 +201,7 @@ class TestPurgeInstances:
         cognite_files_2000_list: NodeList[CogniteFile],
         files_by_node_id: dict[dm.NodeId, dict[str, Any]],
         monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         config = purge_client.config
         rsps = purge_responses
@@ -235,11 +238,28 @@ class TestPurgeInstances:
                 json={"items": {"root": instance_dumps[1000:]}, "nextCursor": {"root": None}},
             ),
         ]
-        ts_objects = list(timeseries_by_node_id.values()) if instance_type == "timeseries" else []
-        file_objects = list(files_by_node_id.values()) if instance_type == "files" else []
         if unlink:
-            respx_mock.post(config.create_api_url("/timeseries/byids")).respond(json={"items": ts_objects})
-            respx_mock.post(config.create_api_url("/files/byids")).respond(json={"items": file_objects})
+
+            def ts_byids_callback(request: httpx.Request) -> httpx.Response:
+                body = json.loads(request.content.decode("utf-8"))
+                requested_ids = {
+                    dm.NodeId(space=item["instanceId"]["space"], external_id=item["instanceId"]["externalId"])
+                    for item in body.get("items", [])
+                }
+                filtered = [v for k, v in timeseries_by_node_id.items() if k in requested_ids]
+                return httpx.Response(status_code=200, json={"items": filtered})
+
+            def files_byids_callback(request: httpx.Request) -> httpx.Response:
+                body = json.loads(request.content.decode("utf-8"))
+                requested_ids = {
+                    dm.NodeId(space=item["instanceId"]["space"], external_id=item["instanceId"]["externalId"])
+                    for item in body.get("items", [])
+                }
+                filtered = [v for k, v in files_by_node_id.items() if k in requested_ids]
+                return httpx.Response(status_code=200, json={"items": filtered})
+
+            respx_mock.post(config.create_api_url("/timeseries/byids")).mock(side_effect=ts_byids_callback)
+            respx_mock.post(config.create_api_url("/files/byids")).mock(side_effect=files_byids_callback)
         if unlink and not dry_run and instance_type == "timeseries":
             respx_mock.post(config.create_api_url("/timeseries/unlink-instance-ids")).mock(
                 return_value=httpx.Response(
@@ -268,6 +288,7 @@ class TestPurgeInstances:
         result = cmd.instances(
             client,
             InstanceViewSelector(view=SelectedView(space="cdf_cdm", external_id="CogniteTimeSeries", version="v1")),
+            log_dir=tmp_path,
             dry_run=dry_run,
             unlink=unlink,
             verbose=False,

--- a/tests_smoke/test_commands/test_purge.py
+++ b/tests_smoke/test_commands/test_purge.py
@@ -389,6 +389,7 @@ class TestPurgeSmoke:
             dry_run=False,
             unlink=True,
             verbose=False,
+            log_dir=tmp_path / "log",
         )
         if results.deleted != 2:
             raise AssertionError(f"Expected 2 deleted instances from purge, got {results.deleted!r}")


### PR DESCRIPTION
# Description

<img width="1439" height="269" alt="image" src="https://github.com/user-attachments/assets/b6e8cdad-13f4-423a-a251-fd93e4af14a5" />


## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Improved

- The command `cdf data purge instances` now gives more detailed output. It also writes to file.
- Instrumentation of `cdf data purge instances`
