### PR TITLE
Fix migration upload failure for custom ingestionMapping views

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -279,7 +279,7 @@ def asset_centric_to_dm(
                 source=ViewId(
                     space=INSTANCE_SOURCE_VIEW_ID.space,
                     external_id=INSTANCE_SOURCE_VIEW_ID.external_id,
-                    version=view_source.view_id.version,
+                    version=INSTANCE_SOURCE_VIEW_ID.version,
                 ),
                 properties=instance_source_properties,
             )


### PR DESCRIPTION
# Description

The `InstanceSource` sidecar attached to migrated nodes was tagged with the ingestion view's version instead of `v1` which is used for `InstanceSource`. For any non-`v1` ingestion view (e.g. a custom `CustomTimeSeries/1_0` mapping), the sidecar ended up as `cognite_migration:InstanceSource/1_0`, which `as_pending_instance_id` could subsequently not locate when linking — failing the upload with the error `ValueError: Cannot extract ID from item of type 'NodeRequest'`. Default mappings to CogniteTimeSeries or other views tagged with version `v1` succeeded due to the identical version string, which masked the bug.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fix `cdf migrate timeseries` and `cdf migrate files` failing at upload when the `ingestionMapping` targets a view with a version different from `v1`.