### PR TITLE
[CDF-28015] Fix cdf auth verify failing with 400 on projects without legacy InField

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
@@ -394,9 +394,11 @@ class InFieldCDMLocationConfigIO(ResourceIO[NodeId, InFieldCDMLocationConfigRequ
     def create_acl(cls, actions: set[Literal["READ", "WRITE"]], scope: ScopeDefinition) -> Iterable[AclType]:
         if isinstance(scope, AllScope | SpaceIDScope):
             yield DataModelInstancesAcl(actions=as_instance_acl_actions(actions), scope=scope)
-        # Reading APM_Config is always required to check for legacy InField conflicts.
-        yield DataModelsAcl(actions=["READ"], scope=SpaceIDScope(space_ids=[APM_CONFIG_SPACE]))
-        yield DataModelInstancesAcl(actions=["READ"], scope=SpaceIDScope(space_ids=[APM_CONFIG_SPACE]))
+        if not isinstance(scope, AllScope):
+            # Reading APM_Config is always required to check for legacy InField conflicts.
+            # AllScope already covers any space, so these are only needed for scoped deployments.
+            yield DataModelsAcl(actions=["READ"], scope=SpaceIDScope(space_ids=[APM_CONFIG_SPACE]))
+            yield DataModelInstancesAcl(actions=["READ"], scope=SpaceIDScope(space_ids=[APM_CONFIG_SPACE]))
 
     @cached_property
     def _legacy_instance_spaces(self) -> set[str]:


### PR DESCRIPTION
# Description

`cdf auth verify` was failing with `400: invalid capability reference(s)` when creating or updating the `cognite_toolkit_service_principal` group on projects without the `APM_Config` space. This bug was introduced in #3015, which added unconditional `SpaceIDScope(APM_Config)` capability yields to `InFieldCDMLocationConfigIO.create_acl` — causing them to appear in the toolkit group even when `AllScope` was passed. The fix guards those yields behind `if not isinstance(scope, AllScope)`, since `AllScope` already covers any space.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fix `cdf auth verify` failing with a 400 error on projects without InField deployed.
