### PR TITLE
[CDF-27900, CDF-27901] Fix ignoreUnknownIds 400 error in RuleSets retrieve API

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/api/rulesets.py
+++ b/cognite_toolkit/_cdf_tk/client/api/rulesets.py
@@ -3,7 +3,12 @@
 from collections.abc import Iterable, Sequence
 
 from cognite_toolkit._cdf_tk.client.cdf_client import CDFResourceAPI, Endpoint, PagedResponse
-from cognite_toolkit._cdf_tk.client.http_client import HTTPClient, ItemsSuccessResponse, SuccessResponse
+from cognite_toolkit._cdf_tk.client.http_client import (
+    HTTPClient,
+    ItemsSuccessResponse,
+    SuccessResponse,
+    ToolkitAPIError,
+)
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.ruleset import RuleSetRequest, RuleSetResponse
 
@@ -37,9 +42,14 @@ class RuleSetsAPI(CDFResourceAPI[RuleSetResponse]):
     def retrieve(self, external_ids: Sequence[ExternalId], ignore_unknown_ids: bool = False) -> list[RuleSetResponse]:
         if not external_ids:
             return []
-        return self._request_item_response(
-            external_ids, method="retrieve", extra_body={"ignoreUnknownIds": ignore_unknown_ids}
-        )
+        try:
+            return self._request_item_response(external_ids, method="retrieve")
+        except ToolkitAPIError as e:
+            if ignore_unknown_ids and e.missing:
+                missing_ids = {m.get("externalId") for m in e.missing if isinstance(m, dict)}
+                known = [eid for eid in external_ids if eid.external_id not in missing_ids]
+                return self._request_item_response(known, method="retrieve") if known else []
+            raise
 
     def delete(self, external_ids: Sequence[ExternalId]) -> None:
         self._request_no_response(external_ids, "delete")

--- a/cognite_toolkit/_cdf_tk/client/api/rulesets.py
+++ b/cognite_toolkit/_cdf_tk/client/api/rulesets.py
@@ -3,12 +3,7 @@
 from collections.abc import Iterable, Sequence
 
 from cognite_toolkit._cdf_tk.client.cdf_client import CDFResourceAPI, Endpoint, PagedResponse
-from cognite_toolkit._cdf_tk.client.http_client import (
-    HTTPClient,
-    ItemsSuccessResponse,
-    SuccessResponse,
-    ToolkitAPIError,
-)
+from cognite_toolkit._cdf_tk.client.http_client import HTTPClient, ItemsSuccessResponse, SuccessResponse
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.ruleset import RuleSetRequest, RuleSetResponse
 
@@ -42,14 +37,9 @@ class RuleSetsAPI(CDFResourceAPI[RuleSetResponse]):
     def retrieve(self, external_ids: Sequence[ExternalId], ignore_unknown_ids: bool = False) -> list[RuleSetResponse]:
         if not external_ids:
             return []
-        try:
-            return self._request_item_response(external_ids, method="retrieve")
-        except ToolkitAPIError as e:
-            if ignore_unknown_ids and e.missing:
-                missing_ids = {m.get("externalId") for m in e.missing if isinstance(m, dict)}
-                known = [eid for eid in external_ids if eid.external_id not in missing_ids]
-                return self._request_item_response(known, method="retrieve") if known else []
-            raise
+        if ignore_unknown_ids:
+            return self._request_item_split_retries(external_ids, method="retrieve")
+        return self._request_item_response(external_ids, method="retrieve")
 
     def delete(self, external_ids: Sequence[ExternalId]) -> None:
         self._request_no_response(external_ids, "delete")

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_ruleset.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_ruleset.py
@@ -1,12 +1,19 @@
 """Unit tests for RuleSet and RuleSetVersion CRUDs."""
 
+import gzip
+import json
 import tempfile
 from pathlib import Path
 
+import httpx
 import pytest
+import respx
 import yaml
 
-from cognite_toolkit._cdf_tk.client.identifiers import RuleSetVersionId
+from cognite_toolkit._cdf_tk.client import ToolkitClientConfig
+from cognite_toolkit._cdf_tk.client.api.rulesets import RuleSetsAPI
+from cognite_toolkit._cdf_tk.client.http_client import HTTPClient
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, RuleSetVersionId
 from cognite_toolkit._cdf_tk.client.testing import ToolkitClientMock
 from cognite_toolkit._cdf_tk.exceptions import ToolkitFileNotFoundError
 from cognite_toolkit._cdf_tk.resource_ios._resource_ios.rulesets import RuleSetVersionIO
@@ -164,3 +171,52 @@ class TestRuleSetVersionYAML:
             {"ruleSetExternalId": "my_rules", "version": "1.0.0", "rules": ["a"]}
         )
         assert yaml_obj.as_id() == RuleSetVersionId(rule_set_external_id="my_rules", version="1.0.0")
