### PR TITLE
feat(infield): add validation for DataExplorationConfig and ViewMappings in InFieldCDMLocationConfig

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
@@ -462,10 +462,7 @@ class InFieldCDMLocationConfigIO(ResourceIO[NodeId, InFieldCDMLocationConfigRequ
         elif len(json_path) == 3 and json_path[0] == "dataFilters" and json_path[2] == "instanceSpaces":
             # Handles dataFilters.<entity>.instanceSpaces (e.g., files, assets, operations, timeSeries, etc.)
             return diff_list_hashable(local, cdf)
-        elif json_path == ("dataExplorationConfig", "filters"):
+        elif json_path == ("viewMappings", "observations"):
             return diff_list_identifiable(local, cdf, get_identifier=hash_dict)
-        elif len(json_path) == 4 and json_path[:2] == ("dataExplorationConfig", "filters") and json_path[3] == "values":
-            # Handles dataExplorationConfig.filters[i].values
-            return diff_list_hashable(local, cdf)
 
         return super().diff_list(local, cdf, json_path)

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
@@ -462,7 +462,7 @@ class InFieldCDMLocationConfigIO(ResourceIO[NodeId, InFieldCDMLocationConfigRequ
         elif len(json_path) == 3 and json_path[0] == "dataFilters" and json_path[2] == "instanceSpaces":
             # Handles dataFilters.<entity>.instanceSpaces (e.g., files, assets, operations, timeSeries, etc.)
             return diff_list_hashable(local, cdf)
-        elif json_path == ("viewMappings", "observations"):
+        elif json_path == ("viewMappings", "observation"):
             return diff_list_identifiable(local, cdf, get_identifier=hash_dict)
 
         return super().diff_list(local, cdf, json_path)

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
@@ -85,6 +85,8 @@ class ViewMappings(BaseModelResource):
     activity: ViewMapping | None = None
 
     file: ViewMapping | None = None
+    # As of 27/04-26, observation only supported for one view,
+    # but we keep the list for future flexibility.
     observation: list[ViewMapping] | None = Field(None, min_length=1, max_length=1)
 
 

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import Field
 
@@ -88,6 +88,12 @@ class ViewMappings(BaseModelResource):
     observation: list[ViewMapping] | None = None
 
 
+class DataExplorationConfig(BaseModelResource):
+    """Data exploration configuration."""
+
+    asset_properties_card: ViewMapping | None = None
+
+
 class Discipline(BaseModelResource):
     """Discipline configuration."""
 
@@ -123,9 +129,7 @@ class InFieldCDMLocationConfigYAML(ToolkitResource):
     data_storage: DataStorage | None = None
     view_mappings: ViewMappings | None = None
     disciplines: list[Discipline] | None = None
-    # Data exploration Config is as of 26/04-26 in development.
-    # Thus, we do not validate it (i.e., not creating a pydantic model for it) but allow any dict to be passed in.
-    data_exploration_config: dict[str, Any] | None = None
+    data_exploration_config: DataExplorationConfig | None = None
 
     def as_id(self) -> NodeId:
         return NodeId(space=self.space, external_id=self.external_id)

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
@@ -85,7 +85,7 @@ class ViewMappings(BaseModelResource):
     activity: ViewMapping | None = None
 
     file: ViewMapping | None = None
-    observation: list[ViewMapping] | None = None
+    observations: list[ViewMapping] | None = Field(None, min_length=1, max_length=1)
 
 
 class DataExplorationConfig(BaseModelResource):

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
@@ -85,7 +85,7 @@ class ViewMappings(BaseModelResource):
     activity: ViewMapping | None = None
 
     file: ViewMapping | None = None
-    observations: list[ViewMapping] | None = Field(None, min_length=1, max_length=1)
+    observation: list[ViewMapping] | None = Field(None, min_length=1, max_length=1)
 
 
 class DataExplorationConfig(BaseModelResource):

--- a/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InFieldCDMLocationConfig.yaml
+++ b/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InFieldCDMLocationConfig.yaml
@@ -65,7 +65,7 @@ viewMappings:
     space: sp_maintenance_space
     version: v1
     externalId: MaintenanceOrder
-  observations:
+  observation:
   - space: sp_observations_space
     version: v1
     externalId: FieldObservation

--- a/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InFieldCDMLocationConfig.yaml
+++ b/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InFieldCDMLocationConfig.yaml
@@ -75,15 +75,7 @@ disciplines:
 - name: Civil
   externalId: discipline_civil
 dataExplorationConfig:
-  enabled: true
-  defaultView: asset_hierarchy
-  searchEnabled: true
-  filters:
-  - type: status
-    values:
-    - active
-    - inactive
-  - type: location
-    values:
-    - plant_a
-    - plant_b
+  assetPropertiesCard:
+    space: customer_idm_extention
+    version: v2
+    externalId: AssetPropertiesCard

--- a/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InFieldCDMLocationConfig.yaml
+++ b/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InFieldCDMLocationConfig.yaml
@@ -65,6 +65,10 @@ viewMappings:
     space: sp_maintenance_space
     version: v1
     externalId: MaintenanceOrder
+  observations:
+  - space: sp_observations_space
+    version: v1
+    externalId: FieldObservation
 disciplines:
 - name: Electrical
   externalId: discipline_electrical

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
@@ -114,10 +114,10 @@ def invalid_test_cases() -> Iterable:
             "externalId": "my_config",
             "space": "my_space",
             "viewMappings": {
-                "observations": [],
+                "observation": [],
             },
         },
-        {"In viewMappings.observations list should have at least 1 item after validation, not 0"},
+        {"In viewMappings.observation list should have at least 1 item after validation, not 0"},
         id="Empty observation list in viewMappings",
     )
     yield pytest.param(
@@ -125,13 +125,13 @@ def invalid_test_cases() -> Iterable:
             "externalId": "my_config",
             "space": "my_space",
             "viewMappings": {
-                "observations": [
+                "observation": [
                     {"space": "my_space", "version": "v1", "externalId": "ObsA"},
                     {"space": "my_space", "version": "v1", "externalId": "ObsB"},
                 ],
             },
         },
-        {"In viewMappings.observations list should have at most 1 item after validation, not 2"},
+        {"In viewMappings.observation list should have at most 1 item after validation, not 2"},
         id="Multiple observations in viewMappings not supported",
     )
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
@@ -83,6 +83,32 @@ def invalid_test_cases() -> Iterable:
         },
         id="Multiple type mismatches across nested structures",
     )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
