### PR TITLE
[CDF-27869] Fix confusing defaults in cdf auth init selection prompts

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_auth_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_auth_app.py
@@ -21,6 +21,15 @@ class AuthApp(typer.Typer):
 
     def init(
         self,
+        reset: Annotated[
+            bool,
+            typer.Option(
+                "--reset",
+                help="Start over from scratch, ignoring any existing environment variables. "
+                "An existing .env file will be backed up before being overwritten.",
+                hidden=True,
+            ),
+        ] = False,
         verbose: Annotated[
             bool,
             typer.Option(
@@ -40,7 +49,7 @@ class AuthApp(typer.Typer):
         """
         # We do not pass in a client here as this is typically used to create the .env file needed for authentication.
         cmd = AuthCommand()
-        cmd.run(lambda: cmd.init())
+        cmd.run(lambda: cmd.init(reset=reset))
 
     def verify(
         self,

--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -80,21 +80,27 @@ class VerifyAuthResult:
 
 
 class AuthCommand(ToolkitCommand):
-    def init(self) -> None:
+    def init(self, reset: bool = False) -> None:
         env_vars: EnvironmentVariables | None = None
         try:
             env_vars = EnvironmentVariables.create_from_environment()
         except ToolkitMissingValueError:
             ...
 
-        ask_user = True
-        if env_vars and not env_vars.get_missing_vars():
-            print("Auth variables are already set.")
-            ask_user = questionary.confirm("Do you want to reconfigure the auth variables?", default=False).unsafe_ask()
+        if reset:
+            env_vars = prompt_user_environment_variables(current=None)
+            self._store_dotenv(env_vars, force_overwrite=True)
+        else:
+            ask_user = True
+            if env_vars and not env_vars.get_missing_vars():
+                print("Auth variables are already set.")
+                ask_user = questionary.confirm(
+                    "Do you want to reconfigure the auth variables?", default=False
+                ).unsafe_ask()
 
-        if ask_user or not env_vars:
-            env_vars = prompt_user_environment_variables(env_vars)
-            self._store_dotenv(env_vars)
+            if ask_user or not env_vars:
+                env_vars = prompt_user_environment_variables(env_vars)
+                self._store_dotenv(env_vars)
 
         client = env_vars.get_client()
         try:
@@ -104,7 +110,7 @@ class AuthCommand(ToolkitCommand):
 
         print("[green]The credentials are valid.[/green]")
 
-    def _store_dotenv(self, env_vars: EnvironmentVariables) -> None:
+    def _store_dotenv(self, env_vars: EnvironmentVariables, force_overwrite: bool = False) -> None:
         new_env_file = env_vars.create_dotenv_file()
         if Path(".env").exists():
             existing = Path(".env").read_text(encoding="utf-8")
@@ -114,11 +120,15 @@ class AuthCommand(ToolkitCommand):
             self.warn(MediumSeverityWarning("'.env' file already exists"))
             filename = next(f"backup_{no}.env" for no in itertools.count() if not Path(f"backup_{no}.env").exists())
 
-            if questionary.confirm(
-                f"Do you want to overwrite the existing '.env' file? The existing will be renamed to {filename}",
-                default=False,
-            ).unsafe_ask():
+            if (
+                force_overwrite
+                or questionary.confirm(
+                    f"Do you want to overwrite the existing '.env' file? The existing will be renamed to {filename}",
+                    default=False,
+                ).unsafe_ask()
+            ):
                 shutil.move(".env", filename)
+                print(f"Existing '.env' backed up to {filename!r}.")
                 Path(".env").write_text(new_env_file, encoding="utf-8")
         elif questionary.confirm("Do you want to save these to .env file for next time?", default=True).unsafe_ask():
             Path(".env").write_text(new_env_file, encoding="utf-8")

--- a/cognite_toolkit/_cdf_tk/utils/auth.py
+++ b/cognite_toolkit/_cdf_tk/utils/auth.py
@@ -510,13 +510,14 @@ def prompt_user_environment_variables(current: EnvironmentVariables | None = Non
             idp_tenant_id = user_value
 
     optional_values = env_vars.get_optional_with_value()
-    print("Additional variables:")
-    for field_, value in optional_values:
-        print(f"  {field_.name}={value}")
-    if questionary.confirm("Do you want to change any of these variables?", default=False).unsafe_ask():
+    if optional_values:
+        print("Additional variables:")
         for field_, value in optional_values:
-            user_value = get_user_value(field_, value, provider, cdf_cluster, cdf_project, idp_tenant_id)
-            setattr(env_vars, field_.name, user_value)
+            print(f"  {field_.name}={value}")
+        if questionary.confirm("Do you want to change any of these variables?", default=False).unsafe_ask():
+            for field_, value in optional_values:
+                user_value = get_user_value(field_, value, provider, cdf_cluster, cdf_project, idp_tenant_id)
+                setattr(env_vars, field_.name, user_value)
     return env_vars
 
 

--- a/cognite_toolkit/_cdf_tk/utils/auth.py
+++ b/cognite_toolkit/_cdf_tk/utils/auth.py
@@ -35,7 +35,7 @@ PROVIDER_DESCRIPTION = {
     "other": "Use other IDP to authenticate",
 }
 LOGIN_FLOW_DESCRIPTION = {
-    "device_code": "Sign in via a browser on any device — no service principal needed (recommended for first-time setup)",
+    "device_code": "Sign in via a browser on any device — no service principal needed (best for local setup)",
     "interactive": "Sign in via the browser on this machine with your user credentials",
     "client_credentials": "Use a service principal with client ID and secret (for CI/CD or automated workloads)",
     "token": "Supply a pre-existing token directly",

--- a/cognite_toolkit/_cdf_tk/utils/auth.py
+++ b/cognite_toolkit/_cdf_tk/utils/auth.py
@@ -35,10 +35,10 @@ PROVIDER_DESCRIPTION = {
     "other": "Use other IDP to authenticate",
 }
 LOGIN_FLOW_DESCRIPTION = {
-    "client_credentials": "Setup a service principal with client credentials",
-    "interactive": "Login using the browser with your user credentials",
-    "device_code": "Login using the browser with your user credentials using device code flow",
-    "token": "Use a Token directly to authenticate",
+    "device_code": "Sign in via a browser on any device — no service principal needed (recommended for local setup)",
+    "interactive": "Sign in via the browser on this machine with your user credentials",
+    "client_credentials": "Use a service principal with client ID and secret (for CI/CD or automated workloads)",
+    "token": "Supply a pre-existing token directly",
 }
 
 
@@ -119,7 +119,7 @@ class EnvironmentVariables:
     IDP_TENANT_ID: str | None = field(
         default=None,
         metadata=EnvOptions(
-            display_name="Tenant id for MS Entra",
+            display_name="Tenant id for Microsoft Entra ID",
             example={"entra_id": "00000000-0000-0000-0000-000000000000 or mytenant.onmicrosoft.com"},
             required=frozenset(
                 [("entra_id", "device_code"), ("entra_id", "client_credentials"), ("entra_id", "interactive")]
@@ -480,11 +480,19 @@ def prompt_user_environment_variables(current: EnvironmentVariables | None = Non
         login_flow = questionary.select(
             "Choose the login flow (How do you going to authenticate?)",
             choices=choices,
-            default=current.LOGIN_FLOW if current else "client_credentials",
+            default=current.LOGIN_FLOW if current else "device_code",
         ).unsafe_ask()
 
-    cdf_cluster = questionary.text("Enter the CDF cluster", default=current.CDF_CLUSTER if current else "").unsafe_ask()
-    cdf_project = questionary.text("Enter the CDF project", default=current.CDF_PROJECT if current else "").unsafe_ask()
+    cdf_cluster = questionary.text(
+        "Enter the CDF cluster (e.g. westeurope-1)",
+        default=current.CDF_CLUSTER if current else "",
+        validate=lambda v: True if v.strip() else "CDF cluster cannot be empty",
+    ).unsafe_ask()
+    cdf_project = questionary.text(
+        "Enter the CDF project",
+        default=current.CDF_PROJECT if current else "",
+        validate=lambda v: True if v.strip() else "CDF project cannot be empty",
+    ).unsafe_ask()
     args: dict[str, Any] = (
         current.dump(include_os=False)
         if current and _is_unchanged(current, provider, login_flow, cdf_project, cdf_cluster)  # type: ignore[arg-type]
@@ -502,6 +510,7 @@ def prompt_user_environment_variables(current: EnvironmentVariables | None = Non
             idp_tenant_id = user_value
 
     optional_values = env_vars.get_optional_with_value()
+    print("Additional variables:")
     for field_, value in optional_values:
         print(f"  {field_.name}={value}")
     if questionary.confirm("Do you want to change any of these variables?", default=False).unsafe_ask():
@@ -516,24 +525,37 @@ def get_user_value(
 ) -> Any:
     is_secret = field_.metadata["is_secret"]
     display_name = field_.metadata["display_name"]
+    hint = ""
     if value:
         default = value
     else:
         default_example = field_.metadata["default_example"]
-        default = (
+        example = (
             field_.metadata["example"]
             .get(provider, default_example)
             .format(CDF_CLUSTER=cdf_cluster, CDF_PROJECT=cdf_project, IDP_TENANT_ID=idp_tenant_id)
         )
+        # Use the example as a pre-filled default only when it is a concrete value
+        # (i.e. all template placeholders have been resolved).  Strings that still
+        # look like documentation hints (contain "<", ">", or " or ") are shown as
+        # hint text in the question label instead, so the user cannot accidentally
+        # submit them verbatim.
+        if example and not any(marker in example for marker in ("<", ">", " or ")):
+            default = example
+        else:
+            default = ""
+            if example:
+                hint = f" (e.g. {example})"
 
     if isinstance(value, list):
         default = ",".join(value)
     elif value is not None and not isinstance(value, str):
         default = str(value)
+    prompt = f"Enter the {display_name}{hint}:"
     if is_secret:
-        user_value = questionary.password(f"Enter the {display_name}:", default=default).unsafe_ask()
+        user_value = questionary.password(prompt, default=default).unsafe_ask()
     else:
-        user_value = questionary.text(f"Enter the {display_name}:", default=default).unsafe_ask()
+        user_value = questionary.text(prompt, default=default).unsafe_ask()
     if user_value is None:
         raise typer.Exit(0)
     if field_.type is int:

--- a/tests/test_unit/test_cdf_tk/test_utils/test_auth.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_auth.py
@@ -5,12 +5,19 @@ from unittest import mock
 import pytest
 
 from cognite_toolkit._cdf_tk.exceptions import ToolkitMissingValueError
-from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
+from cognite_toolkit._cdf_tk.utils.auth import (
+    LOGIN_FLOW_DESCRIPTION,
+    EnvironmentVariables,
+    prompt_user_environment_variables,
+)
+from tests.test_unit.utils import MockQuestionary
 
 PROJECT_AND_CLUSTER = {
     "CDF_CLUSTER": "toolkit-cluster",
     "CDF_PROJECT": "the-toolkit-project",
 }
+
+AUTH_MODULE = "cognite_toolkit._cdf_tk.utils.auth"
 
 
 class TestEnvironmentVariables:
@@ -164,3 +171,36 @@ CDF_CLIENT_TIMEOUT=30
 CDF_CLIENT_MAX_WORKERS=5
 """
         )
+
+
+class TestPromptUserEnvironmentVariables:
+    def test_device_code_is_first_login_flow(self) -> None:
+        first_flow = next(iter(LOGIN_FLOW_DESCRIPTION))
+        assert first_flow == "device_code", (
+            "device_code should be the first login flow so new users see it as the default"
+        )
+
+    def test_new_user_defaults_to_device_code_entra_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Simulate a first-time user pressing Enter on every prompt:
+        # provider=entra_id, flow=device_code, cluster=westeurope-1, project=my-project,
+        # IDP_TENANT_ID=my-tenant, optional vars unchanged
+        with MockQuestionary(
+            AUTH_MODULE,
+            monkeypatch,
+            answers=[
+                "entra_id",  # provider select
+                "device_code",  # login flow select — this is the new default
+                "westeurope-1",  # CDF cluster
+                "my-project",  # CDF project
+                "my-tenant.onmicrosoft.com",  # IDP_TENANT_ID
+                False,  # "change optional vars?"
+            ],
+        ):
+            env = prompt_user_environment_variables()
+
+        assert env.LOGIN_FLOW == "device_code"
+        assert env.PROVIDER == "entra_id"
+        assert env.CDF_CLUSTER == "westeurope-1"
+        assert env.CDF_PROJECT == "my-project"
+        assert env.IDP_TENANT_ID == "my-tenant.onmicrosoft.com"
+        assert not env.get_missing_vars()


### PR DESCRIPTION
# Description

Fixes confusing defaults and UX issues in the `cdf auth init` interactive flow that caused users following naive defaults to end up with an invalid or incompatible configuration.

**Changes:**

- **Reorder login flow choices** — `device_code` is now first and the default for new users. It only requires a tenant ID and a browser sign-in, making it the most approachable starting point. `client_credentials` (the old default) requires a pre-existing service principal with client ID + secret, which most first-time users don't have.
- **Clearer login flow descriptions** — all four flows now have concise, action-oriented labels.
- **Validate CDF cluster and project inputs** — empty values are now rejected inline rather than silently accepted and failing at the end.
- **Cluster prompt shows an example** — the prompt now reads `Enter the CDF cluster (e.g. westeurope-1)`.
- **Example strings are hints, not defaults** — fields like `IDP_TENANT_ID` previously pre-filled the input with `"00000000-0000-0000-0000-000000000000 or mytenant.onmicrosoft.com"`, which users could accidentally submit verbatim. These are now shown as `(e.g. ...)` label text; only concrete resolved values are pre-filled.
- **Fix display name** — `"Tenant id for MS Entra"` → `"Tenant id for Microsoft Entra ID"`.
- **`--reset` flag** — hidden `cdf auth init --reset` flag to start the wizard from scratch, ignoring existing env vars. Any existing `.env` is automatically backed up without a confirmation prompt.
- **"Additional variables:" header** — printed before the derived optional variable list so users understand what they're looking at.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- `cdf auth init` now defaults to the `device_code` login flow (browser sign-in, no service principal required) instead of `client_credentials`, preventing first-time users from failing at the credential-verification step.
- Example/hint strings (e.g. tenant ID placeholder) are no longer pre-filled as default values in prompts — they are shown as label hints instead.
- CDF cluster and project prompts now reject empty input inline.