### PR TITLE
[CDF-27815]📓 Download API format

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -331,7 +331,7 @@ class DownloadApp(typer.Typer):
         """This command will download assets from CDF into a temporary directory."""
         client = EnvironmentVariables.create_from_environment().get_client()
         if data_sets is None:
-            data_sets, file_format, compression, output_dir, limit = self._asset_centric_interactive(
+            data_sets, file_format, compression, output_dir, limit, api_format = self._asset_centric_interactive(
                 AssetInteractiveSelect(client, "download"),
                 file_format,
                 compression,
@@ -372,7 +372,7 @@ class DownloadApp(typer.Typer):
         display_name: str,
         max_limit: int | None = None,
         available_formats: type[Enum] = AssetCentricFormats,
-    ) -> tuple[list[str], AssetCentricFormats, CompressionFormat, Path, int]:
+    ) -> tuple[list[str], AssetCentricFormats, CompressionFormat, Path, int, ApiFormat]:
         data_sets = selector.select_data_sets()
         file_format = questionary.select(
             f"Select format to download the {display_name} in:",
@@ -398,7 +398,17 @@ class DownloadApp(typer.Typer):
                 validate=lambda value: value.lstrip("-").isdigit() and (max_limit is None or int(value) <= max_limit),
             ).unsafe_ask()
         )
