### PR TITLE
EMT-388 Update generate-aliasing-workflow to write into module workflows/ folder

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_entity_matching_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_entity_matching_app.py
@@ -36,17 +36,29 @@ class EntityMatchingApp(typer.Typer):
                 readable=True,
             ),
         ],
-        output_dir: Annotated[
-            Path | None,
+        module: Annotated[
+            str | None,
             typer.Option(
-                "--output-dir",
-                "-o",
-                help="Directory where the generated YAML files will be written. "
-                "Defaults to a 'generated/' folder next to the input file.",
+                "--module",
+                "-m",
+                help="Name of an existing module or a new module to write the workflow files into.",
             ),
         ] = None,
+        organization_dir: Annotated[
+            Path,
+            typer.Option(
+                "--organization-dir",
+                "-o",
+                help="Path to the organization directory containing the modules/ folder.",
+            ),
+        ] = CDF_TOML.cdf.default_organization_dir,
     ) -> None:
-        """Generate Workflow and WorkflowVersion YAML files from an aliasing-rules input file."""
-        resolved_output_dir = output_dir or (input_yaml.parent / "generated")
+        """Generate Workflow and WorkflowVersion YAML files into a module's workflows/ folder."""
         cmd = EntityMatchingCommand()
-        cmd.run(lambda: cmd.generate_aliasing_workflow(input_yaml=input_yaml, output_dir=resolved_output_dir))
+        cmd.run(
+            lambda: cmd.generate_aliasing_workflow(
+                input_yaml=input_yaml,
+                module_name=module,
+                organization_dir=organization_dir,
+            )
+        )

--- a/cognite_toolkit/_cdf_tk/commands/entity_matching.py
+++ b/cognite_toolkit/_cdf_tk/commands/entity_matching.py
@@ -6,6 +6,7 @@ from rich import print
 from rich.panel import Panel
 
 from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
+from cognite_toolkit._cdf_tk.commands.resources import ResourcesCommand
 
 # ---------------------------------------------------------------------------
 # Static mock YAML templates
@@ -72,9 +73,10 @@ class EntityMatchingCommand(ToolkitCommand):
     def generate_aliasing_workflow(
         self,
         input_yaml: Path,
-        output_dir: Path,
+        module_name: str | None,
+        organization_dir: Path,
     ) -> None:
-        """Generate Workflow and WorkflowVersion YAMLs from an aliasing-rules input file.
+        """Generate Workflow and WorkflowVersion YAMLs into a module's workflows/ folder.
 
         Currently writes static mock files. Future iterations will translate
         rules from the input YAML into the workflow task definitions.
@@ -82,6 +84,11 @@ class EntityMatchingCommand(ToolkitCommand):
         if not input_yaml.exists():
             raise FileNotFoundError(f"Input file not found: {input_yaml}")
 
+        module_path = ResourcesCommand(
+            skip_tracking=True, silent=True
+        )._get_or_prompt_module_path(module_name, organization_dir, verbose=False)
+
+        output_dir = module_path / "workflows"
         output_dir.mkdir(parents=True, exist_ok=True)
 
         stem = input_yaml.stem


### PR DESCRIPTION
# Description

Updates generate-aliasing-workflow to write generated Workflow and WorkflowVersion YAMLs directly into the user's modules/<module>/workflows/ directory, so the standard cdf build + cdf deploy pipeline can pick them up without any extra steps.

Replaces --output-dir with --module and --organization-dir options, reusing the existing ResourcesCommand._get_or_prompt_module_path for interactive module selection (existing, new, or fully interactive).
## Bump

- [ ] Patch
- [x] Skip

