### PR TITLE
[CDF-28014] Fix chart download silently dropping charts due to server-side list cap

### DIFF
--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -203,3 +203,6 @@ STREAM_MUTABLE_TEMPLATE_NAME = frozenset(("BasicLiveData",))
 SUBSELECTION_LIMIT_QUERY_ENDPOINT = 1_000
 
 MISSING_NONCE = "<missingNonce>"
+
+# Hard server-side cap on /storage/charts/charts/list; the endpoint rejects a limit parameter.
+CHARTS_LIST_LIMIT = 10_000

--- a/cognite_toolkit/_cdf_tk/dataio/_applications.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_applications.py
@@ -30,10 +30,10 @@ from cognite_toolkit._cdf_tk.client.resource_classes.chart_scheduled_calculation
     ChartScheduledCalculationResponse,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.charts_data import MonitoringJobReference
-from cognite_toolkit._cdf_tk.constants import MISSING_NONCE
+from cognite_toolkit._cdf_tk.constants import CHARTS_LIST_LIMIT, MISSING_NONCE
 from cognite_toolkit._cdf_tk.exceptions import ToolkitNotImplementedError
 from cognite_toolkit._cdf_tk.feature_flags import Flags
-from cognite_toolkit._cdf_tk.tk_warnings import HighSeverityWarning
+from cognite_toolkit._cdf_tk.tk_warnings import HighSeverityWarning, MediumSeverityWarning
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 
@@ -100,15 +100,30 @@ class ChartIO(UploadableDataIO[ChartSelector, ChartResponse, ChartRequest]):
         limit: int | None = None,
         bookmark: Bookmark | None = None,
     ) -> Iterable[Page[ChartResponse]]:
-        selected_charts = self.client.charts.list(visibility=None)
-        self._existing_charts = {chart.external_id for chart in selected_charts}
         if isinstance(selector, AllChartsSelector):
-            ...
+            selected_charts = self.client.charts.list(visibility=None)
+            self._existing_charts = {chart.external_id for chart in selected_charts}
+            if len(selected_charts) >= CHARTS_LIST_LIMIT:
+                MediumSeverityWarning(
+                    f"The Charts list endpoint returned {len(selected_charts)} items, which is the "
+                    "server-side maximum. Additional charts may exist but cannot be retrieved due to "
+                    "an API limitation."
+                ).print_warning(console=self.client.console)
         elif isinstance(selector, ChartOwnerSelector):
+            selected_charts = self.client.charts.list(visibility=None)
+            self._existing_charts = {chart.external_id for chart in selected_charts}
             selected_charts = [chart for chart in selected_charts if chart.owner_id == selector.owner_id]
         elif isinstance(selector, ChartExternalIdSelector):
-            external_id_set = set(selector.external_ids)
-            selected_charts = [chart for chart in selected_charts if chart.external_id in external_id_set]
+            selected_charts = self.client.charts.retrieve(
+                [ExternalId(external_id=eid) for eid in selector.external_ids]
+            )
+            self._existing_charts = {chart.external_id for chart in selected_charts}
+            missing_count = len(selector.external_ids) - len(selected_charts)
+            if missing_count:
+                HighSeverityWarning(
+                    f"{missing_count} of {len(selector.external_ids)} selected charts could not be "
+                    "retrieved and will be skipped."
+                ).print_warning(console=self.client.console)
         else:
             raise ToolkitNotImplementedError(f"Unsupported selector type {type(selector).__name__!r} for ChartIO")
 

--- a/cognite_toolkit/_cdf_tk/dataio/_applications.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_applications.py
@@ -112,12 +112,17 @@ class ChartIO(UploadableDataIO[ChartSelector, ChartResponse, ChartRequest]):
         elif isinstance(selector, ChartOwnerSelector):
             selected_charts = self.client.charts.list(visibility=None)
             self._existing_charts = {chart.external_id for chart in selected_charts}
