### PR TITLE
[CDF-28000] Add ViewIO dependency to DataProductVersionIO

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
@@ -12,6 +12,7 @@ from cognite_toolkit._cdf_tk.resource_ios._base_ios import ResourceIO
 from cognite_toolkit._cdf_tk.yaml_classes import DataProductVersionYAML
 
 from .data_product import DataProductIO
+from .datamodel import ViewIO
 from .rulesets import RuleSetVersionIO
 
 
@@ -22,7 +23,7 @@ class DataProductVersionIO(ResourceIO[DataProductVersionId, DataProductVersionRe
     resource_write_cls = DataProductVersionRequest
     kind = "DataProductVersion"
     yaml_cls = DataProductVersionYAML
-    dependencies = frozenset({DataProductIO, RuleSetVersionIO})
+    dependencies = frozenset({DataProductIO, RuleSetVersionIO, ViewIO})
     parent_resource = frozenset({DataProductIO})
     support_drop = True
     support_update = True

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_product_version.py
@@ -2,17 +2,18 @@ from collections.abc import Hashable, Iterable, Sequence
 from typing import Any, Literal, final
 
 from cognite_toolkit._cdf_tk.client._resource_base import Identifier
-from cognite_toolkit._cdf_tk.client.identifiers import DataProductVersionId, ExternalId, RuleSetVersionId
+from cognite_toolkit._cdf_tk.client.identifiers import DataProductVersionId, ExternalId, RuleSetVersionId, ViewId
 from cognite_toolkit._cdf_tk.client.resource_classes.data_product_version import (
     DataProductVersionRequest,
     DataProductVersionResponse,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.group import AclType, ScopeDefinition
 from cognite_toolkit._cdf_tk.resource_ios._base_ios import ResourceIO
+from cognite_toolkit._cdf_tk.resource_ios._resource_ios.datamodel import ViewIO
+from cognite_toolkit._cdf_tk.utils import in_dict
 from cognite_toolkit._cdf_tk.yaml_classes import DataProductVersionYAML
 
 from .data_product import DataProductIO
-from .datamodel import ViewIO
 from .rulesets import RuleSetVersionIO
 
 
@@ -64,6 +65,16 @@ class DataProductVersionIO(ResourceIO[DataProductVersionId, DataProductVersionRe
                     RuleSetVersionIO,
                     RuleSetVersionId(rule_set_external_id=rule["externalId"], version=rule["version"]),
                 )
+        for view in item.get("views", []):
+            if in_dict(("space", "externalId", "version"), view):
+                yield (
+                    ViewIO,
+                    ViewId(
+                        space=view["space"],
+                        external_id=view["externalId"],
+                        version=str(view["version"]),
+                    ),
+                )
 
     @classmethod
     def get_dependencies(cls, resource: DataProductVersionYAML) -> Iterable[tuple[type[ResourceIO], Identifier]]:
@@ -71,6 +82,8 @@ class DataProductVersionIO(ResourceIO[DataProductVersionId, DataProductVersionRe
         if resource.quality:
             for rule in resource.quality.rules:
                 yield RuleSetVersionIO, rule.as_id()
+        for view in resource.views:
+            yield ViewIO, ViewId(space=view.space, external_id=view.external_id, version=str(view.version))
 
     def dump_resource(
         self, resource: DataProductVersionResponse, local: dict[str, Any] | None = None

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_data_product_version.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_data_product_version.py
@@ -10,6 +10,13 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_product_version import
 )
 from cognite_toolkit._cdf_tk.client.testing import ToolkitClientMock
 from cognite_toolkit._cdf_tk.resource_ios._resource_ios.data_product_version import DataProductVersionIO
+from cognite_toolkit._cdf_tk.resource_ios._resource_ios.datamodel import ViewIO
+
+
+class TestDataProductVersionIODependencies:
+    def test_view_is_in_class_dependencies(self) -> None:
+        """Regression test for CDF-28000: views must deploy before data product versions."""
+        assert ViewIO in DataProductVersionIO.dependencies
 
 
 class TestDataProductVersionIODumpResource:

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_data_product_version.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_data_product_version.py
@@ -1,7 +1,11 @@
 """Unit tests for DataProductVersionIO."""
 
+from collections.abc import Hashable
 from typing import ClassVar
 
+import pytest
+
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, RuleSetVersionId, ViewId
 from cognite_toolkit._cdf_tk.client.resource_classes.data_product_version import (
     DataProductVersionQuality,
     DataProductVersionRequest,
@@ -9,14 +13,83 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_product_version import
     DataProductVersionView,
 )
 from cognite_toolkit._cdf_tk.client.testing import ToolkitClientMock
+from cognite_toolkit._cdf_tk.resource_ios import ResourceIO
+from cognite_toolkit._cdf_tk.resource_ios._resource_ios.data_product import DataProductIO
 from cognite_toolkit._cdf_tk.resource_ios._resource_ios.data_product_version import DataProductVersionIO
 from cognite_toolkit._cdf_tk.resource_ios._resource_ios.datamodel import ViewIO
+from cognite_toolkit._cdf_tk.resource_ios._resource_ios.rulesets import RuleSetVersionIO
+from cognite_toolkit._cdf_tk.yaml_classes import DataProductVersionYAML
 
 
 class TestDataProductVersionIODependencies:
     def test_view_is_in_class_dependencies(self) -> None:
         """Regression test for CDF-28000: views must deploy before data product versions."""
         assert ViewIO in DataProductVersionIO.dependencies
+
+    def test_get_dependencies_yields_view_references(self) -> None:
+        resource = DataProductVersionYAML.model_validate(
+            {
+                "dataProductExternalId": "my-product",
+                "version": "1.0.0",
+                "views": [
+                    {
+                        "space": "my-space",
+                        "externalId": "MyView",
+                        "version": "1",
+                    }
+                ],
+            }
+        )
+
+        actual = list(DataProductVersionIO.get_dependencies(resource))
+
+        assert actual == [
+            (DataProductIO, ExternalId(external_id="my-product")),
+            (ViewIO, ViewId(space="my-space", external_id="MyView", version="1")),
+        ]
+
+    @pytest.mark.parametrize(
+        "item, expected",
+        [
+            pytest.param(
+                {
+                    "dataProductExternalId": "my-product",
+                    "version": "1.0.0",
+                    "views": [
+                        {
+                            "space": "my-space",
+                            "externalId": "MyView",
+                            "version": "1",
+                        }
+                    ],
+                },
+                [
+                    (DataProductIO, ExternalId(external_id="my-product")),
+                    (ViewIO, ViewId(space="my-space", external_id="MyView", version="1")),
+                ],
+                id="view reference yields ViewIO dependency",
+            ),
+            pytest.param(
+                {
+                    "dataProductExternalId": "my-product",
+                    "version": "1.0.0",
+                    "quality": {"rules": [{"externalId": "my-ruleset", "version": "1.0.0"}]},
+                },
+                [
+                    (DataProductIO, ExternalId(external_id="my-product")),
+                    (
+                        RuleSetVersionIO,
+                        RuleSetVersionId(rule_set_external_id="my-ruleset", version="1.0.0"),
+                    ),
+                ],
+                id="quality rule yields RuleSetVersionIO dependency",
+            ),
+        ],
+    )
+    def test_get_dependent_items(self, item: dict, expected: list[tuple[type[ResourceIO], Hashable]]) -> None:
+        actual = list(DataProductVersionIO.get_dependent_items(item))
+
+        assert actual == expected
 
 
 class TestDataProductVersionIODumpResource:


### PR DESCRIPTION
## Description

Deploying a `DataProductVersion` that references views on a fresh project can fail with HTTP 400 because views may not exist yet. The topological deploy sorter had no constraint ordering `ViewIO` before `DataProductVersionIO`.

This PR adds `ViewIO` to `DataProductVersionIO.dependencies` so views are deployed before data product versions.

Fixes https://cognitedata.atlassian.net/browse/CDF-28000

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Data product version deploy order on fresh projects: views now deploy before data product versions that reference them.