### PR TITLE
Fix FunctionLimits crash on non-GKE clusters where responseSizeMb is absent

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/function.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/function.py
@@ -76,4 +76,5 @@ class FunctionLimits(BaseModelObject):
     cpu_cores: ResourceLimit
     memory_gb: ResourceLimit
     runtimes: list[FunctionRuntime]
-    response_size_mb: int
+    # As of 24.04.2026 this is marked as a required field in the API, but it's currently only returned for projects on Gcloud
+    response_size_mb: int | None = None


### PR DESCRIPTION
# Description

The CDF API documents `responseSizeMb` as a required field in the function limits response, as verified with the Functions team, it is only returned for projects hosted on GKE. On AKS/EKS clusters the field is absent entirely, causing a Pydantic validation error (that is further swallowed by a catch-all except) when fetching function limits. Mark the field as optional with a `None` default.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fix validation failing when running `cdf build` with functions on Azure/AWS project
