### PR TITLE
Enable cog-content-design Cursor plugin

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -2,6 +2,9 @@
   "plugins": {
     "continual-learning": {
       "enabled": true
+    },
+    "cognite-ai-tools/cog-content-design": {
+      "enabled": true
     }
   }
 }


### PR DESCRIPTION
# Description

Enable the `cognite-ai-tools/cog-content-design` Cursor plugin in `.cursor/settings.json` so contributors get the UX writing agent skill (`ux-writing`) when opening this repo. Plugin source: [ai-tooling-marketplace `cog-content-design`](https://github.com/cognitedata/ai-tooling-marketplace/tree/main/plugins/cog-content-design).

## Bump

- [ ] Patch
- [x] Skip

## Changelog

### Added

- Enabled `cognite-ai-tools/cog-content-design` plugin in project Cursor settings for Cognite UX writing standards