### PR TITLE
EMT-388 Update generate-aliasing-workflow to write into module workflows/ folder

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_entity_matching_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_entity_matching_app.py
@@ -36,17 +36,29 @@ class EntityMatchingApp(typer.Typer):
                 readable=True,
             ),
         ],
-        output_dir: Annotated[
-            Path | None,
+        module: Annotated[
+            str | None,
             typer.Option(
-                "--output-dir",
-                "-o",
-                help="Directory where the generated YAML files will be written. "
-                "Defaults to a 'generated/' folder next to the input file.",
+                "--module",
+                "-m",
+                help="Name of an existing module or a new module to write the workflow files into.",
             ),
         ] = None,
+        organization_dir: Annotated[
+            Path,
+            typer.Option(
+                "--organization-dir",
+                "-o",
+                help="Path to the organization directory containing the modules/ folder.",
+            ),
+        ] = CDF_TOML.cdf.default_organization_dir,
     ) -> None:
-        """Generate Workflow and WorkflowVersion YAML files from an aliasing-rules input file."""
-        resolved_output_dir = output_dir or (input_yaml.parent / "generated")
+        """Generate Workflow and WorkflowVersion YAML files into a module's workflows/ folder."""
         cmd = EntityMatchingCommand()
-        cmd.run(lambda: cmd.generate_aliasing_workflow(input_yaml=input_yaml, output_dir=resolved_output_dir))
+        cmd.run(
+            lambda: cmd.generate_aliasing_workflow(
+                input_yaml=input_yaml,
+                module_name=module,
+                organization_dir=organization_dir,
+            )
+        )

--- a/cognite_toolkit/_cdf_tk/apps/_entity_matching_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_entity_matching_app.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from pathlib import Path
 from typing import Annotated, Any
 

--- a/cognite_toolkit/_cdf_tk/commands/entity_matching.py
+++ b/cognite_toolkit/_cdf_tk/commands/entity_matching.py
@@ -4,7 +4,7 @@ from rich import print
 from rich.panel import Panel
 
 from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
-from cognite_toolkit._cdf_tk.commands.resources import ResourcesCommand
+from cognite_toolkit._cdf_tk.utils.module_resolver import ModuleResolver
 
 # ---------------------------------------------------------------------------
 # Static mock YAML templates
@@ -82,9 +82,7 @@ class EntityMatchingCommand(ToolkitCommand):
         if not input_yaml.exists():
             raise FileNotFoundError(f"Input file not found: {input_yaml}")
 
-        module_path = ResourcesCommand(skip_tracking=True, silent=True)._get_or_prompt_module_path(
-            module_name, organization_dir, verbose=False
-        )
+        module_path = ModuleResolver.get_or_prompt_module_path(organization_dir, module_name)
 
         output_dir = module_path / "workflows"
         output_dir.mkdir(parents=True, exist_ok=True)

--- a/cognite_toolkit/_cdf_tk/commands/entity_matching.py
+++ b/cognite_toolkit/_cdf_tk/commands/entity_matching.py
@@ -84,9 +84,9 @@ class EntityMatchingCommand(ToolkitCommand):
         if not input_yaml.exists():
             raise FileNotFoundError(f"Input file not found: {input_yaml}")
 
-        module_path = ResourcesCommand(
-            skip_tracking=True, silent=True
-        )._get_or_prompt_module_path(module_name, organization_dir, verbose=False)
+        module_path = ResourcesCommand(skip_tracking=True, silent=True)._get_or_prompt_module_path(
+            module_name, organization_dir, verbose=False
+        )
 
         output_dir = module_path / "workflows"
         output_dir.mkdir(parents=True, exist_ok=True)

--- a/cognite_toolkit/_cdf_tk/commands/entity_matching.py
+++ b/cognite_toolkit/_cdf_tk/commands/entity_matching.py
@@ -6,6 +6,7 @@ from rich import print
 from rich.panel import Panel
 
 from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
+from cognite_toolkit._cdf_tk.commands.resources import ResourcesCommand
 
 # ---------------------------------------------------------------------------
 # Static mock YAML templates
