### PR TITLE
[CDF-28021] Fix view deploy failing due to cross-references between created and updated views

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -37,6 +37,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ResourceDeleteError,
     ResourceRetrievalError,
     ResourceUpdateError,
+    ResourceUpsertError,
     ToolkitError,
     ToolkitNotADirectoryError,
     ToolkitValidationError,
@@ -171,7 +172,7 @@ class ResourceToDeploy(Generic[T_Identifier, T_RequestResource]):
     def get_ids(
         self,
         crud: ResourceIO[T_Identifier, T_RequestResource, T_ResponseResource],
-        action: Literal["create", "delete", "update"],
+        action: Literal["create", "delete", "update", "upsert"],
     ) -> list[T_Identifier]:
         if action == "create":
             return [crud.get_id(resource) for resource in self.to_create]
@@ -179,6 +180,8 @@ class ResourceToDeploy(Generic[T_Identifier, T_RequestResource]):
             return self.to_delete
         elif action == "update":
             return [crud.get_id(resource) for resource in self.to_update]
+        elif action == "upsert":
+            return [crud.get_id(resource) for resource in self.to_create + self.to_update]
         else:
             return []
 
@@ -934,17 +937,28 @@ class DeployV2Command(ToolkitCommand):
         deploy_dir: Path | None = None,
     ) -> DeploymentResult:
         deleted, created, updated = 0, 0, 0
-        action: Literal["create", "delete", "update"] | None = None
+        action: Literal["create", "delete", "update", "upsert"] | None = None
         try:
             if resources.to_delete:
                 action = "delete"
                 deleted = crud.delete(resources.to_delete)
-            if resources.to_create:
-                action = "create"
-                created = len(crud.create(resources.to_create))
-            if resources.to_update:
-                action = "update"
-                updated = len(crud.update(resources.to_update))
+            if isinstance(crud, ViewIO) and (resources.to_create and resources.to_update):
+                # Since the upsert endpoint for views validates cross-references between views, we need to
+                # to combine the create and update operations to avoid dependency errors in
+                # case a view to be updated references a view to be created and vice versa.
+                action = "upsert"
+                to_create_ids = {crud.get_id(item) for item in resources.to_create}  # type: ignore[arg-type]
+                to_upsert = [*resources.to_create, *resources.to_update]
+                upserted = crud.create(to_upsert)  # type: ignore[arg-type]
+                created = sum(1 for view in upserted if crud.get_id(view) in to_create_ids)
+                updated = len(upserted) - created
+            else:
+                if resources.to_create:
+                    action = "create"
+                    created = len(crud.create(resources.to_create))
+                if resources.to_update:
+                    action = "update"
+                    updated = len(crud.update(resources.to_update))
         except ToolkitAPIError as error:
             cls._handle_deploy_error(error, action, crud, resources, skipped_cruds, deploy_dir)
         except ValidationError as error:
