### PR TITLE
[CDF-28014 followup] Add cursor-based pagination for Charts list

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/api/charts.py
+++ b/cognite_toolkit/_cdf_tk/client/api/charts.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from cognite_toolkit._cdf_tk.client.cdf_client import CDFResourceAPI, PagedResponse
 from cognite_toolkit._cdf_tk.client.cdf_client.api import Endpoint
-from cognite_toolkit._cdf_tk.client.http_client import HTTPClient, ItemsSuccessResponse, RequestMessage, SuccessResponse
+from cognite_toolkit._cdf_tk.client.http_client import HTTPClient, ItemsSuccessResponse, SuccessResponse
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.chart import (
     ChartRequest,
@@ -86,13 +86,4 @@ class ChartsAPI(CDFResourceAPI[ChartResponse]):
         body: dict[str, Any] = {}
         if filter_params:
             body["filter"] = filter_params
-        endpoint = self._method_endpoint_map["list"]
-        # Note that even though the internal docs specify that limit is supported for this endpoint,
-        # you get: "Encountered an unknown key 'limit' at offset 50 at path: $" if you pass it.
-        request = RequestMessage(
-            endpoint_url=self._make_url(endpoint.path),
-            method=endpoint.method,
-            body_content=body,
-        )
-        response = self._http_client.request_single_retries(request).get_success_or_raise(request)
-        return self._validate_page_response(response).items
+        return self._list(body=body)

--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -203,6 +203,3 @@ STREAM_MUTABLE_TEMPLATE_NAME = frozenset(("BasicLiveData",))
 SUBSELECTION_LIMIT_QUERY_ENDPOINT = 1_000
 
 MISSING_NONCE = "<missingNonce>"
-
-# Hard server-side cap on /storage/charts/charts/list; the endpoint rejects a limit parameter.
-CHARTS_LIST_LIMIT = 10_000

--- a/cognite_toolkit/_cdf_tk/dataio/_applications.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_applications.py
@@ -30,10 +30,10 @@ from cognite_toolkit._cdf_tk.client.resource_classes.chart_scheduled_calculation
     ChartScheduledCalculationResponse,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.charts_data import MonitoringJobReference
-from cognite_toolkit._cdf_tk.constants import CHARTS_LIST_LIMIT, MISSING_NONCE
+from cognite_toolkit._cdf_tk.constants import MISSING_NONCE
 from cognite_toolkit._cdf_tk.exceptions import ToolkitNotImplementedError
 from cognite_toolkit._cdf_tk.feature_flags import Flags
-from cognite_toolkit._cdf_tk.tk_warnings import HighSeverityWarning, MediumSeverityWarning
+from cognite_toolkit._cdf_tk.tk_warnings import HighSeverityWarning
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 
@@ -103,21 +103,9 @@ class ChartIO(UploadableDataIO[ChartSelector, ChartResponse, ChartRequest]):
         if isinstance(selector, AllChartsSelector):
             selected_charts = self.client.charts.list(visibility=None)
             self._existing_charts = {chart.external_id for chart in selected_charts}
-            if len(selected_charts) >= CHARTS_LIST_LIMIT:
-                MediumSeverityWarning(
-                    f"The Charts list endpoint returned {len(selected_charts)} items, which is the "
-                    "server-side maximum. Additional charts may exist but cannot be retrieved due to "
-                    "an API limitation."
-                ).print_warning(console=self.client.console)
         elif isinstance(selector, ChartOwnerSelector):
             selected_charts = self.client.charts.list(visibility=None)
             self._existing_charts = {chart.external_id for chart in selected_charts}
-            if len(selected_charts) >= CHARTS_LIST_LIMIT:
-                MediumSeverityWarning(
-                    f"The Charts list endpoint returned {len(selected_charts)} items, which is the "
-                    "server-side maximum. Additional charts may exist but cannot be retrieved due to "
-                    "an API limitation."
-                ).print_warning(console=self.client.console)
             selected_charts = [chart for chart in selected_charts if chart.owner_id == selector.owner_id]
         elif isinstance(selector, ChartExternalIdSelector):
             selected_charts = self.client.charts.retrieve(

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -45,7 +45,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.group.acls import ChartsAdm
 from cognite_toolkit._cdf_tk.client.resource_classes.resource_view_mapping import ResourceViewMappingResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.streams import StreamResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.three_d import ThreeDModelClassicResponse
-from cognite_toolkit._cdf_tk.constants import CHARTS_LIST_LIMIT
 from cognite_toolkit._cdf_tk.exceptions import ToolkitMissingResourceError, ToolkitValueError
 
 from . import humanize_collection
@@ -421,12 +420,6 @@ class InteractiveChartSelect:
             )
 
         available_charts = self.client.charts.list(visibility=select_filter.visibility)
-        if len(available_charts) >= CHARTS_LIST_LIMIT:
-            questionary.print(
-                f"Warning: The Charts list endpoint returned {len(available_charts)} items, which is the "
-                "server-side maximum. There may be additional charts that could not be listed.",
-                style="fg:yellow bold",
-            )
         if select_filter.select_all and select_filter.owned_by is None:
             return [chart.external_id for chart in available_charts]
 

--- a/tests/test_unit/test_cdf_tk/test_client/test_charts.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_charts.py
@@ -1,4 +1,3 @@
-import gzip
 import json
 from collections.abc import Iterator
 
@@ -69,6 +68,7 @@ class TestChartAPI:
         assert len(result) == 1
         assert isinstance(result[0], ChartResponse)
 
+    @pytest.mark.usefixtures("disable_gzip")
     def test_list_pagination(self, toolkit_config: ToolkitClientConfig, respx_mock: respx.MockRouter) -> None:
         client = ToolkitClient(config=toolkit_config)
         url = toolkit_config.create_app_url("/storage/charts/charts/list")
@@ -107,18 +107,11 @@ class TestChartAPI:
         assert len(result) == 2
         assert [chart.external_id for chart in result] == ["chart_page_1", "chart_page_2"]
         assert len(respx_mock.calls) == 2
-        first_request_body = json.loads(_request_json(respx_mock.calls[0].request))
-        second_request_body = json.loads(_request_json(respx_mock.calls[1].request))
+        first_request_body = json.loads(respx_mock.calls[0].request.content)
+        second_request_body = json.loads(respx_mock.calls[1].request.content)
         assert first_request_body["limit"] == 1000
         assert "cursor" not in first_request_body
         assert second_request_body["cursor"] == "cursor_1"
-
-
-def _request_json(request: httpx.Request) -> bytes:
-    raw = request.content
-    if len(raw) >= 2 and raw[:2] == b"\x1f\x8b":
-        return gzip.decompress(raw)
-    return raw
 
 
 def chart_data_generator() -> Iterator[tuple]:

--- a/tests/test_unit/test_cdf_tk/test_client/test_charts.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_charts.py
@@ -1,6 +1,6 @@
-from collections.abc import Iterator
 import gzip
 import json
+from collections.abc import Iterator
 
 import httpx
 import pytest
@@ -85,7 +85,9 @@ class TestChartAPI:
             ),
             owner_id="toolkit_test_user",
         )
