### PR TITLE
[CDF-27855] Align dump command API errors on ToolkitAPIError

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/http_client/__init__.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/__init__.py
@@ -7,7 +7,7 @@ from ._data_classes import (
     RequestMessage,
     SuccessResponse,
 )
-from ._exception import ToolkitAPIError
+from ._exception import ToolkitAPIError, toolkit_api_error_from_cognite
 from ._item_classes import (
     ItemsFailedRequest,
     ItemsFailedResponse,
@@ -30,4 +30,5 @@ __all__ = [
     "RequestMessage",
     "SuccessResponse",
     "ToolkitAPIError",
+    "toolkit_api_error_from_cognite",
 ]

--- a/cognite_toolkit/_cdf_tk/client/http_client/_exception.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_exception.py
@@ -1,4 +1,7 @@
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
+
+from cognite.client.exceptions import CogniteAPIError
 
 if TYPE_CHECKING:
     from cognite_toolkit._cdf_tk.client.http_client._data_classes import FailedResponse, RequestMessage
@@ -48,3 +51,28 @@ class ToolkitAPIError(Exception):
             debug_info["duplicated"] = self.duplicated
 
         return debug_info
+
+
+def _missing_or_duplicated_as_dict_list(items: Sequence[Any] | None) -> list[dict[str, Any]] | None:
+    if items is None:
+        return None
+    normalized: list[dict[str, Any]] = []
+    for item in items:
+        if isinstance(item, dict):
+            normalized.append(item)
+        else:
+            normalized.append({"identifier": item})
+    return normalized or None
+
+
+def toolkit_api_error_from_cognite(error: CogniteAPIError) -> ToolkitAPIError:
+    """Build a ``ToolkitAPIError`` from a Cognite SDK ``CogniteAPIError`` (same surface fields where possible)."""
+    return ToolkitAPIError(
+        message=error.message,
+        missing=_missing_or_duplicated_as_dict_list(error.missing),
+        duplicated=_missing_or_duplicated_as_dict_list(error.duplicated),
+        code=error.code,
+        is_auto_retryable=None,
+        request=None,
+        response=None,
+    )

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -23,7 +23,7 @@ from rich.console import Console
 from rich.panel import Panel
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
-from cognite_toolkit._cdf_tk.client.http_client import ToolkitAPIError
+from cognite_toolkit._cdf_tk.client.http_client import ToolkitAPIError, toolkit_api_error_from_cognite
 from cognite_toolkit._cdf_tk.client.identifiers import (
     ExternalId,
     NameId,
@@ -94,6 +94,10 @@ from cognite_toolkit._cdf_tk.utils.useful_types import T_ID
 from ._base import ToolkitCommand
 
 _INTERACTIVE_SELECT_HELPER_TEXT = " Use arrow keys to navigate and space key to select. Press enter to confirm."
+
+
+def _as_toolkit_api_error(error: CogniteAPIError | ToolkitAPIError) -> ToolkitAPIError:
+    return toolkit_api_error_from_cognite(error) if isinstance(error, CogniteAPIError) else error
 
 
 class ResourceFinder(Iterable, ABC, Generic[T_ID]):
@@ -663,13 +667,14 @@ class FunctionFinder(ResourceFinder[tuple[str, ...]]):
     def dump_function_code(self, function: FunctionResponse, folder: Path) -> None:
         try:
             zip_bytes = self.client.files.download_bytes(id=function.file_id)
-        except CogniteAPIError as e:
-            if e.code == 400 and "File ids not found" in e.message:
+        except (CogniteAPIError, ToolkitAPIError) as e:
+            te = _as_toolkit_api_error(e)
+            if te.code == 400 and "File ids not found" in te.message:
                 HighSeverityWarning(
                     f"The function {function.external_id!r} does not have code to dump. It is not available in CDF."
                 ).print_warning()
                 return
-            raise
+            raise te
         try:
             top_level = f"{sanitize_filename(function.external_id or 'unknown_external_id')}/"
             with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
@@ -744,13 +749,14 @@ class StreamlitFinder(ResourceFinder[tuple[str, ...]]):
         """
         try:
             content = self.client.files.download_bytes(external_id=app.external_id)
-        except CogniteAPIError as e:
-            if e.code == 400 and e.missing:
+        except (CogniteAPIError, ToolkitAPIError) as e:
+            te = _as_toolkit_api_error(e)
+            if te.code == 400 and te.missing:
                 HighSeverityWarning(
                     f"The source code for {app.external_id!r} could not be retrieved from CDF."
                 ).print_warning(console=console)
                 return
-            raise
+            raise te
 
         try:
             json_content = json.loads(content)
@@ -919,7 +925,10 @@ class DumpResourceCommand(ToolkitCommand):
                 try:
                     resources = loader.retrieve(list(identifiers))
                 except (CogniteAPIError, ToolkitAPIError) as e:
-                    raise ResourceRetrievalError(f"Failed to retrieve {humanize_collection(identifiers)}: {e!s}") from e
+                    te = _as_toolkit_api_error(e)
+                    raise ResourceRetrievalError(
+                        f"Failed to retrieve {humanize_collection(identifiers)}: {te!s}"
+                    ) from te
                 if len(resources) == 0:
                     raise ToolkitResourceMissingError(
                         f"Resource(s) {humanize_collection(identifiers)} not found", str(identifiers)

--- a/tests/test_unit/test_cdf_tk/test_utils/test_http_client.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_http_client.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 import respx
+from cognite.client.exceptions import CogniteAPIError
 
 from cognite_toolkit._cdf_tk.client import ToolkitClientConfig
 from cognite_toolkit._cdf_tk.client._resource_base import RequestItem
@@ -20,6 +21,8 @@ from cognite_toolkit._cdf_tk.client.http_client import (
     ItemsSuccessResponse,
     RequestMessage,
     SuccessResponse,
+    ToolkitAPIError,
+    toolkit_api_error_from_cognite,
 )
 
 
@@ -466,3 +469,24 @@ class TestItemMessage:
         )
 
         assert message.tracker.max_failures_before_abort == 10
+
+
+class TestToolkitAPIErrorFromCognite:
+    def test_maps_message_code_missing_duplicated(self) -> None:
+        cognite = CogniteAPIError(
+            "nope",
+            400,
+            missing=[{"id": 1}, {"id": 2}],
+            duplicated=[{"externalId": "x"}],
+        )
+        toolkit = toolkit_api_error_from_cognite(cognite)
+        assert isinstance(toolkit, ToolkitAPIError)
+        assert toolkit.message == "nope"
+        assert toolkit.code == 400
+        assert toolkit.missing == [{"id": 1}, {"id": 2}]
+        assert toolkit.duplicated == [{"externalId": "x"}]
+
+    def test_normalizes_non_dict_missing_entries(self) -> None:
+        cognite = CogniteAPIError("missing item", 404, missing=["a", "b"])
+        toolkit = toolkit_api_error_from_cognite(cognite)
+        assert toolkit.missing == [{"identifier": "a"}, {"identifier": "b"}]

--- a/tests/test_unit/test_toolkit_package.py
+++ b/tests/test_unit/test_toolkit_package.py
@@ -94,7 +94,7 @@ def test_no_cognite_sdk_imports() -> None:
     The goal is to fully remove the cognite-sdk dependency from the toolkit (with the exception of Auth and protobuf files).
     This test tracks progress toward that goal.
     """
-    _assert_import_violations(_extract_cognite_sdk_imports, "cognite.client imports", 102)
+    _assert_import_violations(_extract_cognite_sdk_imports, "cognite.client imports", 103)
 
 
 def _parse_package_name(dependency: str) -> str:


### PR DESCRIPTION
# Description

Dump subcommands mixed `CogniteAPIError` (classic SDK) and `ToolkitAPIError` (toolkit client). This adds `toolkit_api_error_from_cognite()` and uses it at the dump boundary—function and Streamlit file downloads, and loader retrieve failures—so propagated failures are consistently `ToolkitAPIError` (and `ResourceRetrievalError` chains from that).

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Align exception types raised by `cdf dump` commands on `ToolkitAPIError` (CDF-27855).