### PR TITLE
Fix quality.rules wire format: use externalId not ruleSetExternalId

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_product_version.py
@@ -7,7 +7,7 @@ from cognite_toolkit._cdf_tk.client._resource_base import (
     ResponseResource,
     UpdatableRequestResource,
 )
-from cognite_toolkit._cdf_tk.client.identifiers import DataProductVersionId, RuleSetVersionId, SemanticVersion
+from cognite_toolkit._cdf_tk.client.identifiers import DataProductVersionId, SemanticVersion
 from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 
 SpaceId = Annotated[str, Field(pattern=SPACE_FORMAT_PATTERN, max_length=43)]
@@ -30,8 +30,15 @@ class DataProductVersionTerms(BaseModelObject):
     limitations: str | None = None
 
 
+class RuleSetVersionRef(BaseModelObject):
+    """Wire representation of a RuleSetVersionReference as defined in the API spec."""
+
+    external_id: str
+    version: SemanticVersion
+
+
 class DataProductVersionQuality(BaseModelObject):
-    rules: list[RuleSetVersionId] = Field(default_factory=list)
+    rules: list[RuleSetVersionRef] = Field(default_factory=list)
 
 
 class DataProductVersion(BaseModelObject):

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
@@ -58,10 +58,10 @@ class DataProductVersionIO(ResourceIO[DataProductVersionId, DataProductVersionRe
         if "dataProductExternalId" in item:
             yield DataProductIO, ExternalId(external_id=item["dataProductExternalId"])
         for rule in (item.get("quality") or {}).get("rules", []):
-            if "ruleSetExternalId" in rule and "version" in rule:
+            if "externalId" in rule and "version" in rule:
                 yield (
                     RuleSetVersionIO,
-                    RuleSetVersionId(rule_set_external_id=rule["ruleSetExternalId"], version=rule["version"]),
+                    RuleSetVersionId(rule_set_external_id=rule["externalId"], version=rule["version"]),
                 )
 
     @classmethod

--- a/cognite_toolkit/_cdf_tk/yaml_classes/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/data_product_version.py
@@ -38,11 +38,11 @@ class DataProductVersionTerms(BaseModelResource):
 
 
 class DataProductVersionQualityRule(BaseModelResource):
-    rule_set_external_id: str = Field(description="External ID of the referenced rule set.")
+    external_id: str = Field(description="External ID of the referenced rule set.")
     version: SemanticVersion = Field(description="Version of the referenced rule set.")
 
     def as_id(self) -> RuleSetVersionId:
-        return RuleSetVersionId(rule_set_external_id=self.rule_set_external_id, version=self.version)
+        return RuleSetVersionId(rule_set_external_id=self.external_id, version=self.version)
 
 
 class DataProductVersionQuality(BaseModelResource):

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_data_product_version.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_data_product_version.py
@@ -117,6 +117,20 @@ class TestDataProductVersionRequest:
 
         assert update["update"]["views"] == {"add": [self._v_cdm_3d]}
 
+    def test_as_update_quality_always_omitted(self) -> None:
+        """quality is create-only (not in DataProductVersionPatch) so it must never appear in update payloads."""
+        request = DataProductVersionRequest.model_validate(
+            {
+                "dataProductExternalId": "my-product",
+                "version": "1.0.0",
+                "quality": {"rules": [{"externalId": "my-ruleset", "version": "1.0.0"}]},
+            }
+        )
+
+        for mode in ("patch", "replace"):
+            update = request.as_update(mode=mode)  # type: ignore[arg-type]
+            assert "quality" not in update["update"], f"quality must not appear in {mode} update payload"
+
     def test_as_update_replace_view_removed_locally_is_ignored(self) -> None:
         """View refs are immutable/append-only in the API — a view present in CDF but
         absent locally must not generate a remove operation."""


### PR DESCRIPTION
## Summary

- The API spec defines `quality.rules` items as `RuleSetVersionReference` with `{externalId, version}`, not `{ruleSetExternalId, version}`
- Replaces `list[RuleSetVersionId]` in `DataProductVersionQuality` with a new `RuleSetVersionRef` class whose `external_id` field serialises as `externalId` on the wire
- Renames `DataProductVersionQualityRule.rule_set_external_id` → `external_id` so the correct user-facing YAML field is `externalId:` (not `ruleSetExternalId:`)
- Updates `get_dependent_items` to key on `"externalId"` in the raw dict

## Correct YAML

```yaml
quality:
  rules:
    - externalId: my-ruleset
      version: "1.0.0"
```

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Fix `quality.rules` wire format to use `externalId` instead of `ruleSetExternalId` when serialising data product version quality rules.
