### PR TITLE
[CDF-27845] diff_table: intra-line character-level highlighting

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -371,9 +371,7 @@ class BuildV2Command(ToolkitCommand):
             summary_sections.append(ToolkitPanelSection(title="Issue details", content=issue_details_section_content))
 
         border_style = {0: AuraColor.GREEN.rich, 1: AuraColor.AMBER.rich, 2: AuraColor.RED.rich}[border_color]
-        console.print(
-            ToolkitPanel(Group(*summary_sections), title="[bold]Loading modules[/]", border_style=border_style)
-        )
+        console.print(ToolkitPanel(Group(*summary_sections), title="Loading modules", border_style=border_style))
 
         if errors:
             console.print("\n")
@@ -797,7 +795,7 @@ class BuildV2Command(ToolkitCommand):
         console.print(
             ToolkitPanel(
                 Group(*validation_sections),
-                title="[bold]Planning validation[/]",
+                title="Planning validation",
                 border_style=border_style,
             )
         )
@@ -971,7 +969,7 @@ class BuildV2Command(ToolkitCommand):
         console.print(
             ToolkitPanel(
                 "\n".join(summary_lines),
-                title=f"[bold]Built to directory {build_dir_display}[/]",
+                title=f"Built to directory {build_dir_display}",
                 border_style=border_color,
             )
         )

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -6,7 +6,6 @@ from typing import overload
 from cognite.client.exceptions import CogniteAPIError, CogniteDuplicatedError
 from rich import print
 from rich.markup import escape
-from rich.panel import Panel
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client._resource_base import T_Identifier, T_RequestResource, T_ResponseResource
@@ -56,6 +55,7 @@ from cognite_toolkit._cdf_tk.tk_warnings.other import (
     LowSeverityWarning,
     ToolkitDependenciesIncludedWarning,
 )
+from cognite_toolkit._cdf_tk.ui import ToolkitPanel
 from cognite_toolkit._cdf_tk.utils import humanize_collection, read_yaml_file
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 
@@ -168,16 +168,11 @@ class DeployCommand(ToolkitCommand):
 
     @staticmethod
     def _start_message(build_dir: Path, dry_run: bool, env_vars: EnvironmentVariables) -> None:
-        environment_vars = ""
-        if not _RUNNING_IN_BROWSER:
-            environment_vars = f"\n\nConnected to {env_vars.as_string()}"
         verb = "Checking" if dry_run else "Deploying"
-        print(
-            Panel(
-                f"[bold]{verb}[/]resource files from {build_dir} directory.{environment_vars}",
-                expand=False,
-            )
-        )
+        content = f"[bold]{verb}[/] resource files from {build_dir} directory."
+        if not _RUNNING_IN_BROWSER:
+            content += f"\n\nConnected to {env_vars.as_string()}"
+        print(ToolkitPanel(content, title="[bold]Deploy[/]", expand=False))
 
     def clean_all_resources(
         self,
@@ -193,14 +188,10 @@ class DeployCommand(ToolkitCommand):
         verbose: bool,
     ) -> None:
         # Drop has to be done in the reverse order of deploy.
-        if drop and drop_data:
-            print(Panel("[bold] Cleaning resources as --drop and --drop-data are passed[/]"))
-        elif drop:
-            print(Panel("[bold] Cleaning resources as --drop is passed[/]"))
-        elif drop_data:
-            print(Panel("[bold] Cleaning resources as --drop-data is passed[/]"))
-        else:
+        if not (drop or drop_data):
             return None
+        flags = "--drop and --drop-data" if (drop and drop_data) else ("--drop" if drop else "--drop-data")
+        print(ToolkitPanel(f"Cleaning resources as {flags} is passed", title="[bold]Clean[/]", expand=False))
 
         for loader_cls in reversed(ordered_loaders):
             if not issubclass(loader_cls, ResourceIO):
@@ -289,7 +280,7 @@ class DeployCommand(ToolkitCommand):
 
         """
         if verbose:
-            print(Panel("[bold]DEPLOYING resources...[/]"))
+            print(ToolkitPanel("[bold]Deploying resources...[/]", title="[bold]Deploy[/]", expand=False))
 
         if ordered_loaders is None:
             selected_loaders = self._clean_command.get_selected_loaders(build_dir, set(), None)

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -55,7 +55,7 @@ from cognite_toolkit._cdf_tk.tk_warnings.other import (
     LowSeverityWarning,
     ToolkitDependenciesIncludedWarning,
 )
-from cognite_toolkit._cdf_tk.ui import ToolkitPanel
+from cognite_toolkit._cdf_tk.ui import AuraColor, ToolkitPanel
 from cognite_toolkit._cdf_tk.utils import humanize_collection, read_yaml_file
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 
@@ -172,7 +172,7 @@ class DeployCommand(ToolkitCommand):
         content = f"[bold]{verb}[/] resource files from {build_dir} directory."
         if not _RUNNING_IN_BROWSER:
             content += f"\n\nConnected to {env_vars.as_string()}"
-        print(ToolkitPanel(content, title="[bold]Deploy[/]", expand=False))
+        print(ToolkitPanel(content, title="[bold]Deploy[/]"))
 
     def clean_all_resources(
         self,
@@ -191,7 +191,11 @@ class DeployCommand(ToolkitCommand):
         if not (drop or drop_data):
             return None
         flags = "--drop and --drop-data" if (drop and drop_data) else ("--drop" if drop else "--drop-data")
-        print(ToolkitPanel(f"Cleaning resources as {flags} is passed", title="[bold]Clean[/]", expand=False))
+        print(
+            ToolkitPanel(
+                f"Cleaning resources as {flags} is passed", title="[bold]Clean[/]", border_style=AuraColor.AMBER.rich
+            )
+        )
 
         for loader_cls in reversed(ordered_loaders):
             if not issubclass(loader_cls, ResourceIO):
@@ -280,7 +284,7 @@ class DeployCommand(ToolkitCommand):
 
         """
         if verbose:
-            print(ToolkitPanel("[bold]Deploying resources...[/]", title="[bold]Deploy[/]", expand=False))
+            print(ToolkitPanel("[bold]Deploying resources...[/]", title="[bold]Deploy[/]"))
 
         if ordered_loaders is None:
             selected_loaders = self._clean_command.get_selected_loaders(build_dir, set(), None)

--- a/cognite_toolkit/_cdf_tk/commands/deploy.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy.py
@@ -172,7 +172,7 @@ class DeployCommand(ToolkitCommand):
         content = f"[bold]{verb}[/] resource files from {build_dir} directory."
         if not _RUNNING_IN_BROWSER:
             content += f"\n\nConnected to {env_vars.as_string()}"
