### PR TITLE
fix: suppress subagents empty list in agent idempotency check

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/agent.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/agent.py
@@ -119,7 +119,7 @@ class AgentIO(ResourceIO[ExternalId, AgentRequest, AgentResponse]):
             # Instructions are optional, if not set the server set them to an empty string.
             # We remove them from the dumped resource to ensure it will be equal to the local resource.
             dumped.pop("instructions", None)
-        for key in ["labels", "exampleQuestions", "skills"]:
+        for key in ["labels", "exampleQuestions", "skills", "subagents"]:
             if key not in local and not dumped.get(key):
                 # If the local resource does not have the key and the server set Agent has it set to an empty list,
                 # we remove it from the dumped resource to ensure it will be equal to the local resource.


### PR DESCRIPTION
# Description

The CDF Agents API returns `subagents: []` on every `AgentResponse` even though the field is absent from the API spec and local YAMLs never define it. This caused `test_deploy_complete_org` to fail because the second deploy always detected a spurious diff (`subagents: []` in CDF vs nothing in local) and triggered an unnecessary update.

Add `subagents` to the existing list of undocumented empty fields that are stripped from the CDF dump when absent in the local config — matching the same handling already in place for `labels`, `exampleQuestions`, and `skills`.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Agent deploy is now idempotent when the API returns `subagents: []` for agents that do not define subagents locally.