### PR TITLE
chore(infield): Remove alpha flag for InFieldCDMLocationConfig module

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/__init__.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/__init__.py
@@ -92,7 +92,6 @@ if not FeatureFlag.is_enabled(Flags.GRAPHQL):
 if not FeatureFlag.is_enabled(Flags.INFIELD):
     _EXCLUDED_CRUDS.add(InfieldV1IO)
     _EXCLUDED_CRUDS.add(InFieldLocationConfigIO)
-    _EXCLUDED_CRUDS.add(InFieldCDMLocationConfigIO)
 if not FeatureFlag.is_enabled(Flags.MIGRATE):
     _EXCLUDED_CRUDS.add(ResourceViewMappingIO)
 if not FeatureFlag.is_enabled(Flags.SIGNALS):

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_fieldops.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_fieldops.py
@@ -74,7 +74,6 @@ class TestInfieldV1Loader:
 
 
 class TestInFieldCDMLocationConfigCRUD:
-    @pytest.mark.skipif(not Flags.INFIELD.is_enabled(), reason="Alpha feature is not enabled")
     def test_skip_illegal_configuration(self) -> None:
         legacy_space = "my_infield_legacy_space"
         item = InFieldCDMLocationConfigRequest(


### PR DESCRIPTION
# Description

Remove the `INFIELD` alpha feature-flag gating for `InFieldCDMLocationConfigIO`. Also drops the corresponding skipif on its unit test.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Added

- The `InFieldCDMLocationConfig` resource is now generally available and no longer requires the `infield` alpha feature flag.