-        print(ToolkitPanel(content, title="[bold]Deploy[/]"))
+        print(ToolkitPanel(content, title="Deploy"))
 
     def clean_all_resources(
         self,
@@ -192,9 +192,7 @@ class DeployCommand(ToolkitCommand):
             return None
         flags = "--drop and --drop-data" if (drop and drop_data) else ("--drop" if drop else "--drop-data")
         print(
-            ToolkitPanel(
-                f"Cleaning resources as {flags} is passed", title="[bold]Clean[/]", border_style=AuraColor.AMBER.rich
-            )
+            ToolkitPanel(f"Cleaning resources as {flags} is passed", title="Clean", border_style=AuraColor.AMBER.rich)
         )
 
         for loader_cls in reversed(ordered_loaders):
@@ -284,7 +282,7 @@ class DeployCommand(ToolkitCommand):
 
         """
         if verbose:
-            print(ToolkitPanel("[bold]Deploying resources...[/]", title="[bold]Deploy[/]"))
+            print(ToolkitPanel("[bold]Deploying resources...[/]", title="Deploy"))
 
         if ordered_loaders is None:
             selected_loaders = self._clean_command.get_selected_loaders(build_dir, set(), None)

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -576,7 +576,8 @@ class DeployV2Command(ToolkitCommand):
                 results.append(result)
 
                 progress.update(task_id, advance=len(step.files))
-            progress.update(task_id, description=f"Finished {options.operation}ing.")
+            finished = "Finished dry-run." if options.dry_run else f"Finished {options.operation}ing."
+            progress.update(task_id, description=finished)
         return results
 
     @classmethod

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -934,7 +934,7 @@ class DeployV2Command(ToolkitCommand):
         table.add_column("Skipped", justify="right", style="yellow")
         table.add_column("Total", justify="right", style="cyan")
         if is_dry_run:
-            table.add_column(f"Can {operation}", justify="right")
+            table.add_column("Able to deploy", justify="right")
 
         total = DeploymentResult(
             "All",

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -730,8 +730,8 @@ class DeployV2Command(ToolkitCommand):
                     resources.to_delete.append(identifier)
                     resources.to_create.append(resource.request)
                 if options.verbose:
-                    old_lines = yaml_safe_dump(cdf_dict, sort_keys=True).splitlines()
-                    new_lines = yaml_safe_dump(resource.raw_dict, sort_keys=True).splitlines()
+                    old_lines = yaml_safe_dump(cdf_dict).splitlines()
+                    new_lines = yaml_safe_dump(resource.raw_dict).splitlines()
                     for sensitive in crud.sensitive_strings(resource.request):
                         old_lines = [line.replace(sensitive, "********") for line in old_lines]
                         new_lines = [line.replace(sensitive, "********") for line in new_lines]

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -427,7 +427,7 @@ class DeployV2Command(ToolkitCommand):
         console.print(
             ToolkitPanel(
                 Group(startup_section, read_dir_section, plan_section),
-                title="[bold]Setting up deploy[/]",
+                title=f"Setting up {operation}",
                 border_style=border_style,
             )
         )
@@ -723,7 +723,7 @@ class DeployV2Command(ToolkitCommand):
                     console.print(
                         ToolkitPanel(
                             diff_str,
-                            title=f"[bold]{crud.display_name}:[/] {identifier}",
+                            title=f"{crud.display_name}: {identifier}",
                         )
                     )
         return resources
@@ -905,13 +905,13 @@ class DeployV2Command(ToolkitCommand):
             console.print(
                 ToolkitPanel(
                     f"No resources were {operation}ed.",
-                    title=f"[bold]{operation.title()} summary[/]",
+                    title=f"{operation.title()} summary",
                 )
             )
             return
 
         is_dry_run = results[0].is_dry_run
-        panel_title = f"[bold]{operation.title()} summary[/]"
+        panel_title = f"{operation.title()} summary"
         if is_dry_run:
             panel_title += " [dim](dry run)[/]"
 
@@ -1086,7 +1086,7 @@ class DeployV2Command(ToolkitCommand):
                         )
                     ),
                 ),
-                title="[bold]Deprecation warning[/]",
+                title="Deprecation warning",
                 border_style=AuraColor.AMBER.rich,
             )
         )

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -51,9 +51,17 @@ from cognite_toolkit._cdf_tk.tk_warnings import (
     catch_warnings,
 )
 from cognite_toolkit._cdf_tk.tracker import Tracker
-from cognite_toolkit._cdf_tk.ui import AuraColor, ToolkitPanel, ToolkitPanelSection, ToolkitTable, hanging_indent
-from cognite_toolkit._cdf_tk.utils import humanize_collection, sanitize_filename, to_diff
+from cognite_toolkit._cdf_tk.ui import (
+    AuraColor,
+    ToolkitPanel,
+    ToolkitPanelSection,
+    ToolkitTable,
+    diff_table,
+    hanging_indent,
+)
+from cognite_toolkit._cdf_tk.utils import humanize_collection, sanitize_filename
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
+from cognite_toolkit._cdf_tk.utils.file import yaml_safe_dump
 from cognite_toolkit._version import __version__
 
 Operation: TypeAlias = Literal["deploy", "clean"]
@@ -722,12 +730,14 @@ class DeployV2Command(ToolkitCommand):
                     resources.to_delete.append(identifier)
                     resources.to_create.append(resource.request)
                 if options.verbose:
-                    diff_str = "\n".join(to_diff(cdf_dict, resource.raw_dict))
+                    old_lines = yaml_safe_dump(cdf_dict, sort_keys=True).splitlines()
+                    new_lines = yaml_safe_dump(resource.raw_dict, sort_keys=True).splitlines()
                     for sensitive in crud.sensitive_strings(resource.request):
-                        diff_str = diff_str.replace(sensitive, "********")
+                        old_lines = [line.replace(sensitive, "********") for line in old_lines]
+                        new_lines = [line.replace(sensitive, "********") for line in new_lines]
                     console.print(
                         ToolkitPanel(
-                            diff_str,
+                            diff_table(old_lines, new_lines),
                             title=f"{crud.display_name}: {identifier}",
                         )
                     )

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -12,6 +12,7 @@ import questionary
 from pydantic import ValidationError
 from rich.console import Console, Group, RenderableType
 from rich.markup import escape
+from rich.padding import Padding
 from rich.progress import Progress
 from yaml import YAMLError
 
@@ -324,9 +325,9 @@ class DeployV2Command(ToolkitCommand):
     ) -> list[DeploymentStep]:
         startup_section = ToolkitPanelSection(
             content=[
-                f"Build path: {build_dir.path.as_posix()}",
-                f"CDF project: {cdf_project!r}",
+                f"Target project: {cdf_project!r}",
                 f"Toolkit version: {__version__!s}",
+                f"Build path: {build_dir.path.as_posix()}/",
             ],
         )
 
@@ -386,7 +387,7 @@ class DeployV2Command(ToolkitCommand):
                 )
             )
         read_dir_section = ToolkitPanelSection(
-            title=f"Build directory ({build_dir.path.as_posix()})",
+            title="Processed build directory",
             content=read_dir_subsections,
         )
 
@@ -396,7 +397,7 @@ class DeployV2Command(ToolkitCommand):
             console.print(
                 ToolkitPanel(
                     Group(
-                        startup_section,
+                        Padding(startup_section, (0, 0, 1, 0)),
                         read_dir_section,
                         ToolkitPanelSection(
                             description=f"[bold]Failed to create plan for {operation}:[/] {escape(str(e))}"
@@ -416,7 +417,7 @@ class DeployV2Command(ToolkitCommand):
             step_count = len(plan)
             total_files = sum(len(step.files) for step in plan)
             plan_section = ToolkitPanelSection(
-                title=f"{operation.title()} plan",
+                title="Plan",
                 content=[
                     f"[green]✓[/] [bold]{step_count}[/] resource types to {operation}",
                     f"[green]✓[/] [bold]{total_files}[/] resource files to {operation}",
@@ -426,8 +427,8 @@ class DeployV2Command(ToolkitCommand):
         border_style = AuraColor.AMBER.rich if (has_issues or not plan) else AuraColor.GREEN.rich
         console.print(
             ToolkitPanel(
-                Group(startup_section, read_dir_section, plan_section),
-                title=f"Setting up {operation}",
+                Group(Padding(startup_section, (0, 0, 1, 0)), read_dir_section, plan_section),
+                title=f"Setting up {operation} operation",
                 border_style=border_style,
             )
         )

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -359,7 +359,7 @@ class DeployV2Command(ToolkitCommand):
             if build_dir.skipped_directories:
                 read_dir_subsections.append(
                     ToolkitPanelSection(
-                        title="Skipped directories",
+                        title="Skipped directories (excluded by --include)",
                         content=[
                             hanging_indent("○", dir_.directory.as_posix(), marker_style="dim")
                             for dir_ in build_dir.skipped_directories
@@ -369,7 +369,7 @@ class DeployV2Command(ToolkitCommand):
             if build_dir.invalid_directories:
                 read_dir_subsections.append(
                     ToolkitPanelSection(
-                        title="Invalid directories",
+                        title="Invalid directories (will be skipped)",
                         content=[
                             hanging_indent("✗", inv_dir.as_posix(), marker_style=AuraColor.RED.rich)
                             for inv_dir in build_dir.invalid_directories
@@ -379,7 +379,7 @@ class DeployV2Command(ToolkitCommand):
             if invalid_yaml_file_count:
                 read_dir_subsections.append(
                     ToolkitPanelSection(
-                        title="Invalid YAML files",
+                        title="Invalid YAML files (will be skipped)",
                         content=[
                             hanging_indent("✗", file.as_posix(), marker_style=AuraColor.RED.rich)
                             for dir_ in build_dir.resource_directories

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -71,10 +71,6 @@ class DeployOptions:
     environment_variables: dict[str, str | None] | None = None
     deployment_dir: Path | None = None
 
-    @property
-    def operation_noun(self) -> str:
-        return {"deploy": "deployment", "clean": "deletion"}[self.operation]
-
 
 @dataclass
 class ResourceDirectory:
@@ -212,12 +208,7 @@ class DeployV2Command(ToolkitCommand):
         client = env_vars.get_client(is_strict_validation=build_dir.is_strict_validation)
 
         self._validate_cdf_project(build_dir, options.operation, options.cdf_project, env_vars.CDF_PROJECT)
-        self._display_startup(options.operation, build_dir.path, client.config.project, client.console)
-        self._display_read_dir(build_dir, client.console, options.verbose)
-
-        plan = self.create_deployment_plan(build_dir)
-
-        self._display_plan(plan, options.operation, options.operation_noun, client.console)
+        plan = self._display_setup(options.operation, build_dir, client.config.project, client.console, options.verbose)
 
         clean_result: Sequence[DeploymentResult] | None = None
         if options.drop and (options.operation == "clean" or not options.dry_run):
@@ -232,7 +223,7 @@ class DeployV2Command(ToolkitCommand):
         if clean_result is not None:
             self._merge_clean_results(results, clean_result)
 
-        self._display_results(results, options.operation, options.operation_noun, client.console, options.verbose)
+        self._display_results(results, options.operation, client.console, options.verbose)
         self._track_deployment_result(self.tracker, client, results, options.operation)
 
         if build_lineage and (raw_files := self._find_raw_tables(build_lineage)):
@@ -323,85 +314,126 @@ class DeployV2Command(ToolkitCommand):
             cdf_project=cdf_project,
         )
 
-    def _display_startup(self, operation: str, build_dir: Path, cdf_project: str, console: Console) -> None:
-        console.print(
-            ToolkitPanel(
-                ToolkitPanelSection(
-                    content=[
-                        f"[bold]{operation.title()}ing[/] {build_dir.as_posix()}",
-                        f"Toolkit version: {__version__!s}",
-                        f"CDF project: {cdf_project!r}",
-                    ]
-                ),
-                title=f"[bold]{operation.title()}[/]",
-            )
+    def _display_setup(
+        self,
+        operation: str,
+        build_dir: ReadBuildDirectory,
+        cdf_project: str,
+        console: Console,
+        verbose: bool,
+    ) -> list[DeploymentStep]:
+        startup_section = ToolkitPanelSection(
+            content=[
+                f"Build path: {build_dir.path.as_posix()}",
+                f"CDF project: {cdf_project!r}",
+                f"Toolkit version: {__version__!s}",
+            ],
         )
 
-    def _display_read_dir(self, build_dir: ReadBuildDirectory, console: Console, verbose: bool) -> None:
-        warnings = list(build_dir.create_warnings())
+        read_dir_warnings = list(build_dir.create_warnings())
         resource_dir_count = len(build_dir.resource_directories)
         skipped_dir_count = len(build_dir.skipped_directories)
         invalid_dir_count = len(build_dir.invalid_directories)
-
         resource_file_count = sum(
             len(files) for dir_ in build_dir.resource_directories for files in dir_.files_by_crud.values()
         )
         invalid_yaml_file_count = sum(len(dir_.invalid_files) for dir_ in build_dir.resource_directories)
+        has_issues = bool(read_dir_warnings or invalid_dir_count or invalid_yaml_file_count)
 
-        has_issues = bool(warnings or invalid_dir_count or invalid_yaml_file_count)
-
-        summary_lines = [
+        read_dir_summary = [
             f"[green]✓[/] [bold]{resource_dir_count}[/] resource directories",
             f"[green]✓[/] [bold]{resource_file_count:,}[/] resource files",
         ]
-        if warnings:
-            summary_lines.append(f"[yellow]![/] [bold]{len(warnings)}[/] warnings during reading")
+        if read_dir_warnings:
+            read_dir_summary.append(f"[yellow]![/] [bold]{len(read_dir_warnings)}[/] warnings during reading")
         if skipped_dir_count:
-            summary_lines.append(f"[dim]○[/] [bold]{skipped_dir_count}[/] skipped directories")
+            read_dir_summary.append(f"[dim]○[/] [bold]{skipped_dir_count}[/] skipped directories")
         if invalid_dir_count:
-            summary_lines.append(f"[red]✗[/] [bold]{invalid_dir_count}[/] invalid directories")
+            read_dir_summary.append(f"[red]✗[/] [bold]{invalid_dir_count}[/] invalid directories")
         if invalid_yaml_file_count:
-            summary_lines.append(f"[red]✗[/] [bold]{invalid_yaml_file_count}[/] invalid yaml files")
+            read_dir_summary.append(f"[red]✗[/] [bold]{invalid_yaml_file_count}[/] invalid yaml files")
 
-        sections: list[RenderableType] = [ToolkitPanelSection(content=summary_lines)]
-
+        read_dir_subsections: list[RenderableType] = [ToolkitPanelSection(content=read_dir_summary)]
         if verbose:
             if build_dir.skipped_directories:
                 t = ToolkitTable("Directory")
                 for dir_ in build_dir.skipped_directories:
                     t.add_row(dir_.directory.as_posix())
-                sections.append(ToolkitPanelSection(title="Skipped directories", content=[t.as_panel_detail()]))
+                read_dir_subsections.append(
+                    ToolkitPanelSection(title="Skipped directories", content=[t.as_panel_detail()])
+                )
             if build_dir.invalid_directories:
                 t = ToolkitTable("Directory")
                 t.columns[0].style = "red"
                 for inv_dir in build_dir.invalid_directories:
                     t.add_row(inv_dir.as_posix())
-                sections.append(ToolkitPanelSection(title="Invalid directories", content=[t.as_panel_detail()]))
+                read_dir_subsections.append(
+                    ToolkitPanelSection(title="Invalid directories", content=[t.as_panel_detail()])
+                )
             if invalid_yaml_file_count:
                 t = ToolkitTable("File")
                 t.columns[0].style = "red"
                 for dir_ in build_dir.resource_directories:
                     for file in dir_.invalid_files:
                         t.add_row(file.as_posix())
-                sections.append(ToolkitPanelSection(title="Invalid YAML files", content=[t.as_panel_detail()]))
+                read_dir_subsections.append(
+                    ToolkitPanelSection(title="Invalid YAML files", content=[t.as_panel_detail()])
+                )
         elif skipped_dir_count or invalid_dir_count or invalid_yaml_file_count:
-            sections.append(
+            read_dir_subsections.append(
                 ToolkitPanelSection(
                     description=f"{HINT_LEAD_TEXT} Use --verbose to see details about skipped and invalid directories and files."
                 )
             )
-
-        console.print(
-            ToolkitPanel(
-                Group(*sections),
-                title=f"[bold]Build directory ({build_dir.path.as_posix()})[/]",
-                border_style=AuraColor.AMBER.rich if has_issues else AuraColor.GREEN.rich,
-            )
+        read_dir_section = ToolkitPanelSection(
+            title=f"Build directory ({build_dir.path.as_posix()})",
+            content=read_dir_subsections,
         )
 
-        if warnings:
-            for warning in warnings:
+        try:
+            plan = self.create_deployment_plan(build_dir)
+        except Exception as e:
+            console.print(
+                ToolkitPanel(
+                    Group(
+                        startup_section,
+                        read_dir_section,
+                        ToolkitPanelSection(
+                            description=f"[bold]Failed to create plan for {operation}:[/] {escape(str(e))}"
+                        ),
+                    ),
+                    title=operation,
+                    border_style=AuraColor.AMBER.rich,
+                )
+            )
+            for warning in read_dir_warnings:
                 self.warn(warning, console=console)
+            raise
+
+        if not plan:
+            plan_section = ToolkitPanelSection(description=f"[bold]No resources to {operation}.[/]")
+        else:
+            step_count = len(plan)
+            total_files = sum(len(step.files) for step in plan)
+            plan_section = ToolkitPanelSection(
+                title=f"{operation.title()} plan",
+                content=[
+                    f"[green]✓[/] [bold]{step_count}[/] resource types to {operation}",
+                    f"[green]✓[/] [bold]{total_files}[/] resource files to {operation}",
+                ],
+            )
+
+        border_style = AuraColor.AMBER.rich if (has_issues or not plan) else AuraColor.GREEN.rich
+        console.print(
+            ToolkitPanel(
+                Group(startup_section, read_dir_section, plan_section),
+                title="[bold]Setting up deploy[/]",
+                border_style=border_style,
+            )
+        )
+        for warning in read_dir_warnings:
+            self.warn(warning, console=console)
+        return plan
 
     def _validate_cdf_project(
         self,
@@ -472,34 +504,6 @@ class DeployV2Command(ToolkitCommand):
         return plan
 
     @classmethod
-    def _display_plan(cls, plan: list[DeploymentStep], operation: str, operation_noun: str, console: Console) -> None:
-        if not plan:
-            console.print(
-                ToolkitPanel(
-                    f"[bold yellow]No resources to {operation}.[/]",
-                    title=f"[bold]{operation_noun.title()} plan[/]",
-                    border_style=AuraColor.AMBER.rich,
-                )
-            )
-            return
-
-        step_count = len(plan)
-        total_files = sum(len(step.files) for step in plan)
-
-        console.print(
-            ToolkitPanel(
-                ToolkitPanelSection(
-                    content=[
-                        f"[green]✓[/] [bold]{step_count}[/] resource types to {operation}",
-                        f"[green]✓[/] [bold]{total_files}[/] resource files to {operation}",
-                    ]
-                ),
-                title=f"[bold]{operation_noun.title()} plan[/]",
-                border_style=AuraColor.GREEN.rich,
-            )
-        )
-
-    @classmethod
     def apply_plan(
         cls, client: ToolkitClient, plan: list[DeploymentStep], options: DeployOptions, is_delete: bool = False
     ) -> Sequence[DeploymentResult]:
@@ -518,7 +522,7 @@ class DeployV2Command(ToolkitCommand):
         console = client.console
         with Progress(console=console) as progress:
             total_files = sum(len(step.files) for step in plan)
-            task_id = progress.add_task(f"Starting {options.operation_noun}", total=total_files)
+            task_id = progress.add_task(f"Starting {options.operation}", total=total_files)
             for step in plan:
                 crud = step.crud_cls.create_loader(client)
                 resource_name = crud.display_name
@@ -895,19 +899,19 @@ class DeployV2Command(ToolkitCommand):
 
     @classmethod
     def _display_results(
-        cls, results: Sequence[DeploymentResult], operation: str, operation_noun: str, console: Console, verbose: bool
+        cls, results: Sequence[DeploymentResult], operation: str, console: Console, verbose: bool
     ) -> None:
         if not results:
             console.print(
                 ToolkitPanel(
                     f"No resources were {operation}ed.",
-                    title=f"[bold]{operation_noun.title()} summary[/]",
+                    title=f"[bold]{operation.title()} summary[/]",
                 )
             )
             return
 
         is_dry_run = results[0].is_dry_run
-        panel_title = f"[bold]{operation_noun.title()} summary[/]"
+        panel_title = f"[bold]{operation.title()} summary[/]"
         if is_dry_run:
             panel_title += " [dim](dry run)[/]"
 
@@ -974,7 +978,7 @@ class DeployV2Command(ToolkitCommand):
             sections.append(
                 ToolkitPanelSection(
                     description=(
-                        f"{HINT_LEAD_TEXT}A total of {total.skipped_count} resources were skipped during {operation_noun}. "
+                        f"{HINT_LEAD_TEXT}A total of {total.skipped_count} resources were skipped during {operation}. "
                         f"The most common reasons were: {', '.join(f'{code} ({count} occurrences)' for code, count in most_common)}. "
                         f"Use --verbose to see all skipped resources."
                     )

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -414,8 +414,6 @@ class DeployV2Command(ToolkitCommand):
                     border_style=AuraColor.AMBER.rich,
                 )
             )
-            for warning in read_dir_warnings:
-                self.warn(warning, console=console)
             raise
 
         if not plan:
@@ -439,8 +437,6 @@ class DeployV2Command(ToolkitCommand):
                 border_style=border_style,
             )
         )
-        for warning in read_dir_warnings:
-            self.warn(warning, console=console)
         return plan
 
     def _validate_cdf_project(

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -51,7 +51,7 @@ from cognite_toolkit._cdf_tk.tk_warnings import (
     catch_warnings,
 )
 from cognite_toolkit._cdf_tk.tracker import Tracker
-from cognite_toolkit._cdf_tk.ui import AuraColor, ToolkitPanel, ToolkitPanelSection, ToolkitTable
+from cognite_toolkit._cdf_tk.ui import AuraColor, ToolkitPanel, ToolkitPanelSection, ToolkitTable, hanging_indent
 from cognite_toolkit._cdf_tk.utils import humanize_collection, sanitize_filename, to_diff
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 from cognite_toolkit._version import __version__
@@ -357,28 +357,35 @@ class DeployV2Command(ToolkitCommand):
         read_dir_subsections: list[RenderableType] = [ToolkitPanelSection(content=read_dir_summary)]
         if verbose:
             if build_dir.skipped_directories:
-                t = ToolkitTable("Directory")
-                for dir_ in build_dir.skipped_directories:
-                    t.add_row(dir_.directory.as_posix())
                 read_dir_subsections.append(
-                    ToolkitPanelSection(title="Skipped directories", content=[t.as_panel_detail()])
+                    ToolkitPanelSection(
+                        title="Skipped directories",
+                        content=[
+                            hanging_indent("○", dir_.directory.as_posix(), marker_style="dim")
+                            for dir_ in build_dir.skipped_directories
+                        ],
+                    )
                 )
             if build_dir.invalid_directories:
-                t = ToolkitTable("Directory")
-                t.columns[0].style = "red"
-                for inv_dir in build_dir.invalid_directories:
-                    t.add_row(inv_dir.as_posix())
                 read_dir_subsections.append(
-                    ToolkitPanelSection(title="Invalid directories", content=[t.as_panel_detail()])
+                    ToolkitPanelSection(
+                        title="Invalid directories",
+                        content=[
+                            hanging_indent("✗", inv_dir.as_posix(), marker_style=AuraColor.RED.rich)
+                            for inv_dir in build_dir.invalid_directories
+                        ],
+                    )
                 )
             if invalid_yaml_file_count:
-                t = ToolkitTable("File")
-                t.columns[0].style = "red"
-                for dir_ in build_dir.resource_directories:
-                    for file in dir_.invalid_files:
-                        t.add_row(file.as_posix())
                 read_dir_subsections.append(
-                    ToolkitPanelSection(title="Invalid YAML files", content=[t.as_panel_detail()])
+                    ToolkitPanelSection(
+                        title="Invalid YAML files",
+                        content=[
+                            hanging_indent("✗", file.as_posix(), marker_style=AuraColor.RED.rich)
+                            for dir_ in build_dir.resource_directories
+                            for file in dir_.invalid_files
+                        ],
+                    )
                 )
         elif skipped_dir_count or invalid_dir_count or invalid_yaml_file_count:
             read_dir_subsections.append(
@@ -986,10 +993,19 @@ class DeployV2Command(ToolkitCommand):
                 )
             )
         elif verbose and total.skipped:
-            skipped_table = ToolkitTable("Resource", "File", "Code", "Reason")
-            for skip in total.skipped:
-                skipped_table.add_row(str(skip.id), skip.source_file.as_posix(), skip.code, skip.reason)
-            sections.append(ToolkitPanelSection(title="Skipped resources", content=[skipped_table.as_panel_detail()]))
+            sections.append(
+                ToolkitPanelSection(
+                    title="Skipped resources",
+                    content=[
+                        hanging_indent(
+                            "○",
+                            f"[bold]{skip.id}[/] {skip.source_file.as_posix()} [{skip.code}] {skip.reason}",
+                            marker_style="dim",
+                        )
+                        for skip in total.skipped
+                    ],
+                )
+            )
 
         console.print(ToolkitPanel(Group(*sections), title=panel_title))
 

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -10,11 +10,9 @@ from typing import Any, Generic, Literal, TypeAlias
 
 import questionary
 from pydantic import ValidationError
-from rich.console import Console
+from rich.console import Console, Group, RenderableType
 from rich.markup import escape
-from rich.panel import Panel
 from rich.progress import Progress
-from rich.table import Table
 from yaml import YAMLError
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
@@ -52,6 +50,7 @@ from cognite_toolkit._cdf_tk.tk_warnings import (
     catch_warnings,
 )
 from cognite_toolkit._cdf_tk.tracker import Tracker
+from cognite_toolkit._cdf_tk.ui import AuraColor, ToolkitPanel, ToolkitPanelSection, ToolkitTable
 from cognite_toolkit._cdf_tk.utils import humanize_collection, sanitize_filename, to_diff
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 from cognite_toolkit._version import __version__
@@ -326,10 +325,15 @@ class DeployV2Command(ToolkitCommand):
 
     def _display_startup(self, operation: str, build_dir: Path, cdf_project: str, console: Console) -> None:
         console.print(
-            Panel(
-                f"{operation.title()}ing {build_dir.as_posix()} directory:\n  - Toolkit Version '{__version__!s}'\n"
-                f"  - CDF project {cdf_project!r}",
-                expand=False,
+            ToolkitPanel(
+                ToolkitPanelSection(
+                    content=[
+                        f"[bold]{operation.title()}ing[/] {build_dir.as_posix()}",
+                        f"Toolkit version: {__version__!s}",
+                        f"CDF project: {cdf_project!r}",
+                    ]
+                ),
+                title=f"[bold]{operation.title()}[/]",
             )
         )
 
@@ -359,43 +363,45 @@ class DeployV2Command(ToolkitCommand):
         if invalid_yaml_file_count:
             summary_lines.append(f"[red]✗[/] [bold]{invalid_yaml_file_count}[/] invalid yaml files")
 
+        sections: list[RenderableType] = [ToolkitPanelSection(content=summary_lines)]
+
+        if verbose:
+            if build_dir.skipped_directories:
+                t = ToolkitTable("Directory")
+                for dir_ in build_dir.skipped_directories:
+                    t.add_row(dir_.directory.as_posix())
+                sections.append(ToolkitPanelSection(title="Skipped directories", content=[t.as_panel_detail()]))
+            if build_dir.invalid_directories:
+                t = ToolkitTable("Directory")
+                t.columns[0].style = "red"
+                for inv_dir in build_dir.invalid_directories:
+                    t.add_row(inv_dir.as_posix())
+                sections.append(ToolkitPanelSection(title="Invalid directories", content=[t.as_panel_detail()]))
+            if invalid_yaml_file_count:
+                t = ToolkitTable("File")
+                t.columns[0].style = "red"
+                for dir_ in build_dir.resource_directories:
+                    for file in dir_.invalid_files:
+                        t.add_row(file.as_posix())
+                sections.append(ToolkitPanelSection(title="Invalid YAML files", content=[t.as_panel_detail()]))
+        elif skipped_dir_count or invalid_dir_count or invalid_yaml_file_count:
+            sections.append(
+                ToolkitPanelSection(
+                    description=f"{HINT_LEAD_TEXT} Use --verbose to see details about skipped and invalid directories and files."
+                )
+            )
+
         console.print(
-            Panel(
-                "\n".join(summary_lines),
+            ToolkitPanel(
+                Group(*sections),
                 title=f"[bold]Build directory ({build_dir.path.as_posix()})[/]",
-                border_style="yellow" if has_issues else "green",
-                expand=False,
+                border_style=AuraColor.AMBER.rich if has_issues else AuraColor.GREEN.rich,
             )
         )
 
         if warnings:
             for warning in warnings:
                 self.warn(warning, console=console)
-
-        if not verbose and (skipped_dir_count or invalid_dir_count or invalid_yaml_file_count):
-            console.print(
-                f"{HINT_LEAD_TEXT} Use --verbose flag to get more details about the skipped and invalid directories and files."
-            )
-        if verbose:
-            if build_dir.skipped_directories:
-                table = Table(title="Skipped Directories", expand=False, show_edge=False)
-                table.add_column("Directory", style="dim")
-                for dir_ in build_dir.skipped_directories:
-                    table.add_row(dir_.directory.as_posix())
-                console.print(table)
-            if build_dir.invalid_directories:
-                table = Table(title="Invalid Directories", expand=False, show_edge=False)
-                table.add_column("Directory", style="red")
-                for inv_dir in build_dir.invalid_directories:
-                    table.add_row(inv_dir.as_posix())
-                console.print(table)
-            if invalid_yaml_file_count:
-                table = Table(title="Invalid YAML Files", expand=False, show_edge=False)
-                table.add_column("File", style="red")
-                for dir_ in build_dir.resource_directories:
-                    for file in dir_.invalid_files:
-                        table.add_row(file.as_posix())
-                console.print(table)
 
     def _validate_cdf_project(
         self,
@@ -468,22 +474,28 @@ class DeployV2Command(ToolkitCommand):
     @classmethod
     def _display_plan(cls, plan: list[DeploymentStep], operation: str, operation_noun: str, console: Console) -> None:
         if not plan:
-            console.print(f"[bold yellow]No resources to {operation}.[/]")
+            console.print(
+                ToolkitPanel(
+                    f"[bold yellow]No resources to {operation}.[/]",
+                    title=f"[bold]{operation_noun.title()} plan[/]",
+                    border_style=AuraColor.AMBER.rich,
+                )
+            )
             return
 
         step_count = len(plan)
         total_files = sum(len(step.files) for step in plan)
 
-        summary_lines = [
-            f"[green]✓[/] [bold]{step_count}[/] resource types to {operation}",
-            f"[green]✓[/] [bold]{total_files}[/] resources to {operation}",
-        ]
         console.print(
-            Panel(
-                "\n".join(summary_lines),
+            ToolkitPanel(
+                ToolkitPanelSection(
+                    content=[
+                        f"[green]✓[/] [bold]{step_count}[/] resource types to {operation}",
+                        f"[green]✓[/] [bold]{total_files}[/] resource files to {operation}",
+                    ]
+                ),
                 title=f"[bold]{operation_noun.title()} plan[/]",
-                border_style="green",
-                expand=False,
+                border_style=AuraColor.GREEN.rich,
             )
         )
 
@@ -705,10 +717,9 @@ class DeployV2Command(ToolkitCommand):
                     for sensitive in crud.sensitive_strings(resource.request):
                         diff_str = diff_str.replace(sensitive, "********")
                     console.print(
-                        Panel(
+                        ToolkitPanel(
                             diff_str,
-                            title=f"{crud.display_name}: {identifier}",
-                            expand=False,
+                            title=f"[bold]{crud.display_name}:[/] {identifier}",
                         )
                     )
         return resources
@@ -887,14 +898,20 @@ class DeployV2Command(ToolkitCommand):
         cls, results: Sequence[DeploymentResult], operation: str, operation_noun: str, console: Console, verbose: bool
     ) -> None:
         if not results:
-            console.print(f"No resources were {operation}ed.")
+            console.print(
+                ToolkitPanel(
+                    f"No resources were {operation}ed.",
+                    title=f"[bold]{operation_noun.title()} summary[/]",
+                )
+            )
             return
 
         is_dry_run = results[0].is_dry_run
-        title = f"{operation_noun.title()} Summary"
+        panel_title = f"[bold]{operation_noun.title()} summary[/]"
         if is_dry_run:
-            title += " (dry run)"
-        table = Table(title=title, show_lines=False)
+            panel_title += " [dim](dry run)[/]"
+
+        table = ToolkitTable()
         table.add_column("Resource", style="cyan")
         if is_dry_run:
             table.add_column("Would create", justify="right", style="green")
@@ -904,7 +921,6 @@ class DeployV2Command(ToolkitCommand):
             table.add_column("Created", justify="right", style="green")
             table.add_column("Updated", justify="right", style="yellow")
             table.add_column("Deleted", justify="right", style="red")
-
         table.add_column("Unchanged", justify="right", style="dim")
         table.add_column("Skipped", justify="right", style="yellow")
         table.add_column("Total", justify="right", style="cyan")
@@ -932,11 +948,7 @@ class DeployV2Command(ToolkitCommand):
                 str(result.total_count),
             ]
             if is_dry_run:
-                if result.is_missing_write_acl:
-                    row.append("[red]No[/]")
-                else:
-                    row.append("[green]Yes[/]")
-
+                row.append("[red]No[/]" if result.is_missing_write_acl else "[green]Yes[/]")
             table.add_row(*row)
             total += result
 
@@ -952,28 +964,29 @@ class DeployV2Command(ToolkitCommand):
                 f"[bold]{total.total_count}[/]",
             ]
             if is_dry_run:
-                if total.is_missing_write_acl:
-                    last_row.append("[red]No[/]")
-                else:
-                    last_row.append("[green]Yes[/]")
-
+                last_row.append("[red]No[/]" if total.is_missing_write_acl else "[green]Yes[/]")
             table.add_row(*last_row)
 
-        console.print(table)
+        sections: list[RenderableType] = [ToolkitPanelSection(content=[table.as_panel_detail()])]
 
         if total.skipped and not verbose:
             most_common = Counter(skip.code for skip in total.skipped).most_common(n=3)
-            console.print(
-                f"{HINT_LEAD_TEXT}A total of {total.skipped_count} resources were skipped during {operation_noun}. "
-                f"The most common reasons were: {', '.join(f'{code} ({count} occurrences)' for code, count in most_common)}. "
-                f"Use --verbose flag to get details about all skipped resources."
+            sections.append(
+                ToolkitPanelSection(
+                    description=(
+                        f"{HINT_LEAD_TEXT}A total of {total.skipped_count} resources were skipped during {operation_noun}. "
+                        f"The most common reasons were: {', '.join(f'{code} ({count} occurrences)' for code, count in most_common)}. "
+                        f"Use --verbose to see all skipped resources."
+                    )
+                )
             )
-        if verbose and total.skipped:
-            skipped_str = [
-                f"{skip.id!s} in file {skip.source_file.as_posix()} | {skip.code} | {skip.reason}"
-                for skip in total.skipped
-            ]
-            console.print(Panel("\n".join(skipped_str), title="Skipped resources", expand=False))
+        elif verbose and total.skipped:
+            skipped_table = ToolkitTable("Resource", "File", "Code", "Reason")
+            for skip in total.skipped:
+                skipped_table.add_row(str(skip.id), skip.source_file.as_posix(), skip.code, skip.reason)
+            sections.append(ToolkitPanelSection(title="Skipped resources", content=[skipped_table.as_panel_detail()]))
+
+        console.print(ToolkitPanel(Group(*sections), title=panel_title))
 
     @classmethod
     def _track_deployment_result(
@@ -1054,14 +1067,22 @@ class DeployV2Command(ToolkitCommand):
     def _display_deprecation_warning(cls, raw_files: Mapping[RawTableSelector, list[Path]], console: Console) -> None:
         raw_table_count = len(raw_files)
         file_count = sum(len(files) for files in raw_files.values())
+        plural_t = "" if raw_table_count == 1 else "s"
+        plural_f = "" if file_count == 1 else "s"
         console.print(
-            Panel(
-                f"[yellow]Deprecation Warning[/]\n\n"
-                f"You are deploying {raw_table_count} raw table{'' if raw_table_count == 1 else 's'} based on {file_count} file{'' if file_count == 1 else 's'}.\n\n"
-                f"Support for deploying raw tables through the deploy command will be removed in a future release. "
-                f"Please migrate your raw tables to use the new data plugin. See the documentation for more details.",
-                title="Deprecation Warning",
-                border_style="yellow",
-                expand=False,
+            ToolkitPanel(
+                Group(
+                    ToolkitPanelSection(
+                        description=f"[bold]{raw_table_count}[/] raw table{plural_t} from [bold]{file_count}[/] file{plural_f}."
+                    ),
+                    ToolkitPanelSection(
+                        description=(
+                            "Support for deploying raw tables through the deploy command will be removed in a future release. "
+                            "Please migrate your raw tables to use the new data plugin. See the documentation for more details."
+                        )
+                    ),
+                ),
+                title="[bold]Deprecation warning[/]",
+                border_style=AuraColor.AMBER.rich,
             )
         )

--- a/cognite_toolkit/_cdf_tk/ui.py
+++ b/cognite_toolkit/_cdf_tk/ui.py
@@ -133,6 +133,14 @@ class ToolkitTable(Table):
         return Padding(self, (1, 0, 1, 2))
 
 
+def _yaml_key(line: str) -> str | None:
+    stripped = line.lstrip()
+    if ":" in stripped:
+        key = stripped.split(":")[0].strip()
+        return key or None
+    return None
+
+
 def diff_table(old_lines: list[str], new_lines: list[str], context: int = 2) -> RenderableType:
     """Side-by-side diff table comparing old (left) and new (right) lines.
 
@@ -174,10 +182,21 @@ def diff_table(old_lines: list[str], new_lines: list[str], context: int = 2) -> 
             for line in new_lines[j1:j2]:
                 table.add_row(f"[{AuraColor.GREEN.rich}]{line}[/]", "")
         elif tag == "replace":
-            for line in new_lines[j1:j2]:
-                table.add_row(f"[{AuraColor.GREEN.rich}]{line}[/]", "")
-            for line in old_lines[i1:i2]:
-                table.add_row("", f"[{AuraColor.RED.rich}]{line}[/]")
+            old_block = old_lines[i1:i2]
+            new_block = new_lines[j1:j2]
+            old_by_key = {_yaml_key(line): line for line in old_block if _yaml_key(line)}
+            seen_old_keys: set[str] = set()
+            for line in new_block:
+                key = _yaml_key(line)
+                if key and key in old_by_key:
+                    seen_old_keys.add(key)
+                    table.add_row(f"[{AuraColor.GREEN.rich}]{line}[/]", f"[{AuraColor.RED.rich}]{old_by_key[key]}[/]")
+                else:
+                    table.add_row(f"[{AuraColor.GREEN.rich}]{line}[/]", "")
+            for line in old_block:
+                key = _yaml_key(line)
+                if key not in seen_old_keys:
+                    table.add_row("", f"[{AuraColor.RED.rich}]{line}[/]")
 
     return table
 

--- a/cognite_toolkit/_cdf_tk/ui.py
+++ b/cognite_toolkit/_cdf_tk/ui.py
@@ -149,8 +149,8 @@ def diff_table(old_lines: list[str], new_lines: list[str], context: int = 2) -> 
         highlight=False,
         show_header=True,
     )
