### PR TITLE
[CDF-27825] Replace data product version views on update

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_product_version.py
@@ -79,7 +79,7 @@ class DataProductVersionRequest(DataProductVersion, UpdatableRequestResource):
                 update["terms"] = {"modify": terms_modify}
 
         if dumped.get("views"):
-            update["views"] = {"add": dumped["views"]}
+            update["views"] = {"add" if mode == "patch" else "set": dumped["views"]}
 
         update_item["update"] = update
         return update_item

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/agent.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/agent.py
@@ -119,7 +119,7 @@ class AgentIO(ResourceIO[ExternalId, AgentRequest, AgentResponse]):
             # Instructions are optional, if not set the server set them to an empty string.
             # We remove them from the dumped resource to ensure it will be equal to the local resource.
             dumped.pop("instructions", None)
-        for key in ["labels", "exampleQuestions"]:
+        for key in ["labels", "exampleQuestions", "skills"]:
             if key not in local and not dumped.get(key):
                 # If the local resource does not have the key and the server set Agent has it set to an empty list,
                 # we remove it from the dumped resource to ensure it will be equal to the local resource.

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_agent.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_agent.py
@@ -3,8 +3,36 @@ from collections.abc import Hashable
 import pytest
 
 from cognite_toolkit._cdf_tk.client.identifiers import DataModelId, ExternalId
+from cognite_toolkit._cdf_tk.client.resource_classes.agent import AgentResponse
+from cognite_toolkit._cdf_tk.client.testing import ToolkitClientMock
 from cognite_toolkit._cdf_tk.resource_ios import DataModelIO, FunctionIO, ResourceIO
 from cognite_toolkit._cdf_tk.resource_ios._resource_ios.agent import AgentIO
+
+
+class TestAgentIODumpResource:
+    def test_dump_resource_ignores_empty_skills_when_omitted_locally(self) -> None:
+        client = ToolkitClientMock()
+        io = AgentIO(client, None, None)
+        local = {
+            "externalId": "my_agent",
+            "name": "My Agent",
+            "runtimeVersion": "0.9.9",
+        }
+        resource = AgentResponse.model_validate(
+            {
+                "externalId": "my_agent",
+                "name": "My Agent",
+                "createdTime": 0,
+                "lastUpdatedTime": 0,
+                "ownerId": "owner",
+                "runtimeVersion": "0.9.9",
+                "skills": [],
+            }
+        )
+
+        dumped = io.dump_resource(resource, local)
+
+        assert dumped == local
 
 
 class TestAgentIODependencies:

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_data_product_version.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_data_product_version.py
@@ -2,6 +2,7 @@
 
 from cognite_toolkit._cdf_tk.client.resource_classes.data_product_version import (
     DataProductVersionQuality,
+    DataProductVersionRequest,
     DataProductVersionResponse,
 )
 from cognite_toolkit._cdf_tk.client.testing import ToolkitClientMock
@@ -49,3 +50,33 @@ class TestDataProductVersionIODumpResource:
         dumped = io.dump_resource(resource, local)
 
         assert "quality" in dumped
+
+
+class TestDataProductVersionRequest:
+    def test_as_update_replaces_views_in_replace_mode(self) -> None:
+        request = DataProductVersionRequest.model_validate(
+            {
+                "dataProductExternalId": "my-product",
+                "version": "1.0.0",
+                "views": [
+                    {
+                        "space": "cdf_cdm",
+                        "externalId": "Cognite3DModel",
+                        "version": "v1",
+                    }
+                ],
+            }
+        )
+
+        update = request.as_update(mode="replace")
+
+        assert update["update"]["views"] == {
+            "set": [
+                {
+                    "space": "cdf_cdm",
+                    "externalId": "Cognite3DModel",
+                    "version": "v1",
+                    "instanceSpaces": {"read": [], "write": []},
+                }
+            ]
+        }


### PR DESCRIPTION
# Description

Fixes DataProductVersion updates so replace-mode deploys send the full desired `views` list with `set` instead of appending views with `add`. This avoids duplicate-view failures when a data product version is redeployed or force-updated without changing its views.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Use `views.set` for replace-mode DataProductVersion updates to avoid appending duplicate existing views.