### PR TITLE
Fix "cdf data download files" overwrites and CogniteFile/document filter issues

### DIFF
--- a/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
@@ -56,6 +56,14 @@ MULTI_FILE_PART_MAX_SIZE_BYTES = 4_000 * 1024 * 1024  # Each part in a multi-par
 MULTI_FILE_MAX_PART_COUNT = 250  # Maximum number of parts
 
 
+def create_download_filepath(file_directory: Path, name: str, mime_type: str | None, external_id: str) -> Path:
+    filename = Path(sanitize_filename(name))
+    if filename.suffix == "" and mime_type and (guessed_extension := mimetypes.guess_extension(mime_type)):
+        filename = filename.with_suffix(guessed_extension)
+    prefixed_filename = f"{sanitize_filename(external_id)}_{filename.name}"
+    return file_directory / prefixed_filename
+
+
 class FileMetadataContentIO(
     TableDataIO[FileMetadataContentSelectorV2, FileMetadataResponse],
     TableUploadableDataIO[FileMetadataContentSelectorV2, FileMetadataResponse, FileMetadataRequest],
@@ -184,14 +192,10 @@ class FileMetadataContentIO(
                         )
                     )
                 else:
-                    filepath = self._file_directory / sanitize_filename(file.name)
-                    if (
-                        filepath.suffix == ""
-                        and file.mime_type
-                        and (guessed_extension := mimetypes.guess_extension(file.mime_type))
-                    ):
-                        # Recover file extension if missing.
-                        filepath = filepath.with_suffix(guessed_extension)
+                    file_prefix = file.external_id or str(file.id)
+                    filepath = create_download_filepath(
+                        self._file_directory, file.name, file.mime_type, file_prefix
+                    )
                     has_downloaded = self._try_download_content(file, filepath, item.display_name)
                     if has_downloaded:
                         file.filepath = filepath
@@ -619,13 +623,9 @@ class CogniteFileContentIO(
                         )
                     )
                 else:
-                    filepath = self._file_directory / sanitize_filename(file.name or item.external_id)
-                    if (
-                        filepath.suffix == ""
-                        and file.mime_type
-                        and (guessed_extension := mimetypes.guess_extension(file.mime_type))
-                    ):
-                        filepath = filepath.with_suffix(guessed_extension)
+                    filepath = create_download_filepath(
+                        self._file_directory, file.name or item.external_id, file.mime_type, item.external_id
+                    )
                     has_downloaded = self._try_download_content(file, filepath, item.display_name)
                     if has_downloaded:
                         file.filepath = filepath

--- a/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
@@ -57,7 +57,10 @@ MULTI_FILE_MAX_PART_COUNT = 250  # Maximum number of parts
 
 
 def create_download_filepath(file_directory: Path, name: str, mime_type: str | None, file_prefix: str) -> Path:
-    filename = Path(sanitize_filename(name))
+    sanitized_name = (
+        sanitize_filename(name) or "file"
+    )  # If the name is empty, we use "file" as the name to avoid exception in with_suffix
+    filename = Path(sanitized_name)
     if filename.suffix == "" and mime_type and (guessed_extension := mimetypes.guess_extension(mime_type)):
         filename = filename.with_suffix(guessed_extension)
     prefixed_filename = f"{sanitize_filename(file_prefix)}_{filename.name}"

--- a/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
@@ -193,9 +193,7 @@ class FileMetadataContentIO(
                     )
                 else:
                     file_prefix = file.external_id or str(file.id)
-                    filepath = create_download_filepath(
-                        self._file_directory, file.name, file.mime_type, file_prefix
-                    )
+                    filepath = create_download_filepath(self._file_directory, file.name, file.mime_type, file_prefix)
                     has_downloaded = self._try_download_content(file, filepath, item.display_name)
                     if has_downloaded:
                         file.filepath = filepath

--- a/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_file_contentv2.py
@@ -56,11 +56,11 @@ MULTI_FILE_PART_MAX_SIZE_BYTES = 4_000 * 1024 * 1024  # Each part in a multi-par
 MULTI_FILE_MAX_PART_COUNT = 250  # Maximum number of parts
 
 
-def create_download_filepath(file_directory: Path, name: str, mime_type: str | None, external_id: str) -> Path:
+def create_download_filepath(file_directory: Path, name: str, mime_type: str | None, file_prefix: str) -> Path:
     filename = Path(sanitize_filename(name))
     if filename.suffix == "" and mime_type and (guessed_extension := mimetypes.guess_extension(mime_type)):
         filename = filename.with_suffix(guessed_extension)
