### PR TITLE
EMT-376 Add entity-matching command family to cdf dev

### DIFF
--- a/cdf.toml
+++ b/cdf.toml
@@ -15,6 +15,7 @@ create = true
 extend-download = true
 extend-upload = true
 data-products = true
+entity-matching = false
 
 [plugins]
 run = true

--- a/cognite_toolkit/_cdf_tk/apps/__init__.py
+++ b/cognite_toolkit/_cdf_tk/apps/__init__.py
@@ -1,10 +1,10 @@
 from ._auth_app import AuthApp
 from ._core_app import CoreApp
-from ._entity_matching_app import EntityMatchingApp
 from ._data_app import DataApp
 from ._dev_app import DevApp
 from ._download_app import DownloadApp
 from ._dump_app import DumpApp
+from ._entity_matching_app import EntityMatchingApp
 from ._import_app import ImportApp
 from ._landing_app import LandingApp
 from ._migrate_app import MigrateApp
@@ -21,8 +21,8 @@ __all__ = [
     "DataApp",
     "DevApp",
     "DownloadApp",
-    "EntityMatchingApp",
     "DumpApp",
+    "EntityMatchingApp",
     "ImportApp",
     "LandingApp",
     "MigrateApp",

--- a/cognite_toolkit/_cdf_tk/apps/__init__.py
+++ b/cognite_toolkit/_cdf_tk/apps/__init__.py
@@ -1,5 +1,6 @@
 from ._auth_app import AuthApp
 from ._core_app import CoreApp
+from ._entity_matching_app import EntityMatchingApp
 from ._data_app import DataApp
 from ._dev_app import DevApp
 from ._download_app import DownloadApp
@@ -20,6 +21,7 @@ __all__ = [
     "DataApp",
     "DevApp",
     "DownloadApp",
+    "EntityMatchingApp",
     "DumpApp",
     "ImportApp",
     "LandingApp",

--- a/cognite_toolkit/_cdf_tk/apps/_dev_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dev_app.py
@@ -11,6 +11,7 @@ from cognite_toolkit._cdf_tk.commands import ResourcesCommand
 from cognite_toolkit._cdf_tk.feature_flags import FeatureFlag, Flags
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 
+from ._entity_matching_app import EntityMatchingApp
 from ._run import RunApp
 
 CDF_TOML = CDFToml.load(Path.cwd())
@@ -23,6 +24,8 @@ class DevApp(typer.Typer):
         self.add_typer(RunApp(*args, **kwargs), name="run")
         if FeatureFlag.is_enabled(Flags.CREATE):
             self.command("create")(self.create)
+        if FeatureFlag.is_enabled(Flags.ENTITY_MATCHING):
+            self.add_typer(EntityMatchingApp(*args, **kwargs), name="entity-matching")
 
     @staticmethod
     def main(ctx: typer.Context) -> None:

--- a/cognite_toolkit/_cdf_tk/apps/_entity_matching_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_entity_matching_app.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Any
+
+import typer
+from rich import print
+
+from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
+from cognite_toolkit._cdf_tk.commands.entity_matching import EntityMatchingCommand
+
+CDF_TOML = CDFToml.load(Path.cwd())
+
+
+class EntityMatchingApp(typer.Typer):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.callback(invoke_without_command=True)(self.main)
+        self.command("generate-aliasing-workflow")(self.generate_aliasing_workflow)
+
+    @staticmethod
+    def main(ctx: typer.Context) -> None:
+        """Commands for entity matching."""
+        if ctx.invoked_subcommand is None:
+            print("Use [bold yellow]cdf dev entity-matching --help[/] for more information.")
+
+    def generate_aliasing_workflow(
+        self,
+        input_yaml: Annotated[
+            Path,
+            typer.Argument(
+                help="Path to the aliasing-rules YAML input file.",
+                exists=True,
+                file_okay=True,
+                dir_okay=False,
+                readable=True,
+            ),
+        ],
+        output_dir: Annotated[
+            Path | None,
+            typer.Option(
+                "--output-dir",
+                "-o",
+                help="Directory where the generated YAML files will be written. "
+                "Defaults to a 'generated/' folder next to the input file.",
+            ),
+        ] = None,
+    ) -> None:
+        """Generate Workflow and WorkflowVersion YAML files from an aliasing-rules input file."""
+        resolved_output_dir = output_dir or (input_yaml.parent / "generated")
+        cmd = EntityMatchingCommand()
+        cmd.run(lambda: cmd.generate_aliasing_workflow(input_yaml=input_yaml, output_dir=resolved_output_dir))

--- a/cognite_toolkit/_cdf_tk/commands/__init__.py
+++ b/cognite_toolkit/_cdf_tk/commands/__init__.py
@@ -15,6 +15,7 @@ from .clean import CleanCommand
 from .deploy import DeployCommand
 from .deploy_v2.command import DeploymentStep, DeployOptions, DeployV2Command
 from .dump_resource import DumpResourceCommand
+from .entity_matching import EntityMatchingCommand
 from .functions import FunctionsCommand
 from .init import InitCommand
 from .modules import ModulesCommand
@@ -35,6 +36,7 @@ __all__ = [
     "DeploymentStep",
     "DownloadCommand",
     "DumpResourceCommand",
+    "EntityMatchingCommand",
     "FunctionsCommand",
     "InitCommand",
     "MigrationCommand",

--- a/cognite_toolkit/_cdf_tk/commands/entity_matching.py
+++ b/cognite_toolkit/_cdf_tk/commands/entity_matching.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from rich import print
+from rich.panel import Panel
+
+from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
+
+# ---------------------------------------------------------------------------
+# Static mock YAML templates
+# These will be replaced with dynamic translation from input rules later.
+# ---------------------------------------------------------------------------
+
+_WORKFLOW_YAML = """\
+externalId: entity_matching_aliasing
+description: Entity matching aliasing workflow
+"""
+
+_WORKFLOW_VERSION_YAML = """\
+workflowExternalId: entity_matching_aliasing
+version: 'v1'
+workflowDefinition:
+  description: 'Entity matching aliasing workflow'
+  tasks:
+    - externalId: configurator
+      type: function
+      name: Configurator
+      retries: 0
+      parameters:
+        function:
+          externalId: aliasing_aliasing_configurator
+          data:
+            path: /
+            method: POST
+      onFailure: abortWorkflow
+      dependsOn: []
+
+    - externalId: key_extraction
+      type: jsonMapping
+      name: Extract Keys from Properties
+      retries: 0
+      parameters:
+        jsonMapping:
+          expression: ${configurator.output.response.key_extraction_expression}
+          inputs:
+            - input
+          input: ${workflow.input}
+      onFailure: abortWorkflow
+      dependsOn:
+        - externalId: configurator
+
+    - externalId: aliasing_task
+      type: jsonMapping
+      name: Aliasing
+      retries: 0
+      parameters:
+        jsonMapping:
+          expression: ${configurator.output.response.aliasing_expression}
+          inputs:
+            - input
+          input: ${key_extraction.output.result}
+      onFailure: abortWorkflow
+      dependsOn:
+        - externalId: key_extraction
+"""
+
+
+class EntityMatchingCommand(ToolkitCommand):
+    """Commands for the entity-matching family."""
+
+    def generate_aliasing_workflow(
+        self,
+        input_yaml: Path,
+        output_dir: Path,
+    ) -> None:
+        """Generate Workflow and WorkflowVersion YAMLs from an aliasing-rules input file.
+
+        Currently writes static mock files. Future iterations will translate
+        rules from the input YAML into the workflow task definitions.
+        """
+        if not input_yaml.exists():
+            raise FileNotFoundError(f"Input file not found: {input_yaml}")
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        stem = input_yaml.stem
+
+        workflow_path = output_dir / f"{stem}.Workflow.yaml"
+        workflow_version_path = output_dir / f"{stem}.WorkflowVersion.yaml"
+
+        workflow_path.write_text(_WORKFLOW_YAML, encoding="utf-8")
+        self.console(f"Generated {workflow_path.as_posix()}")
+
+        workflow_version_path.write_text(_WORKFLOW_VERSION_YAML, encoding="utf-8")
+        self.console(f"Generated {workflow_version_path.as_posix()}")
+
+        print(Panel(f"Generated 2 files in {output_dir.as_posix()}", title="Success", style="green", expand=False))

--- a/cognite_toolkit/_cdf_tk/feature_flags.py
+++ b/cognite_toolkit/_cdf_tk/feature_flags.py
@@ -78,6 +78,10 @@ class Flags(Enum):
         visible=True,
         description="Enables JSON output format for the modules list command",
     )
+    ENTITY_MATCHING = FlagMetadata(
+        visible=True,
+        description="Enables the entity-matching command family under the dev plugin",
+    )
 
     def is_enabled(self) -> bool:
         return FeatureFlag.is_enabled(self)


### PR DESCRIPTION
Introduces the cdf dev entity-matching command family under the dev plugin, gated by the entity_matching flag.
Adds the first command generate-aliasing-workflow, which generates a static Workflow and WorkflowVersion YAML from an input file. Dynamic translation of aliasing rules from the input YAML is out of scope for this PR and will follow.

## Bump

- [ ] Patch
- [x] Skip