### PR TITLE
[CDF-27905] Fix smoke test EOFError: pass cdf_project explicitly in test_build_deploy

### DIFF
--- a/tests_smoke/test_commands/test_build_deploy.py
+++ b/tests_smoke/test_commands/test_build_deploy.py
@@ -1,9 +1,10 @@
+import os
 from pathlib import Path
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.dataset import DataSetResponse
-from cognite_toolkit._cdf_tk.commands import BuildV2Command, DeployV2Command
+from cognite_toolkit._cdf_tk.commands import BuildV2Command, DeployOptions, DeployV2Command
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import BuildParameters
 from cognite_toolkit._cdf_tk.constants import MODULES
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
@@ -56,6 +57,10 @@ runtime: py312""")
             client=toolkit_client,
         )
         env_vars = EnvironmentVariables.create_from_environment()
-        DeployV2Command(skip_tracking=True).deploy(env_vars=env_vars, user_build_dir=tmp_path / "build")
+        DeployV2Command(skip_tracking=True).deploy(
+            env_vars=env_vars,
+            user_build_dir=tmp_path / "build",
+            options=DeployOptions(cdf_project=os.environ["CDF_PROJECT"]),
+        )
 
         toolkit_client.tool.functions.delete([ExternalId(external_id=external_id)], ignore_unknown_ids=True)

--- a/tests_smoke/test_commands/test_build_deploy.py
+++ b/tests_smoke/test_commands/test_build_deploy.py
@@ -60,7 +60,10 @@ runtime: py312""")
         DeployV2Command(skip_tracking=True).deploy(
             env_vars=env_vars,
             user_build_dir=tmp_path / "build",
-            options=DeployOptions(cdf_project=os.environ["CDF_PROJECT"]),
+            options=DeployOptions(
+                cdf_project=env_vars.CDF_PROJECT,
+                environment_variables=env_vars.dump(),
+            ),
         )
 
         toolkit_client.tool.functions.delete([ExternalId(external_id=external_id)], ignore_unknown_ids=True)

--- a/tests_smoke/test_commands/test_build_deploy.py
+++ b/tests_smoke/test_commands/test_build_deploy.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient


### PR DESCRIPTION
# Description

Daily smoke tests on bluefield/orangefield/greenfield were failing with a bare `EOFError`.
The root cause was `test_build_deploy_function` calling `DeployV2Command.deploy()` without
passing a `DeployOptions` with `cdf_project` set. This caused the deploy command's
`_validate_cdf_project` to fall through to an interactive `questionary.text().unsafe_ask()`
prompt, which raises `EOFError` in CI where stdin is unavailable.

Fix: pass `DeployOptions(cdf_project=os.environ["CDF_PROJECT"])` explicitly so the
interactive prompt path is never reached in CI.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Smoke test `test_build_deploy_function` no longer hits interactive prompt in CI,
  fixing the `EOFError` failures on all clusters.