-        page_two = page_one.model_copy(update={"external_id": "chart_page_2", "data": page_one.data.model_copy(update={"name": "Page 2"})})
+        page_two = page_one.model_copy(
+            update={"external_id": "chart_page_2", "data": page_one.data.model_copy(update={"name": "Page 2"})}
+        )
 
         respx_mock.post(url).mock(
             side_effect=[

--- a/tests/test_unit/test_cdf_tk/test_client/test_charts.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_charts.py
@@ -1,5 +1,8 @@
 from collections.abc import Iterator
+import gzip
+import json
 
+import httpx
 import pytest
 import respx
 import yaml
@@ -65,6 +68,55 @@ class TestChartAPI:
         assert isinstance(result, list)
         assert len(result) == 1
         assert isinstance(result[0], ChartResponse)
+
+    def test_list_pagination(self, toolkit_config: ToolkitClientConfig, respx_mock: respx.MockRouter) -> None:
+        client = ToolkitClient(config=toolkit_config)
+        url = toolkit_config.create_app_url("/storage/charts/charts/list")
+        page_one = ChartResponse(
+            external_id="chart_page_1",
+            created_time=1,
+            last_updated_time=2,
+            visibility="PUBLIC",
+            data=ChartData(
+                version=1,
+                name="Page 1",
+                date_from="2025-04-26T22:00:00.000Z",
+                date_to="2025-05-27T21:59:59.999Z",
+            ),
+            owner_id="toolkit_test_user",
+        )
+        page_two = page_one.model_copy(update={"external_id": "chart_page_2", "data": page_one.data.model_copy(update={"name": "Page 2"})})
+
+        respx_mock.post(url).mock(
+            side_effect=[
+                httpx.Response(
+                    status_code=200,
+                    json={"items": [page_one.dump()], "nextCursor": "cursor_1"},
+                ),
+                httpx.Response(
+                    status_code=200,
+                    json={"items": [page_two.dump()], "nextCursor": None},
+                ),
+            ]
+        )
+
+        result = client.charts.list(visibility="PUBLIC")
+
+        assert len(result) == 2
+        assert [chart.external_id for chart in result] == ["chart_page_1", "chart_page_2"]
+        assert len(respx_mock.calls) == 2
+        first_request_body = json.loads(_request_json(respx_mock.calls[0].request))
+        second_request_body = json.loads(_request_json(respx_mock.calls[1].request))
+        assert first_request_body["limit"] == 1000
+        assert "cursor" not in first_request_body
+        assert second_request_body["cursor"] == "cursor_1"
+
+
+def _request_json(request: httpx.Request) -> bytes:
+    raw = request.content
+    if len(raw) >= 2 and raw[:2] == b"\x1f\x8b":
+        return gzip.decompress(raw)
+    return raw
 
 
 def chart_data_generator() -> Iterator[tuple]:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -786,6 +786,7 @@ class TestMigrationCommand:
             status_code=200,
             json={
                 "items": [chart.dump() for chart in charts],
+                "nextCursor": None,
             },
         )
         # TimeSeries Instance ID lookup (uses toolkit InstancesAPI → httpx)

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_applications.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_applications.py
@@ -180,7 +180,8 @@ class TestChartIO:
                             ],
                         },
                     },
-                ]
+                ],
+                "nextCursor": None,
             },
         )
         respx_mock.post(ts_url).respond(


### PR DESCRIPTION
# Description

The Charts list endpoint now supports cursor-based pagination as of [https://github.com/cognitedata/application-data-storage/pull/911](https://github.com/cognitedata/application-data-storage/pull/911), so `ChartsAPI.list()` uses the shared `_list()` helper instead of a single unpaginated request. Chart download, migration, and interactive selection therefore retrieve all charts beyond the previous 10,000-item cap, and the related limit warnings have been removed.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Improved

- The `cdf data download charts` and `cdf migrate charts` commands now supports projects with more than 10,000 Charts in total.