+    table.add_column(f"[{AuraColor.GREEN.rich}]Local (desired)[/]", overflow="fold", ratio=1, no_wrap=False)
     table.add_column(f"[{AuraColor.RED.rich}]CDF (current)[/]", overflow="fold", ratio=1, no_wrap=False)
-    table.add_column("[Local (desired)", overflow="fold", ratio=1, no_wrap=False)
 
     for tag, i1, i2, j1, j2 in matcher.get_opcodes():
         if tag == "equal":
@@ -169,15 +169,15 @@ def diff_table(old_lines: list[str], new_lines: list[str], context: int = 2) -> 
                     table.add_row(f"[dim]{line}[/]", f"[dim]{line}[/]")
         elif tag == "delete":
             for line in old_lines[i1:i2]:
-                table.add_row(f"[{AuraColor.RED.rich}]{line}[/]", "")
+                table.add_row("", f"[{AuraColor.RED.rich}]{line}[/]")
         elif tag == "insert":
             for line in new_lines[j1:j2]:
-                table.add_row("", f"[{AuraColor.GREEN.rich}]{line}[/]")
+                table.add_row(f"[{AuraColor.GREEN.rich}]{line}[/]", "")
         elif tag == "replace":
-            for line in old_lines[i1:i2]:
-                table.add_row(f"[{AuraColor.RED.rich}]{line}[/]", "")
             for line in new_lines[j1:j2]:
