### PR TITLE
Fix RuleSetVersion .ttl file not found during deploy after build_v2

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/rulesets.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/rulesets.py
@@ -175,9 +175,15 @@ class RuleSetVersionIO(ResourceIO[RuleSetVersionId, RuleSetVersionRequest, RuleS
 
         rule_set_id = item.get("ruleSetExternalId", item.get("rule_set_external_id", filepath.stem))
 
-        # Look for .ttl by convention: {stem}.ttl or {rule_set_external_id}.ttl
+        # Strip the kind suffix from the stem to support the build_v2 naming convention where the
+        # extra file is written as "{filestem}{suffix}" (without the resource kind in the name).
+        stem_no_kind = filepath.stem
+        if stem_no_kind.lower().endswith(cls.kind.lower()):
+            stem_no_kind = stem_no_kind[: -len(cls.kind)].removesuffix(".")
+
         ttl_candidates = [
             filepath.parent / f"{filepath.stem}.ttl",
+            filepath.parent / f"{stem_no_kind}.ttl",
             filepath.parent / f"{rule_set_id}.ttl",
         ]
         ttl_path = next((p for p in ttl_candidates if p.exists()), None)
@@ -214,9 +220,14 @@ class RuleSetVersionIO(ResourceIO[RuleSetVersionId, RuleSetVersionRequest, RuleS
             rule_set_id = item.get("ruleSetExternalId", item.get("rule_set_external_id", filepath.stem))
             if "rules" in item:
                 continue
-            # Look for .ttl by convention: {stem}.ttl or {rule_set_external_id}.ttl
+            # Strip the kind suffix from the stem to support the build_v2 naming convention where the
+            # extra file is written as "{filestem}{suffix}" (without the resource kind in the name).
+            stem_no_kind = filepath.stem
+            if stem_no_kind.lower().endswith(self.kind.lower()):
+                stem_no_kind = stem_no_kind[: -len(self.kind)].removesuffix(".")
             ttl_candidates = [
                 filepath.parent / f"{filepath.stem}.ttl",
+                filepath.parent / f"{stem_no_kind}.ttl",
                 filepath.parent / f"{rule_set_id}.ttl",
             ]
             ttl_path = next((p for p in ttl_candidates if p.exists()), None)


### PR DESCRIPTION
# Description

`cdf deploy` raises `ToolkitFileNotFoundError` for RuleSetVersion resources
because `build_v2` writes the companion `.ttl` file using `{filestem}{suffix}`
where `filestem` strips the resource kind from the YAML stem. The deploy step
(`load_resource_file` / `get_extra_files` in `RuleSetVersionIO`) only looked for
`{stem}.ttl` (kind included) and `{ruleSetExternalId}.ttl`, so it always missed
the built file. Added a third candidate that strips the kind suffix to match the
build_v2 convention.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- `cdf deploy` no longer fails with `ToolkitFileNotFoundError` for RuleSetVersion
  resources when using the build_v2 pipeline: the `.ttl` lookup now also checks
  the build_v2 filename convention (`{stem-without-kind}.ttl`).