-    prefixed_filename = f"{sanitize_filename(external_id)}_{filename.name}"
+    prefixed_filename = f"{sanitize_filename(file_prefix)}_{filename.name}"
     return file_directory / prefixed_filename
 
 
@@ -623,8 +623,9 @@ class CogniteFileContentIO(
                         )
                     )
                 else:
+                    file_prefix = f"{file.space}_{file.external_id}"
                     filepath = create_download_filepath(
-                        self._file_directory, file.name or item.external_id, file.mime_type, item.external_id
+                        self._file_directory, file.name or file.external_id, file.mime_type, file_prefix
                     )
                     has_downloaded = self._try_download_content(file, filepath, item.display_name)
                     if has_downloaded:

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -1240,11 +1240,12 @@ class DocumentsInteractiveSelect:
             "Which property do you want to filter by?",
             choices=[Choice(title=" > ".join(map(str, option)), value=option) for option in sorted(available_options)],
         ).unsafe_ask()
+        if filter_type is None:
+            return
 
         buckets = self.client.tool.documents.unique(
             property=filter_type, filter=self.status.current_filter, query=self.status.search_query
         )
-        self.status.attempted_options.add(filter_type)
         if len(buckets) == 0:
             self.client.console.print(f"No documents found for filtering on {filter_type!r}.", style="bold red")
             return
@@ -1259,9 +1260,12 @@ class DocumentsInteractiveSelect:
                 choices=[
                     Choice(title=f"{bucket.value!s} (count {bucket.count})", value=bucket.value) for bucket in buckets
                 ],
-                validator=lambda choices: True if choices else "You must select at least one value.",
+                validate=lambda choices: True if choices else "You must select at least one value.",
             ).unsafe_ask()
+            if not selected_values:
+                return
             filter[filter_type] = {"in": {"property": list(filter_type), "values": list(selected_values)}}