-                table.add_row("", f"[{AuraColor.GREEN.rich}]{line}[/]")
+                table.add_row(f"[{AuraColor.GREEN.rich}]{line}[/]", "")
+            for line in old_lines[i1:i2]:
+                table.add_row("", f"[{AuraColor.RED.rich}]{line}[/]")
 
     return table
 

--- a/cognite_toolkit/_cdf_tk/ui.py
+++ b/cognite_toolkit/_cdf_tk/ui.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence
 from difflib import SequenceMatcher
 from enum import Enum
-from itertools import zip_longest
 from typing import Any, ClassVar, Literal
 
 import questionary
@@ -146,12 +145,12 @@ def diff_table(old_lines: list[str], new_lines: list[str], context: int = 2) -> 
         box=rich_box.SIMPLE,
         show_edge=False,
         padding=(0, 1),
-        expand=True,
+        expand=False,
         highlight=False,
         show_header=True,
     )
     table.add_column(f"[{AuraColor.RED.rich}]CDF (current)[/]", overflow="fold", ratio=1, no_wrap=False)
-    table.add_column(f"[{AuraColor.GREEN.rich}]Local (desired)[/]", overflow="fold", ratio=1, no_wrap=False)
+    table.add_column("[Local (desired)", overflow="fold", ratio=1, no_wrap=False)
 
     for tag, i1, i2, j1, j2 in matcher.get_opcodes():
         if tag == "equal":