+
+
+class TestRuleSetsAPIRetrieve:
+    """CDF-27901: /rulesets/byids does not accept 'ignoreUnknownIds'."""
+
+    def test_retrieve_does_not_send_ignore_unknown_ids(
+        self, toolkit_config: ToolkitClientConfig, respx_mock: respx.MockRouter
+    ) -> None:
+        api = RuleSetsAPI(HTTPClient(toolkit_config))
+        rule_set = {"externalId": "my_rules", "name": "My Rules", "createdTime": 1000}
+        respx_mock.post(toolkit_config.create_api_url("/rulesets/byids")).mock(
+            return_value=httpx.Response(status_code=200, json={"items": [rule_set]})
+        )
+
+        api.retrieve([ExternalId(external_id="my_rules")])
+
+        assert len(respx_mock.calls) == 1
+        body = json.loads(gzip.decompress(respx_mock.calls[0].request.content))
+        assert "ignoreUnknownIds" not in body
+
+    def test_ignore_unknown_ids_retries_without_missing(
+        self, toolkit_config: ToolkitClientConfig, respx_mock: respx.MockRouter
+    ) -> None:
+        """When ignore_unknown_ids=True and the API reports missing IDs, retry with only the known IDs."""
+        api = RuleSetsAPI(HTTPClient(toolkit_config))
+        rule_set = {"externalId": "exists", "name": "Exists", "createdTime": 1000}
+        error_body = {"error": {"code": 400, "message": "IDs not found", "missing": [{"externalId": "missing_one"}]}}
+
+        call_count = 0
+
+        def side_effect(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return httpx.Response(status_code=400, json=error_body)
+            return httpx.Response(status_code=200, json={"items": [rule_set]})
+
+        respx_mock.post(toolkit_config.create_api_url("/rulesets/byids")).mock(side_effect=side_effect)
+
+        result = api.retrieve(
+            [ExternalId(external_id="exists"), ExternalId(external_id="missing_one")],
+            ignore_unknown_ids=True,
+        )
+
+        assert call_count == 2
+        assert len(result) == 1
+        assert result[0].external_id == "exists"
+        body = json.loads(gzip.decompress(respx_mock.calls[1].request.content))
+        assert body["items"] == [{"externalId": "exists"}]

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_ruleset.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_ruleset.py
@@ -191,20 +191,23 @@ class TestRuleSetsAPIRetrieve:
         body = json.loads(gzip.decompress(respx_mock.calls[0].request.content))
         assert "ignoreUnknownIds" not in body
 
-    def test_ignore_unknown_ids_retries_without_missing(
+    def test_ignore_unknown_ids_skips_missing(
         self, toolkit_config: ToolkitClientConfig, respx_mock: respx.MockRouter
     ) -> None:
-        """When ignore_unknown_ids=True and the API reports missing IDs, retry with only the known IDs."""
+        """When ignore_unknown_ids=True, unknown IDs are silently skipped via _request_item_split_retries.
+
+        _request_item_split_retries first tries a batch; on failure it retries each item individually,
+        yielding only the successful ones. With 2 items this produces 3 API calls total:
+        1 batch (fails) + 2 individual (one succeeds, one fails and is dropped).
+        """
         api = RuleSetsAPI(HTTPClient(toolkit_config))
         rule_set = {"externalId": "exists", "name": "Exists", "createdTime": 1000}
-        error_body = {"error": {"code": 400, "message": "IDs not found", "missing": [{"externalId": "missing_one"}]}}
-
-        call_count = 0
+        error_body = {"error": {"code": 400, "message": "IDs not found"}}
 
         def side_effect(request: httpx.Request) -> httpx.Response:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
+            body = json.loads(gzip.decompress(request.content))
+            items = body.get("items", [])
+            if any(i.get("externalId") == "missing_one" for i in items):
                 return httpx.Response(status_code=400, json=error_body)
             return httpx.Response(status_code=200, json={"items": [rule_set]})
 
@@ -215,8 +218,5 @@ class TestRuleSetsAPIRetrieve:
             ignore_unknown_ids=True,
         )
 
-        assert call_count == 2
         assert len(result) == 1
         assert result[0].external_id == "exists"
-        body = json.loads(gzip.decompress(respx_mock.calls[1].request.content))
-        assert body["items"] == [{"externalId": "exists"}]


### PR DESCRIPTION
# Description

The `/rulesets/byids` endpoint rejects requests containing `ignoreUnknownIds` as an unknown key, causing a 400 error during dry-run/deploy when comparing RuleSets to CDF.

The fix removes `ignoreUnknownIds` from the request body. Since the `/rulesets/byids` endpoint does not support it server-side (unlike Agents, SignalSinks etc.), we implement it client-side instead: if the API returns a 400 with a `missing` list and `ignore_unknown_ids=True` was requested, we strip the unknown IDs and retry with only the known ones. This matches the semantics of other per-item GET APIs in the codebase (DataProducts, RuleSetVersions).

## Bump

- [x] Patch
- [ ]  Skip

## Changelog

### Fixed

- Fix 400 error `"Encountered an unknown key 'ignoreUnknownIds'"` when retrieving RuleSets via `/rulesets/byids` during deploy/dry-run.