+        self.status.attempted_options.add(filter_type)
 
     def _select_dataset(self) -> None:
         buckets = self.client.tool.documents.unique(
@@ -1322,6 +1326,6 @@ class DocumentsInteractiveSelect:
         documents = questionary.checkbox(
             "Select documents:",
             choices=choices,
-            validator=lambda choices: True if choices else "You must select at least one document.",
+            validate=lambda choices: True if choices else "You must select at least one document.",
         ).unsafe_ask()
         return SelectedDocuments(documents, self.status)

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -1134,11 +1134,13 @@ class DocumentSelectStatus:
 
     @property
     def current_filter(self) -> dict[str, Any] | None:
-        if not self.document_filter and not self.metadata_filter and self.data_set_id is None:
-            return None
-        leaf_filter = [*self.document_filter.values(), *self.metadata_filter.values()]
+        leaf_filter: list[dict[str, Any]] = [*self.document_filter.values(), *self.metadata_filter.values()]
         if self.data_set_id is not None:
             leaf_filter.append({"equals": {"property": ["sourceFile", "dataSetId"], "value": self.data_set_id}})
+        if self.is_cognite_file:
+            leaf_filter.append({"exists": {"property": ["instanceId", "space"]}})
+        if not leaf_filter:
+            return None
         return {"and": leaf_filter}
 
 
@@ -1175,6 +1177,8 @@ class DocumentsInteractiveSelect:
             if action == "abort":
                 raise ToolkitValueError("Aborted document selection.")
             elif action == "finished":
+                if count == 0:
+                    raise ToolkitValueError("No documents match the current filter. Adjust the filter or abort.")
                 break
             elif action == "filter-document-properties":
                 self._update_filter(
@@ -1215,18 +1219,17 @@ class DocumentsInteractiveSelect:
             choices.append(Choice(title="Select individual documents by name", value="name"))
         choices.append(Choice(title="Abort", value="abort"))
         suffix = ""
-        if count <= self.max_selected:
+        if count == 0:
+            suffix = " No documents match the current filter."
+        elif count <= self.max_selected:
             choices.append(Choice(title="Finished", value="finished"))
         else:
             suffix = f" You have to filter down to below {self.max_selected} documents to continue."
         query_note = ""
         if self.status.search_query is not None:
             query_note = f' Active full-text query: "{self.status.search_query}".'
-        caveat = ""
-        if selected_file_type == "dms":
-            caveat = " (approximate)"
         return questionary.select(
-            f"{count} documents found{caveat}. How would you like to proceed?{query_note}{suffix}",
+            f"{count} documents found. How would you like to proceed?{query_note}{suffix}",
             choices=choices,
         ).unsafe_ask()
 
@@ -1293,6 +1296,12 @@ class DocumentsInteractiveSelect:
 
     def _set_cognite_file(self) -> None:
         self.status.is_cognite_file = True
+        count = self.client.tool.documents.count(filter=self.status.current_filter, query=self.status.search_query)
+        if count == 0:
+            self.client.console.print(
+                "No CogniteFiles found with the current filter. Reverting the CogniteFile filter.", style="bold red"
+            )
+            self.status.is_cognite_file = False
 
     def _prompt_search_query(self) -> None:
         answer = questionary.text(

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -1215,7 +1215,7 @@ class DocumentsInteractiveSelect:
             choices.append(
                 Choice(title="Search documents (full-text query)", value="search"),
             )
-        if count <= self.MAX_TERMINAL_CHOICES:
+        if 0 < count <= self.MAX_TERMINAL_CHOICES:
             choices.append(Choice(title="Select individual documents by name", value="name"))
         choices.append(Choice(title="Abort", value="abort"))
         suffix = ""

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
@@ -9,8 +9,8 @@ from cognite_toolkit._cdf_tk.client.http_client import (
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import InstanceSlimDefinition
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import (
-    DownloadResponse,
     FILEPATH,
+    DownloadResponse,
     FileMetadataResponse,
 )
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
@@ -59,9 +59,10 @@ class TestFileMetadataContentIO:
 
         with monkeypatch_toolkit_client() as client:
             client.tool.filemetadata.retrieve.return_value = [file_one, file_two]
-            client.tool.filemetadata.get_download_url.side_effect = (
-                lambda ids: [DownloadResponse(id=identifier.id, download_url=f"https://example.com/{identifier.id}") for identifier in ids]
-            )
+            client.tool.filemetadata.get_download_url.side_effect = lambda ids: [
+                DownloadResponse(id=identifier.id, download_url=f"https://example.com/{identifier.id}")
+                for identifier in ids
+            ]
             client.tool.filemetadata.download_file.side_effect = download_file
 
             io = FileMetadataContentIO(client, config_directory=tmp_path, file_directory=file_directory)

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
@@ -49,7 +49,6 @@ class TestFileMetadataContentIO:
         file_two = FileMetadataResponse(
             id=2,
             name="ny.png",
-            external_id="image-2",
             created_time=1,
             last_updated_time=1,
             uploaded=True,
@@ -71,9 +70,9 @@ class TestFileMetadataContentIO:
         downloaded_files = [data_item.item for page in pages for data_item in page.items]
         assert len(downloaded_files) == 2
         first_path = file_directory / "image-1_ny.png"
-        second_path = file_directory / "image-2_ny.png"
+        second_path = file_directory / "2_ny.png"
         assert first_path.read_bytes() == b"image-1_ny.png"
-        assert second_path.read_bytes() == b"image-2_ny.png"
+        assert second_path.read_bytes() == b"2_ny.png"
         assert downloaded_files[0].filepath == first_path
         assert downloaded_files[1].filepath == second_path
 

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
@@ -8,12 +8,13 @@ from cognite_toolkit._cdf_tk.client.http_client import (
     SuccessResponse,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import InstanceSlimDefinition
-from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FILEPATH, FileMetadataResponse
-from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
-from cognite_toolkit._cdf_tk.dataio._file_contentv2 import (
-    CogniteFileContentIO,
-    FileMetadataContentIO,
+from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import (
+    DownloadResponse,
+    FILEPATH,
+    FileMetadataResponse,
 )
+from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
+from cognite_toolkit._cdf_tk.dataio._file_contentv2 import CogniteFileContentIO, FileMetadataContentIO
 from cognite_toolkit._cdf_tk.dataio.selectors import (
     FILENAME_VARIABLE,
     CogniteFileFilesSelectorV2,
@@ -23,11 +24,59 @@ from cognite_toolkit._cdf_tk.dataio.selectors import (
     FileMetadataFilesSelectorV2,
     FileMetadataTemplateSelectorV2,
     FileMetadataTemplateV2,
+    InternalWithNameId,
 )
 from cognite_toolkit._cdf_tk.utils.fileio import MultiFileReader
 
 
 class TestFileMetadataContentIO:
+    def test_download_duplicate_names_are_not_overwritten(self, tmp_path: Path) -> None:
+        file_directory = tmp_path / "files"
+        selector = FileMetadataFilesSelectorV2(
+            ids=(
+                InternalWithNameId(id=1, name="ny.png"),
+                InternalWithNameId(id=2, name="ny.png"),
+            ),
+        )
+        file_one = FileMetadataResponse(
+            id=1,
+            name="ny.png",
+            external_id="image-1",
+            created_time=1,
+            last_updated_time=1,
+            uploaded=True,
+        )
+        file_two = FileMetadataResponse(
+            id=2,
+            name="ny.png",
+            external_id="image-2",
+            created_time=1,
+            last_updated_time=1,
+            uploaded=True,
+        )
+
+        def download_file(download_url: str, destination: Path) -> None:
+            destination.write_bytes(destination.name.encode())
+
+        with monkeypatch_toolkit_client() as client:
+            client.tool.filemetadata.retrieve.return_value = [file_one, file_two]
+            client.tool.filemetadata.get_download_url.side_effect = (
+                lambda ids: [DownloadResponse(id=identifier.id, download_url=f"https://example.com/{identifier.id}") for identifier in ids]
+            )
+            client.tool.filemetadata.download_file.side_effect = download_file
+
+            io = FileMetadataContentIO(client, config_directory=tmp_path, file_directory=file_directory)
+            pages = list(io.stream_data(selector))
+
+        downloaded_files = [data_item.item for page in pages for data_item in page.items]
+        assert len(downloaded_files) == 2
+        first_path = file_directory / "image-1_ny.png"
+        second_path = file_directory / "image-2_ny.png"
+        assert first_path.read_bytes() == b"image-1_ny.png"
+        assert second_path.read_bytes() == b"image-2_ny.png"
+        assert downloaded_files[0].filepath == first_path
+        assert downloaded_files[1].filepath == second_path
+
     def test_upload_using_template(self, tmp_path: Path) -> None:
         file_directory = tmp_path / "target"
         file_directory.mkdir()

--- a/tests/test_unit/test_cdf_tk/test_utils/test_interactive_select.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_interactive_select.py
@@ -1363,6 +1363,44 @@ class TestDocumentsInteractiveSelect:
         assert isinstance(result, SelectedDocuments)
         assert result.documents == docs
 
+    def test_select_documents_is_cognite_file_applies_exists_filter(self, monkeypatch) -> None:
+        docs = self._sample_documents()
+        answers = ["is-cognite-file", "finished"]
+        cognite_file_filter = {
+            "and": [{"exists": {"property": ["instanceId", "space"]}}],
+        }
+        with (
+            monkeypatch_toolkit_client() as client,
+            MockQuestionary(DocumentsInteractiveSelect.__module__, monkeypatch, answers),
+        ):
+            client.tool.documents.unique.return_value = []
+            client.tool.documents.count.return_value = 5
+            client.tool.documents.list.return_value = docs
+
+            selector = DocumentsInteractiveSelect(client)
+            result = selector.select_documents()
+
+        assert client.tool.documents.count.call_args_list[0].kwargs.get("filter") is None
+        assert client.tool.documents.count.call_args_list[-1].kwargs.get("filter") == cognite_file_filter
+        client.tool.documents.list.assert_called_once_with(filter=cognite_file_filter, limit=100)
+        assert selector.status.is_cognite_file is True
+        assert result.documents == docs
+
+    def test_select_documents_is_cognite_file_reverts_when_zero(self, monkeypatch) -> None:
+        answers = ["is-cognite-file", "abort"]
+        with (
+            monkeypatch_toolkit_client() as client,
+            MockQuestionary(DocumentsInteractiveSelect.__module__, monkeypatch, answers),
+        ):
+            client.tool.documents.unique.return_value = []
+            client.tool.documents.count.side_effect = [3520, 0, 3520]
+
+            selector = DocumentsInteractiveSelect(client)
+            with pytest.raises(ToolkitValueError, match=r"Aborted document selection."):
+                selector.select_documents()
+
+        assert selector.status.is_cognite_file is False
+
     def test_select_documents_search_then_finished(self, monkeypatch) -> None:
         docs = self._sample_documents()
         answers = ["search", "turbine", "finished"]


### PR DESCRIPTION
# Description

Fixes several issues in interactive file download (`cdf data download files --include-file-contents`):

- Files with the same **Name** but different IDs overwrote each other on disk. Downloaded files are now prefixed with a unique identifier (external ID / internal ID for classic files, `space_externalId` for CogniteFiles).
- A typo in the document filter checkbox (`validator` → `validate`) let empty selections through and caused a 400 from the documents API.
- The "Is CogniteFile" menu option only flipped an internal routing flag instead of actually filtering in the documents API; selecting it could leave classic files in the selection and crash the download with `NotImplementedError`. It now applies a real `exists(instanceId.space)` filter. Additionally, it reverts with a warning if it matches zero documents, and the menu no longer offers "Finished" or to do further filtering when on an empty result set.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fixes a bug in `cdf data download files` where files with the same name would overwrite each other when downloaded.
- Fixes a bug in `cdf data download files` that would lead to a crash when confirming a document filter without selecting any values.
- Fixes an issue with the "Is CogniteFile" option in `cdf data download files` where the selected files would not actually be CogniteFiles but classic files instead.