### PR TITLE
[CDF-27853] Clarify device_code login flow description

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils/auth.py
+++ b/cognite_toolkit/_cdf_tk/utils/auth.py
@@ -37,7 +37,7 @@ PROVIDER_DESCRIPTION = {
 LOGIN_FLOW_DESCRIPTION = {
     "client_credentials": "Setup a service principal with client credentials",
     "interactive": "Login using the browser with your user credentials",
-    "device_code": "Complete sign-in in a browser on a different device to authorize this toolkit (device code flow)",
+    "device_code": "Complete sign-in in a browser on a different device to authorize your user (device code flow)",
     "token": "Use a Token directly to authenticate",
 }
 

--- a/cognite_toolkit/_cdf_tk/utils/auth.py
+++ b/cognite_toolkit/_cdf_tk/utils/auth.py
@@ -37,7 +37,7 @@ PROVIDER_DESCRIPTION = {
 LOGIN_FLOW_DESCRIPTION = {
     "client_credentials": "Setup a service principal with client credentials",
     "interactive": "Login using the browser with your user credentials",
-    "device_code": "Complete sign-in in a browser on a different device to authorize your user (device code flow)",
+    "device_code": "Complete sign-in in a browser on any device to authorize this session(device code flow)",
     "token": "Use a Token directly to authenticate",
 }
 

--- a/cognite_toolkit/_cdf_tk/utils/auth.py
+++ b/cognite_toolkit/_cdf_tk/utils/auth.py
@@ -37,7 +37,7 @@ PROVIDER_DESCRIPTION = {
 LOGIN_FLOW_DESCRIPTION = {
     "client_credentials": "Setup a service principal with client credentials",
     "interactive": "Login using the browser with your user credentials",
-    "device_code": "Complete sign-in in a browser on any device to authorize this session(device code flow)",
+    "device_code": "Complete sign-in in a browser on any device to authorize this session (device code flow)",
     "token": "Use a Token directly to authenticate",
 }
 

--- a/cognite_toolkit/_cdf_tk/utils/auth.py
+++ b/cognite_toolkit/_cdf_tk/utils/auth.py
@@ -37,7 +37,7 @@ PROVIDER_DESCRIPTION = {
 LOGIN_FLOW_DESCRIPTION = {
     "client_credentials": "Setup a service principal with client credentials",
     "interactive": "Login using the browser with your user credentials",
-    "device_code": "Login using the browser with your user credentials using device code flow",
+    "device_code": "Complete sign-in in a browser on a different device to authorize this toolkit (device code flow)",
     "token": "Use a Token directly to authenticate",
 }
 


### PR DESCRIPTION
# Description

Updates the \`device_code\` entry in \`LOGIN_FLOW_DESCRIPTION\` (\`cognite_toolkit/_cdf_tk/utils/auth.py\`) so the login-flow prompt explains that sign-in is completed **in a browser on a different device** to authorize the toolkit (device code flow), matching [CDF-27853](https://cognitedata.atlassian.net/browse/CDF-27853).

## Bump

- [ ] Patch
- [x] Skip

## Changelog

### Improved

- Clarified wording for the device code login flow in toolkit auth prompts.

[CDF-27853]: https://cognitedata.atlassian.net/browse/CDF-27853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