### PR TITLE
[CDF-27866] Fix duplicate-400 on DataProductVersion redeploy by diffing views before update

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/api/data_product_versions.py
+++ b/cognite_toolkit/_cdf_tk/client/api/data_product_versions.py
@@ -103,14 +103,31 @@ class DataProductVersionsAPI(CDFResourceAPI[DataProductVersionResponse]):
         items: Sequence[DataProductVersionRequest],
         mode: Literal["patch", "replace"] = "replace",
     ) -> list[DataProductVersionResponse]:
+        """Apply updates; in ``replace`` mode we retrieve first so ``as_update`` can diff views.
+
+        The patch API only supports ``views.add`` (no full replace). We need the live view list
+        to compute add/remove keys and avoid resending existing refs (duplicate 400).
+        """
         results: list[DataProductVersionResponse] = []
         for dp_ext_id, group in self._group_by_parent(items).items():
             url = self._make_url(self._method_endpoint_map["update"].path.format(externalId=dp_ext_id))
             for item in group:
+                cdf_views = None
+                if mode == "replace":
+                    current = self.retrieve(
+                        [
+                            DataProductVersionId(
+                                data_product_external_id=dp_ext_id,
+                                version=item.version,
+                            )
+                        ],
+                        ignore_unknown_ids=True,
+                    )
+                    cdf_views = current[0].views if current else []
                 request = RequestMessage(
                     endpoint_url=url,
                     method="POST",
-                    body_content={"items": [item.as_update(mode=mode)]},
+                    body_content={"items": [item.as_update(mode=mode, cdf_views=cdf_views)]},
                     api_version=self._api_version,
                 )
                 response = self._http_client.request_single_retries(request)

--- a/cognite_toolkit/_cdf_tk/client/api/data_product_versions.py
+++ b/cognite_toolkit/_cdf_tk/client/api/data_product_versions.py
@@ -111,19 +111,12 @@ class DataProductVersionsAPI(CDFResourceAPI[DataProductVersionResponse]):
         results: list[DataProductVersionResponse] = []
         for dp_ext_id, group in self._group_by_parent(items).items():
             url = self._make_url(self._method_endpoint_map["update"].path.format(externalId=dp_ext_id))
+            cdf_views_by_version: dict[str, list] = {}
+            if mode == "replace":
+                ids = [DataProductVersionId(data_product_external_id=dp_ext_id, version=item.version) for item in group]
+                cdf_views_by_version = {v.version: v.views for v in self.retrieve(ids, ignore_unknown_ids=True)}
             for item in group:
