### PR TITLE
[CDF-28023] Exclude AppIO and AppVersionIO from doc URL check

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils/fileio/_writers.py
+++ b/cognite_toolkit/_cdf_tk/utils/fileio/_writers.py
@@ -259,7 +259,7 @@ class CSVWriter(TableWriter[TextIOWrapper]):
         return csv_writer
 
 
-class ParquetWriter(TableWriter["pq.ParquetWriter"]):
+class ParquetWriter(TableWriter["pq.ParquetWriter"]):  # type: ignore[type-var]
     FORMAT = ".parquet"
 
     def __init__(

--- a/cognite_toolkit/_cdf_tk/utils/fileio/_writers.py
+++ b/cognite_toolkit/_cdf_tk/utils/fileio/_writers.py
@@ -259,7 +259,7 @@ class CSVWriter(TableWriter[TextIOWrapper]):
         return csv_writer
 
 
-class ParquetWriter(TableWriter["pq.ParquetWriter"]):  # type: ignore[type-var]
+class ParquetWriter(TableWriter["pq.ParquetWriter"]):
     FORMAT = ".parquet"
 
     def __init__(

--- a/tests_smoke/test_cruds/test_resource_crud.py
+++ b/tests_smoke/test_cruds/test_resource_crud.py
@@ -5,6 +5,8 @@ import httpx
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.resource_ios import (
     CRUD_LIST,
+    AppIO,
+    AppVersionIO,
     DataProductIO,
     DataProductVersionIO,
     Loader,
@@ -15,8 +17,8 @@ from cognite_toolkit._cdf_tk.resource_ios import (
     RoboticsDataPostProcessingIO,
 )
 
-# These are unofficial APIs that do not have public documentation,
-# only accessible for Cognite employees. We exclude them from the doc_url test.
+# APIs excluded from the doc_url test: either unofficial/internal APIs not publicly documented,
+# or APIs whose public documentation is not yet available.
 INTERNAL_DOCS = {
     RoboticMapIO,
     RoboticFrameIO,
@@ -25,6 +27,8 @@ INTERNAL_DOCS = {
     RoboticsDataPostProcessingIO,
     DataProductIO,
     DataProductVersionIO,
+    AppIO,
+    AppVersionIO,
 }
 
 


### PR DESCRIPTION
# Description

The App Hosting API is not yet publicly documented. `AppIO` and
`AppVersionIO` are added to `INTERNAL_DOCS` in the smoke test alongside
the existing robotics and data product exclusions, so the CI doc URL
check no longer reports 404s for these resources.

Also removes a stale `# type: ignore[type-var]` comment in `_writers.py`
that mypy 2.x flagged as unused.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Exclude `AppIO` and `AppVersionIO` from the doc URL accessibility check (App Hosting API not yet publicly documented)