### PR TITLE
[CDF-27971] Fix NotImplementedError when pulling extraction pipelines with contacts field

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/extraction_pipeline.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/extraction_pipeline.py
@@ -167,6 +167,8 @@ class ExtractionPipelineIO(ResourceIO[ExternalId, ExtractionPipelineRequest, Ext
     ) -> tuple[dict[int, int], list[int]]:
         if json_path == ("rawTables",):
             return diff_list_identifiable(local, cdf, get_identifier=lambda x: (x["dbName"], x["tableName"]))
+        if json_path == ("contacts",):
+            return diff_list_force_hashable(local, cdf)
         return super().diff_list(local, cdf, json_path)
 
     def create(self, items: Sequence[ExtractionPipelineRequest]) -> list[ExtractionPipelineResponse]:

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_extraction_pipeline.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_extraction_pipeline.py
@@ -122,6 +122,19 @@ class TestExtractionPipelineLoader:
 
         assert list(actual) == expected
 
+    def test_diff_list_contacts_does_not_raise(self, monkeypatch: MonkeyPatch) -> None:
+        loader = ExtractionPipelineIO(MagicMock(spec=ToolkitClient), None, MagicMock(spec=Console))
+        local = [{"name": "Alice", "email": "alice@example.com", "role": "owner", "sendNotification": True}]
+        cdf = [
+            {"name": "Alice", "email": "alice@example.com", "role": "owner", "sendNotification": True},
+            {"name": "Bob", "email": "bob@example.com", "role": "viewer", "sendNotification": False},
+        ]
+
+        local_by_cdf, added = loader.diff_list(local, cdf, ("contacts",))
+
+        assert local_by_cdf == {0: 0}
+        assert added == [1]
+
     @patch.dict(
         os.environ,
         {


### PR DESCRIPTION
# Description

`cdf pull` crashes with `NotImplementedError` when an extraction pipeline has a `contacts` field. `ExtractionPipelineIO.diff_list` only handled `rawTables` and fell through to the base class for all other list fields — the base class raises `NotImplementedError` unconditionally. Fix adds a `contacts` branch using `diff_list_force_hashable`, matching how `ExtractionPipelineConfigIO` handles config arrays.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Fixed `NotImplementedError` when running `cdf pull` on extraction pipelines that have a `contacts` field