@@ -175,11 +174,10 @@ def diff_table(old_lines: list[str], new_lines: list[str], context: int = 2) -> 
             for line in new_lines[j1:j2]:
                 table.add_row("", f"[{AuraColor.GREEN.rich}]{line}[/]")
         elif tag == "replace":
-            for old, new in zip_longest(old_lines[i1:i2], new_lines[j1:j2], fillvalue=""):
-                table.add_row(
-                    f"[{AuraColor.RED.rich}]{old}[/]" if old else "",
-                    f"[{AuraColor.GREEN.rich}]{new}[/]" if new else "",
-                )
+            for line in old_lines[i1:i2]:
+                table.add_row(f"[{AuraColor.RED.rich}]{line}[/]", "")
+            for line in new_lines[j1:j2]:
+                table.add_row("", f"[{AuraColor.GREEN.rich}]{line}[/]")
 
     return table
 

--- a/cognite_toolkit/_cdf_tk/ui.py
+++ b/cognite_toolkit/_cdf_tk/ui.py
@@ -147,9 +147,11 @@ def diff_table(old_lines: list[str], new_lines: list[str], context: int = 2) -> 
         show_edge=False,
         padding=(0, 1),
         expand=True,
+        highlight=False,
+        show_header=True,
     )
-    table.add_column("CDF", overflow="fold", ratio=1)
-    table.add_column("Local", overflow="fold", ratio=1)
+    table.add_column(f"[{AuraColor.RED.rich}]CDF (current)[/]", overflow="fold", ratio=1, no_wrap=False)
+    table.add_column(f"[{AuraColor.GREEN.rich}]Local (desired)[/]", overflow="fold", ratio=1, no_wrap=False)
 
     for tag, i1, i2, j1, j2 in matcher.get_opcodes():
         if tag == "equal":

