### PR TITLE
Fix AUTH-001 giving false positive warning for resources scoped to a space instead of a dataset

### DIFF
--- a/cognite_toolkit/_cdf_tk/rules/_auth.py
+++ b/cognite_toolkit/_cdf_tk/rules/_auth.py
@@ -44,10 +44,13 @@ class CheckDataSetMissing(ToolkitLocalRule):
             data_set_external_id = getattr(resource, "data_set_external_id", None)
             # Some resources (e.g. functions) can be scoped to a space instead of a dataset, so we also check for space,
             # But only if the resource actually has a space field.
-            space = getattr(resource, "space", None) if "space" in type(resource).model_fields else None
+            supports_space = "space" in type(resource).model_fields
+            space = getattr(resource, "space", None) if supports_space else None
             if data_set_external_id is None and space is None:
-                yield Recommendation(
-                    message=f"Missing data set external ID for {resource.as_id()!s} {source_file.resource_type!s}",
-                    code=self.CODE,
-                    fix=f"Add a dataset association to the {source_file.resource_type!s}.",
-                )
+                if supports_space:
+                    message = f"Missing data set external ID or space for {resource.as_id()!s} {source_file.resource_type!s}"
+                    fix = f"Add a dataset or space association to the {source_file.resource_type!s}."
+                else:
+                    message = f"Missing data set external ID for {resource.as_id()!s} {source_file.resource_type!s}"
+                    fix = f"Add a dataset association to the {source_file.resource_type!s}."
+                yield Recommendation(message=message, code=self.CODE, fix=fix)

--- a/cognite_toolkit/_cdf_tk/rules/_auth.py
+++ b/cognite_toolkit/_cdf_tk/rules/_auth.py
@@ -48,7 +48,9 @@ class CheckDataSetMissing(ToolkitLocalRule):
             space = getattr(resource, "space", None) if supports_space else None
             if data_set_external_id is None and space is None:
                 if supports_space:
-                    message = f"Missing data set external ID or space for {resource.as_id()!s} {source_file.resource_type!s}"
+                    message = (
+                        f"Missing data set external ID or space for {resource.as_id()!s} {source_file.resource_type!s}"
+                    )
                     fix = f"Add a dataset or space association to the {source_file.resource_type!s}."
                 else:
                     message = f"Missing data set external ID for {resource.as_id()!s} {source_file.resource_type!s}"

--- a/cognite_toolkit/_cdf_tk/rules/_auth.py
+++ b/cognite_toolkit/_cdf_tk/rules/_auth.py
@@ -42,7 +42,10 @@ class CheckDataSetMissing(ToolkitLocalRule):
             if "data_set_external_id" not in type(resource).model_fields:
                 continue
             data_set_external_id = getattr(resource, "data_set_external_id", None)
-            if data_set_external_id is None:
+            # Some resources (e.g. functions) can be scoped to a space instead of a dataset, so we also check for space,
+            # But only if the resource actually has a space field.
+            space = getattr(resource, "space", None) if "space" in type(resource).model_fields else None
+            if data_set_external_id is None and space is None:
                 yield Recommendation(
                     message=f"Missing data set external ID for {resource.as_id()!s} {source_file.resource_type!s}",
                     code=self.CODE,


### PR DESCRIPTION
# Description

The AUTH-001 rule fires a recommendation when `dataSetExternalId` is missing, but some resources (currently only functions) can use `space` as a valid alternative for scoping. The check now skips the recommendation when the resource has a declared `space` field set. Only declared model fields are considered to avoid false negatives from accidental YAML extras.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fix spurious AUTH-001 recommendation on functions that use `space` instead of `dataSetExternalId` for dataset scoping.
