### PR TITLE
Fix instance space validation in dataset-based migration path

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
@@ -103,7 +103,7 @@ class AssetCentricMigrationIO(
                 raise ToolkitValueError(
                     f"Missing instance space that maps to {selector.data_set_external_id!r}. Have you run `cdf migrate data-sets`?"
                 )
-            instance_spaces = [SpaceId(space=space_source.space)]
+            instance_spaces = [SpaceId(space=space_source.instance_space)]
             iterator = self._stream_given_dataset(selector, space_source, limit)
         else:
             raise ToolkitNotImplementedError(f"Selector {type(selector)} is not supported for stream_data")


### PR DESCRIPTION
# Description

`cdf migrate assets/events/timeseries/files --data-set <ds>` runs a pre-flight check to verify the target instance space exists before starting the migration. Due to a wrong attribute reference (`space_source.space` instead of `space_source.instance_space`), the check was always validating `"cognite_migration"` (the node in `SpaceSource`'s own space) rather than the actual target instance space of the mapping (which is on the `instanceSpace` property in `SpaceSource`. The migration would then proceed, and if the target instance space was missing, users would get a failure mid-migration instead of an early, actionable error.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- [alpha] When running the `cdf migrate assets/events/timeseries/files` commands, toolkit will now validate ahead of time whether the target instance space is missing, instead of failing mid-migration.