--- a/cognite_toolkit/_cdf_tk/ui.py
+++ b/cognite_toolkit/_cdf_tk/ui.py
@@ -48,7 +48,7 @@ class ToolkitPanel(Panel):
         **kwargs: Any,
     ) -> None:
         if isinstance(title, str):
-            title = Text(title, style="bold")
+            title = Text.from_markup(title, style="bold")
         super().__init__(
             renderable,
             box,

--- a/cognite_toolkit/_cdf_tk/ui.py
+++ b/cognite_toolkit/_cdf_tk/ui.py
@@ -1,5 +1,7 @@
 from collections.abc import Sequence
+from difflib import SequenceMatcher
 from enum import Enum
+from itertools import zip_longest
 from typing import Any, ClassVar, Literal
 
 import questionary
@@ -11,7 +13,15 @@ from rich.style import StyleType
 from rich.table import Table
 from rich.text import Text
 
-__all__ = ["QUESTIONARY_STYLE", "AuraColor", "ToolkitPanel", "ToolkitPanelSection", "ToolkitTable", "hanging_indent"]
+__all__ = [
+    "QUESTIONARY_STYLE",
+    "AuraColor",
+    "ToolkitPanel",
+    "ToolkitPanelSection",
+    "ToolkitTable",
+    "diff_table",
+    "hanging_indent",
+]
 
 
 # https://cognitedata.github.io/aura/primitives/colors
@@ -122,6 +132,54 @@ class ToolkitTable(Table):
 
     def as_panel_detail(self) -> RenderableType:
         return Padding(self, (1, 0, 1, 2))
+
+
+def diff_table(old_lines: list[str], new_lines: list[str], context: int = 2) -> RenderableType:
+    """Side-by-side diff table comparing old (left) and new (right) lines.
+
+    Equal regions larger than 2*context+1 lines are collapsed to a '…' separator.
+    Deleted lines are shown in red on the left, inserted lines in green on the right.
+    """
+    matcher = SequenceMatcher(None, old_lines, new_lines, autojunk=False)
+
+    table = Table(
+        box=rich_box.SIMPLE,
+        show_edge=False,
+        padding=(0, 1),
+        expand=True,
+    )
+    table.add_column("CDF", overflow="fold", ratio=1)
+    table.add_column("Local", overflow="fold", ratio=1)
+
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            block = old_lines[i1:i2]
+            if len(block) <= 2 * context + 1:
+                for line in block:
+                    table.add_row(f"[dim]{line}[/]", f"[dim]{line}[/]")
+            else:
+                for line in block[:context]:
+                    table.add_row(f"[dim]{line}[/]", f"[dim]{line}[/]")
+                table.add_row(
+                    f"[{AuraColor.MOUNTAIN.rich}]…[/]",
+                    f"[{AuraColor.MOUNTAIN.rich}]…[/]",
+                )
+                for line in block[-context:]:
+                    table.add_row(f"[dim]{line}[/]", f"[dim]{line}[/]")
+        elif tag == "delete":
+            for line in old_lines[i1:i2]:
+                table.add_row(f"[{AuraColor.RED.rich}]{line}[/]", "")
+        elif tag == "insert":
+            for line in new_lines[j1:j2]:
+                table.add_row("", f"[{AuraColor.GREEN.rich}]{line}[/]")
+        elif tag == "replace":
+            for old, new in zip_longest(old_lines[i1:i2], new_lines[j1:j2], fillvalue=""):
+                table.add_row(
+                    f"[{AuraColor.RED.rich}]{old}[/]" if old else "",
+                    f"[{AuraColor.GREEN.rich}]{new}[/]" if new else "",
+                )
+
+    return table
 
 
 QUESTIONARY_STYLE = questionary.Style(

--- a/cognite_toolkit/_cdf_tk/ui.py
+++ b/cognite_toolkit/_cdf_tk/ui.py
@@ -41,14 +41,18 @@ class ToolkitPanel(Panel):
         renderable: RenderableType,
         box: rich_box.Box = rich_box.ROUNDED,
         *,
+        title: str | Text | None = None,
         title_align: Literal["left", "center", "right"] = "left",
         subtitle_align: Literal["left", "center", "right"] = "left",
         padding: int | tuple[int] | tuple[int, int] | tuple[int, int, int, int] = (1, 2),
         **kwargs: Any,
     ) -> None:
+        if isinstance(title, str):
+            title = Text(title, style="bold")
         super().__init__(
             renderable,
             box,
+            title=title,
             title_align=title_align,
             subtitle_align=subtitle_align,
             padding=padding,

--- a/cognite_toolkit/_cdf_tk/ui.py
+++ b/cognite_toolkit/_cdf_tk/ui.py
@@ -141,6 +141,25 @@ def _yaml_key(line: str) -> str | None:
     return None
 
 
+def _highlight_diff(old_str: str, new_str: str) -> tuple[str, str]:
+    """Return (new_highlighted, old_highlighted) with changed character spans wrapped in [bold]."""
+    matcher = SequenceMatcher(None, old_str, new_str, autojunk=False)
+    old_parts: list[str] = []
+    new_parts: list[str] = []
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            old_parts.append(old_str[i1:i2])
+            new_parts.append(new_str[j1:j2])
+        elif tag == "delete":
+            old_parts.append(f"[bold]{old_str[i1:i2]}[/bold]")
+        elif tag == "insert":
+            new_parts.append(f"[bold]{new_str[j1:j2]}[/bold]")
+        elif tag == "replace":
+            old_parts.append(f"[bold]{old_str[i1:i2]}[/bold]")
+            new_parts.append(f"[bold]{new_str[j1:j2]}[/bold]")
+    return "".join(new_parts), "".join(old_parts)
+
+
 def diff_table(old_lines: list[str], new_lines: list[str], context: int = 2) -> RenderableType:
     """Side-by-side diff table comparing old (left) and new (right) lines.
 
@@ -190,7 +209,8 @@ def diff_table(old_lines: list[str], new_lines: list[str], context: int = 2) -> 
                 key = _yaml_key(line)
                 if key and key in old_by_key:
                     seen_old_keys.add(key)
-                    table.add_row(f"[{AuraColor.GREEN.rich}]{line}[/]", f"[{AuraColor.RED.rich}]{old_by_key[key]}[/]")
+                    local_hl, cdf_hl = _highlight_diff(old_by_key[key], line)
+                    table.add_row(f"[{AuraColor.GREEN.rich}]{local_hl}[/]", f"[{AuraColor.RED.rich}]{cdf_hl}[/]")
                 else:
                     table.add_row(f"[{AuraColor.GREEN.rich}]{line}[/]", "")
             for line in old_block:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_diff_table.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_diff_table.py
@@ -1,0 +1,57 @@
+"""Visual tests for diff_table — run with `pytest -s` to see rendered output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from rich.console import Console
+
+from cognite_toolkit._cdf_tk.ui import ToolkitPanel, diff_table
+from cognite_toolkit._cdf_tk.utils.file import yaml_safe_dump
+
+_FUNCTION_YAML = (
+    Path(__file__).resolve().parents[5] / "cognite_toolkit/modules/operator/functions/toolkit.Function.yaml"
+)
+
+
+def _load() -> dict:
+    return yaml.safe_load(_FUNCTION_YAML.read_text())
+
+
+def _render(title: str, old: dict, new: dict, console: Console) -> None:
+    old_lines = yaml_safe_dump(old).splitlines()
+    new_lines = yaml_safe_dump(new).splitlines()
+    console.print(ToolkitPanel(diff_table(old_lines, new_lines), title=title))
+
+
+@pytest.fixture
+def console() -> Console:
+    return Console(width=120)
+
+
+class TestDiffTableVariations:
+    def test_field_value_changed(self, console: Console) -> None:
+        local = _load()
+        cdf = {**local, "runtime": "py311", "cpu": 1.0}
+        _render("Field value changed (runtime + cpu)", local, cdf, console)
+
+    def test_field_added_locally(self, console: Console) -> None:
+        local = _load()
+        cdf = {k: v for k, v in local.items() if k not in {"envVars", "memory"}}
+        _render("Fields added locally (envVars + memory missing in CDF)", local, cdf, console)
+
+    def test_field_removed_locally(self, console: Console) -> None:
+        local = {k: v for k, v in _load().items() if k != "description"}
+        cdf = _load()
+        _render("Field removed locally (description in CDF only)", local, cdf, console)
+
+    def test_minimal_cdf_state(self, console: Console) -> None:
+        local = _load()
+        cdf = {"externalId": local["externalId"], "status": "Failed"}
+        _render("Minimal CDF state (failed function, full local definition)", local, cdf, console)
+
+    def test_no_diff(self, console: Console) -> None:
+        resource = _load()
+        _render("No diff (identical)", resource, resource, console)


### PR DESCRIPTION
## Summary

- Adds `_highlight_diff(old_str, new_str)` helper that runs a second `SequenceMatcher` pass at character granularity on key-matched YAML line pairs
- Changed character spans are wrapped in `[bold]` so readers immediately see *what* changed (e.g. `py**311**` vs `py**312**`) without scanning the full line
- Wired into the key-matched branch of the `replace` handler in `diff_table`

Stacks on top of [cdf-27845/tidy-deploy-output](https://github.com/cognitedata/toolkit/compare/cdf-27845/tidy-deploy-output) — merge that first.

## Test plan

- [ ] Run visual tests with `uv run pytest tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_diff_table.py -s -v` and inspect `test_field_value_changed` output — changed value chars should appear bold
- [ ] Verify no regression on insert/delete rows (no highlighting expected there)
- [ ] Verify equal rows remain dim

🤖 Generated with [Claude Code](https://claude.com/claude-code)