+            "dataExplorationConfig": {
+                "unknownField": "bad_value",
+            },
+        },
+        {"In dataExplorationConfig unknown field: 'unknownField'"},
+        id="Unknown field in dataExplorationConfig",
+    )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
+            "dataExplorationConfig": {
+                "assetPropertiesCard": {
+                    "space": "my_space",
+                    "version": "v1",
+                    # Missing externalId
+                },
+            },
+        },
+        {"In dataExplorationConfig.assetPropertiesCard missing required field: 'externalId'"},
+        id="Missing required field in dataExplorationConfig.assetPropertiesCard",
+    )
 
 
 class TestInfieldCDMLocationConfigYAML:

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
@@ -109,6 +109,31 @@ def invalid_test_cases() -> Iterable:
         {"In dataExplorationConfig.assetPropertiesCard missing required field: 'externalId'"},
         id="Missing required field in dataExplorationConfig.assetPropertiesCard",
     )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
+            "viewMappings": {
+                "observations": [],
+            },
+        },
+        {"In viewMappings.observations list should have at least 1 item after validation, not 0"},
+        id="Empty observation list in viewMappings",
+    )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
+            "viewMappings": {
+                "observations": [
+                    {"space": "my_space", "version": "v1", "externalId": "ObsA"},
+                    {"space": "my_space", "version": "v1", "externalId": "ObsB"},
+                ],
+            },
+        },
+        {"In viewMappings.observations list should have at most 1 item after validation, not 2"},
+        id="Multiple observations in viewMappings not supported",
+    )
 
 
 class TestInfieldCDMLocationConfigYAML:

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags.yaml
@@ -160,18 +160,10 @@ InFieldCDMLocationConfigResponse:
         - gp_infield_template_admins
         - gp_location_admins
       dataExplorationConfig:
-        defaultView: asset_hierarchy
-        enabled: true
-        filters:
-        - type: status
-          values:
-          - active
-          - inactive
-        - type: location
-          values:
-          - plant_a
-          - plant_b
-        searchEnabled: true
+        assetPropertiesCard:
+          externalId: AssetPropertiesCard
+          space: customer_idm_extention
+          version: v2
       dataFilters:
         assets:
           instanceSpaces:

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags.yaml
@@ -227,6 +227,10 @@ InFieldCDMLocationConfigResponse:
           externalId: Notification
           space: sp_notifications_space
           version: v1
+        observations:
+        - externalId: FieldObservation
+          space: sp_observations_space
+          version: v1
         operation:
           externalId: Operation
           space: sp_operations_space

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags.yaml
@@ -227,7 +227,7 @@ InFieldCDMLocationConfigResponse:
           externalId: Notification
           space: sp_notifications_space
           version: v1
-        observations:
+        observation:
         - externalId: FieldObservation
           space: sp_observations_space
           version: v1

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags_v2.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags_v2.yaml
@@ -217,7 +217,7 @@ InFieldCDMLocationConfigResponse:
           externalId: Notification
           space: sp_notifications_space
           version: v1
-        observations:
+        observation:
         - externalId: FieldObservation
           space: sp_observations_space
           version: v1

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags_v2.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags_v2.yaml
@@ -217,6 +217,10 @@ InFieldCDMLocationConfigResponse:
           externalId: Notification
           space: sp_notifications_space
           version: v1
+        observations:
+        - externalId: FieldObservation
+          space: sp_observations_space
+          version: v1
         operation:
           externalId: Operation
           space: sp_operations_space

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags_v2.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags_v2.yaml
@@ -150,18 +150,10 @@ InFieldCDMLocationConfigResponse:
         - gp_infield_template_admins
         - gp_location_admins
       dataExplorationConfig:
-        defaultView: asset_hierarchy
-        enabled: true
-        filters:
-        - type: status
-          values:
-          - active
-          - inactive
-        - type: location
-          values:
-          - plant_a
-          - plant_b
-        searchEnabled: true
+        assetPropertiesCard:
+          externalId: AssetPropertiesCard
+          space: customer_idm_extention
+          version: v2
       dataFilters:
         assets:
           instanceSpaces:


### PR DESCRIPTION
# Description

DataExplorationConfig will now be used for configurations for asset cards in infield. It is currently not being used for anything else, so I removed all deprecated fields, and added validation for how it should look like.

Another is to change the view mappings validation for observations list. For now, it should only allow one item (there was also a typo.

Tasks: 
- https://cognitedata.atlassian.net/browse/FO-3487
- https://cognitedata.atlassian.net/browse/FO-3513

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Improved

- [alpha] When running `cdf build` with InfieldCDMLocationConfig resources, Toolkit will now more strictly validate these.
