### PR TITLE
[CDF-27909] Fix EOFError in test_purge_instances_with_unlink: mock questionary on _utils

### DIFF
--- a/.cursor/skills/send-it/SKILL.md
+++ b/.cursor/skills/send-it/SKILL.md
@@ -47,6 +47,12 @@ If the user chose **Stage only**, stop here.
   - Propose a title: `[TICKET-ID] Description of changes`.
   - Draft a body by reading `.github/pull_request_template.md` and filling it in
     using `git log main..HEAD --oneline`.
+  - **Always ask the user which bump type applies** using the AskQuestion tool:
+    > **"What bump type should this PR use?"**
+    > - **Patch** — backwards-compatible bug fix or small improvement
+    > - **Skip** — no version bump (e.g. docs, CI, test-only changes)
+  - Reflect the answer in the PR body's Bump section: check the chosen option, leave the other unchecked.
+    Both checkboxes must always be present: `- [x] Patch` / `- [ ] Skip` or `- [ ] Patch` / `- [x] Skip`.
   - Show the proposed PR title and body, and **ask for confirmation** before creating it.
   - If the user confirms, create the PR as a **draft**:
 

--- a/tests_smoke/test_commands/test_purge.py
+++ b/tests_smoke/test_commands/test_purge.py
@@ -380,6 +380,7 @@ class TestPurgeSmoke:
         mock_questionary.confirm.return_value.ask.return_value = True
         mock_questionary.text.return_value.unsafe_ask.return_value = client.config.project
         monkeypatch.setattr("cognite_toolkit._cdf_tk.commands._purge.questionary", mock_questionary)
+        monkeypatch.setattr("cognite_toolkit._cdf_tk.commands._utils.questionary", mock_questionary)
 
         purge = PurgeCommand(silent=True)
 


### PR DESCRIPTION
# Description

The smoke test \`TestPurgeSmoke::test_purge_instances_with_unlink\` was failing with \`EOFError\`
on all clusters because \`questionary\` was only mocked on the \`_purge\` module, but the
\`confirm_by_typing_project_name()\` helper imported from \`_utils.py\` has its own
\`questionary\` import that was not patched — causing the real \`questionary.text().unsafe_ask()\`
to hit a missing stdin in CI.

Fix: add a second \`monkeypatch.setattr\` to also patch \`_utils.questionary\`.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Fixed \`EOFError\` in \`test_purge_instances_with_unlink\` smoke test by mocking \`questionary\` on \`cognite_toolkit._cdf_tk.commands._utils\` in addition to \`_purge\`.