### PR TITLE
Fix dry-run constraint errors and source-id attribution in FDM→CDM migration

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -131,6 +131,8 @@ class MigrationCommand(ToolkitCommand):
         results_by_selector: dict[str, list[ItemsResult]] = {}
         data.logger = logger
         mapper.logger = logger
+        mapper.dry_run = dry_run
+
         for step in plan:
             if step.message:
                 console.print(step.message)

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1338,20 +1338,23 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
         self._connection_creator.update_cache(source)
         nodes, other_side_by_edge_type_and_direction_by_source = self._as_nodes_and_edges(source)
         mapped_instances: list[NodeOrEdgeRequest | None] = []
-        issue_by_node_id: dict[NodeId, InstanceConversionIssue] = {}
+        issue_by_source_node_id: dict[NodeId, InstanceConversionIssue] = {}
+        source_id_by_target_id: dict[NodeId, NodeId] = {}
         target_view_ids: set[ViewId] = set()
         for node in nodes:
-            node_id = node.as_id()
+            source_node_id = node.as_id()
             if node.space not in self._connection_creator.space_mapping:
-                issue_by_node_id[node_id] = InstanceConversionIssue(
-                    id=str(node_id), errors=[f"No target space mapping for source space '{node.space}'"]
+                issue_by_source_node_id[source_node_id] = InstanceConversionIssue(
+                    id=str(source_node_id),
+                    errors=[f"No target space mapping for source space '{node.space}'"],
                 )
                 continue
             mapped_node, edges, issue = self._map_single_node(
-                node, other_side_by_edge_type_and_direction_by_source[node.as_id()]
+                node, other_side_by_edge_type_and_direction_by_source[source_node_id]
             )
+            source_id_by_target_id[mapped_node.as_id()] = source_node_id
             if issue.has_issues:
-                issue_by_node_id[node_id] = issue
+                issue_by_source_node_id[source_node_id] = issue
             target_view_ids.update(
                 source_view_id
                 for source_view_id in (node.properties or {}).keys()
@@ -1363,15 +1366,17 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
         # Post Validation - check that all direct relation with constraints exists.
         self._connection_creator.update_view_cache(view_ids=target_view_ids)
         self._update_existing_node_cache(mapped_instances)
-        self._check_existence_of_required_targets(mapped_instances, issue_by_node_id)
+        self._check_existence_of_required_targets(
+            mapped_instances, issue_by_source_node_id, source_id_by_target_id
+        )
 
-        if issue_by_node_id:
+        if issue_by_source_node_id:
             self.logger.log(
                 [
                     instance_conversion_issue_as_migration_entry(
                         issue, source="FDM instances", destination="CDM instances"
                     )
-                    for issue in issue_by_node_id.values()
+                    for issue in issue_by_source_node_id.values()
                 ]
             )
         return mapped_instances
@@ -1430,7 +1435,9 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
     ) -> tuple[list[InstanceSource], list[EdgeRequest], InstanceConversionIssue]:
         sources: list[InstanceSource] = []
         new_edges: list[EdgeRequest] = []
-        issue = InstanceConversionIssue(id=str(new_id))
+        # Issue id must reference the source node so it matches what the downloader registered
+        # with the migration logger (the destination NodeId would not be in the registry).
+        issue = InstanceConversionIssue(id=str(node.as_id()))
         for view_or_container_id, source_properties in (node.properties or {}).items():
             if not (context := self._create_context(view_or_container_id, issue, node.as_id(), new_id)):
                 continue
@@ -1541,7 +1548,8 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
     def _check_existence_of_required_targets(
         self,
         mapped_instances: Sequence[NodeRequest | EdgeRequest | None],
-        issue_by_node_id: dict[NodeId, InstanceConversionIssue],
+        issue_by_source_node_id: dict[NodeId, InstanceConversionIssue],
+        source_id_by_target_id: dict[NodeId, NodeId],
     ) -> None:
         """This method removes all direct relations property values that have a container constraint
         where the target node does not exist, and adds an issue to the source node for each removed relation.
@@ -1564,19 +1572,22 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
                 is removed.
         """
 
-        for node_id, direct_relation_property_ids, source in self._iterate_constrained_direct_relation_properties(
+        for target_node_id, direct_relation_property_ids, source in self._iterate_constrained_direct_relation_properties(
             mapped_instances
         ):
             if source.properties is None:
                 continue
+            source_node_id = source_id_by_target_id.get(target_node_id, target_node_id)
             for prop_id, required_container in direct_relation_property_ids.items():
                 value = source.properties[prop_id]
                 if isinstance(value, NodeId) and not self._is_existing_by_node_id.get(value, False):
                     message = f"Cannot create direct relation to {value!s}. The node does not exist and requires to have properties in the {required_container!s} container."
-                    if node_id not in issue_by_node_id:
-                        issue_by_node_id[node_id] = InstanceConversionIssue(id=str(node_id), errors=[message])
+                    if source_node_id not in issue_by_source_node_id:
+                        issue_by_source_node_id[source_node_id] = InstanceConversionIssue(
+                            id=str(source_node_id), errors=[message]
+                        )
                     else:
-                        issue_by_node_id[node_id].errors.append(message)
+                        issue_by_source_node_id[source_node_id].errors.append(message)
                     del source.properties[prop_id]
                 elif isinstance(value, list):
                     keep: list[NodeId | JsonValue] = []
@@ -1593,10 +1604,12 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
                             missing_node_ids.add(target_id)
                     if missing_node_ids:
                         error = f"Cannot create direct relations to {humanize_collection(missing_node_ids)}. These nodes does not exist and requires to have properties in the {required_container!s} container."
-                        if node_id not in issue_by_node_id:
-                            issue_by_node_id[node_id] = InstanceConversionIssue(id=str(node_id), errors=[error])
+                        if source_node_id not in issue_by_source_node_id:
+                            issue_by_source_node_id[source_node_id] = InstanceConversionIssue(
+                                id=str(source_node_id), errors=[error]
+                            )
                         else:
-                            issue_by_node_id[node_id].errors.append(error)
+                            issue_by_source_node_id[source_node_id].errors.append(error)
                     source.properties[prop_id] = keep  # type: ignore[assignment]
 
     def _iterate_constrained_direct_relation_properties(

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -119,6 +119,10 @@ class DataMapper(Generic[T_Selector, T_DataResponse, T_DataRequest], ABC):
     def __init__(self, client: ToolkitClient) -> None:
         self.client = client
         self.logger: DataLogger = NoOpLogger()
+        # Set by the migration command before running. When True, mappers should treat
+        # just-mapped target instances as if they had been uploaded, so that downstream
+        # steps' constraint checks do not falsely report them as missing in CDF.
+        self.dry_run: bool = False
 
     def prepare(self, source_selector: T_Selector) -> None:
         """Prepare the data mapper with the given source selector.
@@ -1366,9 +1370,13 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
         # Post Validation - check that all direct relation with constraints exists.
         self._connection_creator.update_view_cache(view_ids=target_view_ids)
         self._update_existing_node_cache(mapped_instances)
-        self._check_existence_of_required_targets(
-            mapped_instances, issue_by_source_node_id, source_id_by_target_id
-        )
+        self._check_existence_of_required_targets(mapped_instances, issue_by_source_node_id, source_id_by_target_id)
+        if self.dry_run:
+            # In a real run these would be uploaded and visible to subsequent steps' constraint
+            # checks. Pre-populate the cache so dry-run output reflects what a real run would do.
+            for instance in mapped_instances:
+                if isinstance(instance, NodeRequest):
+                    self._is_existing_by_node_id[instance.as_id()] = True
 
         if issue_by_source_node_id:
             self.logger.log(
@@ -1572,9 +1580,11 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
                 is removed.
         """
 
-        for target_node_id, direct_relation_property_ids, source in self._iterate_constrained_direct_relation_properties(
-            mapped_instances
-        ):
+        for (
+            target_node_id,
+            direct_relation_property_ids,
+            source,
+        ) in self._iterate_constrained_direct_relation_properties(mapped_instances):
             if source.properties is None:
                 continue
             source_node_id = source_id_by_target_id.get(target_node_id, target_node_id)

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -787,6 +787,88 @@ class TestFDMtoCDMMapper:
             actual = mapper.map(instances)
             assert [item.dump() for item in actual] == [item.dump() for item in expected]
 
+    @pytest.mark.parametrize(
+        "dry_run, expected_log_calls",
+        [
+            pytest.param(True, 0, id="dry-run treats mapped nodes as existing"),
+            pytest.param(False, 1, id="real run surfaces missing target error"),
+        ],
+    )
+    def test_dry_run_treats_mapped_nodes_as_existing(self, dry_run: bool, expected_log_calls: int) -> None:
+        """In a real run, a direct relation pointing at a node mapped in a previous step is fine because that
+        node has already been uploaded. In a dry-run, nothing is uploaded, so without special handling
+        the constraint check would falsely flag the target as missing. The mapper pre-populates its
+        existing-node cache for just-mapped nodes when ``dry_run`` is True.
+        """
+        constrained_container = ContainerId(space="schema_space2", external_id="ConstrainedContainer")
+        source_view = self.SOURCE_VIEW.model_copy(deep=True)
+        source_view.properties["sourceDirect"] = ViewCorePropertyResponse(
+            constraint_state=ConstraintOrIndexState(),
+            type=DirectNodeRelation(),
+            container_property_identifier="sourceDirect",
+            container=self.SOME_CONTAINER_ID,
+        )
+        destination_view = self.DESTINATION_VIEW.model_copy(deep=True)
+        destination_view.properties["constrainedDirect"] = ViewCorePropertyResponse(
+            constraint_state=ConstraintOrIndexState(),
+            type=DirectNodeRelation(container=constrained_container),
+            container_property_identifier="constrainedDirect",
+            container=self.SOME_CONTAINER_ID,
+        )
+
+        with monkeypatch_toolkit_client() as client:
+            client.tool.views.retrieve.return_value = [source_view, destination_view]
+            # The target node referenced by the direct relation does not yet exist in CDF.
+            client.tool.instances.retrieve.return_value = []
+
+            mapping = self.VIEW_MAPPING.model_copy(update={"container_mapping": {"sourceDirect": "constrainedDirect"}})
+            connection_creator = ConnectionCreator(client, space_mapping=self.SPACE_MAPPING)
+            mapper = FDMtoCDMMapper(client, [mapping], connection_creator)
+            mapper.dry_run = dry_run
+            logger = MagicMock(spec=DataLogger)
+            mapper.logger = logger
+            mapper.prepare(MagicMock())
+
+            # First step: map the would-be target of the direct relation.
+            mapper.map(
+                [
+                    NodeResponse(
+                        space=self.SOURCE_SPACE,
+                        external_id="first",
+                        last_updated_time=1,
+                        created_time=0,
+                        version=1,
+                        properties={self.SOURCE_VIEW_ID: {}},
+                    )
+                ]
+            )
+            logger.reset_mock()
+
+            # Second step: map a node whose direct relation points at "first".
+            mapper.map(
+                [
+                    NodeResponse(
+                        space=self.SOURCE_SPACE,
+                        external_id="second",
+                        last_updated_time=1,
+                        created_time=0,
+                        version=1,
+                        properties={
+                            self.SOURCE_VIEW_ID: {"sourceDirect": {"space": self.SOURCE_SPACE, "externalId": "first"}}
+                        },
+                    )
+                ]
+            )
+
+        assert logger.log.call_count == expected_log_calls
+        if expected_log_calls:
+            entries = logger.log.call_args[0][0]
+            assert len(entries) == 1
+            entry = entries[0]
+            assert isinstance(entry, MigrationEntryV2)
+            assert entry.id == f"{self.SOURCE_SPACE}:second"
+            assert "does not exist" in entry.message
+
 
 class TestInFieldLegacyToCDMScheduleMapper:
     SOURCE_SPACE = "source_space"


### PR DESCRIPTION
# Description

Two bug fixes in `FDMtoCDMMapper` used by the `cdf migrate` commands (e.g. `infield-data`):
1. Conversion-issue log entries were in some cases keyed on the destination NodeId, which is not what the downloader registered with the migration logger, so issues couldn't be matched back to their source. They are now keyed on the source NodeId. This created duplicate entries for each of these issues which read `Toolkit bug - missing registration`.
2. The post-validation step that checks required direct-relation targets exist in CDF only looked at instances already in CDF. In a dry-run this produced false-positive "target does not exist" errors for direct relations pointing at instances the dry-run itself was about to create. In dry-run mode, just-mapped nodes are now treated as existing for subsequent constraint checks. We make an assumption now that the write will go through in a dry-run (to avoid an overwhelming amount of potential false positives). 

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- [alpha] Fixed false positive warnings produced by running `cdf migrate infield-data` in dry-run mode.