### PR TITLE
[CDF-28069] Fix cdf migrate infield-configs incorrectly populating dataExplorationConfig

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -20,7 +20,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.apm_config_v1 import (
     APM_CONFIG_SPACE,
     APMConfigResponse,
     Discipline,
-    FeatureConfiguration,
     RootLocationConfiguration,
     RootLocationFeatureToggles,
 )
@@ -355,15 +354,12 @@ class InfieldV2ConfigCreator(MigrationCreator):
         if not config.feature_configuration:
             return location_configs, location_filters
 
-        data_exploration = self._create_data_exploration(config.feature_configuration)
-
         for index, root_location_config in enumerate(config.feature_configuration.root_location_configurations or []):
             identifier = root_location_config.external_id or root_location_config.asset_external_id or f"index {index}"
             try:
                 location_config = self._create_location_config(
                     root_location_config,
                     config.feature_configuration.disciplines,
-                    data_exploration,
                     index,
                 )
             except ToolkitMigrationError as error:
@@ -406,7 +402,7 @@ class InfieldV2ConfigCreator(MigrationCreator):
 
     def _create_location_filter(self, config: RootLocationConfiguration) -> LocationFilterRequest:
         original_external_id = config.external_id or config.asset_external_id or str(uuid.uuid4())
-        external_id = f"location_filter_{original_external_id}"
+        external_id = f"loc_{original_external_id}"
         name = config.display_name or config.asset_external_id or external_id
 
         instance_spaces = [
@@ -429,7 +425,6 @@ class InfieldV2ConfigCreator(MigrationCreator):
         self,
         config: RootLocationConfiguration,
         disciplines: list[Discipline] | None,
-        data_exploration: dict[str, JsonValue],
         index: int,
     ) -> InFieldCDMLocationConfigRequest:
         if (
@@ -497,27 +492,4 @@ class InfieldV2ConfigCreator(MigrationCreator):
             disciplines=[discipline.dump() for discipline in disciplines] if disciplines else None,
             data_storage=data_storage,
             view_mappings=view_mappings,
-            data_exploration_config=data_exploration or None,
         )
-
-    def _create_data_exploration(self, config: FeatureConfiguration) -> dict[str, JsonValue]:
-        data_exploration: dict[str, JsonValue] = {}
-        if config.observations:
-            data_exploration["observations"] = config.observations
-        if config.documents:
-            documents: dict[str, JsonValue] = {}
-            if config.documents.type:
-                documents["type"] = config.documents.type.removeprefix("metadata.")
-            if config.documents.title:
-                documents["title"] = config.documents.title
-            if config.documents.description:
-                documents["description"] = config.documents.description.removeprefix("metadata.")
-            data_exploration["documents"] = documents
-        if config.notifications:
-            data_exploration["notifications"] = config.notifications.dump()
-        if config.asset_page_configuration:
-            dumped = config.asset_page_configuration.dump()
-            # Linkable Asset Key is used for implicit connections in the old Asset.metaadata.
-            dumped.pop("linkableAssetKeys", None)
-            data_exploration["assets"] = dumped
-        return data_exploration

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator/test_create_infield_config.yml
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator/test_create_infield_config.yml
@@ -4,7 +4,6 @@ InField CDM Location Configs:
     - gp_infield_oid_checklist_admins
     templateAdmins:
     - gp_infield_oid_template_admins
-  dataExplorationConfig: null
   dataFilters:
     assets:
       instanceSpaces:
@@ -63,7 +62,7 @@ Location Filters:
     space: cdf_infield
     version: v1
   description: InField location, migrated from old location configuration
-  externalId: location_filter_WMT:VAL
+  externalId: loc_WMT:VAL
   instanceSpaces:
   - sp_infield_oid_app_data
   - sp_asset_oid_source


### PR DESCRIPTION
# Description

Remove the migration of legacy APM `featureConfiguration` fields (`documents`, `notifications`,
`asset_page_configuration`, `observations`) into `dataExplorationConfig` on the InField CDM
location config. Confirmed with the InField team that `dataExplorationConfig` must be configured manually post-migration — none of the old fields map to it in a way that
is actually consumed by InField on CDM. As an additional housekeeping task; aligns the migrated location filter `externalId`
prefix to `loc_` per the naming convention enforced by Value Delivery.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- [alpha] Fix `cdf migrate infield-configs` incorrectly populating `dataExplorationConfig` on migrated
  InField CDM location configs with fields from the legacy APM config that are no longer used by
  InField on CDM.