-        return data_sets, file_format, compression, output_dir, limit
+        api_format = ApiFormat.request
+        if Flags.EXTEND_DOWNLOAD.is_enabled():
+            api_format = questionary.select(
+                message=f"Select the API format to download the {display_name}:",
+                choices=[
+                    Choice(title="Request payload format", value=ApiFormat.request),
+                    Choice(title="API response format", value=ApiFormat.response),
+                ],
+                default=ApiFormat.request,
+            ).unsafe_ask()
+        return data_sets, file_format, compression, output_dir, limit, api_format
 
     def download_timeseries_cmd(
         self,
@@ -464,7 +474,7 @@ class DownloadApp(typer.Typer):
         """This command will download time series from CDF into a temporary directory."""
         client = EnvironmentVariables.create_from_environment().get_client()
         if data_sets is None:
-            data_sets, file_format, compression, output_dir, limit = self._asset_centric_interactive(
+            data_sets, file_format, compression, output_dir, limit, api_format = self._asset_centric_interactive(
                 TimeSeriesInteractiveSelect(client, "download"),
                 file_format,
                 compression,
@@ -556,7 +566,7 @@ class DownloadApp(typer.Typer):
         """This command will download events from CDF into a temporary directory."""
         client = EnvironmentVariables.create_from_environment().get_client()
         if data_sets is None:
-            data_sets, file_format, compression, output_dir, limit = self._asset_centric_interactive(
+            data_sets, file_format, compression, output_dir, limit, api_format = self._asset_centric_interactive(
                 EventInteractiveSelect(client, "download"),
                 file_format,
                 compression,
@@ -669,7 +679,7 @@ class DownloadApp(typer.Typer):
                 include_file_contents = False
             if not include_file_contents:
                 # Continue with regular interactive selection
-                data_sets, file_format, compression, output_dir, limit = self._asset_centric_interactive(
+                data_sets, file_format, compression, output_dir, limit, api_format = self._asset_centric_interactive(
                     FileMetadataInteractiveSelect(client, "download"),
                     file_format,
                     compression,

--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -129,6 +129,11 @@ class InstanceTypes(str, Enum):
     edge = "edge"
 
 
+class ApiFormat(str, Enum):
+    request = "request"
+    response = "response"
+
+
 class CompressionFormat(str, Enum):
     gzip = "gzip"
     none = "none"
@@ -186,6 +191,14 @@ class DownloadApp(typer.Typer):
                 help="Format to download the raw tables in. Supported formats: ndjson, yaml",
             ),
         ] = RawFormats.ndjson,
+        api_format: Annotated[
+            ApiFormat,
+            typer.Option(
+                "--api-format",
+                help="API communication format. 'request' uses the request payload format, 'response' uses the API response format.",
+                hidden=not Flags.EXTEND_DOWNLOAD.is_enabled(),
+            ),
+        ] = ApiFormat.request,
         compression: Annotated[
             CompressionFormat,
             typer.Option(
@@ -245,7 +258,7 @@ class DownloadApp(typer.Typer):
                     )
                     for item in selected_tables
                 ],
-                io=RawIO(client),
+                io=RawIO(client, api_format=api_format.value),
                 output_dir=output_dir,
                 file_format=f".{file_format.value}",
                 compression=compression.value,
@@ -273,6 +286,14 @@ class DownloadApp(typer.Typer):
                 help="Format to download the assets in.",
             ),
         ] = AssetCentricFormats.csv,
+        api_format: Annotated[
+            ApiFormat,
+            typer.Option(
+                "--api-format",
+                help="API communication format. 'request' uses the request payload format, 'response' uses the API response format.",
+                hidden=not Flags.EXTEND_DOWNLOAD.is_enabled(),
+            ),
+        ] = ApiFormat.request,
         compression: Annotated[
             CompressionFormat,
             typer.Option(
@@ -331,7 +352,7 @@ class DownloadApp(typer.Typer):
         cmd.run(
             lambda: cmd.download(
                 selectors=selectors,
-                io=AssetDataIO(client),
+                io=AssetDataIO(client, api_format=api_format.value),
                 output_dir=output_dir,
                 file_format=f".{file_format.value}",
                 compression=compression.value,
@@ -398,6 +419,14 @@ class DownloadApp(typer.Typer):
                 help="Format to download the time series in.",
             ),
         ] = AssetCentricFormats.csv,
+        api_format: Annotated[
+            ApiFormat,
+            typer.Option(
+                "--api-format",
+                help="API communication format. 'request' uses the request payload format, 'response' uses the API response format.",
+                hidden=not Flags.EXTEND_DOWNLOAD.is_enabled(),
+            ),
+        ] = ApiFormat.request,
         compression: Annotated[
             CompressionFormat,
             typer.Option(
@@ -454,7 +483,7 @@ class DownloadApp(typer.Typer):
         cmd.run(
             lambda: cmd.download(
                 selectors=selectors,
-                io=TimeSeriesDataIO(client),
+                io=TimeSeriesDataIO(client, api_format=api_format.value),
                 output_dir=output_dir,
                 file_format=f".{file_format.value}",
                 compression=compression.value,
@@ -482,6 +511,14 @@ class DownloadApp(typer.Typer):
                 help="Format to download the events in.",
             ),
         ] = AssetCentricFormats.csv,
+        api_format: Annotated[
+            ApiFormat,
+            typer.Option(
+                "--api-format",
+                help="API communication format. 'request' uses the request payload format, 'response' uses the API response format.",
+                hidden=not Flags.EXTEND_DOWNLOAD.is_enabled(),
+            ),
+        ] = ApiFormat.request,
         compression: Annotated[
             CompressionFormat,
             typer.Option(
@@ -537,7 +574,7 @@ class DownloadApp(typer.Typer):
         cmd.run(
             lambda: cmd.download(
                 selectors=selectors,
-                io=EventDataIO(client),
+                io=EventDataIO(client, api_format=api_format.value),
                 output_dir=output_dir,
                 file_format=f".{file_format.value}",
                 compression=compression.value,
@@ -575,6 +612,14 @@ class DownloadApp(typer.Typer):
                 help="Format to download the file metadata in.",
             ),
         ] = AssetCentricFormats.csv,
+        api_format: Annotated[
+            ApiFormat,
+            typer.Option(
+                "--api-format",
+                help="API communication format. 'request' uses the request payload format, 'response' uses the API response format.",
+                hidden=not Flags.EXTEND_DOWNLOAD.is_enabled(),
+            ),
+        ] = ApiFormat.request,
         compression: Annotated[
             CompressionFormat,
             typer.Option(
@@ -655,6 +700,7 @@ class DownloadApp(typer.Typer):
                     client,
                     config_directory=output_dir / download_dir_name,
                     file_directory=output_dir / download_dir_name / "files",
+                    api_format=api_format.value,
                 )
                 selectors = [
                     CogniteFileFilesSelectorV2(
@@ -676,6 +722,7 @@ class DownloadApp(typer.Typer):
                     client,
                     config_directory=output_dir / download_dir_name,
                     file_directory=output_dir / download_dir_name / "files",
+                    api_format=api_format.value,
                 )
                 selectors = [
                     FileMetadataFilesSelectorV2(
@@ -693,7 +740,7 @@ class DownloadApp(typer.Typer):
                 )
                 for data_set in data_sets
             ]
-            io = FileMetadataDataIO(client)
+            io = FileMetadataDataIO(client, api_format=api_format.value)
         else:
             raise NotImplementedError("Bug in Toolkit. Unexpected execution path.")
 
@@ -727,6 +774,14 @@ class DownloadApp(typer.Typer):
                 help="Format for downloading the asset hierarchy.",
             ),
         ] = HierarchyFormats.ndjson,
+        api_format: Annotated[
+            ApiFormat,
+            typer.Option(
+                "--api-format",
+                help="API communication format. 'request' uses the request payload format, 'response' uses the API response format.",
+                hidden=not Flags.EXTEND_DOWNLOAD.is_enabled(),
+            ),
+        ] = ApiFormat.request,
         compression: Annotated[
             CompressionFormat,
             typer.Option(
@@ -781,7 +836,7 @@ class DownloadApp(typer.Typer):
         cmd.run(
             lambda: cmd.download(
                 selectors=selectors,
-                io=HierarchyIO(client),
+                io=HierarchyIO(client, api_format=api_format.value),
                 output_dir=output_dir,
                 file_format=f".{file_format.value}",
                 compression=compression.value,
@@ -836,6 +891,14 @@ class DownloadApp(typer.Typer):
                 help="Format to download the instances in.",
             ),
         ] = InstanceFormats.ndjson,
+        api_format: Annotated[
+            ApiFormat,
+            typer.Option(
+                "--api-format",
+                help="API communication format. 'request' uses the request payload format, 'response' uses the API response format.",
+                hidden=not Flags.EXTEND_DOWNLOAD.is_enabled(),
+            ),
+        ] = ApiFormat.request,
         compression: Annotated[
             CompressionFormat,
             typer.Option(
@@ -967,7 +1030,7 @@ class DownloadApp(typer.Typer):
         cmd.run(
             lambda: cmd.download(
                 selectors=selectors,
-                io=InstanceIO(client),
+                io=InstanceIO(client, api_format=api_format.value),
                 output_dir=output_dir,
                 file_format=f".{file_format.value}",
                 compression=compression.value,
@@ -1062,6 +1125,14 @@ class DownloadApp(typer.Typer):
                 help="Format for downloading the datapoints.",
             ),
         ] = DatapointFormats.csv,
+        api_format: Annotated[
+            ApiFormat,
+            typer.Option(
+                "--api-format",
+                help="API communication format. 'request' uses the request payload format, 'response' uses the API response format.",
+                hidden=not Flags.EXTEND_DOWNLOAD.is_enabled(),
+            ),
+        ] = ApiFormat.request,
         output_dir: Annotated[
             Path,
             typer.Option(
@@ -1146,7 +1217,7 @@ class DownloadApp(typer.Typer):
         cmd.run(
             lambda: cmd.download(
                 selectors=[selector],
-                io=DatapointsIO(client),
+                io=DatapointsIO(client, api_format=api_format.value),
                 output_dir=output_dir,
                 file_format=f".{file_format.value}",
                 compression="none",
@@ -1172,6 +1243,14 @@ class DownloadApp(typer.Typer):
                 help="Format for downloading the charts.",
             ),
         ] = ChartFormats.ndjson,
+        api_format: Annotated[
+            ApiFormat,
+            typer.Option(
+                "--api-format",
+                help="API communication format. 'request' uses the request payload format, 'response' uses the API response format.",
+                hidden=not Flags.EXTEND_DOWNLOAD.is_enabled(),
+            ),
+        ] = ApiFormat.request,
         skip_backend_services: Annotated[
             bool,
             typer.Option(
@@ -1227,7 +1306,7 @@ class DownloadApp(typer.Typer):
         cmd.run(
             lambda: cmd.download(
                 selectors=[selector],
-                io=ChartIO(client, skip_backend_services=skip_backend_services),
+                io=ChartIO(client, skip_backend_services=skip_backend_services, api_format=api_format.value),
                 output_dir=output_dir,
                 file_format=f".{file_format.value}",
                 compression=compression.value,
@@ -1253,6 +1332,14 @@ class DownloadApp(typer.Typer):
                 help="Format for downloading the canvas.",
             ),
         ] = CanvasFormats.ndjson,
+        api_format: Annotated[
+            ApiFormat,
+            typer.Option(
+                "--api-format",
+                help="API communication format. 'request' uses the request payload format, 'response' uses the API response format.",
+                hidden=not Flags.EXTEND_DOWNLOAD.is_enabled(),
+            ),
+        ] = ApiFormat.request,
         compression: Annotated[
             CompressionFormat,
             typer.Option(
@@ -1300,7 +1387,7 @@ class DownloadApp(typer.Typer):
         cmd.run(
             lambda: cmd.download(
                 selectors=[selector],
-                io=CanvasIO(client),
+                io=CanvasIO(client, api_format=api_format.value),
                 output_dir=output_dir,
                 file_format=f".{file_format.value}",
                 compression=compression.value,
@@ -1356,6 +1443,14 @@ class DownloadApp(typer.Typer):
                 help="Format to download the records in.",
             ),
         ] = RecordFormats.ndjson,
+        api_format: Annotated[
+            ApiFormat,
+            typer.Option(
+                "--api-format",
+                help="API communication format. 'request' uses the request payload format, 'response' uses the API response format.",
+                hidden=not Flags.EXTEND_DOWNLOAD.is_enabled(),
+            ),
+        ] = ApiFormat.request,
         compression: Annotated[
             CompressionFormat,
             typer.Option(
@@ -1464,7 +1559,7 @@ class DownloadApp(typer.Typer):
         cmd.run(
             lambda: cmd.download(
                 selectors=selectors,
-                io=RecordIO(client),
+                io=RecordIO(client, api_format=api_format.value),
                 output_dir=output_dir,
                 file_format=f".{file_format.value}",
                 compression=compression.value,

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/asset.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/asset.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 from pydantic import JsonValue
 
@@ -46,3 +46,14 @@ class AssetResponse(Asset, ResponseResource[AssetRequest]):
     @classmethod
     def request_cls(cls) -> type[AssetRequest]:
         return AssetRequest
+
+    def dump(
+        self, camel_case: bool = True, exclude_extra: bool = False, unpack_aggregates: bool = False
+    ) -> dict[str, Any]:
+        dumped = super().dump(camel_case=camel_case, exclude_extra=exclude_extra)
+        if unpack_aggregates and self.aggregates is not None:
+            dumped["childCount"] = self.aggregates.child_count
+            dumped["depth"] = self.aggregates.depth
+            dumped["path"] = self.aggregates.path
+            dumped.pop("aggregates", None)
+        return dumped

--- a/cognite_toolkit/_cdf_tk/dataio/_applications.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_applications.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Iterable, Sequence
 from itertools import chain
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 from cognite.client.credentials import OAuthDeviceCode
 from cognite.client.data_classes.data_modeling import EdgeId
@@ -76,8 +76,9 @@ class ChartIO(UploadableDataIO[ChartSelector, ChartResponse, ChartRequest]):
         skip_existing: bool = False,
         skip_backend_services: bool = not Flags.EXTEND_UPLOAD.is_enabled(),
         skip_strict_mode: bool = False,
+        api_format: Literal["request", "response"] = "request",
     ) -> None:
-        super().__init__(client)
+        super().__init__(client, api_format=api_format)
         # We need to store existing charts as we use different endpoints depending on whether
         # the chart exist or not. Note this scales O(n) and not O(1) with memory wrt to number of Charts.
         # However, we know that there are only a few 1000s Charts at most, thus this should not be a problem.
@@ -165,6 +166,9 @@ class ChartIO(UploadableDataIO[ChartSelector, ChartResponse, ChartRequest]):
     def data_to_json_chunk(
         self, data_chunk: Page[ChartResponse], selector: ChartSelector | None = None
     ) -> Page[dict[str, JsonVal]]:
+        if self.api_format == "response":
+            result = [DataItem(tracking_id=item.tracking_id, item=item.item.dump()) for item in data_chunk.items]
+            return data_chunk.create_from(result)
         self._populate_timeseries_id_cache([item.item for item in data_chunk.items])
         result = [
             DataItem(tracking_id=item.tracking_id, item=self._dump_resource(item.item)) for item in data_chunk.items
@@ -525,9 +529,13 @@ class CanvasIO(UploadableDataIO[CanvasSelector, IndustrialCanvasResponse, Indust
     BASE_SELECTOR = CanvasSelector
 
     def __init__(
-        self, client: ToolkitClient, exclude_existing_version: bool = True, include_solution_tags: bool = True
+        self,
+        client: ToolkitClient,
+        exclude_existing_version: bool = True,
+        include_solution_tags: bool = True,
+        api_format: Literal["request", "response"] = "request",
     ) -> None:
-        super().__init__(client)
+        super().__init__(client, api_format=api_format)
         self.exclude_existing_version = exclude_existing_version
         self.include_solution_tags = include_solution_tags
 
@@ -634,6 +642,9 @@ class CanvasIO(UploadableDataIO[CanvasSelector, IndustrialCanvasResponse, Indust
     def data_to_json_chunk(
         self, data_chunk: Page[IndustrialCanvasResponse], selector: CanvasSelector | None = None
     ) -> Page[dict[str, JsonVal]]:
+        if self.api_format == "response":
+            result = [DataItem(tracking_id=item.tracking_id, item=item.item.dump()) for item in data_chunk.items]
+            return data_chunk.create_from(result)
         self._populate_id_cache([item.item for item in data_chunk.items])
         result = [
             DataItem(tracking_id=item.tracking_id, item=self._dump_resource(item.item)) for item in data_chunk.items

--- a/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
@@ -281,19 +281,37 @@ class AssetDataIO(UploadableAssetCentricIO[AssetResponse, AssetRequest]):
             metadata_schema.extend(
                 [SchemaColumn(name=f"metadata.{key}", type="string", is_array=False) for key in sorted(metadata_keys)]
             )
-        asset_schema = [
-            SchemaColumn(name="externalId", type="string"),
-            SchemaColumn(name="name", type="string"),
-            SchemaColumn(name="parentExternalId", type="string"),
-            SchemaColumn(name="description", type="string"),
-            SchemaColumn(name="dataSetExternalId", type="string"),
-            SchemaColumn(name="source", type="string"),
-            SchemaColumn(name="labels", type="string", is_array=True),
-            SchemaColumn(name="geoLocation", type="json"),
-            SchemaColumn(name="childCount", type="integer"),
-            SchemaColumn(name="depth", type="integer"),
-            SchemaColumn(name="path", type="string", is_array=True),
-        ]
+        if self.api_format == "response":
+            asset_schema = [
+                SchemaColumn(name="id", type="integer"),
+                SchemaColumn(name="externalId", type="string"),
+                SchemaColumn(name="name", type="string"),
+                SchemaColumn(name="parentId", type="integer"),
+                SchemaColumn(name="parentExternalId", type="string"),
+                SchemaColumn(name="description", type="string"),
+                SchemaColumn(name="dataSetId", type="integer"),
+                SchemaColumn(name="source", type="string"),
+                SchemaColumn(name="labels", type="json"),
+                SchemaColumn(name="geoLocation", type="json"),
+                SchemaColumn(name="createdTime", type="integer"),
+                SchemaColumn(name="lastUpdatedTime", type="integer"),
+                SchemaColumn(name="rootId", type="integer"),
+                SchemaColumn(name="aggregates", type="json"),
+            ]
+        else:
+            asset_schema = [
+                SchemaColumn(name="externalId", type="string"),
+                SchemaColumn(name="name", type="string"),
+                SchemaColumn(name="parentExternalId", type="string"),
+                SchemaColumn(name="description", type="string"),
+                SchemaColumn(name="dataSetExternalId", type="string"),
+                SchemaColumn(name="source", type="string"),
+                SchemaColumn(name="labels", type="string", is_array=True),
+                SchemaColumn(name="geoLocation", type="json"),
+                SchemaColumn(name="childCount", type="integer"),
+                SchemaColumn(name="depth", type="integer"),
+                SchemaColumn(name="path", type="string", is_array=True),
+            ]
         return asset_schema + metadata_schema
 
     def stream_data(
@@ -417,20 +435,42 @@ class FileMetadataDataIO(AssetCentricIO[FileMetadataResponse]):
             metadata_schema.extend(
                 [SchemaColumn(name=f"metadata.{key}", type="string", is_array=False) for key in sorted(metadata_keys)]
             )
-        file_schema = [
-            SchemaColumn(name="externalId", type="string"),
-            SchemaColumn(name="name", type="string"),
-            SchemaColumn(name="directory", type="string"),
-            SchemaColumn(name="mimeType", type="string"),
-            SchemaColumn(name="dataSetExternalId", type="string"),
-            SchemaColumn(name="assetExternalIds", type="string", is_array=True),
-            SchemaColumn(name="source", type="string"),
-            SchemaColumn(name="sourceCreatedTime", type="integer"),
-            SchemaColumn(name="sourceModifiedTime", type="integer"),
-            SchemaColumn(name="securityCategories", type="string", is_array=True),
-            SchemaColumn(name="labels", type="string", is_array=True),
-            SchemaColumn(name="geoLocation", type="json"),
-        ]
+        if self.api_format == "response":
+            file_schema = [
+                SchemaColumn(name="id", type="integer"),
+                SchemaColumn(name="externalId", type="string"),
+                SchemaColumn(name="name", type="string"),
+                SchemaColumn(name="directory", type="string"),
+                SchemaColumn(name="mimeType", type="string"),
+                SchemaColumn(name="dataSetId", type="integer"),
+                SchemaColumn(name="assetIds", type="integer", is_array=True),
+                SchemaColumn(name="source", type="string"),
+                SchemaColumn(name="sourceCreatedTime", type="integer"),
+                SchemaColumn(name="sourceModifiedTime", type="integer"),
+                SchemaColumn(name="securityCategories", type="integer", is_array=True),
+                SchemaColumn(name="labels", type="json"),
+                SchemaColumn(name="geoLocation", type="json"),
+                SchemaColumn(name="createdTime", type="integer"),
+                SchemaColumn(name="lastUpdatedTime", type="integer"),
+                SchemaColumn(name="uploadedTime", type="integer"),
+                SchemaColumn(name="uploaded", type="boolean"),
+                SchemaColumn(name="instanceId", type="json"),
+            ]
+        else:
+            file_schema = [
+                SchemaColumn(name="externalId", type="string"),
+                SchemaColumn(name="name", type="string"),
+                SchemaColumn(name="directory", type="string"),
+                SchemaColumn(name="mimeType", type="string"),
+                SchemaColumn(name="dataSetExternalId", type="string"),
+                SchemaColumn(name="assetExternalIds", type="string", is_array=True),
+                SchemaColumn(name="source", type="string"),
+                SchemaColumn(name="sourceCreatedTime", type="integer"),
+                SchemaColumn(name="sourceModifiedTime", type="integer"),
+                SchemaColumn(name="securityCategories", type="string", is_array=True),
+                SchemaColumn(name="labels", type="string", is_array=True),
+                SchemaColumn(name="geoLocation", type="json"),
+            ]
         return file_schema + metadata_schema
 
     def stream_data(
@@ -588,18 +628,37 @@ class TimeSeriesDataIO(UploadableAssetCentricIO[TimeSeriesResponse, TimeSeriesRe
             metadata_schema.extend(
                 [SchemaColumn(name=f"metadata.{key}", type="string", is_array=False) for key in sorted(metadata_keys)]
             )
-        ts_schema = [
-            SchemaColumn(name="externalId", type="string"),
-            SchemaColumn(name="name", type="string"),
-            SchemaColumn(name="isString", type="boolean"),
-            SchemaColumn(name="unit", type="string"),
-            SchemaColumn(name="unitExternalId", type="string"),
-            SchemaColumn(name="assetExternalId", type="string"),
-            SchemaColumn(name="isStep", type="boolean"),
-            SchemaColumn(name="description", type="string"),
-            SchemaColumn(name="securityCategories", type="string", is_array=True),
-            SchemaColumn(name="dataSetExternalId", type="string"),
-        ]
+        if self.api_format == "response":
+            ts_schema = [
+                SchemaColumn(name="id", type="integer"),
+                SchemaColumn(name="externalId", type="string"),
+                SchemaColumn(name="name", type="string"),
+                SchemaColumn(name="isString", type="boolean"),
+                SchemaColumn(name="unit", type="string"),
+                SchemaColumn(name="unitExternalId", type="string"),
+                SchemaColumn(name="assetId", type="integer"),
+                SchemaColumn(name="isStep", type="boolean"),
+                SchemaColumn(name="description", type="string"),
+                SchemaColumn(name="securityCategories", type="integer", is_array=True),
+                SchemaColumn(name="dataSetId", type="integer"),
+                SchemaColumn(name="instanceId", type="json"),
+                SchemaColumn(name="type", type="string"),
+                SchemaColumn(name="createdTime", type="integer"),
+                SchemaColumn(name="lastUpdatedTime", type="integer"),
+            ]
+        else:
+            ts_schema = [
+                SchemaColumn(name="externalId", type="string"),
+                SchemaColumn(name="name", type="string"),
+                SchemaColumn(name="isString", type="boolean"),
+                SchemaColumn(name="unit", type="string"),
+                SchemaColumn(name="unitExternalId", type="string"),
+                SchemaColumn(name="assetExternalId", type="string"),
+                SchemaColumn(name="isStep", type="boolean"),
+                SchemaColumn(name="description", type="string"),
+                SchemaColumn(name="securityCategories", type="string", is_array=True),
+                SchemaColumn(name="dataSetExternalId", type="string"),
+            ]
         return ts_schema + metadata_schema
 
 
@@ -625,17 +684,33 @@ class EventDataIO(UploadableAssetCentricIO[EventResponse, EventRequest]):
             metadata_schema.extend(
                 [SchemaColumn(name=f"metadata.{key}", type="string", is_array=False) for key in sorted(metadata_keys)]
             )
-        event_schema = [
-            SchemaColumn(name="externalId", type="string"),
-            SchemaColumn(name="dataSetExternalId", type="string"),
-            SchemaColumn(name="startTime", type="integer"),
-            SchemaColumn(name="endTime", type="integer"),
-            SchemaColumn(name="type", type="string"),
-            SchemaColumn(name="subtype", type="string"),
-            SchemaColumn(name="description", type="string"),
-            SchemaColumn(name="assetExternalIds", type="string", is_array=True),
-            SchemaColumn(name="source", type="string"),
-        ]
+        if self.api_format == "response":
+            event_schema = [
+                SchemaColumn(name="id", type="integer"),
+                SchemaColumn(name="externalId", type="string"),
+                SchemaColumn(name="dataSetId", type="integer"),
+                SchemaColumn(name="startTime", type="integer"),
+                SchemaColumn(name="endTime", type="integer"),
+                SchemaColumn(name="type", type="string"),
+                SchemaColumn(name="subtype", type="string"),
+                SchemaColumn(name="description", type="string"),
+                SchemaColumn(name="assetIds", type="integer", is_array=True),
+                SchemaColumn(name="source", type="string"),
+                SchemaColumn(name="createdTime", type="integer"),
+                SchemaColumn(name="lastUpdatedTime", type="integer"),
+            ]
+        else:
+            event_schema = [
+                SchemaColumn(name="externalId", type="string"),
+                SchemaColumn(name="dataSetExternalId", type="string"),
+                SchemaColumn(name="startTime", type="integer"),
+                SchemaColumn(name="endTime", type="integer"),
+                SchemaColumn(name="type", type="string"),
+                SchemaColumn(name="subtype", type="string"),
+                SchemaColumn(name="description", type="string"),
+                SchemaColumn(name="assetExternalIds", type="string", is_array=True),
+                SchemaColumn(name="source", type="string"),
+            ]
         return event_schema + metadata_schema
 
     def stream_data(

--- a/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
@@ -298,7 +298,7 @@ class AssetDataIO(UploadableAssetCentricIO[AssetResponse, AssetRequest]):
                 SchemaColumn(name="rootId", type="integer"),
                 SchemaColumn(name="childCount", type="integer"),
                 SchemaColumn(name="depth", type="integer"),
-                SchemaColumn(name="path", type="string", is_array=True),
+                SchemaColumn(name="path", type="json"),
             ]
         else:
             asset_schema = [

--- a/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Hashable, Iterable, Sequence
-from typing import Any, ClassVar, Generic
+from typing import Any, ClassVar, Generic, Literal
 
 from cognite.client.data_classes import Label, LabelDefinition
 
@@ -61,8 +61,8 @@ class AssetCentricIO(
     CHUNK_SIZE = 1000
     BASE_SELECTOR = AssetCentricSelector
 
-    def __init__(self, client: ToolkitClient) -> None:
-        super().__init__(client)
+    def __init__(self, client: ToolkitClient, api_format: Literal["request", "response"] = "request") -> None:
+        super().__init__(client, api_format=api_format)
         self._aggregator = self._get_aggregator()
         self._downloaded_data_sets_by_selector: dict[AssetCentricSelector, set[int]] = defaultdict(set)
         self._downloaded_labels_by_selector: dict[AssetCentricSelector, set[str]] = defaultdict(set)
@@ -264,8 +264,8 @@ class AssetDataIO(UploadableAssetCentricIO[AssetResponse, AssetRequest]):
     RESOURCE_TYPE = "asset"
     UPLOAD_ENDPOINT = "/assets"
 
-    def __init__(self, client: ToolkitClient) -> None:
-        super().__init__(client)
+    def __init__(self, client: ToolkitClient, api_format: Literal["request", "response"] = "request") -> None:
+        super().__init__(client, api_format=api_format)
         self._crud = AssetIO.create_loader(self.client)
         self._metadata_keys: dict[AssetCentricSelector | None, set[str]] = {}
 
@@ -342,6 +342,10 @@ class AssetDataIO(UploadableAssetCentricIO[AssetResponse, AssetRequest]):
         raw_items = [di.item for di in data_chunk.items]
         if selector in self._metadata_keys:
             self._metadata_keys[selector].update(key for item in raw_items for key in (item.metadata or {}).keys())
+        if self.api_format == "response":
+            return data_chunk.create_from(
+                [DataItem(tracking_id=di.tracking_id, item=di.item.dump()) for di in data_chunk.items]
+            )
         self._populate_data_set_id_cache(raw_items)
         asset_ids = {
             segment["id"]
@@ -396,8 +400,8 @@ class FileMetadataDataIO(AssetCentricIO[FileMetadataResponse]):
     RESOURCE_TYPE = "file"
     UPLOAD_ENDPOINT = "/files"
 
-    def __init__(self, client: ToolkitClient) -> None:
-        super().__init__(client)
+    def __init__(self, client: ToolkitClient, api_format: Literal["request", "response"] = "request") -> None:
+        super().__init__(client, api_format=api_format)
         self._crud = FileMetadataCRUD.create_loader(self.client)
         self._metadata_keys: dict[AssetCentricSelector | None, set[str]] = {}
 
@@ -477,6 +481,10 @@ class FileMetadataDataIO(AssetCentricIO[FileMetadataResponse]):
         raw_items = [di.item for di in data_chunk.items]
         if selector in self._metadata_keys:
             self._metadata_keys[selector].update(key for item in raw_items for key in (item.metadata or {}).keys())
+        if self.api_format == "response":
+            return data_chunk.create_from(
+                [DataItem(tracking_id=di.tracking_id, item=di.item.dump()) for di in data_chunk.items]
+            )
         self._populate_data_set_id_cache(raw_items)
         self._populate_asset_id_cache(raw_items)
         self._populate_security_category_cache(raw_items)
@@ -492,8 +500,8 @@ class TimeSeriesDataIO(UploadableAssetCentricIO[TimeSeriesResponse, TimeSeriesRe
     UPLOAD_ENDPOINT = "/timeseries"
     RESOURCE_TYPE = "timeseries"
 
-    def __init__(self, client: ToolkitClient) -> None:
-        super().__init__(client)
+    def __init__(self, client: ToolkitClient, api_format: Literal["request", "response"] = "request") -> None:
+        super().__init__(client, api_format=api_format)
         self._crud = TimeSeriesCRUD.create_loader(self.client)
         self._metadata_keys: dict[AssetCentricSelector | None, set[str]] = {}
 
@@ -547,6 +555,10 @@ class TimeSeriesDataIO(UploadableAssetCentricIO[TimeSeriesResponse, TimeSeriesRe
         raw_items = [di.item for di in data_chunk.items]
         if selector in self._metadata_keys:
             self._metadata_keys[selector].update(key for item in raw_items for key in (item.metadata or {}).keys())
+        if self.api_format == "response":
+            return data_chunk.create_from(
+                [DataItem(tracking_id=di.tracking_id, item=di.item.dump()) for di in data_chunk.items]
+            )
         self._populate_data_set_id_cache(raw_items)
         self._populate_security_category_cache(raw_items)
         asset_ids = {item.asset_id for item in raw_items if item.asset_id is not None}
@@ -596,8 +608,8 @@ class EventDataIO(UploadableAssetCentricIO[EventResponse, EventRequest]):
     UPLOAD_ENDPOINT = "/events"
     RESOURCE_TYPE = "event"
 
-    def __init__(self, client: ToolkitClient) -> None:
-        super().__init__(client)
+    def __init__(self, client: ToolkitClient, api_format: Literal["request", "response"] = "request") -> None:
+        super().__init__(client, api_format=api_format)
         self._crud = EventIO.create_loader(self.client)
         self._metadata_keys: dict[AssetCentricSelector | None, set[str]] = {}
 
@@ -671,7 +683,9 @@ class EventDataIO(UploadableAssetCentricIO[EventResponse, EventRequest]):
         if selector in self._metadata_keys:
             self._metadata_keys[selector].update(key for item in raw_items for key in (item.metadata or {}).keys())
         if self.api_format == "response":
-            return data_chunk.create_from([di.dump() for di in raw_items])
+            return data_chunk.create_from(
+                [DataItem(tracking_id=di.tracking_id, item=di.item.dump()) for di in data_chunk.items]
+            )
         self._populate_data_set_id_cache(raw_items)
         self._populate_asset_id_cache(raw_items)
 
@@ -697,12 +711,12 @@ class HierarchyIO(ConfigurableDataIO[AssetCentricSelector, AssetCentricResource]
     CHUNK_SIZE = 1000
     BASE_SELECTOR = AssetCentricSelector
 
-    def __init__(self, client: ToolkitClient) -> None:
-        super().__init__(client)
-        self._asset_io = AssetDataIO(client)
-        self._file_io = FileMetadataDataIO(client)
-        self._timeseries_io = TimeSeriesDataIO(client)
-        self._event_io = EventDataIO(client)
+    def __init__(self, client: ToolkitClient, api_format: Literal["request", "response"] = "request") -> None:
+        super().__init__(client, api_format=api_format)
+        self._asset_io = AssetDataIO(client, api_format=api_format)
+        self._file_io = FileMetadataDataIO(client, api_format=api_format)
+        self._timeseries_io = TimeSeriesDataIO(client, api_format=api_format)
+        self._event_io = EventDataIO(client, api_format=api_format)
         self._io_by_kind: dict[str, AssetCentricIO] = {
             self._asset_io.KIND: self._asset_io,
             self._file_io.KIND: self._file_io,

--- a/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
@@ -291,7 +291,7 @@ class AssetDataIO(UploadableAssetCentricIO[AssetResponse, AssetRequest]):
                 SchemaColumn(name="description", type="string"),
                 SchemaColumn(name="dataSetId", type="integer"),
                 SchemaColumn(name="source", type="string"),
-                SchemaColumn(name="labels", type="string", is_array=True),
+                SchemaColumn(name="labels", type="json"),
                 SchemaColumn(name="geoLocation", type="json"),
                 SchemaColumn(name="createdTime", type="integer"),
                 SchemaColumn(name="lastUpdatedTime", type="integer"),

--- a/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
@@ -296,7 +296,9 @@ class AssetDataIO(UploadableAssetCentricIO[AssetResponse, AssetRequest]):
                 SchemaColumn(name="createdTime", type="integer"),
                 SchemaColumn(name="lastUpdatedTime", type="integer"),
                 SchemaColumn(name="rootId", type="integer"),
-                SchemaColumn(name="aggregates", type="json"),
+                SchemaColumn(name="childCount", type="integer"),
+                SchemaColumn(name="depth", type="integer"),
+                SchemaColumn(name="path", type="string", is_array=True),
             ]
         else:
             asset_schema = [

--- a/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
@@ -291,7 +291,7 @@ class AssetDataIO(UploadableAssetCentricIO[AssetResponse, AssetRequest]):
                 SchemaColumn(name="description", type="string"),
                 SchemaColumn(name="dataSetId", type="integer"),
                 SchemaColumn(name="source", type="string"),
-                SchemaColumn(name="labels", type="json"),
+                SchemaColumn(name="labels", type="string", is_array=True),
                 SchemaColumn(name="geoLocation", type="json"),
                 SchemaColumn(name="createdTime", type="integer"),
                 SchemaColumn(name="lastUpdatedTime", type="integer"),

--- a/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
@@ -670,6 +670,8 @@ class EventDataIO(UploadableAssetCentricIO[EventResponse, EventRequest]):
         raw_items = [di.item for di in data_chunk.items]
         if selector in self._metadata_keys:
             self._metadata_keys[selector].update(key for item in raw_items for key in (item.metadata or {}).keys())
+        if self.api_format == "response":
+            return data_chunk.create_from([di.dump() for di in raw_items])
         self._populate_data_set_id_cache(raw_items)
         self._populate_asset_id_cache(raw_items)
 

--- a/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
@@ -364,7 +364,10 @@ class AssetDataIO(UploadableAssetCentricIO[AssetResponse, AssetRequest]):
             self._metadata_keys[selector].update(key for item in raw_items for key in (item.metadata or {}).keys())
         if self.api_format == "response":
             return data_chunk.create_from(
-                [DataItem(tracking_id=di.tracking_id, item=di.item.dump()) for di in data_chunk.items]
+                [
+                    DataItem(tracking_id=di.tracking_id, item=di.item.dump(unpack_aggregates=True))
+                    for di in data_chunk.items
+                ]
             )
         self._populate_data_set_id_cache(raw_items)
         asset_ids = {

--- a/cognite_toolkit/_cdf_tk/dataio/_base.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_base.py
@@ -99,13 +99,18 @@ class DataIO(ABC, Generic[T_Selector, T_DataResponse]):
 
     Args:
         client: An instance of ToolkitClient to interact with the CDF API.
+        api_format: The format to download to convert in the data_to_json_chunk method.
+            This can be either "request" or "response", depending on whether the data is
+            in the form of request objects or response objects. The default is "request".
     """
 
     CHUNK_SIZE: ClassVar[int]
     BASE_SELECTOR: ClassVar[type[DataSelector]]
 
-    def __init__(self, client: ToolkitClient) -> None:
+    def __init__(self, client: ToolkitClient, api_format: Literal["request", "response"] = "request") -> None:
         self.client = client
+        self.api_format = api_format
+
         self._logger: DataLogger = NoOpLogger()
 
     @property

--- a/cognite_toolkit/_cdf_tk/dataio/_datapoints.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_datapoints.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable, Mapping
 from itertools import groupby
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar, Literal, cast
 
 from cognite.client._proto.data_point_insertion_request_pb2 import DataPointInsertionItem, DataPointInsertionRequest
 from cognite.client._proto.data_point_list_response_pb2 import DataPointListResponse
@@ -67,8 +67,8 @@ class DatapointsIO(
     MAX_PER_REQUEST_DATAPOINTS = 100_000
     MAX_PER_REQUEST_DATAPOINTS_AGGREGATION = 10_000
 
-    def __init__(self, client: ToolkitClient) -> None:
-        super().__init__(client)
+    def __init__(self, client: ToolkitClient, api_format: Literal["request", "response"] = "request") -> None:
+        super().__init__(client, api_format=api_format)
         self._warned_columns: set[str] = set()
         self._epoc_converter = _EpochConverter(nullable=True)
         self._numeric_converter = _Float64Converter(nullable=True)

--- a/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
@@ -2,6 +2,7 @@ import mimetypes
 from collections import defaultdict
 from collections.abc import Hashable, Iterable, Sequence
 from pathlib import Path
+from typing import Literal
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.http_client import (
@@ -79,8 +80,9 @@ class FileMetadataContentIO(
         config_directory: Path,
         file_directory: Path | None = None,
         overwrite: bool = False,
+        api_format: Literal["request", "response"] = "request",
     ) -> None:
-        super().__init__(client)
+        super().__init__(client, api_format=api_format)
         self.overwrite = overwrite
         self._config_directory = config_directory
         self._file_directory = file_directory
@@ -284,7 +286,18 @@ class FileMetadataContentIO(
             self._metadata_keys[selector].update(
                 key for item in data_chunk for key in (item.item.metadata or {}).keys()
             )
-        dumped: list[DataItem[dict[str, JsonVal]]] = []
+        if self.api_format == "response":
+            dumped: list[DataItem[dict[str, JsonVal]]] = []
+            for item in data_chunk.items:
+                dumped_item = item.item.dump()
+                if item.item.filepath:
+                    dumped_filepath = item.item.filepath
+                    if dumped_filepath.is_relative_to(self._config_directory):
+                        dumped_filepath = dumped_filepath.relative_to(self._config_directory)
+                    dumped_item[FILEPATH] = dumped_filepath.as_posix()
+                dumped.append(DataItem(tracking_id=item.tracking_id, item=dumped_item))
+            return data_chunk.create_from(dumped)
+        dumped = []
         for item in data_chunk.items:
             dumped_item = self._crud.dump_resource(item.item)
             # Preserve filepath
@@ -509,8 +522,9 @@ class CogniteFileContentIO(
         config_directory: Path,
         file_directory: Path | None = None,
         overwrite: bool = False,
+        api_format: Literal["request", "response"] = "request",
     ) -> None:
-        super().__init__(client)
+        super().__init__(client, api_format=api_format)
         self.overwrite = overwrite
         self._config_directory = config_directory
         self._file_directory = file_directory
@@ -670,7 +684,18 @@ class CogniteFileContentIO(
     def data_to_json_chunk(
         self, data_chunk: Page[CogniteFileResponse], selector: CogniteFileContentSelectorV2 | None = None
     ) -> Page[dict[str, JsonVal]]:
-        dumped: list[DataItem[dict[str, JsonVal]]] = []
+        if self.api_format == "response":
+            dumped: list[DataItem[dict[str, JsonVal]]] = []
+            for item in data_chunk.items:
+                dumped_item = item.item.dump()
+                if item.item.filepath:
+                    dumped_filepath = item.item.filepath
+                    if dumped_filepath.is_relative_to(self._config_directory):
+                        dumped_filepath = dumped_filepath.relative_to(self._config_directory)
+                    dumped_item[FILEPATH] = dumped_filepath.as_posix()
+                dumped.append(DataItem(tracking_id=item.tracking_id, item=dumped_item))
+            return data_chunk.create_from(dumped)
+        dumped = []
         for item in data_chunk.items:
             dumped_item = self._crud.dump_resource(item.item)
             if item.item.filepath:

--- a/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
@@ -110,21 +110,44 @@ class FileMetadataContentIO(
             metadata_schema.extend(
                 [SchemaColumn(name=f"metadata.{key}", type="string", is_array=False) for key in sorted(metadata_keys)]
             )
-        file_schema = [
-            SchemaColumn(name="name", type="string"),
-            SchemaColumn(name="externalId", type="string"),
-            SchemaColumn(name="directory", type="string"),
-            SchemaColumn(name="mimeType", type="string"),
-            SchemaColumn(name="dataSetExternalId", type="string"),
-            SchemaColumn(name="assetExternalIds", type="string", is_array=True),
-            SchemaColumn(name="source", type="string"),
-            SchemaColumn(name="sourceCreatedTime", type="integer"),
-            SchemaColumn(name="sourceModifiedTime", type="integer"),
-            SchemaColumn(name="securityCategories", type="string", is_array=True),
-            SchemaColumn(name="labels", type="string", is_array=True),
-            SchemaColumn(name="geoLocation", type="json"),
-            SchemaColumn(name=FILEPATH, type="string"),
-        ]
+        if self.api_format == "response":
+            file_schema = [
+                SchemaColumn(name="id", type="integer"),
+                SchemaColumn(name="name", type="string"),
+                SchemaColumn(name="externalId", type="string"),
+                SchemaColumn(name="directory", type="string"),
+                SchemaColumn(name="mimeType", type="string"),
+                SchemaColumn(name="dataSetId", type="integer"),
+                SchemaColumn(name="assetIds", type="integer", is_array=True),
+                SchemaColumn(name="source", type="string"),
+                SchemaColumn(name="sourceCreatedTime", type="integer"),
+                SchemaColumn(name="sourceModifiedTime", type="integer"),
+                SchemaColumn(name="securityCategories", type="integer", is_array=True),
+                SchemaColumn(name="labels", type="json"),
+                SchemaColumn(name="geoLocation", type="json"),
+                SchemaColumn(name="createdTime", type="integer"),
+                SchemaColumn(name="lastUpdatedTime", type="integer"),
+                SchemaColumn(name="uploadedTime", type="integer"),
+                SchemaColumn(name="uploaded", type="boolean"),
+                SchemaColumn(name="instanceId", type="json"),
+                SchemaColumn(name=FILEPATH, type="string"),
+            ]
+        else:
+            file_schema = [
+                SchemaColumn(name="name", type="string"),
+                SchemaColumn(name="externalId", type="string"),
+                SchemaColumn(name="directory", type="string"),
+                SchemaColumn(name="mimeType", type="string"),
+                SchemaColumn(name="dataSetExternalId", type="string"),
+                SchemaColumn(name="assetExternalIds", type="string", is_array=True),
+                SchemaColumn(name="source", type="string"),
+                SchemaColumn(name="sourceCreatedTime", type="integer"),
+                SchemaColumn(name="sourceModifiedTime", type="integer"),
+                SchemaColumn(name="securityCategories", type="string", is_array=True),
+                SchemaColumn(name="labels", type="string", is_array=True),
+                SchemaColumn(name="geoLocation", type="json"),
+                SchemaColumn(name=FILEPATH, type="string"),
+            ]
         return file_schema + metadata_schema
 
     def stream_data(

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -174,24 +174,46 @@ class InstanceIO(
 
     def get_schema(self, selector: InstanceSelector) -> list[SchemaColumn]:
         instance_type, view_id = self._get_instance_type_and_view_id(selector)
-        instance_columns: list[SchemaColumn] = [
-            SchemaColumn(name="space", type="string"),
-            SchemaColumn(name="externalId", type="string"),
-            SchemaColumn(name="type.space", type="string"),
-            SchemaColumn(name="type.externalId", type="string"),
-            SchemaColumn(name="existingVersion", type="integer"),
-        ]
-        if instance_type == "edge":
-            instance_columns.extend(
-                [
-                    SchemaColumn(name="startNode.space", type="string"),
-                    SchemaColumn(name="startNode.externalId", type="string"),
-                    SchemaColumn(name="endNode.space", type="string"),
-                    SchemaColumn(name="endNode.externalId", type="string"),
-                ]
-            )
+        if self.api_format == "response":
+            instance_columns: list[SchemaColumn] = [
+                SchemaColumn(name="space", type="string"),
+                SchemaColumn(name="externalId", type="string"),
+                SchemaColumn(name="instanceType", type="string"),
+                SchemaColumn(name="version", type="integer"),
+                SchemaColumn(name="createdTime", type="integer"),
+                SchemaColumn(name="lastUpdatedTime", type="integer"),
+            ]
+            if instance_type == "edge":
+                instance_columns.extend(
+                    [
+                        SchemaColumn(name="type.space", type="string"),
+                        SchemaColumn(name="type.externalId", type="string"),
+                        SchemaColumn(name="startNode.space", type="string"),
+                        SchemaColumn(name="startNode.externalId", type="string"),
+                        SchemaColumn(name="endNode.space", type="string"),
+                        SchemaColumn(name="endNode.externalId", type="string"),
+                    ]
+                )
+            instance_columns.append(SchemaColumn(name="properties", type="json"))
+        else:
+            instance_columns = [
+                SchemaColumn(name="space", type="string"),
+                SchemaColumn(name="externalId", type="string"),
+                SchemaColumn(name="type.space", type="string"),
+                SchemaColumn(name="type.externalId", type="string"),
+                SchemaColumn(name="existingVersion", type="integer"),
+            ]
+            if instance_type == "edge":
+                instance_columns.extend(
+                    [
+                        SchemaColumn(name="startNode.space", type="string"),
+                        SchemaColumn(name="startNode.externalId", type="string"),
+                        SchemaColumn(name="endNode.space", type="string"),
+                        SchemaColumn(name="endNode.externalId", type="string"),
+                    ]
+                )
         property_columns: list[SchemaColumn] = []
-        if view_id is not None:
+        if view_id is not None and self.api_format == "request":
             views = self.client.tool.views.retrieve([view_id.as_id()], include_inherited_properties=True)
             if not views:
                 raise ToolkitValueError(f"View {view_id.as_id()} not found.")

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -194,7 +194,6 @@ class InstanceIO(
                         SchemaColumn(name="endNode.externalId", type="string"),
                     ]
                 )
-            instance_columns.append(SchemaColumn(name="properties", type="json"))
         else:
             instance_columns = [
                 SchemaColumn(name="space", type="string"),
@@ -213,7 +212,7 @@ class InstanceIO(
                     ]
                 )
         property_columns: list[SchemaColumn] = []
-        if view_id is not None and self.api_format == "request":
+        if view_id is not None:
             views = self.client.tool.views.retrieve([view_id.as_id()], include_inherited_properties=True)
             if not views:
                 raise ToolkitValueError(f"View {view_id.as_id()} not found.")

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -78,8 +78,13 @@ class InstanceIO(
     )
     BASE_SELECTOR = InstanceSelector
 
-    def __init__(self, client: ToolkitClient, remove_existing_version: bool = True) -> None:
-        super().__init__(client)
+    def __init__(
+        self,
+        client: ToolkitClient,
+        remove_existing_version: bool = True,
+        api_format: Literal["request", "response"] = "request",
+    ) -> None:
+        super().__init__(client, api_format=api_format)
         self._remove_existing_version = remove_existing_version
         # Cache for view to read-only properties mapping
         self._view_readonly_properties_cache: dict[ViewId, set[str]] = {}
@@ -452,10 +457,13 @@ class InstanceIO(
     def data_to_json_chunk(
         self, data_chunk: Page[NodeOrEdgeResponse], selector: InstanceSelector | None = None
     ) -> Page[dict[str, JsonVal]]:
-        result = [
-            DataItem(tracking_id=item.tracking_id, item=item.item.as_request_resource().dump())
-            for item in data_chunk.items
-        ]
+        if self.api_format == "response":
+            result = [DataItem(tracking_id=item.tracking_id, item=item.item.dump()) for item in data_chunk.items]
+        else:
+            result = [
+                DataItem(tracking_id=item.tracking_id, item=item.item.as_request_resource().dump())
+                for item in data_chunk.items
+            ]
         return data_chunk.create_from(result)
 
     def json_to_resource(self, item_json: dict[str, JsonVal]) -> NodeOrEdgeRequest:

--- a/cognite_toolkit/_cdf_tk/dataio/_raw.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_raw.py
@@ -82,7 +82,12 @@ class RawIO(
     def data_to_json_chunk(
         self, data_chunk: Page[Row], selector: RawTableSelector | None = None
     ) -> Page[dict[str, JsonVal]]:
-        result = [DataItem(tracking_id=item.tracking_id, item=item.item.as_write().dump()) for item in data_chunk.items]
+        if self.api_format == "response":
+            result = [DataItem(tracking_id=item.tracking_id, item=item.item.dump()) for item in data_chunk.items]
+        else:
+            result = [
+                DataItem(tracking_id=item.tracking_id, item=item.item.as_write().dump()) for item in data_chunk.items
+            ]
         return data_chunk.create_from(result)
 
     def json_to_resource(self, item_json: dict[str, JsonVal]) -> RowWrite:

--- a/cognite_toolkit/_cdf_tk/dataio/_records.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_records.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import Iterable
+from typing import Literal
 
 from pydantic import JsonValue
 
@@ -35,8 +36,8 @@ class RecordIO(
     MAX_TOTAL_RECORDS = 1_000_000
     BASE_SELECTOR = RecordContainerSelector
 
-    def __init__(self, client: ToolkitClient) -> None:
-        super().__init__(client)
+    def __init__(self, client: ToolkitClient, api_format: Literal["request", "response"] = "request") -> None:
+        super().__init__(client, api_format=api_format)
         self._stream_by_external_id: dict[str, StreamResponse] = {}
 
     def _get_stream(self, stream_external_id: str) -> StreamResponse:
@@ -189,10 +190,13 @@ class RecordIO(
     def data_to_json_chunk(
         self, data_chunk: Page[RecordResponse], selector: RecordContainerSelector | None = None
     ) -> Page[dict[str, JsonVal]]:
-        result = [
-            DataItem(tracking_id=item.tracking_id, item=item.item.as_request_resource().dump())
-            for item in data_chunk.items
-        ]
+        if self.api_format == "response":
+            result = [DataItem(tracking_id=item.tracking_id, item=item.item.dump()) for item in data_chunk.items]
+        else:
+            result = [
+                DataItem(tracking_id=item.tracking_id, item=item.item.as_request_resource().dump())
+                for item in data_chunk.items
+            ]
         return data_chunk.create_from(result)
 
     def json_to_resource(self, item_json: dict[str, JsonVal]) -> RecordRequest:


### PR DESCRIPTION
# Description

Originally, the data plugin is made for moving data form one project to another. However, for other use cases we need internal ids or other properties that are only on the response objects. For example, when manually populating lineage in migration

example output for assets 
```csv
id,externalId,name,parentId,parentExternalId,description,dataSetId,source,labels,geoLocation,createdTime,lastUpdatedTime,rootId,childCount,depth,path
227559521378059,test__asset_depth_5_asset_3,Asset 3 depth@5,2834947965952511,test__asset_depth_4_asset_14,,1310591977447252,,,,1741027506282,1741027506282,3458622188929348,0,5,"[{""id"": 3458622188929348}, {""id"": 1464608003010351}, {""id"": 6175199081316037}, {""id"": 5373346051401989}, {""id"": 2834947965952511}, {""id"": 227559521378059}]"
232251232980145,test__asset_depth_5_asset_2,Asset 2 depth@5,5011548116444115,test__asset_depth_4_asset_1,,1310591977447252,,,,1741027506282,1741027506282,3458622188929348,0,5,"[{""id"": 3458622188929348}, {""id"": 1464608003010351}, {""id"": 6175199081316037}, {""id"": 3757834179110400}, {""id"": 5011548116444115}, {""id"": 232251232980145}]"
235222438295024,test__asset_depth_5_asset_57,Asset 57 depth@5,5562820088350745,test__asset_depth_4_asset_8,,1310591977447252,,,,1741027506282,1741027506282,3458622188929348,0,5,"[{""id"": 3458622188929348}, {""id"": 1464608003010351}, {""id"": 6175199081316037}, {""id"": 6438652508627805}, {""id"": 5562820088350745}, {""id"": 235222438295024}]"
```


## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- [alpha] For all `cdf data download` methods, allow the user to select `--api-format`. This means you can now download in `response` format in addition to the default `request`. 