@@ -965,7 +979,7 @@ class DeployV2Command(ToolkitCommand):
     def _handle_deploy_error(
         cls,
         error: ToolkitAPIError,
-        action: Literal["create", "delete", "update"] | None,
+        action: Literal["create", "delete", "update", "upsert"] | None,
         crud: ResourceIO[T_Identifier, T_RequestResource, T_ResponseResource],
         resources: ResourceToDeploy[T_Identifier, T_RequestResource],
         skipped_cruds: Set[type[ResourceIO]],
@@ -1003,7 +1017,7 @@ class DeployV2Command(ToolkitCommand):
     def _handle_validation_error(
         cls,
         error: ValidationError,
-        action: Literal["retrieve", "create", "delete", "update"] | None,
+        action: Literal["retrieve", "create", "delete", "update", "upsert"] | None,
         crud: ResourceIO[T_Identifier, T_RequestResource, T_ResponseResource],
         resources: Sequence[T_RequestResource],
         deploy_dir: Path | None = None,
@@ -1027,7 +1041,7 @@ class DeployV2Command(ToolkitCommand):
 
     @classmethod
     def _missing_environment_variables(
-        cls, crud: ResourceIO, resources: ResourceToDeploy, action: Literal["create", "delete", "update"]
+        cls, crud: ResourceIO, resources: ResourceToDeploy, action: Literal["create", "delete", "update", "upsert"]
     ) -> str | None:
         item_ids = resources.get_ids(crud, action)
         match = set(item_ids) & set(resources.missing_env_vars_by_id)
@@ -1041,11 +1055,14 @@ class DeployV2Command(ToolkitCommand):
         return f"\n  {HINT_LEAD_TEXT}This is likely due to missing environment variable{suffix}: {variables_str}"
 
     @classmethod
-    def _get_resource_exception(cls, action: Literal["create", "retrieve", "update", "delete"]) -> type[ToolkitError]:
+    def _get_resource_exception(
+        cls, action: Literal["create", "retrieve", "update", "delete", "upsert"]
+    ) -> type[ToolkitError]:
         return {
             "update": ResourceUpdateError,
             "delete": ResourceDeleteError,
             "create": ResourceCreationError,
+            "upsert": ResourceUpsertError,
             "retrieve": ResourceRetrievalError,
         }[action]
 

--- a/cognite_toolkit/_cdf_tk/exceptions.py
+++ b/cognite_toolkit/_cdf_tk/exceptions.py
@@ -190,6 +190,10 @@ class ResourceCreationError(ToolkitError):
     pass
 
 
+class ResourceUpsertError(ToolkitError):
+    pass
+
+
 class ResourceDeleteError(ToolkitError): ...
 
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_deploy_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_deploy_v2.py
@@ -7,12 +7,19 @@ import pytest
 from cognite.client.data_classes.data_modeling.statistics import InstanceStatistics, SpaceStatistics
 
 from cognite_toolkit._cdf_tk.client.identifiers import ViewId
+from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import ViewRequest
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._container import (
     ContainerInspectResult,
     ContainerInspectResultItem,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._space import SpaceResponse
-from cognite_toolkit._cdf_tk.commands.deploy_v2.command import DeploymentStep, DeployOptions, DeployV2Command
+from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
+from cognite_toolkit._cdf_tk.commands.deploy_v2.command import (
+    DeploymentStep,
+    DeployOptions,
+    DeployV2Command,
+    ResourceToDeploy,
+)
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 from cognite_toolkit._cdf_tk.resource_ios import ContainerCRUD, EdgeCRUD, NodeCRUD, SpaceCRUD, ViewIO
 
@@ -268,3 +275,25 @@ class TestCheckNoOutOfScopeViewReferences:
             raises_ctx,
         ):
             cmd._validate_plan_container_references(client, plan, DeployOptions(drop=True, operation=operation))
+
+
+class TestDeployResourcesSpecialHandling:
+    def test_upserts_views_in_dependency_order(self) -> None:
+        base_view = ViewRequest(space="sp_space", external_id="Base", version="v1")
+        derived_view = ViewRequest(
+            space="sp_space",
+            external_id="Derived",
+            version="v1",
+            implements=[ViewId(space="sp_space", external_id="Base", version="v1")],
+        )
+
+        with monkeypatch_toolkit_client() as client:
+            client.tool.views.create.side_effect = lambda items: list(items)
+            loader = ViewIO(client, Path("build_dir"), None)
+            resources: ResourceToDeploy = ResourceToDeploy(to_create=[derived_view], to_update=[base_view])
+            result = DeployV2Command.deploy_resources(loader, resources, set())
+
+        assert result.created_count == 1
+        assert result.updated_count == 1
+        deployed_ids = [view.external_id for call in client.tool.views.create.call_args_list for view in call[0][0]]
+        assert deployed_ids.index("Base") < deployed_ids.index("Derived")

--- a/tests/test_unit/test_cdf_tk/test_commands/test_deploy_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_deploy_v2.py
@@ -277,7 +277,7 @@ class TestCheckNoOutOfScopeViewReferences:
             cmd._validate_plan_container_references(client, plan, DeployOptions(drop=True, operation=operation))
 
 
-class TestDeployResourcesSpecialHandling:
+class TestDeployResourcesSpecialUpsertHandling:
     def test_upserts_views_in_dependency_order(self) -> None:
         base_view = ViewRequest(space="sp_space", external_id="Base", version="v1")
         derived_view = ViewRequest(


### PR DESCRIPTION
# Description

When deploying views where a view to be created references a view to be update, the separate create/update calls could fail validation since we typically split the create and update operations into separate API calls. The reason for this is the stricter consistency validation that was recently introduced in DMS, requiring properties and views to be referenced by Direct Relations and Reverse Direct Relations to be either already deployed to CDF or part of the same deployment batch. 

There is just one endpoint for upserting views, and the `ViewIO.update() `method just passes along to `ViewIO.create()`, so splitting these into separate requests is purely a design choice and not a necessity. This fix makes a specific exception for `ViewIO` and combines the create+update into a single upsert call for when both operations are present (for this specific class only).

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fixes an error that could occur when deploying views that have direct relations and reverse direct relations between views being created and views being updated concurrently.
