### PR TITLE
Fix instance download skipping user-defined parent views

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -637,8 +637,9 @@ class DataModelingSelect:
                     include_global=filter.include_global,
                 )
             views = datamodel.views or []
-            parents = {parent for view in views for parent in view.implements or []}
-            # We only allow the user to select child views
+            global_view_ids = {view.as_id() for view in views if view.is_global}
+            # Skip downloading parent views that belong to system (global) spaces
+            parents = {parent for view in views for parent in view.implements or [] if parent in global_view_ids}
             views = [view for view in views if view.as_id() not in parents]
         else:
             raise NotImplementedError(f"Strategy {filter.strategy} is not implemented.")


### PR DESCRIPTION
# Description

When downloading instances using the `dataModel` strategy, views that are implemented by other views in the same data model were excluded from the download set. This incorrectly also skipped user-defined (non-global) parent views. We should not skip these, as they can contain _more_ instances than the child instances depending on how the datamodel is defined and populated, meaning some instances you could simply not download before through the interactive approach. This fix restricts this exclusion to system/global views only, so user-defined parent views in the same data model are included.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- When using `cdf download instances`, toolkit will no longer skip downloading user-defined views that are implemented by other views in the same datamodel.
