### PR TITLE
Fix chart export stripping flow node data (ToolboxFunction, Constant)

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/chart.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/chart.py
@@ -50,7 +50,17 @@ class ChartResponse(Chart, ResponseResource[ChartRequest], extra="allow"):
         return ChartRequest
 
     def as_request_resource(self, include: Set[BackendService] = BACKEND_SERVICES) -> ChartRequest:
-        chart_request = super().as_request_resource()
+        dumped = self.model_dump(
+            mode="json",
+            by_alias=True,
+            exclude_unset=True,
+            exclude={
+                "created_time",
+                "last_updated_time",
+                "owner_id",
+            },
+        )
+        chart_request = ChartRequest.model_validate(dumped, extra="allow", by_alias=True)
         if self.monitoring_jobs is not None and "monitoring_jobs" in include:
             chart_request.monitoring_jobs = [job.as_request_resource() for job in self.monitoring_jobs]
         if self.scheduled_calculations is not None and "scheduled_calculations" in include:

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_applications.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_applications.py
@@ -249,6 +249,66 @@ class TestChartIO:
         expected = self._create_downloaded_chart(chart, monitoring_job, calculation)
         assert downloaded_chart == expected
 
+    def test_chart_response_to_request_preserves_flow_node_data(self) -> None:
+        chart = ChartResponse.model_validate(
+            {
+                "externalId": _CHART_EXTERNAL_ID,
+                "visibility": "PRIVATE",
+                "ownerId": "owner",
+                "createdTime": 1700000000000,
+                "lastUpdatedTime": 1700000000000,
+                "data": {
+                    "version": 1,
+                    "name": "Chart with calculation",
+                    "dateFrom": "2025-01-01T00:00:00.000Z",
+                    "dateTo": "2025-12-31T23:59:59.999Z",
+                    "workflowCollection": [
+                        {
+                            "id": "workflow-id",
+                            "type": "workflow",
+                            "version": "v2",
+                            "name": "Calculation",
+                            "color": "#1192e8",
+                            "enabled": True,
+                            "settings": {"autoAlign": True},
+                            "flow": {
+                                "elements": [
+                                    {
+                                        "id": "constant-node",
+                                        "type": "Constant",
+                                        "position": {"x": 1.0, "y": 2.0},
+                                        "data": {"name": "Constant", "value": 37},
+                                    },
+                                    {
+                                        "id": "function-node",
+                                        "type": "ToolboxFunction",
+                                        "position": {"x": 3.0, "y": 4.0},
+                                        "data": {
+                                            "selectedOperation": {"op": "add", "version": "1.0"},
+                                            "parameterValues": {"align_timesteps": True},
+                                        },
+                                    },
+                                ]
+                            },
+                        }
+                    ],
+                },
+            },
+            by_alias=True,
+        )
+
+        dumped = chart.as_request_resource().dump()
+        elements = dumped["data"]["workflowCollection"][0]["flow"]["elements"]
+
+        assert elements[0]["data"] == {"name": "Constant", "value": 37}
+        assert elements[1]["data"] == {
+            "selectedOperation": {"op": "add", "version": "1.0"},
+            "parameterValues": {"align_timesteps": True},
+        }
+        assert "ownerId" not in dumped
+        assert "createdTime" not in dumped
+        assert "lastUpdatedTime" not in dumped
+
     def _create_downloaded_chart(
         self,
         chart: ChartResponse,


### PR DESCRIPTION
## Bump
- [x] Patch
- [ ] Minor
- [ ] Major

## Changelog
### Fixed
- Fixed chart export/import stripping flow node data (`selectedOperation`, `parameterValues` for `ToolboxFunction` nodes; `name`, `value` for `Constant` nodes), which caused Fusion to crash with `TypeError: Cannot read properties of undefined (reading 'op')` after a Toolkit round-trip.

## Summary

- `ChartResponse.as_request_resource()` was calling the base class implementation which used `extra="ignore"` when validating the response into a request. This silently dropped any field not declared in Toolkit's `FlowData` Pydantic model — including `selectedOperation`, `parameterValues` (for `ToolboxFunction` nodes) and `name`, `value` (for `Constant` nodes).
- Fusion reads these fields when rendering charts. After a Toolkit export/import, opening the chart in Fusion caused `TypeError: Cannot read properties of undefined (reading 'op')` because `node.data.selectedOperation` was `undefined`.
- Fix: override `as_request_resource()` in `ChartResponse` to dump only the known response-only fields (`created_time`, `last_updated_time`, `owner_id`) explicitly, then validate with `extra="allow"` so all nested node data is preserved opaquely.

## Test plan

- [ ] `test_chart_response_to_request_preserves_flow_node_data` — new regression test verifying that `Constant` (`name`, `value`) and `ToolboxFunction` (`selectedOperation`, `parameterValues`) node data survive the response→request conversion, and that response-only fields are excluded
- [ ] All existing `TestChartIO` tests continue to pass