-                cdf_views = None
-                if mode == "replace":
-                    current = self.retrieve(
-                        [
-                            DataProductVersionId(
-                                data_product_external_id=dp_ext_id,
-                                version=item.version,
-                            )
-                        ],
-                        ignore_unknown_ids=True,
-                    )
-                    cdf_views = current[0].views if current else []
+                cdf_views = cdf_views_by_version.get(item.version, []) if mode == "replace" else None
                 request = RequestMessage(
                     endpoint_url=url,
                     method="POST",

--- a/cognite_toolkit/_cdf_tk/client/api/data_product_versions.py
+++ b/cognite_toolkit/_cdf_tk/client/api/data_product_versions.py
@@ -54,19 +54,19 @@ class DataProductVersionsAPI(CDFResourceAPI[DataProductVersionResponse]):
 
     def create(self, items: Sequence[DataProductVersionRequest]) -> list[DataProductVersionResponse]:
         results: list[DataProductVersionResponse] = []
-        for dp_ext_id, group in self._group_by_parent(items).items():
-            url = self._make_url(self._method_endpoint_map["create"].path.format(externalId=dp_ext_id))
-            for item in group:
+        for data_product_external_id, versions in self._group_by_parent(items).items():
+            url = self._make_url(self._method_endpoint_map["create"].path.format(externalId=data_product_external_id))
+            for version in versions:
                 request = RequestMessage(
                     endpoint_url=url,
                     method="POST",
-                    body_content={"items": [item.dump()]},
+                    body_content={"items": [version.dump()]},
                     api_version=self._api_version,
                 )
                 response = self._http_client.request_single_retries(request)
                 page = self._validate_page_response(response.get_success_or_raise(request))
-                for version in page.items:
-                    version.data_product_external_id = dp_ext_id
+                for created in page.items:
+                    created.data_product_external_id = data_product_external_id
                 results.extend(page.items)
         return results
 
@@ -109,24 +109,29 @@ class DataProductVersionsAPI(CDFResourceAPI[DataProductVersionResponse]):
         to compute add/remove keys and avoid resending existing refs (duplicate 400).
         """
         results: list[DataProductVersionResponse] = []
-        for dp_ext_id, group in self._group_by_parent(items).items():
-            url = self._make_url(self._method_endpoint_map["update"].path.format(externalId=dp_ext_id))
+        for data_product_external_id, versions in self._group_by_parent(items).items():
+            url = self._make_url(self._method_endpoint_map["update"].path.format(externalId=data_product_external_id))
             cdf_views_by_version: dict[str, list] = {}
             if mode == "replace":
-                ids = [DataProductVersionId(data_product_external_id=dp_ext_id, version=item.version) for item in group]
-                cdf_views_by_version = {v.version: v.views for v in self.retrieve(ids, ignore_unknown_ids=True)}
-            for item in group:
-                cdf_views = cdf_views_by_version.get(item.version, []) if mode == "replace" else None
+                ids = [
+                    DataProductVersionId(data_product_external_id=data_product_external_id, version=version.version)
+                    for version in versions
+                ]
+                cdf_views_by_version = {
+                    existing.version: existing.views for existing in self.retrieve(ids, ignore_unknown_ids=True)
+                }
+            for version in versions:
+                cdf_views = cdf_views_by_version.get(version.version, []) if mode == "replace" else None
                 request = RequestMessage(
                     endpoint_url=url,
                     method="POST",
-                    body_content={"items": [item.as_update(mode=mode, cdf_views=cdf_views)]},
+                    body_content={"items": [version.as_update(mode=mode, cdf_views=cdf_views)]},
                     api_version=self._api_version,
                 )
                 response = self._http_client.request_single_retries(request)
                 page = self._validate_page_response(response.get_success_or_raise(request))
-                for ver in page.items:
-                    ver.data_product_external_id = dp_ext_id
+                for updated in page.items:
+                    updated.data_product_external_id = data_product_external_id
                 results.extend(page.items)
         return results
 
@@ -134,8 +139,8 @@ class DataProductVersionsAPI(CDFResourceAPI[DataProductVersionResponse]):
         by_parent: defaultdict[str, list[str]] = defaultdict(list)
         for id_ in ids:
             by_parent[id_.data_product_external_id].append(id_.version)
-        for dp_ext_id, versions in by_parent.items():
-            url = self._make_url(self._method_endpoint_map["delete"].path.format(externalId=dp_ext_id))
+        for data_product_external_id, versions in by_parent.items():
+            url = self._make_url(self._method_endpoint_map["delete"].path.format(externalId=data_product_external_id))
             request = RequestMessage(
                 endpoint_url=url,
                 method="POST",

--- a/cognite_toolkit/_cdf_tk/client/api/data_product_versions.py
+++ b/cognite_toolkit/_cdf_tk/client/api/data_product_versions.py
@@ -103,25 +103,21 @@ class DataProductVersionsAPI(CDFResourceAPI[DataProductVersionResponse]):
         items: Sequence[DataProductVersionRequest],
         mode: Literal["patch", "replace"] = "replace",
     ) -> list[DataProductVersionResponse]:
-        """Apply updates; in ``replace`` mode we retrieve first so ``as_update`` can diff views.
-
-        The patch API only supports ``views.add`` (no full replace). We need the live view list
-        to compute add/remove keys and avoid resending existing refs (duplicate 400).
-        """
+        """Apply updates; in ``replace`` mode we retrieve first so ``as_update`` can diff views. The patch API only supports ``views.add`` (no full replace). We need the live view list to compute add/remove keys and avoid resending existing refs (duplicate 400)."""
         results: list[DataProductVersionResponse] = []
         for data_product_external_id, versions in self._group_by_parent(items).items():
             url = self._make_url(self._method_endpoint_map["update"].path.format(externalId=data_product_external_id))
-            cdf_views_by_version: dict[str, list] = {}
+            views_by_version: dict[str, list] = {}
             if mode == "replace":
                 ids = [
                     DataProductVersionId(data_product_external_id=data_product_external_id, version=version.version)
                     for version in versions
                 ]
-                cdf_views_by_version = {
+                views_by_version = {
                     existing.version: existing.views for existing in self.retrieve(ids, ignore_unknown_ids=True)
                 }
             for version in versions:
-                cdf_views = cdf_views_by_version.get(version.version, []) if mode == "replace" else None
+                cdf_views = views_by_version.get(version.version, []) if mode == "replace" else None
                 request = RequestMessage(
                     endpoint_url=url,
                     method="POST",

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_product_version.py
@@ -86,9 +86,8 @@ class DataProductVersionRequest(DataProductVersion, UpdatableRequestResource):
         if "views" in dumped:
             # View refs are append-only per the API spec — once added they cannot be removed.
             # Only send views.add for refs not already in CDF (avoids duplicate-400 on redeploy).
-            desired = [DataProductVersionView.model_validate(v) for v in dumped["views"]]
             existing_keys = {(v.space, v.external_id, v.version) for v in (cdf_views or [])}
-            to_add = [v for v in desired if (v.space, v.external_id, v.version) not in existing_keys]
+            to_add = [v for v in self.views if (v.space, v.external_id, v.version) not in existing_keys]
             if to_add:
                 update["views"] = {"add": [v.model_dump(mode="json", by_alias=True) for v in to_add]}
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_product_version.py
@@ -83,26 +83,14 @@ class DataProductVersionRequest(DataProductVersion, UpdatableRequestResource):
             if terms_modify:
                 update["terms"] = {"modify": terms_modify}
 
-        if mode == "patch":
-            if dumped.get("views"):
-                update["views"] = {"add": dumped["views"]}
-        elif "views" in dumped:
+        if "views" in dumped:
+            # View refs are append-only per the API spec — once added they cannot be removed.
+            # Only send views.add for refs not already in CDF (avoids duplicate-400 on redeploy).
             desired = [DataProductVersionView.model_validate(v) for v in dumped["views"]]
-            existing = list(cdf_views or [])
-            desired_map = {(v.space, v.external_id, v.version): v for v in desired}
-            existing_map = {(v.space, v.external_id, v.version): v for v in existing}
-            dk, ek = frozenset(desired_map), frozenset(existing_map)
-            views_patch: dict[str, Any] = {}
-            add_keys = dk - ek
-            remove_keys = ek - dk
-            if add_keys:
-                views_patch["add"] = [desired_map[k].model_dump(mode="json", by_alias=True) for k in sorted(add_keys)]
-            if remove_keys:
-                views_patch["remove"] = [
-                    existing_map[k].model_dump(mode="json", by_alias=True) for k in sorted(remove_keys)
-                ]
-            if views_patch:
-                update["views"] = views_patch
+            existing_keys = {(v.space, v.external_id, v.version) for v in (cdf_views or [])}
+            to_add = [v for v in desired if (v.space, v.external_id, v.version) not in existing_keys]
+            if to_add:
+                update["views"] = {"add": [v.model_dump(mode="json", by_alias=True) for v in to_add]}
 
         update_item["update"] = update
         return update_item

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_product_version.py
@@ -53,9 +53,14 @@ class DataProductVersion(BaseModelObject):
 class DataProductVersionRequest(DataProductVersion, UpdatableRequestResource):
     container_fields: ClassVar[frozenset[str]] = frozenset()
 
-    def as_update(self, mode: Literal["patch", "replace"]) -> dict[str, Any]:
-        # The versions update API uses nested {set}/{setNull}/{modify}/{add} operators
-        # instead of a flat body, so we must build the payload manually.
+    def as_update(
+        self,
+        mode: Literal["patch", "replace"],
+        *,
+        cdf_views: list[DataProductVersionView] | None = None,
+    ) -> dict[str, Any]:
+        # DataProductVersionPatch only defines views.add (OpenAPI); append-only updates must not
+        # resend existing view refs (duplicate 400). Diff by view identity (space + externalId + version).
         update_item: dict[str, Any] = {"version": self.version}
         update: dict[str, Any] = {}
         exclude_unset = mode == "patch"
@@ -78,8 +83,26 @@ class DataProductVersionRequest(DataProductVersion, UpdatableRequestResource):
             if terms_modify:
                 update["terms"] = {"modify": terms_modify}
 
-        if dumped.get("views"):
-            update["views"] = {"add" if mode == "patch" else "set": dumped["views"]}
+        if mode == "patch":
+            if dumped.get("views"):
+                update["views"] = {"add": dumped["views"]}
+        elif "views" in dumped:
+            desired = [DataProductVersionView.model_validate(v) for v in dumped["views"]]
+            existing = list(cdf_views or [])
+            desired_map = {(v.space, v.external_id, v.version): v for v in desired}
+            existing_map = {(v.space, v.external_id, v.version): v for v in existing}
+            dk, ek = frozenset(desired_map), frozenset(existing_map)
+            views_patch: dict[str, Any] = {}
+            add_keys = dk - ek
+            remove_keys = ek - dk
+            if add_keys:
+                views_patch["add"] = [desired_map[k].model_dump(mode="json", by_alias=True) for k in sorted(add_keys)]
+            if remove_keys:
+                views_patch["remove"] = [
+                    existing_map[k].model_dump(mode="json", by_alias=True) for k in sorted(remove_keys)
+                ]
+            if views_patch:
+                update["views"] = views_patch
 
         update_item["update"] = update
         return update_item

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_data_product_version.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_data_product_version.py
@@ -1,9 +1,12 @@
 """Unit tests for DataProductVersionIO."""
 
+from typing import Any, ClassVar
+
 from cognite_toolkit._cdf_tk.client.resource_classes.data_product_version import (
     DataProductVersionQuality,
     DataProductVersionRequest,
     DataProductVersionResponse,
+    DataProductVersionView,
 )
 from cognite_toolkit._cdf_tk.client.testing import ToolkitClientMock
 from cognite_toolkit._cdf_tk.resource_ios._resource_ios.data_product_version import DataProductVersionIO
@@ -53,30 +56,111 @@ class TestDataProductVersionIODumpResource:
 
 
 class TestDataProductVersionRequest:
-    def test_as_update_replaces_views_in_replace_mode(self) -> None:
+    _v_cdm_3d: ClassVar[dict[str, Any]] = {
+        "space": "cdf_cdm",
+        "externalId": "Cognite3DModel",
+        "version": "v1",
+        "instanceSpaces": {"read": [], "write": []},
+    }
+
+    def test_as_update_replace_adds_only_net_new_views(self) -> None:
         request = DataProductVersionRequest.model_validate(
             {
                 "dataProductExternalId": "my-product",
                 "version": "1.0.0",
                 "views": [
-                    {
-                        "space": "cdf_cdm",
-                        "externalId": "Cognite3DModel",
-                        "version": "v1",
-                    }
+                    {"space": "cdf_cdm", "externalId": "Cognite3DModel", "version": "v1"},
+                    {"space": "cdf_cdm", "externalId": "OtherView", "version": "v1"},
                 ],
             }
         )
+        existing = [
+            DataProductVersionView.model_validate(self._v_cdm_3d),
+        ]
 
-        update = request.as_update(mode="replace")
+        update = request.as_update(mode="replace", cdf_views=existing)
 
         assert update["update"]["views"] == {
-            "set": [
+            "add": [
                 {
                     "space": "cdf_cdm",
-                    "externalId": "Cognite3DModel",
+                    "externalId": "OtherView",
                     "version": "v1",
                     "instanceSpaces": {"read": [], "write": []},
                 }
             ]
         }
+
+    def test_as_update_replace_removes_views_no_longer_desired(self) -> None:
+        request = DataProductVersionRequest.model_validate(
+            {
+                "dataProductExternalId": "my-product",
+                "version": "1.0.0",
+                "views": [{"space": "cdf_cdm", "externalId": "Cognite3DModel", "version": "v1"}],
+            }
+        )
+        existing = [
+            DataProductVersionView.model_validate(self._v_cdm_3d),
+            DataProductVersionView.model_validate(
+                {
+                    "space": "cdf_cdm",
+                    "externalId": "RemoveMe",
+                    "version": "v1",
+                    "instanceSpaces": {"read": [], "write": []},
+                }
+            ),
+        ]
+
+        update = request.as_update(mode="replace", cdf_views=existing)
+
+        assert update["update"]["views"] == {
+            "remove": [
+                {
+                    "space": "cdf_cdm",
+                    "externalId": "RemoveMe",
+                    "version": "v1",
+                    "instanceSpaces": {"read": [], "write": []},
+                }
+            ]
+        }
+
+    def test_as_update_replace_unchanged_views_omits_views(self) -> None:
+        request = DataProductVersionRequest.model_validate(
+            {
+                "dataProductExternalId": "my-product",
+                "version": "1.0.0",
+                "views": [{"space": "cdf_cdm", "externalId": "Cognite3DModel", "version": "v1"}],
+            }
+        )
+        existing = [DataProductVersionView.model_validate(self._v_cdm_3d)]
+
+        update = request.as_update(mode="replace", cdf_views=existing)
+
+        assert "views" not in update["update"]
+
+    def test_as_update_replace_empty_cdf_is_all_add(self) -> None:
+        request = DataProductVersionRequest.model_validate(
+            {
+                "dataProductExternalId": "my-product",
+                "version": "1.0.0",
+                "views": [{"space": "cdf_cdm", "externalId": "Cognite3DModel", "version": "v1"}],
+            }
+        )
+
+        update = request.as_update(mode="replace", cdf_views=[])
+
+        assert update["update"]["views"] == {"add": [self._v_cdm_3d]}
+
+    def test_as_update_replace_empty_desired_removes_all(self) -> None:
+        request = DataProductVersionRequest.model_validate(
+            {
+                "dataProductExternalId": "my-product",
+                "version": "1.0.0",
+                "views": [],
+            }
+        )
+        existing = [DataProductVersionView.model_validate(self._v_cdm_3d)]
+
+        update = request.as_update(mode="replace", cdf_views=existing)
+
+        assert update["update"]["views"] == {"remove": [self._v_cdm_3d]}

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_data_product_version.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_data_product_version.py
@@ -1,6 +1,6 @@
 """Unit tests for DataProductVersionIO."""
 
-from typing import Any, ClassVar
+from typing import ClassVar
 
 from cognite_toolkit._cdf_tk.client.resource_classes.data_product_version import (
     DataProductVersionQuality,
@@ -56,12 +56,15 @@ class TestDataProductVersionIODumpResource:
 
 
 class TestDataProductVersionRequest:
-    _v_cdm_3d: ClassVar[dict[str, Any]] = {
+    _v_cdm_3d: ClassVar[dict] = {
         "space": "cdf_cdm",
         "externalId": "Cognite3DModel",
         "version": "v1",
         "instanceSpaces": {"read": [], "write": []},
     }
+
+    def _existing(self, **overrides: str) -> list[DataProductVersionView]:
+        return [DataProductVersionView.model_validate({**self._v_cdm_3d, **overrides})]
 
     def test_as_update_replace_adds_only_net_new_views(self) -> None:
         request = DataProductVersionRequest.model_validate(
@@ -74,50 +77,14 @@ class TestDataProductVersionRequest:
                 ],
             }
         )
-        existing = [
-            DataProductVersionView.model_validate(self._v_cdm_3d),
-        ]
 
-        update = request.as_update(mode="replace", cdf_views=existing)
+        update = request.as_update(mode="replace", cdf_views=self._existing())
 
         assert update["update"]["views"] == {
             "add": [
                 {
                     "space": "cdf_cdm",
                     "externalId": "OtherView",
-                    "version": "v1",
-                    "instanceSpaces": {"read": [], "write": []},
-                }
-            ]
-        }
-
-    def test_as_update_replace_removes_views_no_longer_desired(self) -> None:
-        request = DataProductVersionRequest.model_validate(
-            {
-                "dataProductExternalId": "my-product",
-                "version": "1.0.0",
-                "views": [{"space": "cdf_cdm", "externalId": "Cognite3DModel", "version": "v1"}],
-            }
-        )
-        existing = [
-            DataProductVersionView.model_validate(self._v_cdm_3d),
-            DataProductVersionView.model_validate(
-                {
-                    "space": "cdf_cdm",
-                    "externalId": "RemoveMe",
-                    "version": "v1",
-                    "instanceSpaces": {"read": [], "write": []},
-                }
-            ),
-        ]
-
-        update = request.as_update(mode="replace", cdf_views=existing)
-
-        assert update["update"]["views"] == {
-            "remove": [
-                {
-                    "space": "cdf_cdm",
-                    "externalId": "RemoveMe",
                     "version": "v1",
                     "instanceSpaces": {"read": [], "write": []},
                 }
@@ -132,9 +99,8 @@ class TestDataProductVersionRequest:
                 "views": [{"space": "cdf_cdm", "externalId": "Cognite3DModel", "version": "v1"}],
             }
         )
-        existing = [DataProductVersionView.model_validate(self._v_cdm_3d)]
 
-        update = request.as_update(mode="replace", cdf_views=existing)
+        update = request.as_update(mode="replace", cdf_views=self._existing())
 
         assert "views" not in update["update"]
 
@@ -151,7 +117,9 @@ class TestDataProductVersionRequest:
 
         assert update["update"]["views"] == {"add": [self._v_cdm_3d]}
 
-    def test_as_update_replace_empty_desired_removes_all(self) -> None:
+    def test_as_update_replace_view_removed_locally_is_ignored(self) -> None:
+        """View refs are immutable/append-only in the API — a view present in CDF but
+        absent locally must not generate a remove operation."""
         request = DataProductVersionRequest.model_validate(
             {
                 "dataProductExternalId": "my-product",
@@ -159,8 +127,7 @@ class TestDataProductVersionRequest:
                 "views": [],
             }
         )
-        existing = [DataProductVersionView.model_validate(self._v_cdm_3d)]
 
-        update = request.as_update(mode="replace", cdf_views=existing)
+        update = request.as_update(mode="replace", cdf_views=self._existing())
 
-        assert update["update"]["views"] == {"remove": [self._v_cdm_3d]}
+        assert "views" not in update["update"]


### PR DESCRIPTION
## Description

When redeploying a `DataProductVersion` in replace mode, the toolkit was sending all desired views in a single `views.add` payload — including views already present in CDF. Because `views.add` is **append-only** per the API spec, CDF rejects the request with a **400 duplicate error**.

A previous fix attempt (0.8.60) tried switching to `views.set`, but the `DataProductVersion` update API does not support `set` for views — `DataProductVersionPatch` only defines `views.add`.

### Root cause

The API contract (confirmed from the OpenAPI spec) is:
- View refs are **immutable once added** — they cannot be modified or removed.
- The only supported update operation is `views.add`.

### Fix

Before calling the update endpoint in replace mode, the toolkit now retrieves the current version from CDF and diffs the desired views against the existing ones (keyed by `space + externalId + version`). Only **net-new views** are sent in `views.add`. If the local file drops a view that is already in CDF, it is silently ignored — the API does not support removal.

Patch mode behaviour is unchanged (views are only included if explicitly set, which already prevents spurious sends).

### Files changed

- `cognite_toolkit/_cdf_tk/client/resource_classes/data_product_version.py` — `as_update` accepts an optional `cdf_views` list and computes the add-only diff
- `cognite_toolkit/_cdf_tk/client/api/data_product_versions.py` — `update()` fetches the current version in replace mode and passes its views to `as_update`
- `tests/test_unit/test_cdf_tk/test_cruds/test_data_product_version.py` — updated tests covering: add net-new only, unchanged views omitted, empty CDF sends all, view dropped locally is silently ignored

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- `DataProductVersion` redeploy no longer fails with a 400 duplicate error when views are already present in CDF. The update now diffs desired views against CDF and only sends `views.add` for net-new entries.