### PR TITLE
[CDF-27824] Fix unknown ACL action fallback

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
@@ -620,7 +620,7 @@ def _is_unknown_scope_or_action(error: ErrorDetails) -> bool:
     loc = error["loc"]
     if not loc:
         return False
-    is_unknown_action = loc[0] == "action" and isinstance(loc[-1], int)
+    is_unknown_action = loc[0] == "actions" and isinstance(loc[-1], int)
     is_unknown_scope = loc[0] == "scope" and loc[-1] == "scope_name"
     return error["type"] == "literal_error" and (is_unknown_action or is_unknown_scope)
 

--- a/tests/test_unit/test_cdf_tk/test_client/test_group_api_classes.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_group_api_classes.py
@@ -199,6 +199,21 @@ class TestGroupAPIClasses:
         assert acl.acl_name == "myUnknownAcl"
         assert isinstance(acl.scope, ScopeDefinition)
 
+    def test_serialize_deserialize_known_capability_with_unknown_action(self) -> None:
+        """Test that known ACLs with future actions are preserved as unknown ACLs."""
+        acl_dict = {"functionsAcl": {"actions": ["READ", "SOME_FUTURE_ACTION"], "scope": {"all": {}}}}
+        data = {"name": "test-group", "id": 123, "capabilities": [acl_dict]}
+
+        group = GroupRequest.model_validate(data)
+
+        assert isinstance(group, GroupRequest)
+        assert group.dump() == {"name": "test-group", "capabilities": [acl_dict]}
+        assert group.capabilities and len(group.capabilities) == 1
+        acl = group.capabilities[0].acl
+        assert isinstance(acl, UnknownAcl)
+        assert acl.acl_name == "functionsAcl"
+        assert isinstance(acl.scope, ScopeDefinition)
+
     def test_capability_in_sync(self) -> None:
         """Checks that the request/response capabilities are in sync with the YAML spec."""
         request_capabilities = {acl.model_fields["acl_name"].default for acl in get_all_subclasses(Acl)} - {


### PR DESCRIPTION
# Description

Fix group ACL parsing so known ACLs with future or unknown actions are preserved as `UnknownAcl` instead of failing validation. This keeps group config and CDF responses forward-compatible when CDF adds new actions before Toolkit models know about them.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Fixed parsing of known group ACLs with unknown actions so they are preserved and passed through as unknown ACLs.