+            if len(selected_charts) >= CHARTS_LIST_LIMIT:
+                MediumSeverityWarning(
+                    f"The Charts list endpoint returned {len(selected_charts)} items, which is the "
+                    "server-side maximum. Additional charts may exist but cannot be retrieved due to "
+                    "an API limitation."
+                ).print_warning(console=self.client.console)
             selected_charts = [chart for chart in selected_charts if chart.owner_id == selector.owner_id]
         elif isinstance(selector, ChartExternalIdSelector):
             selected_charts = self.client.charts.retrieve(
                 [ExternalId(external_id=eid) for eid in selector.external_ids]
             )
-            self._existing_charts = {chart.external_id for chart in selected_charts}
             missing_count = len(selector.external_ids) - len(selected_charts)
             if missing_count:
                 HighSeverityWarning(

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -45,6 +45,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.group.acls import ChartsAdm
 from cognite_toolkit._cdf_tk.client.resource_classes.resource_view_mapping import ResourceViewMappingResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.streams import StreamResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.three_d import ThreeDModelClassicResponse
+from cognite_toolkit._cdf_tk.constants import CHARTS_LIST_LIMIT
 from cognite_toolkit._cdf_tk.exceptions import ToolkitMissingResourceError, ToolkitValueError
 
 from . import humanize_collection
@@ -420,6 +421,12 @@ class InteractiveChartSelect:
             )
 
         available_charts = self.client.charts.list(visibility=select_filter.visibility)
+        if len(available_charts) >= CHARTS_LIST_LIMIT:
+            questionary.print(
+                f"Warning: The Charts list endpoint returned {len(available_charts)} items, which is the "
+                "server-side maximum. There may be additional charts that could not be listed.",
+                style="fg:yellow bold",
+            )
         if select_filter.select_all and select_filter.owned_by is None:
             return [chart.external_id for chart in available_charts]
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -770,9 +770,9 @@ class TestMigrationCommand:
                 ],
             }
         )
-        # Chart list
+        # Chart retrieve by IDs (used by stream_data for ChartExternalIdSelector)
         respx.post(
-            config.create_app_url("/storage/charts/charts/list"),
+            config.create_app_url("/storage/charts/charts/byids"),
         ).respond(
             status_code=200,
             json={

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -779,6 +779,15 @@ class TestMigrationCommand:
                 "items": [chart.dump() for chart in charts],
             },
         )
+        # Chart list (used by existing_charts property during upload to determine create vs update)
+        respx.post(
+            config.create_app_url("/storage/charts/charts/list"),
+        ).respond(
+            status_code=200,
+            json={
+                "items": [chart.dump() for chart in charts],
+            },
+        )
         # TimeSeries Instance ID lookup (uses toolkit InstancesAPI → httpx)
         respx_mock.post(config.create_api_url("/models/instances/query")).mock(
             return_value=httpx.Response(
@@ -847,7 +856,7 @@ class TestMigrationCommand:
         }
 
         calls = respx_mock.calls
-        assert len(calls) == 5
+        assert len(calls) == 6
         last_call = calls[-1]
         assert last_call.request.url == config.create_app_url("/storage/charts/charts/my_chart")
         assert last_call.request.method == "PUT"


### PR DESCRIPTION
# Description

The Charts list endpoint has a hard server-side limit of 10 000 items and rejects a `limit` parameter, making pagination impossible. `ChartIO.stream_data()` was calling `list(visibility=None)` and filtering, so in projects with >10 000 total charts, charts beyond the cap were silently dropped — in an example users saw "Finished 851 charts" but only 306 downloaded with no explanation. This PR addresses this by switching `ChartExternalIdSelector` to use `retrieve()` (byids) directly, and adding warnings when the list cap is reached for `AllChartsSelector` (manifest-driven) and during interactive selection.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- When using `cdf data download charts`, toolkit will no longer silently skip charts when a project exceeds 10 000 Charts available to the user. A warning is now shown when the limit is reached, and the command now ensures all selected charts (when "All Public Charts" is used) will be downloaded and not skipped.
