### PR TITLE
Use edge types from cdf_cdm in annotation migration

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -510,7 +510,11 @@ def create_edge_properties(
         elif edge_prop_id.endswith(".externalId"):
             # Just an external ID string.
             edge_prop_id = edge_prop_id.removesuffix(".externalId")
-            value = NodeId(space=default_instance_space, external_id=str(flatten_dump[prop_json_path]))
+            edge_space = default_instance_space
+            if resource_type == "annotation" and edge_prop_id == "type":
+                # Annotation edge types (e.g. diagrams.AssetLink) belong to the CDM type space.
+                edge_space = "cdf_cdm"
+            value = NodeId(space=edge_space, external_id=str(flatten_dump[prop_json_path]))
         else:
             issue.invalid_instance_property_types.append(
                 InvalidPropertyDataType(property_id=prop_id, expected_type="EdgeProperty")

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -656,7 +656,7 @@ class TestMigrationCommand:
                 external_id=f"annotation_{asset_annotation.id}",
                 start_node=(space, f"file_{asset_annotation.annotated_resource_id}"),
                 end_node=(space, f"asset_{asset_annotation.data['assetRef']['id']}"),
-                type=(space, asset_annotation.annotation_type),
+                type=("cdf_cdm", asset_annotation.annotation_type),
                 sources=[
                     NodeOrEdgeData(
                         source=dm.ViewId("cdf_cdm", "CogniteDiagramAnnotation", "v1"),
@@ -678,7 +678,7 @@ class TestMigrationCommand:
                 external_id=f"annotation_{file_annotation.id}",
                 start_node=(space, f"file_{file_annotation.annotated_resource_id}"),
                 end_node=(space, f"file_{file_annotation.data['fileRef']['id']}"),
-                type=(space, file_annotation.annotation_type),
+                type=("cdf_cdm", file_annotation.annotation_type),
                 sources=[
                     NodeOrEdgeData(
                         source=dm.ViewId("cdf_cdm", "CogniteDiagramAnnotation", "v1"),

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
@@ -1183,7 +1183,7 @@ class TestAssetCentricConversion:
                     external_id=ANNOTATION_ID.external_id,
                     start_node=NodeId(space="test_space", external_id="file_456_instance"),
                     end_node=NodeId(space="test_space", external_id="asset_123_instance"),
-                    type=NodeId(space="test_space", external_id="diagrams.FileLink"),
+                    type=NodeId(space="cdf_cdm", external_id="diagrams.FileLink"),
                     sources=[
                         InstanceSource(
                             source=ViewId(space="cdf_cdm", external_id="CogniteDiagramAnnotation", version="v1"),


### PR DESCRIPTION
# Description

Fix annotation migration so generated edge types use the CDM type space (`cdf_cdm`) instead of the customer instance space.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- [alpha] Fixes an issue when running `cdf migrate annotations` that would case annotation edge types to use the wrong space.
