### PR TITLE
[CDF-27981] Fix RuleSetVersion deploy always deleting unchanged versions

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/rulesets.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/rulesets.py
@@ -163,6 +163,11 @@ class RuleSetVersionIO(ResourceIO[RuleSetVersionId, RuleSetVersionRequest, RuleS
     def get_dependencies(cls, resource: RuleSetVersionYAML) -> Iterable[tuple[type[ResourceIO], Identifier]]:
         yield RuleSetIO, ExternalId(external_id=resource.rule_set_external_id)
 
+    def dump_resource(self, resource: RuleSetVersionResponse, local: dict[str, Any] | None = None) -> dict[str, Any]:
+        dumped = resource.as_request_resource().dump()
+        dumped["ruleSetExternalId"] = resource.rule_set_external_id
+        return dumped
+
     @classmethod
     def get_extra_files(cls, filepath: Path, identifier: RuleSetVersionId, item: dict[str, Any]) -> Iterable[ReadExtra]:
         """Get extra files for a RuleSetVersion resource.

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_ruleset.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_ruleset.py
@@ -14,6 +14,7 @@ from cognite_toolkit._cdf_tk.client import ToolkitClientConfig
 from cognite_toolkit._cdf_tk.client.api.rulesets import RuleSetsAPI
 from cognite_toolkit._cdf_tk.client.http_client import HTTPClient
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, RuleSetVersionId
+from cognite_toolkit._cdf_tk.client.resource_classes.ruleset_version import RuleSetVersionResponse
 from cognite_toolkit._cdf_tk.client.testing import ToolkitClientMock
 from cognite_toolkit._cdf_tk.exceptions import ToolkitFileNotFoundError
 from cognite_toolkit._cdf_tk.resource_ios._resource_ios.rulesets import RuleSetVersionIO
@@ -153,6 +154,28 @@ class TestRuleSetVersionCRUDSplitResource:
             list(crud.split_resource(base, resource))
             assert resource.get("rules") == [_TURTLE_CONTENT]
             assert "rulesFile" not in resource
+
+
+class TestRuleSetVersionIODumpResource:
+    def test_dump_resource_includes_rule_set_external_id_for_deploy_diff(self) -> None:
+        """Regression test for CDF-27981: deploy must not delete+recreate unchanged versions."""
+        client = ToolkitClientMock()
+        io = RuleSetVersionIO(client, None)
+
+        rules = [_TURTLE_CONTENT]
+        resource = RuleSetVersionResponse(
+            rule_set_external_id="rs_tags",
+            version="1.0.0",
+            rules=rules,
+            created_time=1000,
+        )
+        local = {
+            "ruleSetExternalId": "rs_tags",
+            "version": "1.0.0",
+            "rules": rules,
+        }
+
+        assert io.dump_resource(resource, local) == local
 
 
 class TestRuleSetVersionCRUDGetId:


### PR DESCRIPTION
## Description

Rule set versions were deleted and recreated on every deploy even when unchanged, because `dump_resource` omitted `ruleSetExternalId` (excluded from the Pydantic model as a path parameter). Deploy diff always failed, and delete failed when a data product version referenced the rule set version.

This adds a `dump_resource` override on `RuleSetVersionIO`, matching `DataProductVersionIO`, plus a regression test.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Rule set versions are no longer deleted and recreated on every deploy when nothing has changed (CDF-27981).