### PR TITLE
Fix migrate infield-data not translating legacy sourceView values

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -915,14 +915,32 @@ class InFieldConditionMapping(CustomContainerPropertiesMapping):
     VIEW_IDS: ClassVar[Set[ViewId]] = frozenset({ViewId(space="cdf_apm", external_id="Condition", version="v1")})
 
     def __init__(self, mappings: Sequence[ViewToViewMapping]) -> None:
-        self._source_view_mapping = {
-            self._as_source_view_format(mapping.source_view): self._as_source_view_format(mapping.destination_view)
+        # Keyed on (space, externalId) of the source view so that legacy version values like
+        # 'cdf_apm/TemplateItem/v5' still translate to the current destination view. The version
+        # segment is intentionally ignored; the destination always points at the latest registered
+        # destination view.
+        self._destination_by_versionless_source: dict[tuple[str, str], str] = {
+            (mapping.source_view.space, mapping.source_view.external_id): self._as_source_view_format(
+                mapping.destination_view
+            )
             for mapping in mappings
         }
 
     def _as_source_view_format(self, view_id: ViewId) -> str:
         """The special format used in the sourceView property of InField"""
         return f"{view_id.space}/{view_id.external_id}/{view_id.version!s}"
+
+    @staticmethod
+    def _parse_versionless_view(value: str) -> tuple[str, str] | None:
+        """Parse ``"<space>/<externalId>/<version>"`` into ``(space, externalId)``, dropping
+        the version. Many ``Condition`` instances reference older view versions of e.g. ``TemplateItem``,
+        but we should be migrating all of them to the latest version in CDM, so we translate by
+        only space and external ID. Returns ``None`` for unparseable values."""
+        parts = value.split("/")
+        if len(parts) != 3:
+            return None
+        space, external_id, _version = parts
+        return space, external_id
 
     def convert(
         self, source_properties: dict[str, JsonValue | NodeId | list[NodeId]], context: ConversionContext
@@ -934,10 +952,12 @@ class InFieldConditionMapping(CustomContainerPropertiesMapping):
                 issues.append(
                     f"Invalid sourceView value {value!r} for view {context.source_view_id!s}: expected a string."
                 )
-            elif value not in self._source_view_mapping:
-                issues.append(f"Unexpected sourceView value {value!r} for view {context.source_view_id!s}")
             else:
-                created_properties["sourceView"] = self._source_view_mapping[value]
+                versionless_source = self._parse_versionless_view(value)
+                if versionless_source is None or versionless_source not in self._destination_by_versionless_source:
+                    issues.append(f"Unexpected sourceView value {value!r} for view {context.source_view_id!s}")
+                else:
+                    created_properties["sourceView"] = self._destination_by_versionless_source[versionless_source]
         return ConversionResult(container_properties=created_properties, errors=issues)
 
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_infield_mapping.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_infield_mapping.py
@@ -1,3 +1,6 @@
+from unittest.mock import MagicMock
+
+from cognite_toolkit._cdf_tk.commands._migrate.conversion import InFieldConditionMapping
 from cognite_toolkit._cdf_tk.commands._migrate.infield_data_mappings import (
     create_infield_data_mappings,
     create_infield_schedule_selector,
@@ -12,3 +15,22 @@ class TestInFieldMapping:
     def test_schedule_selector_validation(self) -> None:
         selector = create_infield_schedule_selector()
         assert selector, "Schedule selector creation should not raise an error"
+
+    def test_condition_source_view_translates_legacy_version(self) -> None:
+        condition_mapping = InFieldConditionMapping(create_infield_data_mappings())
+        context = MagicMock()
+
+        result = condition_mapping.convert({"sourceView": "cdf_apm/TemplateItem/v5"}, context)
+
+        assert result.errors == []
+        assert result.container_properties == {"sourceView": "cdf_infield/TemplateItem/v1"}
+
+    def test_condition_source_view_unknown_logical_view_errors(self) -> None:
+        condition_mapping = InFieldConditionMapping(create_infield_data_mappings())
+        context = MagicMock()
+
+        result = condition_mapping.convert({"sourceView": "cdf_apm/Bogus/v1"}, context)
+
+        assert result.container_properties == {}
+        assert len(result.errors) == 1
+        assert "Unexpected sourceView value" in result.errors[0]


### PR DESCRIPTION
# Description

`InFieldConditionMapping` previously required an exact `space/externalId/version` match when translating the `sourceView` string property on `cdf_apm:Condition` instances. In practice, Infield data carries legacy version references from older versions than the most recent in this string (e.g. `cdf_apm/TemplateItem/v5`, while the recentmost version is `cdf_apm/TemplateItem/v7`). This produced `Unexpected sourceView value` warnings and left `Condition.sourceView` empty on the migrated CDM node if the references were not exactly matching the recentmost version. The lookup is now keyed on `(space, externalId)` and the version segment is dropped, so any version of a known logical source view translates to the current destination view.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- [alpha] Fixes a bug in `cdf migrate infield-data` which caused some data in `Condition.sourceView` to fail migrating into the InfieldOnCDM model with a `Unexpected sourceView value` warning.