### PR TITLE
[prep CDF-27701] Extract shared destructive operation guardrail utilities into commands/_utils.py

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -10,12 +10,11 @@ from typing import Any, Literal, cast
 import questionary
 from cognite.client.data_classes import DataSetUpdate
 from cognite.client.data_classes.data_modeling import Edge
-from cognite.client.data_classes.data_modeling.statistics import InstanceStatistics, SpaceStatistics
+from cognite.client.data_classes.data_modeling.statistics import SpaceStatistics
 from pydantic import JsonValue
 from rich import print
 from rich.console import Console
 from rich.panel import Panel
-from rich.table import Table
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client._resource_base import RequestItem
@@ -32,11 +31,9 @@ from cognite_toolkit._cdf_tk.client.identifiers import (
     InstanceDefinitionId,
     InstanceId,
     InternalId,
-    ViewId,
 )
 from cognite_toolkit._cdf_tk.client.request_classes.filters import ContainerFilter
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import NodeId, SpaceId
-from cognite_toolkit._cdf_tk.constants import DMS_SOFT_DELETED_INSTANCE_LIMIT_MARGIN
 from cognite_toolkit._cdf_tk.data_classes import DeployResults, ResourceDeployResult
 from cognite_toolkit._cdf_tk.data_classes._tracking_info import DataTracking
 from cognite_toolkit._cdf_tk.dataio import InstanceIO, Page
@@ -52,7 +49,6 @@ from cognite_toolkit._cdf_tk.dataio.selectors import InstanceSelector
 from cognite_toolkit._cdf_tk.exceptions import (
     AuthorizationError,
     ToolkitMissingResourceError,
-    ToolkitValueError,
 )
 from cognite_toolkit._cdf_tk.protocols import ResourceResponseProtocol
 from cognite_toolkit._cdf_tk.resource_ios import (
@@ -95,35 +91,12 @@ from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 from cognite_toolkit._cdf_tk.utils.validate_access import ValidateAccess
 
 from ._base import ToolkitCommand
-
-
-def validate_soft_delete_purge_headroom(
-    instance_statistics: InstanceStatistics,
-    instances_to_soft_delete: int,
-    *,
-    action: str,
-) -> None:
-    """Abort if the purge would exhaust the soft-delete resource limit."""
-    if instances_to_soft_delete <= 0:
-        return
-    used = instance_statistics.soft_deleted_instances
-    limit = instance_statistics.soft_deleted_instances_limit
-    margin = DMS_SOFT_DELETED_INSTANCE_LIMIT_MARGIN
-    projected = used + instances_to_soft_delete
-    headroom_after = limit - projected
-    if headroom_after < margin:
-        headroom_clause = (
-            f"leaving only {headroom_after:,} instances of headroom, which is less than the required margin of {margin:,}."
-            if headroom_after >= 0
-            else f"exceeding the limit by {-headroom_after:,} instances."
-        )
-        raise ToolkitValueError(
-            f"Cannot proceed with {action}, not enough soft-deleted instance capacity available. "
-            f"Currently {used:,} of {limit:,} instances are soft-deleted. Performing this operation would add up to "
-            f"{instances_to_soft_delete:,} more (projected total: {projected:,}), {headroom_clause} "
-            f"Reduce what you purge, or wait for soft-deleted data to expire before retrying "
-            f"(see: https://docs.cognite.com/cdf/dm/dm_concepts/dm_ingestion#soft-deletion for details)."
-        )
+from ._utils import (
+    confirm_by_typing_project_name,
+    print_soft_delete_panel,
+    validate_no_out_of_scope_view_references,
+    validate_soft_delete_headroom,
+)
 
 
 @dataclass
@@ -344,15 +317,28 @@ class PurgeCommand(ToolkitCommand):
             )
 
         if stats.containers > 0:
-            self._block_if_external_views_reference_containers(client, selected_space)
+            container_ids = [
+                ContainerId(space=c.space, external_id=c.external_id)
+                for c in client.tool.containers.list(filter=ContainerFilter(space=selected_space))
+            ]
+            inspect_results = client.tool.containers.inspect(container_ids)
+            in_scope_view_ids = [
+                view
+                for inspected in inspect_results
+                for view in inspected.inspection_results.involved_views
+                if view.space == selected_space
+            ]
+            validate_no_out_of_scope_view_references(
+                inspect_results, in_scope_view_ids, action="purging this space", scope="space"
+            )
 
         if not dry_run:
             if instance_count > 0:
                 project_instance_statistics = client.data_modeling.statistics.project().instances
