### PR TITLE
[CDF-27549] Add drop confirmation hook and fix build crash on missing identifiers

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -617,7 +617,14 @@ class BuildV2Command(ToolkitCommand):
                 identifier = toolkit_resource.as_id()
             except ValidationError as errors:
                 syntax_warning = self._create_syntax_warning(errors)
-                identifier = crud_class.get_id(parsed_yaml)
+                try:
+                    identifier = crud_class.get_id(parsed_yaml)
+                except KeyError:
+                    return SuccessfulReadYAMLFile(
+                        syntax_warning=syntax_warning,
+                        resources=[],
+                        **args,
+                    )
 
             extra_files = self._substitute_variables_extra_content(
                 crud_class.get_extra_files(resource_file, identifier, parsed_yaml), variables

--- a/cognite_toolkit/_cdf_tk/commands/clean.py
+++ b/cognite_toolkit/_cdf_tk/commands/clean.py
@@ -143,6 +143,10 @@ class CleanCommand(ToolkitCommand):
                 print(f"  Would have deleted {_print_ids_or_length(resource_ids)}.")
             return nr_of_deleted
 
+        if loader.drop_confirmation_message:
+            if not questionary.confirm(loader.drop_confirmation_message, default=False).ask():
+                return 0
+
         try:
             nr_of_deleted += loader.delete(resource_ids)
         except CogniteAPIError as e:

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -722,6 +722,12 @@ class DeployV2Command(ToolkitCommand):
                     result = cls.deploy_dry_run(crud, resources_to_deploy, is_missing_write, options)
                     progress.update(task_id, description=f"Would have {options.operation}ed {resource_name} to CDF")
                 else:
+                    if resources_to_deploy.to_delete and crud.drop_confirmation_message:
+                        progress.stop()
+                        confirmed = questionary.confirm(crud.drop_confirmation_message, default=False).ask()
+                        progress.start()
+                        if not confirmed:
+                            resources_to_deploy.to_delete.clear()
                     progress.update(task_id, description=f"{options.operation.title()}ing {resource_name} to CDF")
                     result = cls.deploy_resources(crud, resources_to_deploy, step.skipped_cruds, options.deployment_dir)
                     progress.update(task_id, description=f"{options.operation.title()}ed {resource_name} successfully.")

--- a/cognite_toolkit/_cdf_tk/resource_ios/_base_ios.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_base_ios.py
@@ -2,7 +2,7 @@ import sys
 from abc import ABC, abstractmethod
 from collections.abc import Hashable, Iterable, Sequence, Sized
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Literal, TypeVar
 
 from pydantic import BaseModel, ConfigDict
 from rich.console import Console
@@ -173,6 +173,7 @@ class ResourceIO(Loader, ABC, Generic[T_Identifier, T_RequestResource, T_Respons
     # Optional to set in the subclass
     support_drop = True
     support_update = True
+    drop_confirmation_message: ClassVar[str | None] = None
     dependencies: "frozenset[type[ResourceIO]]" = frozenset()
     # For example, TransformationNotification and Schedule has Transformation as the parent resource
     # This is used in the iterate method to ensure that nothing is returned if


### PR DESCRIPTION
# Description

Adds a `drop_confirmation_message` class variable to `ResourceIO` such that resource types that have costly or irreversible deletion (e.g. soft-delete with long retention) can prompt the user before `deploy --drop` or `clean` proceeds with deletion. Also fixes a latent crash in `BuildV2Command` where a Pydantic `ValidationError` followed by a `KeyError` from `get_id` (due to missing required fields in the YAML) would produce an unhelpful traceback instead of surfacing the validation warning.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fix crash during build when a YAML file fails validation and is also missing required identifier fields; the validation warning is now surfaced correctly instead.