@@ -72,9 +73,10 @@ class EntityMatchingCommand(ToolkitCommand):
     def generate_aliasing_workflow(
         self,
         input_yaml: Path,
-        output_dir: Path,
+        module_name: str | None,
+        organization_dir: Path,
     ) -> None:
-        """Generate Workflow and WorkflowVersion YAMLs from an aliasing-rules input file.
+        """Generate Workflow and WorkflowVersion YAMLs into a module's workflows/ folder.
 
         Currently writes static mock files. Future iterations will translate
         rules from the input YAML into the workflow task definitions.
@@ -82,6 +84,11 @@ class EntityMatchingCommand(ToolkitCommand):
         if not input_yaml.exists():
             raise FileNotFoundError(f"Input file not found: {input_yaml}")
 
+        module_path = ResourcesCommand(
+            skip_tracking=True, silent=True
+        )._get_or_prompt_module_path(module_name, organization_dir, verbose=False)
+
+        output_dir = module_path / "workflows"
         output_dir.mkdir(parents=True, exist_ok=True)
 
         stem = input_yaml.stem

--- a/cognite_toolkit/_cdf_tk/commands/entity_matching.py
+++ b/cognite_toolkit/_cdf_tk/commands/entity_matching.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from pathlib import Path
 
 from rich import print

--- a/cognite_toolkit/_cdf_tk/commands/entity_matching.py
+++ b/cognite_toolkit/_cdf_tk/commands/entity_matching.py
@@ -74,10 +74,16 @@ class EntityMatchingCommand(ToolkitCommand):
         module_name: str | None,
         organization_dir: Path,
     ) -> None:
-        """Generate Workflow and WorkflowVersion YAMLs into a module's workflows/ folder.
+        """
+        Generate Workflow and WorkflowVersion YAMLs into a module's workflows/ folder.
 
         Currently writes static mock files. Future iterations will translate
         rules from the input YAML into the workflow task definitions.
+
+        Args:
+            input_yaml: Path to the aliasing-rules input file.
+            module_name: Name of the module to write the workflow files into.
+            organization_dir: Path to the organization directory.
         """
         if not input_yaml.exists():
             raise FileNotFoundError(f"Input file not found: {input_yaml}")

--- a/cognite_toolkit/_cdf_tk/commands/resources.py
+++ b/cognite_toolkit/_cdf_tk/commands/resources.py
@@ -1,7 +1,7 @@
 import difflib
 import subprocess
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import questionary
 import typer
@@ -24,7 +24,6 @@ _ALL_SCAFFOLDS: dict[str, list[ScaffoldDef]] = {**_fn_scaffolds()}
 
 
 class ResourcesCommand(ToolkitCommand):
-
     @staticmethod
     def _qualified_name(crud: type[ResourceIO]) -> str:
         return f"{crud.folder_name}.{crud.kind}"

--- a/cognite_toolkit/_cdf_tk/commands/resources.py
+++ b/cognite_toolkit/_cdf_tk/commands/resources.py
@@ -11,11 +11,10 @@ from rich import print
 from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
 from cognite_toolkit._cdf_tk.commands.functions import ScaffoldDef
 from cognite_toolkit._cdf_tk.commands.functions import get_scaffolds as _fn_scaffolds
-from cognite_toolkit._cdf_tk.constants import MODULES
-from cognite_toolkit._cdf_tk.data_classes import ModuleDirectories
 from cognite_toolkit._cdf_tk.resource_ios import RESOURCE_CRUD_LIST, ResourceIO
 from cognite_toolkit._cdf_tk.utils.collection import humanize_collection
 from cognite_toolkit._cdf_tk.utils.file import validate_safe_path, yaml_safe_dump
+from cognite_toolkit._cdf_tk.utils.module_resolver import ModuleResolver
 
 # Scaffold variants keyed by CRUD kind (casefold). Each entry is a list of
 # ScaffoldDef variants the user can choose from after the YAML is created.
@@ -25,46 +24,6 @@ _ALL_SCAFFOLDS: dict[str, list[ScaffoldDef]] = {**_fn_scaffolds()}
 
 
 class ResourcesCommand(ToolkitCommand):
-    def _get_or_prompt_module_path(self, module: str | None, organization_dir: Path, verbose: bool) -> Path:
-        """
-        Check if the module exists in the organization directory and return the module path.
-        If module is not provided, ask the user to select or create a new module.
-        """
-        present_modules = ModuleDirectories.load(organization_dir, None)
-
-        if module:
-            for mod in present_modules:
-                if mod.name.casefold() == module.casefold():
-                    return mod.dir
-
-            if questionary.confirm(f"{module} module not found. Do you want to create a new one?").unsafe_ask():
-                validate_safe_path(module)
-                return organization_dir / MODULES / module
-
-            if verbose:
-                print(f"[red]Aborting as {module} module not found...[/red]")
-            else:
-                print("[red]Aborting...[/red]")
-            raise typer.Exit()
-
-        choices = [Choice(title=mod.name, value=mod.dir) for mod in present_modules]
-        choices.append(Choice(title="<Create new module>", value="NEW"))
-
-        selected = questionary.select("Select a module:", choices=choices).unsafe_ask()
-
-        if selected == "NEW":
-            new_module_name = questionary.text("Enter name for new module:").unsafe_ask()
-            if not new_module_name:
-                print("[red]No module name provided. Aborting...[/red]")
-                raise typer.Exit()
-            validate_safe_path(new_module_name)
-            return organization_dir / MODULES / new_module_name
-
-        if not selected:
-            print("[red]No module selected. Aborting...[/red]")
-            raise typer.Exit()
-
-        return cast(Path, selected)
 
     @staticmethod
     def _qualified_name(crud: type[ResourceIO]) -> str:
@@ -288,7 +247,7 @@ class ResourcesCommand(ToolkitCommand):
             prefix: The prefix for the resource file.
             verbose: Whether to print verbose output.
         """
