### PR TITLE
Surface validator crashes as visible build insights instead of silently dropping them

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -38,7 +38,11 @@ from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import (
     ValidationType,
 )
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltResource, ValidationResult
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import Insight, ModelSyntaxWarning
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import (
+    FailedValidation,
+    Insight,
+    ModelSyntaxWarning,
+)
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._module import (
     SUPPORTS_VARIABLE_REPLACEMENT,
     BuildSource,
@@ -63,7 +67,7 @@ from cognite_toolkit._cdf_tk.resource_ios import (
 )
 from cognite_toolkit._cdf_tk.resource_ios._base_ios import FailedReadExtra, ReadExtra, SuccessExtra
 from cognite_toolkit._cdf_tk.rules import LocalRulesOrchestrator, ToolkitGlobalRuleSet, get_global_rules_registry
-from cognite_toolkit._cdf_tk.rules._base import FailedValidation, RuleSetStatus
+from cognite_toolkit._cdf_tk.rules._base import RuleSetStatus
 from cognite_toolkit._cdf_tk.utils import calculate_hash, humanize_collection, safe_write
 from cognite_toolkit._cdf_tk.utils.file import (
     read_yaml_content,
@@ -791,6 +795,7 @@ class BuildV2Command(ToolkitCommand):
         severity_style = {
             "FileReadError": ("red", "✗"),
             "ConsistencyError": ("red", "✗"),
+            "FailedValidation": ("red", "✗"),
             "ModelSyntaxWarning": ("yellow", "!"),
             "Recommendation": ("blue", "🛈"),
             "IgnoredFileWarning": ("dim", "○"),
@@ -865,13 +870,14 @@ class BuildV2Command(ToolkitCommand):
         max_severity = 0
         for (insight_type, severity), count in sorted(aggregates.items(), key=lambda i: i[1], reverse=True):
             max_severity = max(max_severity, severity)
-            match severity:
-                case severity if severity <= 15:
-                    insight_style = "[green]✓[/]"
-                case severity if 15 < severity <= 35:
-                    insight_style = "[yellow]![/]"
-                case _:
-                    insight_style = "[red]✗[/]"
+            if insight_type == "FailedValidation":
+                insight_style = "[red]✗[/]"
+            elif severity <= 15:
+                insight_style = "[green]✓[/]"
+            elif severity <= 35:
+                insight_style = "[yellow]![/]"
+            else:
+                insight_style = "[red]✗[/]"
 
             summary_lines.append(f"{insight_style} [bold]{count}[/] {insight_type}")
 
@@ -879,7 +885,14 @@ class BuildV2Command(ToolkitCommand):
         if not build_dir_display.endswith("/"):
             build_dir_display = f"{build_dir_display}/"
 
+        has_failed_validation = any(isinstance(i, FailedValidation) for i in insights)
         match max_severity:
+            case severity if severity <= 15 and has_failed_validation:
+                border_color = "yellow"
+                recommendation = (
+                    "[yellow]![/] [bold]Proceed with caution.[/bold]\n"
+                    "One or more validators could not complete. We cannot guarantee these resources are safe to deploy."
+                )
             case severity if severity <= 15:
                 border_color = "green"
                 recommendation = "[green]✓[/] [bold]Ready to deploy.[/bold]\nNo critical errors found. You can proceed with deployment."

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -38,11 +38,7 @@ from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import (
     ValidationType,
 )
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltResource, ValidationResult
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import (
-    FailedValidation,
-    Insight,
-    ModelSyntaxWarning,
-)
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import Insight, ModelSyntaxWarning
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._module import (
     SUPPORTS_VARIABLE_REPLACEMENT,
     BuildSource,
@@ -864,14 +860,13 @@ class BuildV2Command(ToolkitCommand):
         max_severity = 0
         for (insight_type, severity), count in sorted(aggregates.items(), key=lambda i: i[1], reverse=True):
             max_severity = max(max_severity, severity)
-            if insight_type == "FailedValidation":
-                insight_style = "[red]✗[/]"
-            elif severity <= 15:
-                insight_style = "[green]✓[/]"
-            elif severity <= 35:
-                insight_style = "[yellow]![/]"
-            else:
-                insight_style = "[red]✗[/]"
+            match severity:
+                case severity if severity <= 15:
+                    insight_style = "[green]✓[/]"
+                case severity if 15 < severity <= 35:
+                    insight_style = "[yellow]![/]"
+                case _:
+                    insight_style = "[red]✗[/]"
 
             summary_lines.append(f"{insight_style} [bold]{count}[/] {insight_type}")
 
@@ -879,14 +874,7 @@ class BuildV2Command(ToolkitCommand):
         if not build_dir_display.endswith("/"):
             build_dir_display = f"{build_dir_display}/"
 
-        has_failed_validation = any(isinstance(i, FailedValidation) for i in insights)
         match max_severity:
-            case severity if severity <= 15 and has_failed_validation:
-                border_color = "yellow"
-                recommendation = (
-                    "[yellow]![/] [bold]Proceed with caution.[/bold]\n"
-                    "One or more validators could not complete. We cannot guarantee these resources are safe to deploy."
-                )
             case severity if severity <= 15:
                 border_color = "green"
                 recommendation = "[green]✓[/] [bold]Ready to deploy.[/bold]\nNo critical errors found. You can proceed with deployment."
@@ -899,7 +887,7 @@ class BuildV2Command(ToolkitCommand):
             case _:
                 recommendation = (
                     "[red]✗[/] [bold]Do not proceed to deploy.[/bold]\n"
-                    "There are YAML parsing errors that must be fixed before deployment."
+                    "There are critical errors that must be fixed before deployment."
                 )
                 border_color = "red"
         summary_lines.append("")

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -769,15 +769,9 @@ class BuildV2Command(ToolkitCommand):
                 display_name = step.rule.DISPLAY_NAME
                 progress.update(validating_task, description=f"Checking {display_name}...")
 
-                insights: list[Insight] = []
-                failures: list[FailedValidation] = []
-                for result in step.rule.validate():
-                    if isinstance(result, FailedValidation):
-                        failures.append(result)
-                    else:
-                        insights.append(result)
+                insights: list[Insight] = list(step.rule.validate())
 
-                validation_results.append(ValidationResult(name=display_name, insights=insights, failed=failures))
+                validation_results.append(ValidationResult(name=display_name, insights=insights))
                 progress.update(validating_task, advance=1, description=f"Finished checking {display_name}.")
             progress.update(validating_task, description=f"Finished checking. Ran {ready_step_count} validations.")
         return validation_results

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
@@ -11,7 +11,7 @@ from cognite_toolkit._cdf_tk.resource_ios._base_ios import FailedReadExtra, Reso
 from cognite_toolkit._cdf_tk.utils import humanize_collection
 from cognite_toolkit._cdf_tk.utils.file import relative_to_if_possible
 
-from ._insights import ConsistencyError, FailedValidation, FileReadError, IgnoredFileWarning, Insight, InsightList, ModelSyntaxWarning
+from ._insights import ConsistencyError, FileReadError, IgnoredFileWarning, Insight, InsightList, ModelSyntaxWarning
 from ._module import BuildVariable, FailedReadYAMLFile, IgnoredFile, ModuleId, ResourceType
 from ._types import AbsoluteDirPath, AbsoluteFilePath, RelativeDirPath, RelativeFilePath, ValidationType
 
@@ -161,7 +161,6 @@ class BuiltModule(BaseModel):
 class ValidationResult(BaseModel):
     name: str
     insights: list[Insight]
-    failed: list[FailedValidation]
 
 
 class BuildFolder(BaseModel):
@@ -185,7 +184,6 @@ class BuildFolder(BaseModel):
             insights.extend(module.all_insights)
         for result in self.validation_results:
             insights.extend(result.insights)
-            insights.extend(result.failed)
 
         return insights
 

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
@@ -11,7 +11,7 @@ from cognite_toolkit._cdf_tk.resource_ios._base_ios import FailedReadExtra, Reso
 from cognite_toolkit._cdf_tk.utils import humanize_collection
 from cognite_toolkit._cdf_tk.utils.file import relative_to_if_possible
 
-from ._insights import ConsistencyError, FileReadError, IgnoredFileWarning, Insight, InsightList, ModelSyntaxWarning
+from ._insights import ConsistencyError, FailedValidation, FileReadError, IgnoredFileWarning, Insight, InsightList, ModelSyntaxWarning
 from ._module import BuildVariable, FailedReadYAMLFile, IgnoredFile, ModuleId, ResourceType
 from ._types import AbsoluteDirPath, AbsoluteFilePath, RelativeDirPath, RelativeFilePath, ValidationType
 
@@ -158,11 +158,6 @@ class BuiltModule(BaseModel):
         return hash(self.module_id.path)
 
 
-class FailedValidation(BaseModel):
-    message: str
-    source: str
-
-
 class ValidationResult(BaseModel):
     name: str
     insights: list[Insight]
@@ -190,6 +185,7 @@ class BuildFolder(BaseModel):
             insights.extend(module.all_insights)
         for result in self.validation_results:
             insights.extend(result.insights)
+            insights.extend(result.failed)
 
         return insights
 

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_insights.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_insights.py
@@ -42,10 +42,9 @@ class FailedValidation(InsightDefinition):
     """A validator threw an unexpected exception and could not complete.
 
     This should never happen in normal operation — it indicates a bug in the validator itself.
-    Severity is 0 so it does not inflate max_severity in the build summary; it is checked separately.
     """
 
-    severity = 0
+    severity = 60
     source: str
     fix: str | None = "This is an unexpected error in the validator. Please report this as a bug."
 

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_insights.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_insights.py
@@ -38,6 +38,18 @@ class ConsistencyError(InsightDefinition):
     severity = 30
 
 
+class FailedValidation(InsightDefinition):
+    """A validator threw an unexpected exception and could not complete.
+
+    This should never happen in normal operation — it indicates a bug in the validator itself.
+    Severity is 0 so it does not inflate max_severity in the build summary; it is checked separately.
+    """
+
+    severity = 0
+    source: str
+    fix: str | None = "This is an unexpected error in the validator. Please report this as a bug."
+
+
 class IgnoredFileWarning(InsightDefinition):
     severity = 20
 
@@ -48,7 +60,9 @@ class Recommendation(InsightDefinition):
     severity = 10
 
 
-Insight: TypeAlias = ModelSyntaxWarning | ConsistencyError | Recommendation | FileReadError | IgnoredFileWarning
+Insight: TypeAlias = (
+    ModelSyntaxWarning | ConsistencyError | FailedValidation | Recommendation | FileReadError | IgnoredFileWarning
+)
 
 
 def _normalize_csv_cell(text: str) -> str:
@@ -87,7 +101,9 @@ class InsightList(UserList[Insight]):
     @property
     def has_errors(self) -> bool:
         """Returns True if there are any errors (model syntax or consistency) in the insights."""
-        return any(isinstance(insight, (ModelSyntaxWarning, ConsistencyError)) for insight in self.data)
+        return any(
+            isinstance(insight, (ModelSyntaxWarning, ConsistencyError, FailedValidation)) for insight in self.data
+        )
 
     @property
     def summary(self) -> dict[str, int]:

--- a/cognite_toolkit/_cdf_tk/rules/_base.py
+++ b/cognite_toolkit/_cdf_tk/rules/_base.py
@@ -6,8 +6,7 @@ from pydantic import BaseModel
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import BuiltModule
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import FailedValidation
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import Insight
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import FailedValidation, Insight
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._module import Module, SuccessfulReadYAMLFile
 from cognite_toolkit._cdf_tk.yaml_classes.base import ToolkitResource
 

--- a/cognite_toolkit/_cdf_tk/rules/_base.py
+++ b/cognite_toolkit/_cdf_tk/rules/_base.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import BuiltModule
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import FailedValidation
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import FailedValidation
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import Insight
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._module import Module, SuccessfulReadYAMLFile
 from cognite_toolkit._cdf_tk.yaml_classes.base import ToolkitResource

--- a/cognite_toolkit/_cdf_tk/rules/_functions.py
+++ b/cognite_toolkit/_cdf_tk/rules/_functions.py
@@ -4,8 +4,7 @@ from functools import cached_property
 from cognite_toolkit._cdf_tk.client.resource_classes.function import FunctionLimits
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import ResourceType
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltResource
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import FailedValidation
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import ConsistencyError
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import ConsistencyError, FailedValidation
 from cognite_toolkit._cdf_tk.resource_ios import FunctionIO
 from cognite_toolkit._cdf_tk.rules._base import RuleSetStatus, ToolkitGlobalRuleSet
 from cognite_toolkit._cdf_tk.utils import validate_requirements_with_pip

--- a/cognite_toolkit/_cdf_tk/rules/_functions.py
+++ b/cognite_toolkit/_cdf_tk/rules/_functions.py
@@ -3,7 +3,8 @@ from functools import cached_property
 
 from cognite_toolkit._cdf_tk.client.resource_classes.function import FunctionLimits
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import ResourceType
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltResource, FailedValidation
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltResource
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import FailedValidation
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import ConsistencyError
 from cognite_toolkit._cdf_tk.resource_ios import FunctionIO
 from cognite_toolkit._cdf_tk.rules._base import RuleSetStatus, ToolkitGlobalRuleSet


### PR DESCRIPTION
# Description

`FailedValidation` (yielded from `except Exception` blocks in `FunctionRules` and `NeatRuleSet`) was collected into `ValidationResult.failed` but never included in `BuildFolder.all_insights`, so any crash during validation was silently swallowed and the user saw a green build even though the validation didn't run. This PR promotes `FailedValidation` to a proper `InsightDefinition` subclass, adds it to the `Insight` type alias, and surfaces it directly in the build summary with a dedicated "Validation incomplete" warning path to indicate potential issues.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fix validator crashes being silently ignored during `cdf build` — they now appear as visible errors with a "Validation incomplete" warning in the build summary.
