### PR TITLE
feat(infield): added missing required properties for the InfieldActivitiesCardView and InfieldNotificationsCardView

### DIFF
--- a/cognite_toolkit/_cdf_tk/rules/_infield.py
+++ b/cognite_toolkit/_cdf_tk/rules/_infield.py
@@ -16,7 +16,9 @@ from cognite_toolkit._cdf_tk.yaml_classes.infield_cdm_location_config import (
 )
 
 _REQUIRED_PROPERTIES: dict[str, frozenset[str]] = {
-    "assetActivitiesCard": frozenset({"sourceId", "name", "status", "type", "mainAsset", "scheduledEndTime", "scheduledStartTime"}),
+    "assetActivitiesCard": frozenset(
+        {"sourceId", "name", "status", "type", "mainAsset", "scheduledEndTime", "scheduledStartTime"}
+    ),
     "assetNotificationsCard": frozenset(
         {"name", "sourceId", "type", "status", "description", "asset", "createdDate", "priority"}
     ),

--- a/cognite_toolkit/_cdf_tk/rules/_infield.py
+++ b/cognite_toolkit/_cdf_tk/rules/_infield.py
@@ -16,9 +16,9 @@ from cognite_toolkit._cdf_tk.yaml_classes.infield_cdm_location_config import (
 )
 
 _REQUIRED_PROPERTIES: dict[str, frozenset[str]] = {
-    "assetActivitiesCard": frozenset({"sourceId", "name", "status", "type", "mainAsset"}),
+    "assetActivitiesCard": frozenset({"sourceId", "name", "status", "type", "mainAsset", "scheduledEndTime", "scheduledStartTime"}),
     "assetNotificationsCard": frozenset(
-        {"sourceId", "type", "status", "description", "asset", "createdDate", "priority"}
+        {"name", "sourceId", "type", "status", "description", "asset", "createdDate", "priority"}
     ),
 }
 

--- a/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InFieldCDMLocationConfig.yaml
+++ b/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InFieldCDMLocationConfig.yaml
@@ -85,9 +85,9 @@ dataExplorationConfig:
     externalId: AssetPropertiesCard
   assetActivitiesCard:
     space: customer_idm_extention
-    version: v2
+    version: v4
     externalId: InfieldActivitiesCardView
   assetNotificationsCard:
     space: customer_idm_extention
-    version: v1
+    version: v2
     externalId: InfieldNotificationsCardView

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags_v2.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags_v2.yaml
@@ -153,11 +153,11 @@ InFieldCDMLocationConfigResponse:
         assetActivitiesCard:
           externalId: InfieldActivitiesCardView
           space: customer_idm_extention
-          version: v2
+          version: v4
         assetNotificationsCard:
           externalId: InfieldNotificationsCardView
           space: customer_idm_extention
-          version: v1
+          version: v2
         assetPropertiesCard:
           externalId: AssetPropertiesCard
           space: customer_idm_extention


### PR DESCRIPTION
# Description

In version [0.8.92](https://github.com/cognitedata/toolkit/releases/tag/0.8.92), we introduced validation for the required properties of InfieldActivitiesCardView and InfieldNotificationsCardView.

This PR adds additional required properties to ensure all necessary data is properly displayed in the Infield app.

<img width="337" height="262" alt="image" src="https://github.com/user-attachments/assets/83da8191-92c9-498c-9343-005f5f7a1e7e" />
<img width="338" height="259" alt="image" src="https://github.com/user-attachments/assets/b416bcf9-67e8-4709-a15a-fbde629401ef" />


## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Improved

- [alpha] When running cdf build with InFieldCDMLocationConfig resources, Toolkit now more strictly validates assetActivitiesCard and assetNotificationsCard view references and includes additional required properties to ensure data visibility in InField.