-                validate_soft_delete_purge_headroom(
+                validate_soft_delete_headroom(
                     project_instance_statistics, instance_count, action="purging this space (including its instances)"
                 )
-                self._print_instance_purge_soft_delete_panel(project_instance_statistics, instance_count)
+                print_soft_delete_panel(project_instance_statistics, instance_count)
                 acknowledge_soft_delete = questionary.confirm(
                     "Do you understand the soft-delete resource limit impact and wish to continue?",
                     default=False,
@@ -361,7 +347,7 @@ class PurgeCommand(ToolkitCommand):
                     return DeployResults([], "purge", dry_run=dry_run)
             self._print_panel("space", selected_space)
 
-            confirm = self._confirm_purge(f"You are about purge the {selected_space!r} space", client)
+            confirm = confirm_by_typing_project_name(f"You are about purge the {selected_space!r} space", client)
             if not confirm:
                 return DeployResults([], "purge", dry_run=dry_run)
 
@@ -589,8 +575,8 @@ class PurgeCommand(ToolkitCommand):
         if not dry_run:
             self._print_panel("dataSet", selected_data_set_external_id)
         if not dry_run and not auto_yes:
-            confirm = self._confirm_purge(
-                f"You are about t purge the {selected_data_set_external_id!r} dataSet", client
+            confirm = confirm_by_typing_project_name(
+                f"You are about to purge the {selected_data_set_external_id!r} dataSet", client
             )
             if not confirm:
                 return DeployResults([], "purge", dry_run=dry_run)
@@ -722,62 +708,6 @@ class PurgeCommand(ToolkitCommand):
         return to_delete
 
     @staticmethod
-    def _block_if_external_views_reference_containers(client: ToolkitClient, selected_space: str) -> None:
-        """Block the purge if any container in the space is referenced by views in other spaces.
-
-        Uses the ``models/containers/inspect`` endpoint with both the ``involvedViews`` and
-        ``totalInvolvedViewCount`` operations.  The total count is authoritative — it includes views
-        the caller cannot access — so blocking is decided on the count, not the view list.
-        Same-space views are excluded because they are themselves part of the purge.
-        """
-        container_ids = [
-            ContainerId(space=container.space, external_id=container.external_id)
-            for container in client.tool.containers.list(filter=ContainerFilter(space=selected_space))
-        ]
-        if not container_ids:
-            return
-
-        # (external_views_seen, hidden_count) per blocked container
-        blocked: dict[ContainerId, tuple[list[ViewId], int]] = {}
-        for inspected in client.tool.containers.inspect(container_ids):
-            results = inspected.inspection_results
-            external_seen = [view for view in results.involved_views if view.space != selected_space]
-            # Hidden views (not returned in involvedViews) must be from other spaces: purge access
-            # to selected_space implies read access, so any same-space views would be visible.
-            hidden_count = results.involved_view_count - len(results.involved_views)
-            if not external_seen and hidden_count == 0:
-                continue
-            container_id = ContainerId(space=inspected.space, external_id=inspected.external_id)
-            blocked[container_id] = (external_seen, hidden_count)
-        if not blocked:
-            return
-
-        table = Table(
-            title=f"Purge is blocked since containers in [bold]{selected_space}[/bold] are referenced by views in other spaces",
-            title_justify="left",
-            show_lines=True,
-        )
-        table.add_column("Container", no_wrap=True)
-        table.add_column("Referencing view(s)", no_wrap=True)
-        for container_id, (external_seen, hidden_count) in blocked.items():
-            container_label = f"{container_id.space}:{container_id.external_id}"
-            rows: list[tuple[str, str]] = [
-                (container_label if index == 0 else "", f"{view.space}:{view.external_id}/{view.version}")
-                for index, view in enumerate(external_seen)
-            ]
-            if hidden_count > 0:
-                hidden_label = f"[dim italic]{hidden_count} view(s) you do not have access to[/]"
-                rows.append(("" if external_seen else container_label, hidden_label))
-            for label, view_label in rows:
-                table.add_row(label, view_label)
-        print(table)
-        raise ToolkitValueError(
-            f"Cannot proceed with purge of space {selected_space!r}: one or more containers in this space are referenced by views "
-            "in other spaces. Deleting containers that are still referenced by views would cause breaking changes to those views. "
-            "If you are sure you still want to delete these containers, you need to remove all versions of all views that reference these containers (refer to the table above), then re-run the purge."
-        )
-
-    @staticmethod
     def _print_panel(resource_type: str, resource: str) -> None:
         print(
             Panel(
@@ -787,57 +717,6 @@ class PurgeCommand(ToolkitCommand):
                 title=f"Purge {resource_type}",
                 title_align="left",
                 border_style="red",
-                expand=False,
-            )
-        )
-
-    @staticmethod
-    def _print_instance_purge_soft_delete_panel(
-        instance_statistics: InstanceStatistics,
-        instances_to_delete: int,
-    ) -> None:
-        """Step 1 panel: soft-delete resource limit impact and related notices."""
-        used = max(0, instance_statistics.soft_deleted_instances)
-        limit = instance_statistics.soft_deleted_instances_limit
-        projected = used + instances_to_delete
-        remaining_after = max(0, limit - projected)
-        bar_width = 44
-
-        bar = "".join(
-            "[yellow]█[/yellow]"
-            if (i + 0.5) / bar_width * limit < used
-            else "[bright_magenta]█[/bright_magenta]"
-            if (i + 0.5) / bar_width * limit < min(projected, limit)
-            else "[dim]░[/dim]"
-            for i in range(bar_width)
-        )
-        resource_usage_bar = (
-            "[yellow]█[/yellow] [dim]already soft-deleted   [/dim]"
-            "[bright_magenta]█[/bright_magenta] [dim]this purge   [/dim]"
-            "[dim]░ remaining[/dim]\n\n"
-            f"{bar}\n"
-            f"[dim]Limit [/dim][bold]{limit:,}[/bold][dim]  ·  [/dim]"
-            f"[yellow]{used:,}[/yellow][dim] + [/dim][bright_magenta]{instances_to_delete:,}[/bright_magenta]"
-            f"[dim] → [/dim][bold]{projected:,}[/bold][dim] total soft-deleted (est.)  ·  [/dim]"
-            f"[green]{remaining_after:,}[/green][dim] remaining[/dim]"
-        )
-
-        print(
-            Panel(
-                "By continuing this operation you will be deleting instances, which consumes your CDF project-wide "
-                "[bold]soft-delete resource limit[/bold] for instances. If that resource limit is exhausted, you will "
-                "not be able to delete any more instances until the soft-deleted data expires and is hard-deleted per "
-                "the retention policy, which can take multiple days (see "
-                "https://docs.cognite.com/cdf/dm/dm_concepts/dm_ingestion#soft-deletion for details).\n\n"
-                f"[bold]This purge targets up to {instances_to_delete:,} instance(s).[/bold] Each deleted instance "
-                f"counts toward the total soft-delete limit below.\n\n{resource_usage_bar}\n\n"
-                "[bold]NOTE:[/bold] Please be aware, if you intended to delete containers or views, this does not "
-                "require deleting instances. You can delete or change schema resources (containers, views, data models) "
-                "without purging the instance data first. Only run an instance purge when you intend to remove specific "
-                "data which was either ingested by error or is no longer needed or valid.",
-                title="Purging instances: Please acknowledge the following",
-                title_align="left",
-                border_style="yellow",
                 expand=False,
             )
         )
@@ -866,10 +745,8 @@ class PurgeCommand(ToolkitCommand):
             return DeleteResults()
         if not dry_run:
             project_instance_statistics = client.data_modeling.statistics.project().instances
-            validate_soft_delete_purge_headroom(
-                project_instance_statistics, total, action="purging the selected instances"
-            )
-            self._print_instance_purge_soft_delete_panel(project_instance_statistics, total)
+            validate_soft_delete_headroom(project_instance_statistics, total, action="purging the selected instances")
+            print_soft_delete_panel(project_instance_statistics, total)
             acknowledge_soft_delete = questionary.confirm(
                 "Do you understand the soft-delete resource limit impact and wish to continue?",
                 default=False,
@@ -878,7 +755,7 @@ class PurgeCommand(ToolkitCommand):
                 return DeleteResults()
             self._print_panel("instances", str(selector))
 
-            confirm_purge = self._confirm_purge(
+            confirm_purge = confirm_by_typing_project_name(
                 f"You are about to purge all {total:,} instances in {selector!s}", client
             )
             if not confirm_purge:
@@ -924,18 +801,6 @@ class PurgeCommand(ToolkitCommand):
     def _log_filestem(self) -> str:
         log_filestem = f"purge_{date.today().strftime('%Y%m%d')}"
         return log_filestem
-
-    def _confirm_purge(self, message: str, client: ToolkitClient) -> bool:
-        client_project = client.config.project
-        client.console.print(f"{message} in the CDF project [bold]{client_project!r}[/bold]")
-        typed_project = questionary.text("To confirm, please type the name of the CDF project: ").unsafe_ask()
-        if typed_project != client_project:
-            client.console.print(
-                f"The CDF project you typed does not match your credentials {typed_project!r}≠{client_project!r}. Exiting..."
-            )
-            return False
-
-        return True
 
     def validate_instance_access(self, validator: ValidateAccess, instance_spaces: list[str] | None) -> None:
         space_ids = validator.instances(

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -95,7 +95,7 @@ from ._utils import (
     confirm_by_typing_project_name,
     print_soft_delete_panel,
     validate_no_out_of_scope_view_references,
-    validate_soft_delete_headroom,
+    validate_soft_delete_capacity,
 )
 
 
@@ -335,7 +335,7 @@ class PurgeCommand(ToolkitCommand):
         if not dry_run:
             if instance_count > 0:
                 project_instance_statistics = client.data_modeling.statistics.project().instances
-                validate_soft_delete_headroom(
+                validate_soft_delete_capacity(
                     project_instance_statistics.soft_deleted_instances,
                     project_instance_statistics.soft_deleted_instances_limit,
                     instance_count,
@@ -753,7 +753,7 @@ class PurgeCommand(ToolkitCommand):
             return DeleteResults()
         if not dry_run:
             project_instance_statistics = client.data_modeling.statistics.project().instances
-            validate_soft_delete_headroom(
+            validate_soft_delete_capacity(
                 project_instance_statistics.soft_deleted_instances,
                 project_instance_statistics.soft_deleted_instances_limit,
                 total,

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -329,16 +329,24 @@ class PurgeCommand(ToolkitCommand):
                 if view.space == selected_space
             ]
             validate_no_out_of_scope_view_references(
-                inspect_results, in_scope_view_ids, action="purging this space", scope="space"
+                inspect_results, in_scope_view_ids, action="purging this space", scope="space", console=client.console
             )
 
         if not dry_run:
             if instance_count > 0:
                 project_instance_statistics = client.data_modeling.statistics.project().instances
                 validate_soft_delete_headroom(
-                    project_instance_statistics, instance_count, action="purging this space (including its instances)"
+                    project_instance_statistics.soft_deleted_instances,
+                    project_instance_statistics.soft_deleted_instances_limit,
+                    instance_count,
+                    action="purging this space (including its instances)",
                 )
-                print_soft_delete_panel(project_instance_statistics, instance_count)
+                print_soft_delete_panel(
+                    project_instance_statistics.soft_deleted_instances,
+                    project_instance_statistics.soft_deleted_instances_limit,
+                    instance_count,
+                    client.console,
+                )
                 acknowledge_soft_delete = questionary.confirm(
                     "Do you understand the soft-delete resource limit impact and wish to continue?",
                     default=False,
@@ -745,8 +753,18 @@ class PurgeCommand(ToolkitCommand):
             return DeleteResults()
         if not dry_run:
             project_instance_statistics = client.data_modeling.statistics.project().instances
-            validate_soft_delete_headroom(project_instance_statistics, total, action="purging the selected instances")
-            print_soft_delete_panel(project_instance_statistics, total)
+            validate_soft_delete_headroom(
+                project_instance_statistics.soft_deleted_instances,
+                project_instance_statistics.soft_deleted_instances_limit,
+                total,
+                action="purging the selected instances",
+            )
+            print_soft_delete_panel(
+                project_instance_statistics.soft_deleted_instances,
+                project_instance_statistics.soft_deleted_instances_limit,
+                total,
+                client.console,
+            )
             acknowledge_soft_delete = questionary.confirm(
                 "Do you understand the soft-delete resource limit impact and wish to continue?",
                 default=False,

--- a/cognite_toolkit/_cdf_tk/commands/_utils.py
+++ b/cognite_toolkit/_cdf_tk/commands/_utils.py
@@ -1,8 +1,7 @@
 from collections.abc import Sequence
 
 import questionary
-from cognite.client.data_classes.data_modeling.statistics import InstanceStatistics
-from rich import print
+from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
@@ -24,16 +23,24 @@ def _print_ids_or_length(resource_ids: Sequence[T_Identifier,], limit: int = 10)
 
 
 def validate_soft_delete_headroom(
-    instance_statistics: InstanceStatistics,
+    soft_deleted_instances: int,
+    soft_deleted_instances_limit: int,
     instances_to_soft_delete: int,
     *,
     action: str,
 ) -> None:
-    """Abort if the operation would exhaust the soft-delete resource limit."""
+    """Abort if the operation would exhaust the soft-delete resource limit.
+
+    Args:
+        soft_deleted_instances: Current number of soft-deleted instances in the project.
+        soft_deleted_instances_limit: Project-wide soft-delete capacity limit.
+        instances_to_soft_delete: Number of instances this operation would add to soft-delete.
+        action: Human-readable description of the operation, used in the error message.
+    """
     if instances_to_soft_delete <= 0:
         return
-    used = instance_statistics.soft_deleted_instances
-    limit = instance_statistics.soft_deleted_instances_limit
+    used = soft_deleted_instances
+    limit = soft_deleted_instances_limit
     margin = DMS_SOFT_DELETED_INSTANCE_LIMIT_MARGIN
     projected = used + instances_to_soft_delete
     headroom_after = limit - projected
@@ -53,12 +60,21 @@ def validate_soft_delete_headroom(
 
 
 def print_soft_delete_panel(
-    instance_statistics: InstanceStatistics,
+    soft_deleted_instances: int,
+    soft_deleted_instances_limit: int,
     instances_to_delete: int,
+    console: Console,
 ) -> None:
-    """Print a warning panel about soft-delete resource limit impact."""
-    used = max(0, instance_statistics.soft_deleted_instances)
-    limit = instance_statistics.soft_deleted_instances_limit
+    """Print a warning panel about soft-delete resource limit impact.
+
+    Args:
+        soft_deleted_instances: Current number of soft-deleted instances in the project.
+        soft_deleted_instances_limit: Project-wide soft-delete capacity limit.
+        instances_to_delete: Number of instances this operation would soft-delete.
+        console: Console to print to.
+    """
+    used = soft_deleted_instances
+    limit = soft_deleted_instances_limit
     projected = used + instances_to_delete
     remaining_after = max(0, limit - projected)
     bar_width = 44
@@ -82,7 +98,7 @@ def print_soft_delete_panel(
         f"[green]{remaining_after:,}[/green][dim] remaining[/dim]"
     )
 
-    print(
+    console.print(
         Panel(
             "By continuing this operation you will be deleting instances, which consumes your CDF project-wide "
             "[bold]soft-delete resource limit[/bold] for instances. If that resource limit is exhausted, you will "
@@ -104,7 +120,15 @@ def print_soft_delete_panel(
 
 
 def confirm_by_typing_project_name(message: str, client: ToolkitClient) -> bool:
-    """Prompt the user to type the CDF project name to confirm a destructive operation."""
+    """Prompt the user to type the CDF project name to confirm a destructive operation.
+
+    Args:
+        message: Description of the operation shown before the confirmation prompt.
+        client: Toolkit client; its project name and console are used for the prompt.
+
+    Returns:
+        True if the user typed the correct project name, False otherwise.
+    """
     client_project = client.config.project
     client.console.print(f"{message} in the CDF project [bold]{client_project!r}[/bold]")
     typed_project = questionary.text("To confirm, please type the name of the CDF project: ").unsafe_ask()
@@ -122,10 +146,18 @@ def validate_no_out_of_scope_view_references(
     *,
     action: str,
     scope: str,
+    console: Console,
 ) -> None:
     """Raise ToolkitValueError if any view referencing an inspected container is out-of-scope.
 
     Hidden views (those the caller lacks read access to) are always treated as out-of-scope.
+
+    Args:
+        inspect_results: Per-container inspection results from the containers inspect endpoint.
+        in_scope_view_ids: View IDs considered in scope for this operation.
+        action: Human-readable description of the operation, used in the error message.
+        scope: Name of the scope boundary (e.g. "space" or "build directory"), used in the table title.
+        console: Console to print the blocking table to before raising.
     """
     in_scope = set(in_scope_view_ids)
     blocked: dict[ContainerId, tuple[list[ViewId], int]] = {}
@@ -158,7 +190,7 @@ def validate_no_out_of_scope_view_references(
             rows.append(("" if out_of_scope_seen else container_label, hidden_label))
         for label, view_label in rows:
             table.add_row(label, view_label)
-    print(table)
+    console.print(table)
     raise ToolkitValueError(
         f"Cannot proceed with {action}: one or more containers are referenced by views outside "
         f"the current {scope}. Delete or move those views first, then re-run the operation."

--- a/cognite_toolkit/_cdf_tk/commands/_utils.py
+++ b/cognite_toolkit/_cdf_tk/commands/_utils.py
@@ -1,6 +1,17 @@
 from collections.abc import Sequence
 
+import questionary
+from cognite.client.data_classes.data_modeling.statistics import InstanceStatistics
+from rich import print
+from rich.panel import Panel
+from rich.table import Table
+
+from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client._resource_base import T_Identifier
+from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, ViewId
+from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import ContainerInspectResultItem
+from cognite_toolkit._cdf_tk.constants import DMS_SOFT_DELETED_INSTANCE_LIMIT_MARGIN
+from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 
 
 def _print_ids_or_length(resource_ids: Sequence[T_Identifier,], limit: int = 10) -> str:
@@ -10,3 +21,145 @@ def _print_ids_or_length(resource_ids: Sequence[T_Identifier,], limit: int = 10)
         return f"{resource_ids}"
     else:
         return f"{len(resource_ids)} items"
+
+
+def validate_soft_delete_headroom(
+    instance_statistics: InstanceStatistics,
+    instances_to_soft_delete: int,
+    *,
+    action: str,
+) -> None:
+    """Abort if the operation would exhaust the soft-delete resource limit."""
+    if instances_to_soft_delete <= 0:
+        return
+    used = instance_statistics.soft_deleted_instances
+    limit = instance_statistics.soft_deleted_instances_limit
+    margin = DMS_SOFT_DELETED_INSTANCE_LIMIT_MARGIN
+    projected = used + instances_to_soft_delete
+    headroom_after = limit - projected
+    if headroom_after < margin:
+        headroom_clause = (
+            f"leaving only {headroom_after:,} instances of headroom, which is less than the required margin of {margin:,}."
+            if headroom_after >= 0
+            else f"exceeding the limit by {-headroom_after:,} instances."
+        )
+        raise ToolkitValueError(
+            f"Cannot proceed with {action}, not enough soft-deleted instance capacity available. "
+            f"Currently {used:,} of {limit:,} instances are soft-deleted. Performing this operation would add up to "
+            f"{instances_to_soft_delete:,} more (projected total: {projected:,}), {headroom_clause} "
+            f"Reduce what you delete, or wait for soft-deleted data to expire before retrying "
+            f"(see: https://docs.cognite.com/cdf/dm/dm_concepts/dm_ingestion#soft-deletion for details)."
+        )
+
+
+def print_soft_delete_panel(
+    instance_statistics: InstanceStatistics,
+    instances_to_delete: int,
+) -> None:
+    """Print a warning panel about soft-delete resource limit impact."""
+    used = max(0, instance_statistics.soft_deleted_instances)
+    limit = instance_statistics.soft_deleted_instances_limit
+    projected = used + instances_to_delete
+    remaining_after = max(0, limit - projected)
+    bar_width = 44
+
+    bar = "".join(
+        "[yellow]█[/yellow]"
+        if (i + 0.5) / bar_width * limit < used
+        else "[bright_magenta]█[/bright_magenta]"
+        if (i + 0.5) / bar_width * limit < min(projected, limit)
+        else "[dim]░[/dim]"
+        for i in range(bar_width)
+    )
+    resource_usage_bar = (
+        "[yellow]█[/yellow] [dim]already soft-deleted   [/dim]"
+        "[bright_magenta]█[/bright_magenta] [dim]this operation   [/dim]"
+        "[dim]░ remaining[/dim]\n\n"
+        f"{bar}\n"
+        f"[dim]Limit [/dim][bold]{limit:,}[/bold][dim]  ·  [/dim]"
+        f"[yellow]{used:,}[/yellow][dim] + [/dim][bright_magenta]{instances_to_delete:,}[/bright_magenta]"
+        f"[dim] → [/dim][bold]{projected:,}[/bold][dim] total soft-deleted (est.)  ·  [/dim]"
+        f"[green]{remaining_after:,}[/green][dim] remaining[/dim]"
+    )
+
+    print(
+        Panel(
+            "By continuing this operation you will be deleting instances, which consumes your CDF project-wide "
+            "[bold]soft-delete resource limit[/bold] for instances. If that resource limit is exhausted, you will "
+            "not be able to delete any more instances until the soft-deleted data expires and is hard-deleted per "
+            "the retention policy, which can take multiple days (see "
+            "https://docs.cognite.com/cdf/dm/dm_concepts/dm_ingestion#soft-deletion for details).\n\n"
+            f"[bold]This operation targets up to {instances_to_delete:,} instance(s).[/bold] Each deleted instance "
+            f"counts toward the total soft-delete limit below.\n\n{resource_usage_bar}\n\n"
+            "[bold]NOTE:[/bold] Please be aware, if you intended to delete containers or views, this does not "
+            "require deleting instances. You can delete or change schema resources (containers, views, data models) "
+            "without purging the instance data first. Only delete instances when you intend to remove specific "
+            "data which was either ingested by error or is no longer needed or valid.",
+            title="Deleting instances: Please acknowledge the following",
+            title_align="left",
+            border_style="yellow",
+            expand=False,
+        )
+    )
+
+
+def confirm_by_typing_project_name(message: str, client: ToolkitClient) -> bool:
+    """Prompt the user to type the CDF project name to confirm a destructive operation."""
+    client_project = client.config.project
+    client.console.print(f"{message} in the CDF project [bold]{client_project!r}[/bold]")
+    typed_project = questionary.text("To confirm, please type the name of the CDF project: ").unsafe_ask()
+    if typed_project != client_project:
+        client.console.print(
+            f"The CDF project you typed does not match your credentials {typed_project!r}≠{client_project!r}. Exiting..."
+        )
+        return False
+    return True
+
+
+def validate_no_out_of_scope_view_references(
+    inspect_results: Sequence[ContainerInspectResultItem],
+    in_scope_view_ids: Sequence[ViewId],
+    *,
+    action: str,
+    scope: str,
+) -> None:
+    """Raise ToolkitValueError if any view referencing an inspected container is out-of-scope.
+
+    Hidden views (those the caller lacks read access to) are always treated as out-of-scope.
+    """
+    in_scope = set(in_scope_view_ids)
+    blocked: dict[ContainerId, tuple[list[ViewId], int]] = {}
+    for inspected in inspect_results:
+        results = inspected.inspection_results
+        out_of_scope_seen = [view for view in results.involved_views if view not in in_scope]
+        hidden_count = results.involved_view_count - len(results.involved_views)
+        if not out_of_scope_seen and hidden_count == 0:
+            continue
+        container_id = ContainerId(space=inspected.space, external_id=inspected.external_id)
+        blocked[container_id] = (out_of_scope_seen, hidden_count)
+    if not blocked:
+        return
+
+    table = Table(
+        title=f"Container deletion blocked: referenced by views outside this {scope}",
+        title_justify="left",
+        show_lines=True,
+    )
+    table.add_column(f"Container (within this {scope})", no_wrap=True)
+    table.add_column(f"Referencing view (outside this {scope})", no_wrap=True)
+    for container_id, (out_of_scope_seen, hidden_count) in blocked.items():
+        container_label = f"{container_id.space}:{container_id.external_id}"
+        rows: list[tuple[str, str]] = [
+            (container_label if index == 0 else "", f"{view.space}:{view.external_id}/{view.version}")
+            for index, view in enumerate(out_of_scope_seen)
+        ]
+        if hidden_count > 0:
+            hidden_label = f"[dim italic]{hidden_count} view(s) you do not have access to[/]"
+            rows.append(("" if out_of_scope_seen else container_label, hidden_label))
+        for label, view_label in rows:
+            table.add_row(label, view_label)
+    print(table)
+    raise ToolkitValueError(
+        f"Cannot proceed with {action}: one or more containers are referenced by views outside "
+        f"the current {scope}. Delete or move those views first, then re-run the operation."
+    )

--- a/cognite_toolkit/_cdf_tk/commands/_utils.py
+++ b/cognite_toolkit/_cdf_tk/commands/_utils.py
@@ -22,7 +22,7 @@ def _print_ids_or_length(resource_ids: Sequence[T_Identifier,], limit: int = 10)
         return f"{len(resource_ids)} items"
 
 
-def validate_soft_delete_headroom(
+def validate_soft_delete_capacity(
     soft_deleted_instances: int,
     soft_deleted_instances_limit: int,
     instances_to_soft_delete: int,
@@ -43,17 +43,17 @@ def validate_soft_delete_headroom(
     limit = soft_deleted_instances_limit
     margin = DMS_SOFT_DELETED_INSTANCE_LIMIT_MARGIN
     projected = used + instances_to_soft_delete
-    headroom_after = limit - projected
-    if headroom_after < margin:
-        headroom_clause = (
-            f"leaving only {headroom_after:,} instances of headroom, which is less than the required margin of {margin:,}."
-            if headroom_after >= 0
-            else f"exceeding the limit by {-headroom_after:,} instances."
+    available_capacity_after = limit - projected
+    if available_capacity_after < margin:
+        capacity_clause = (
+            f"leaving only {available_capacity_after:,} instances of available capacity, which is less than the required margin of {margin:,}."
+            if available_capacity_after >= 0
+            else f"exceeding the limit by {-available_capacity_after:,} instances."
         )
         raise ToolkitValueError(
             f"Cannot proceed with {action}, not enough soft-deleted instance capacity available. "
             f"Currently {used:,} of {limit:,} instances are soft-deleted. Performing this operation would add up to "
-            f"{instances_to_soft_delete:,} more (projected total: {projected:,}), {headroom_clause} "
+            f"{instances_to_soft_delete:,} more (projected total: {projected:,}), {capacity_clause} "
             f"Reduce what you delete, or wait for soft-deleted data to expire before retrying "
             f"(see: https://docs.cognite.com/cdf/dm/dm_concepts/dm_ingestion#soft-deletion for details)."
         )

--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -158,7 +158,7 @@ class URL:
 # CDF projects, such that admins can take action to increase or clean up the capacity before it is too late.
 DMS_INSTANCE_LIMIT_MARGIN = 1_000_000
 
-# Minimum headroom (limit - projected soft-deleted after the purge) required below the soft-deleted instance limit.
+# Minimum available capacity (limit - projected soft-deleted after the operation) required below the soft-deleted instance limit.
 # Currently set to the same value as DMS_INSTANCE_LIMIT_MARGIN.
 DMS_SOFT_DELETED_INSTANCE_LIMIT_MARGIN = 1_000_000
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
@@ -34,7 +34,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.timeseries import TimeSeriesResponse
 from cognite_toolkit._cdf_tk.commands import PurgeCommand
-from cognite_toolkit._cdf_tk.commands._purge import validate_soft_delete_purge_headroom
+from cognite_toolkit._cdf_tk.commands._utils import validate_soft_delete_headroom
 from cognite_toolkit._cdf_tk.dataio.selectors import InstanceViewSelector, SelectedView
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 from tests.test_unit.utils import FakeCogniteResourceGenerator
@@ -208,7 +208,9 @@ class TestPurgeInstances:
         instances = cognite_timeseries_2000_list if instance_type == "timeseries" else cognite_files_2000_list
         client = purge_client
         monkeypatch.setattr("cognite_toolkit._cdf_tk.commands._purge.questionary", MagicMock())
-        monkeypatch.setattr(PurgeCommand, "_confirm_purge", lambda self, msg, client: True)
+        monkeypatch.setattr(
+            "cognite_toolkit._cdf_tk.commands._purge.confirm_by_typing_project_name", lambda msg, client: True
+        )
         if not dry_run:
             rsps.add(
                 responses.GET,
@@ -319,7 +321,9 @@ class TestPurgeSpace:
         space = "test_space"
         rsps = purge_responses
         monkeypatch.setattr("cognite_toolkit._cdf_tk.commands._purge.questionary", MagicMock())
-        monkeypatch.setattr(PurgeCommand, "_confirm_purge", lambda self, msg, client: True)
+        monkeypatch.setattr(
+            "cognite_toolkit._cdf_tk.commands._purge.confirm_by_typing_project_name", lambda msg, client: True
+        )
         container_count = 10
         view_count = 15
         data_model_count = 3
@@ -472,7 +476,9 @@ class TestPurgeSpaceCrossReferenceCheck:
         config = purge_client.config
         space = "test_space"
         monkeypatch.setattr("cognite_toolkit._cdf_tk.commands._purge.questionary", MagicMock())
-        monkeypatch.setattr(PurgeCommand, "_confirm_purge", lambda self, msg, client: True)
+        monkeypatch.setattr(
+            "cognite_toolkit._cdf_tk.commands._purge.confirm_by_typing_project_name", lambda msg, client: True
+        )
 
         rsps.add(
             responses.POST,
@@ -512,8 +518,8 @@ class TestPurgeSpaceCrossReferenceCheck:
         delete_route = respx_mock.post(config.create_api_url("/models/containers/delete"))
 
         cmd = PurgeCommand(silent=True)
-        with pytest.raises(ToolkitValueError, match="Cannot proceed with purge"):
-            cmd.space(purge_client, space, log_dir=tmp_path, dry_run=dry_run)
+        with pytest.raises(ToolkitValueError, match="Cannot proceed with purging this space"):
+            cmd.space(purge_client, space, tmp_path, dry_run=dry_run)
         assert delete_route.call_count == 0
 
     @pytest.mark.parametrize("dry_run", [True, False])
@@ -530,7 +536,9 @@ class TestPurgeSpaceCrossReferenceCheck:
         config = purge_client.config
         space = "test_space"
         monkeypatch.setattr("cognite_toolkit._cdf_tk.commands._purge.questionary", MagicMock())
-        monkeypatch.setattr(PurgeCommand, "_confirm_purge", lambda self, msg, client: True)
+        monkeypatch.setattr(
+            "cognite_toolkit._cdf_tk.commands._purge.confirm_by_typing_project_name", lambda msg, client: True
+        )
 
         rsps.add(
             responses.POST,
@@ -561,51 +569,9 @@ class TestPurgeSpaceCrossReferenceCheck:
         delete_route = respx_mock.post(config.create_api_url("/models/containers/delete"))
 
         cmd = PurgeCommand(silent=True)
-        with pytest.raises(ToolkitValueError, match="Cannot proceed with purge"):
-            cmd.space(purge_client, space, log_dir=tmp_path, dry_run=dry_run)
+        with pytest.raises(ToolkitValueError, match="Cannot proceed with purging this space"):
+            cmd.space(purge_client, space, tmp_path, dry_run=dry_run)
         assert delete_route.call_count == 0
-
-    def test_does_not_block_when_only_same_space_views_reference_container(
-        self,
-        purge_client: ToolkitClient,
-        respx_mock: respx.MockRouter,
-    ) -> None:
-        """Same-space views are part of the purge and must not trigger the guardrail."""
-        config = purge_client.config
-        space = "test_space"
-
-        gen = FakeCogniteResourceGenerator(seed=3)
-        container = gen.create_instance(ContainerResponse)
-        container.space = space
-        container.external_id = "same_space_container"
-        respx_mock.get(config.create_api_url("/models/containers")).respond(
-            status_code=200, json={"items": [container.dump()]}
-        )
-        respx_mock.post(config.create_api_url("/models/containers/inspect")).respond(
-            status_code=200,
-            json={
-                "items": [
-                    {
-                        "space": space,
-                        "externalId": container.external_id,
-                        "inspectionResults": {
-                            "involvedViewCount": 1,
-                            "involvedViews": [
-                                {
-                                    "type": "view",
-                                    "space": space,
-                                    "externalId": "SameSpaceView",
-                                    "version": "v1",
-                                }
-                            ],
-                        },
-                    }
-                ]
-            },
-        )
-
-        # Should not raise — same-space view is part of the purge
-        PurgeCommand._block_if_external_views_reference_containers(purge_client, space)
 
 
 class TestSoftDeletePurgeHeadroom:
@@ -620,8 +586,8 @@ class TestSoftDeletePurgeHeadroom:
             instances=1000,
             soft_deleted_instances=9_200_000,
         )
-        with pytest.raises(ToolkitValueError, match="Cannot proceed"):
-            validate_soft_delete_purge_headroom(inst_stats, 900_000, action="test purge")
+        with pytest.raises(ToolkitValueError, match="Cannot proceed with test purge"):
+            validate_soft_delete_headroom(inst_stats, 900_000, action="test purge")
 
     def test_validate_ok_when_headroom_sufficient(self) -> None:
         inst_stats = InstanceStatistics(
@@ -634,4 +600,4 @@ class TestSoftDeletePurgeHeadroom:
             instances=1000,
             soft_deleted_instances=100,
         )
-        validate_soft_delete_purge_headroom(inst_stats, 2000, action="test purge")
+        validate_soft_delete_headroom(inst_stats, 2000, action="test purge")

--- a/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
@@ -19,7 +19,7 @@ from cognite.client.data_classes.capabilities import (
 )
 from cognite.client.data_classes.data_modeling import NodeList, Space
 from cognite.client.data_classes.data_modeling.cdm.v1 import CogniteFile, CogniteTimeSeries
-from cognite.client.data_classes.data_modeling.statistics import InstanceStatistics, SpaceStatistics
+from cognite.client.data_classes.data_modeling.statistics import SpaceStatistics
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
 from cognite_toolkit._cdf_tk.client.identifiers import NodeId
@@ -576,28 +576,8 @@ class TestPurgeSpaceCrossReferenceCheck:
 
 class TestSoftDeletePurgeHeadroom:
     def test_validate_blocks_when_headroom_below_margin(self) -> None:
-        inst_stats = InstanceStatistics(
-            nodes=1000,
-            edges=0,
-            soft_deleted_edges=0,
-            soft_deleted_nodes=0,
-            instances_limit=10_000_000,
-            soft_deleted_instances_limit=10_000_000,
-            instances=1000,
-            soft_deleted_instances=9_200_000,
-        )
         with pytest.raises(ToolkitValueError, match="Cannot proceed with test purge"):
-            validate_soft_delete_headroom(inst_stats, 900_000, action="test purge")
+            validate_soft_delete_headroom(9_200_000, 10_000_000, 900_000, action="test purge")
 
     def test_validate_ok_when_headroom_sufficient(self) -> None:
-        inst_stats = InstanceStatistics(
-            nodes=1000,
-            edges=0,
-            soft_deleted_edges=0,
-            soft_deleted_nodes=0,
-            instances_limit=10_000_000,
-            soft_deleted_instances_limit=10_000_000,
-            instances=1000,
-            soft_deleted_instances=100,
-        )
-        validate_soft_delete_headroom(inst_stats, 2000, action="test purge")
+        validate_soft_delete_headroom(100, 10_000_000, 2000, action="test purge")

--- a/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
@@ -34,7 +34,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.timeseries import TimeSeriesResponse
 from cognite_toolkit._cdf_tk.commands import PurgeCommand
-from cognite_toolkit._cdf_tk.commands._utils import validate_soft_delete_headroom
+from cognite_toolkit._cdf_tk.commands._utils import validate_soft_delete_capacity
 from cognite_toolkit._cdf_tk.dataio.selectors import InstanceViewSelector, SelectedView
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 from tests.test_unit.utils import FakeCogniteResourceGenerator
@@ -577,7 +577,7 @@ class TestPurgeSpaceCrossReferenceCheck:
 class TestSoftDeletePurgeHeadroom:
     def test_validate_blocks_when_headroom_below_margin(self) -> None:
         with pytest.raises(ToolkitValueError, match="Cannot proceed with test purge"):
-            validate_soft_delete_headroom(9_200_000, 10_000_000, 900_000, action="test purge")
+            validate_soft_delete_capacity(9_200_000, 10_000_000, 900_000, action="test purge")
 
     def test_validate_ok_when_headroom_sufficient(self) -> None:
-        validate_soft_delete_headroom(100, 10_000_000, 2000, action="test purge")
+        validate_soft_delete_capacity(100, 10_000_000, 2000, action="test purge")

--- a/tests/test_unit/test_toolkit_package.py
+++ b/tests/test_unit/test_toolkit_package.py
@@ -94,7 +94,7 @@ def test_no_cognite_sdk_imports() -> None:
     The goal is to fully remove the cognite-sdk dependency from the toolkit (with the exception of Auth and protobuf files).
     This test tracks progress toward that goal.
     """
-    _assert_import_violations(_extract_cognite_sdk_imports, "cognite.client imports", 103)
+    _assert_import_violations(_extract_cognite_sdk_imports, "cognite.client imports", 102)
 
 
 def _parse_package_name(dependency: str) -> str:

--- a/tests/test_unit/test_toolkit_package.py
+++ b/tests/test_unit/test_toolkit_package.py
@@ -94,7 +94,7 @@ def test_no_cognite_sdk_imports() -> None:
     The goal is to fully remove the cognite-sdk dependency from the toolkit (with the exception of Auth and protobuf files).
     This test tracks progress toward that goal.
     """
-    _assert_import_violations(_extract_cognite_sdk_imports, "cognite.client imports", 102)
+    _assert_import_violations(_extract_cognite_sdk_imports, "cognite.client imports", 103)
 
 
 def _parse_package_name(dependency: str) -> str:


### PR DESCRIPTION
# Description

Refactoring by moving `validate_soft_delete_headroom`, `print_soft_delete_panel`, `confirm_by_typing_project_name`, and `validate_no_out_of_scope_view_references` out of `_purge.py` into a shared `commands/_utils.py`. This is a preparation for applying these same guardrails to `cdf deploy --drop` and `cdf clean` (follow-up PR). No behaviour change in `cdf data purge`.

## Bump

- [ ] Patch
- [x] Skip