### PR TITLE
[CDF-27916] Ignore read-only DM fields when diffing local YAML against CDF

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
@@ -373,6 +373,11 @@ class ContainerCRUD(ResourceContainerIO[ContainerId, ContainerRequest, Container
         for key in ["constraints", "indexes"]:
             cdf_value = dumped.get(key)
             local_value = local.get(key)
+            if isinstance(cdf_value, dict):
+                # Drop server-populated read-only "state" field on each constraint/index.
+                for cdf_item in cdf_value.values():
+                    if isinstance(cdf_item, dict):
+                        cdf_item.pop("state", None)
             if not cdf_value and not local_value:
                 # Both sides represent "no constraints/indexes". The API and
                 # the local YAML can each express this by not including the
@@ -775,6 +780,12 @@ class ViewIO(ResourceIO[ViewId, ViewRequest, ViewResponse]):
                 warning = MediumSeverityWarning(f"Failed to sort implements for view {resource.as_id()}: {e}")
                 warning.print_warning(console=self.console)
 
+        for prop in dumped.get("properties", {}).values():
+            if isinstance(prop, dict):
+                # targetsList is a read-only field populated by the backend on reverse direct
+                # relation connection properties. Drop it from the CDF dump so it doesn't
+                # show up as a spurious diff.
+                prop.pop("targetsList", None)
         local_properties = local.get("properties", {})
         for prop_id, prop in dumped.get("properties", {}).items():
             if prop_id not in local_properties:


### PR DESCRIPTION
# Description

Fixes two issues in diffing containers / views in CDF against local YAML. Container `constraints`/`indexes` API responses include a server-populated `state` field, and reverse direct relation view properties include a server-populated `targetsList` field. These are kept through the `ResponseResource → RequestResource` round-trip via pydantic's `extra="allow"` and end up in `dump_resource`, producing false-positive diffs during dry-runs. Strip them in `ContainerCRUD.dump_resource` and `ViewIO.dump_resource`.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- When running `cdf deploy`, Toolkit no longer reports spurious differences for the read-only `state` field on container constraints/indexes and the read-only `targetsList` field on reverse direct relation connection properties when running.