-        module_path = self._get_or_prompt_module_path(module_name, organization_dir, verbose)
+        module_path = ModuleResolver.get_or_prompt_module_path(organization_dir, module_name, verbose)
 
         for crud in self._resolve_kinds(kind):
             variants = _ALL_SCAFFOLDS.get(crud.kind.casefold())

--- a/cognite_toolkit/_cdf_tk/utils/__init__.py
+++ b/cognite_toolkit/_cdf_tk/utils/__init__.py
@@ -19,6 +19,7 @@ from .hashing import (
     calculate_hash,
     calculate_secure_hash,
 )
+from .module_resolver import ModuleResolver
 from .modules import (
     find_directory_with_subdirectories,
     iterate_modules,
@@ -31,6 +32,7 @@ from .sentry_utils import sentry_exception_filter
 
 __all__ = [
     "GraphQLParser",
+    "ModuleResolver",
     "PipValidationResult",
     "YAMLComment",
     "YAMLWithComments",

--- a/cognite_toolkit/_cdf_tk/utils/module_resolver.py
+++ b/cognite_toolkit/_cdf_tk/utils/module_resolver.py
@@ -2,9 +2,9 @@ from pathlib import Path
 from typing import cast
 
 import questionary
+import typer
 from questionary import Choice
 from rich import print
-import typer
 
 from cognite_toolkit._cdf_tk.constants import MODULES
 from cognite_toolkit._cdf_tk.utils.file import validate_safe_path

--- a/cognite_toolkit/_cdf_tk/utils/module_resolver.py
+++ b/cognite_toolkit/_cdf_tk/utils/module_resolver.py
@@ -18,6 +18,14 @@ class ModuleResolver:
         If module_name matches an existing module, returns its path directly.
         If module_name is given but not found, asks the user to confirm creating a new one.
         If module_name is None, shows an interactive list of existing modules plus a create option.
+
+        Args:
+            organization_dir: Path to the organization directory.
+            module_name: Name of the module.
+            verbose: Whether to print verbose output.
+
+        Returns:
+            The path to the module.
         """
         from cognite_toolkit._cdf_tk.data_classes import ModuleDirectories
 

--- a/cognite_toolkit/_cdf_tk/utils/module_resolver.py
+++ b/cognite_toolkit/_cdf_tk/utils/module_resolver.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+from typing import cast
+
+import questionary
+import typer
+from questionary import Choice
+from rich import print
+
+from cognite_toolkit._cdf_tk.constants import MODULES
+from cognite_toolkit._cdf_tk.utils.file import validate_safe_path
+
+
+class ModuleResolver:
+    @staticmethod
+    def get_or_prompt_module_path(
+        organization_dir: Path, module_name: str | None, verbose: bool = False
+    ) -> Path:
+        """Return the path for the given module name, or prompt the user to select/create one.
+
+        If module_name matches an existing module, returns its path directly.
+        If module_name is given but not found, asks the user to confirm creating a new one.
+        If module_name is None, shows an interactive list of existing modules plus a create option.
+        """
+        from cognite_toolkit._cdf_tk.data_classes import ModuleDirectories
+
+        present_modules = ModuleDirectories.load(organization_dir, None)
+
+        if module_name:
+            for mod in present_modules:
+                if mod.name.casefold() == module_name.casefold():
+                    return mod.dir
+
+            if questionary.confirm(f"{module_name} module not found. Do you want to create a new one?").unsafe_ask():
+                validate_safe_path(module_name)
+                return organization_dir / MODULES / module_name
+
+            if verbose:
+                print(f"[red]Aborting as {module_name} module not found...[/red]")
+            else:
+                print("[red]Aborting...[/red]")
+            raise typer.Exit()
+
+        choices = [Choice(title=mod.name, value=mod.dir) for mod in present_modules]
+        choices.append(Choice(title="<Create new module>", value="NEW"))
+
+        selected = questionary.select("Select a module:", choices=choices).unsafe_ask()
+
+        if selected == "NEW":
+            new_module_name = questionary.text("Enter name for new module:").unsafe_ask()
+            if not new_module_name:
+                print("[red]No module name provided. Aborting...[/red]")
+                raise typer.Exit()
+            validate_safe_path(new_module_name)
+            return organization_dir / MODULES / new_module_name
+
+        if not selected:
+            print("[red]No module selected. Aborting...[/red]")
+            raise typer.Exit()
+
+        return cast(Path, selected)

--- a/cognite_toolkit/_cdf_tk/utils/module_resolver.py
+++ b/cognite_toolkit/_cdf_tk/utils/module_resolver.py
@@ -2,9 +2,9 @@ from pathlib import Path
 from typing import cast
 
 import questionary
-import typer
 from questionary import Choice
 from rich import print
+import typer
 
 from cognite_toolkit._cdf_tk.constants import MODULES
 from cognite_toolkit._cdf_tk.utils.file import validate_safe_path

--- a/cognite_toolkit/_cdf_tk/utils/module_resolver.py
+++ b/cognite_toolkit/_cdf_tk/utils/module_resolver.py
@@ -12,9 +12,7 @@ from cognite_toolkit._cdf_tk.utils.file import validate_safe_path
 
 class ModuleResolver:
     @staticmethod
-    def get_or_prompt_module_path(
-        organization_dir: Path, module_name: str | None, verbose: bool = False
-    ) -> Path:
+    def get_or_prompt_module_path(organization_dir: Path, module_name: str | None, verbose: bool = False) -> Path:
         """Return the path for the given module name, or prompt the user to select/create one.
 
         If module_name matches an existing module, returns its path directly.


### PR DESCRIPTION
# Description

Updates generate-aliasing-workflow to write generated Workflow and WorkflowVersion YAMLs directly into the user's modules/workflows/ directory, so the standard cdf build + cdf deploy pipeline can pick them up without any extra steps.

Replaces --output-dir with --module and --organization-dir options, reusing the existing ResourcesCommand._get_or_prompt_module_path for interactive module selection (existing, new, or fully interactive).

Extracts module resolution logic into a new ModuleResolver utility class (previously a private method on ResourcesCommand), making it reusable across command families.

## Bump

- [ ] Patch
- [x] Skip

## Changelog

### Added/Changed/Improved/Removed/Fixed

- Improved generate-aliasing-workflow to write generated workflow YAMLs into modules instead of a flat output directory
- Added ModuleResolver utility class, extracted from ResourcesCommand
