### PR TITLE
[CDF-28006] Align chart scheduled calculation period validation with backend value

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/chart_scheduled_calculation.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/chart_scheduled_calculation.py
@@ -65,8 +65,8 @@ class ChartScheduledCalculation(BaseModelObject):
     period: int = Field(
         description="Schedule period in milliseconds. It determines the how often the calculation will run"
         + " and the time window for the input and output data."
-        + " The minimum period and window is 5 minute and the maximum is 30 days.",
-        ge=5 * MINUTE_MS,
+        + " The minimum period and window is 1 minute and the maximum is 30 days.",
+        ge=MINUTE_MS,
         le=30 * DAY_MS,
         multiple_of=MINUTE_MS,
     )


### PR DESCRIPTION
# Description

The `ChartScheduledCalculation.period` field had a minimum constraint of `5 * MINUTE_MS`
(300,000 ms), but the tasks-api backend allows periods as low as `MINUTE_MS` (60,000 ms /
1 minute). Charts with 1-minute schedules exist in production and caused a hard
`ValidationError` crash when running `cdf migrate charts`, aborting the migration mid-way.

After some investigation, it turns out the actual backend constraint is defined as `ge=MINUTE_MS` in
`tasks-api`, this change aligns our validation with that

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fix `cdf migrate charts` crashing with a `ValidationError` when encountering charts
  with less than 5 minutes scheduled calculation period.
