### PR TITLE
Fix silent (attempted) deletion of data-bearing resources on deploy when support_update is False

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -688,6 +688,15 @@ class DeployV2Command(ToolkitCommand):
                     continue
                 if crud.support_update:
                     resources.to_update.append(resource.request)
+                elif is_data_resource:
+                    resources.skipped.append(
+                        Skipped(
+                            identifier,
+                            code="HAS-DATA",
+                            source_file=resource.source_files[0],
+                            reason=(f"{identifier!s} contains data and does not support updates. "),
+                        )
+                    )
                 else:
                     resources.to_delete.append(identifier)
                     resources.to_create.append(resource.request)

--- a/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
@@ -9,14 +9,14 @@ import pytest
 import respx
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
-from cognite_toolkit._cdf_tk.client.identifiers import RawDatabaseId, SpaceId
+from cognite_toolkit._cdf_tk.client.identifiers import RawDatabaseId, RawTableId, SpaceId
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._space import SpaceRequest, SpaceResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.function import FunctionResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.function_schedule import (
     FunctionScheduleData,
     FunctionScheduleResponse,
 )
-from cognite_toolkit._cdf_tk.client.resource_classes.raw import RAWDatabaseResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.raw import RAWDatabaseResponse, RAWTableResponse
 from cognite_toolkit._cdf_tk.client.testing import ToolkitClientMock, monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.commands import DeployOptions, DeployV2Command
 from cognite_toolkit._cdf_tk.commands.deploy_v2.command import (
@@ -42,6 +42,7 @@ from cognite_toolkit._cdf_tk.resource_ios import (
     FunctionScheduleIO,
     LabelIO,
     RawDatabaseCRUD,
+    RawTableCRUD,
     ResourceIO,
     SpaceCRUD,
 )
@@ -457,6 +458,36 @@ class TestApplyPlan:
                 ),
                 id="raw_database_with_extra_fields_is_skipped_not_attempted_deleted",
             ),
+            pytest.param(
+                ApplyPlanTestCase(
+                    yaml_files={"raw/my.Table.yaml": "dbName: my_db\ntableName: my_table\nextraField: extra_value\n"},
+                    crud_cls=RawTableCRUD,
+                    cdf_resources=[RAWTableResponse(db_name="my_db", name="my_table", created_time=0)],
+                    acls_missing=False,
+                    options=DeployOptions(dry_run=True),
+                    expected=[
+                        DeploymentResult(
+                            resource_name="raw tables",
+                            is_dry_run=True,
+                            created_count=0,
+                            deleted_count=0,
+                            updated_count=0,
+                            unchanged_count=0,
+                            is_missing_write_acl=False,
+                            skipped=[
+                                Skipped(
+                                    id=RawTableId(db_name="my_db", name="my_table"),
+                                    code="HAS-DATA",
+                                    source_file=Path("raw/my.Table.yaml"),
+                                    reason="my_db.my_table contains data and does not support updates. ",
+                                )
+                            ],
+                        )
+                    ],
+                    expected_skipped_count=1,
+                ),
+                id="raw_table_with_extra_fields_is_skipped_not_attempted_deleted",
+            ),
         ],
     )
     def test_apply_plan(self, case: ApplyPlanTestCase, tmp_path: Path) -> None:
@@ -522,6 +553,8 @@ class TestApplyPlan:
             client.tool.functions.schedules.input_data.return_value = FunctionScheduleData(id=37)
         elif issubclass(case.crud_cls, RawDatabaseCRUD):
             client.tool.raw.databases.list.return_value = case.cdf_resources
+        elif issubclass(case.crud_cls, RawTableCRUD):
+            client.tool.raw.tables.list.return_value = case.cdf_resources
         else:
             pytest.fail(f"Test case for unsupported CRUD class: {case.crud_cls}")
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
@@ -9,13 +9,14 @@ import pytest
 import respx
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
-from cognite_toolkit._cdf_tk.client.identifiers import SpaceId
+from cognite_toolkit._cdf_tk.client.identifiers import RawDatabaseId, SpaceId
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._space import SpaceRequest, SpaceResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.function import FunctionResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.function_schedule import (
     FunctionScheduleData,
     FunctionScheduleResponse,
 )
+from cognite_toolkit._cdf_tk.client.resource_classes.raw import RAWDatabaseResponse
 from cognite_toolkit._cdf_tk.client.testing import ToolkitClientMock, monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.commands import DeployOptions, DeployV2Command
 from cognite_toolkit._cdf_tk.commands.deploy_v2.command import (
@@ -40,6 +41,7 @@ from cognite_toolkit._cdf_tk.resource_ios import (
     DataSetsIO,
     FunctionScheduleIO,
     LabelIO,
+    RawDatabaseCRUD,
     ResourceIO,
     SpaceCRUD,
 )
@@ -425,6 +427,36 @@ class TestApplyPlan:
                 ),
                 id="unchanged_space",
             ),
+            pytest.param(
+                ApplyPlanTestCase(
+                    yaml_files={"raw/my.Database.yaml": "dbName: my_db\ntableName: my_table\n"},
+                    crud_cls=RawDatabaseCRUD,
+                    cdf_resources=[RAWDatabaseResponse(name="my_db", created_time=0)],
+                    acls_missing=False,
+                    options=DeployOptions(dry_run=True),
+                    expected=[
+                        DeploymentResult(
+                            resource_name="raw databases",
+                            is_dry_run=True,
+                            created_count=0,
+                            deleted_count=0,
+                            updated_count=0,
+                            unchanged_count=0,
+                            is_missing_write_acl=False,
+                            skipped=[
+                                Skipped(
+                                    id=RawDatabaseId(name="my_db"),
+                                    code="HAS-DATA",
+                                    source_file=Path("raw/my.Database.yaml"),
+                                    reason="name='my_db' contains data and does not support updates. ",
+                                )
+                            ],
+                        )
+                    ],
+                    expected_skipped_count=1,
+                ),
+                id="raw_database_with_extra_fields_is_skipped_not_attempted_deleted",
+            ),
         ],
     )
     def test_apply_plan(self, case: ApplyPlanTestCase, tmp_path: Path) -> None:
@@ -488,6 +520,8 @@ class TestApplyPlan:
             client.tool.functions.retrieve.return_value = function_responses
             client.tool.functions.schedules.list.return_value = case.cdf_resources
             client.tool.functions.schedules.input_data.return_value = FunctionScheduleData(id=37)
+        elif issubclass(case.crud_cls, RawDatabaseCRUD):
+            client.tool.raw.databases.list.return_value = case.cdf_resources
         else:
             pytest.fail(f"Test case for unsupported CRUD class: {case.crud_cls}")
 


### PR DESCRIPTION
# Description

In `_categorize_resources`, when a resource already existed in CDF and a diff was detected, the code would unconditionally attempt to delete and recreate it if `support_update=False`. This affected some data-bearing resources (e.g. RAW databases, RAW tables) which implement `ResourceContainerIO`. Two root causes combined to expose this for a user upgrading from 0.7 to 0.8:

1. In 0.7, the legacy `RawBuilder` re-routed YAML entries containing `tableName` to the table loader, silently correcting misnamed `.Database.yaml` files. In 0.8, routing is purely by filename suffix, so a `.Database.yaml` containing `tableName` produces a local dict that differs from the CDF dump (`{"dbName": "..."}` vs `{"dbName": "...", "tableName": "..."}`).

2. The diff-detected branch in `_categorize_resources` had no `--drop-data` guard for container resources (unlike the explicit delete branch, which does). Any detected diff on a `ResourceContainerIO` with `support_update=False` would trigger an attempted delete+recreate unconditionally on a plain `cdf deploy`, even without `--drop` or `--drop-data`. 

Note: There was never any danger of accidental data-deletion because we used `recursive=False` in the RAW API delete method, data was protected, but the previous logic could have become a footgun for later.

The fix adds a guard in the `support_update=False` branch: if `is_data_resource` (i.e. the resource is a `ResourceContainerIO`), skip with `HAS-DATA` instead of adding to `to_delete`/`to_create`.

This PR will be followed with a deprecation of and added guardrails for `--drop` and `--drop-data` next.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fix `cdf deploy` incorrectly attempting (unsuccessfully) to delete and recreate RAW databases when a Database.yaml or Table.yaml file was misconfigured with unsupported fields. Toolkit will now skip such misconfigured files completely instead.