### PR TITLE
Fix crash when migrating data sets with invalid space identifiers

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -203,7 +203,9 @@ class MigrateApp(typer.Typer):
                 ExternalId.from_external_ids(data_set), ignore_unknown_ids=True
             )
             if any(
-                dataset.external_id and warn_invalid_space_name(dataset.external_id) for dataset in selected_datasets
+                warn_invalid_space_name(dataset.external_id)
+                for dataset in selected_datasets
+                if dataset.external_id is not None
             ):
                 auto_fix = questionary.confirm(
                     "Some selected data sets have characters in their external IDs that are not valid in space identifiers. "

--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -78,6 +78,7 @@ from cognite_toolkit._cdf_tk.utils.interactive_select import (
     ThreeDInteractiveSelect,
     ViewSelectFilter,
 )
+from cognite_toolkit._cdf_tk.utils.text import warn_invalid_space_name
 from cognite_toolkit._cdf_tk.utils.useful_types import AssetCentricKind
 
 TODAY = date.today()
@@ -198,6 +199,17 @@ class MigrateApp(typer.Typer):
             # Interactive model
             selector = AssetInteractiveSelect(client, "migrate")
             data_set = selector.select_data_sets()
+            selected_datasets = client.tool.datasets.retrieve(
+                ExternalId.from_external_ids(data_set), ignore_unknown_ids=True
+            )
+            if any(
+                dataset.external_id and warn_invalid_space_name(dataset.external_id) for dataset in selected_datasets
+            ):
+                auto_fix = questionary.confirm(
+                    "Some selected data sets have characters in their external IDs that are not valid in space identifiers. "
+                    "Do you want to automatically fix this by replacing these invalid character / truncating the external ID? (Datasets with invalid characters will be skipped if No)",
+                    default=auto_fix,
+                ).unsafe_ask()
             dry_run = questionary.confirm("Do you want to perform a dry run?", default=dry_run).unsafe_ask()
             output_dir = Path(
                 questionary.path(

--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -207,7 +207,7 @@ class MigrateApp(typer.Typer):
             ):
                 auto_fix = questionary.confirm(
                     "Some selected data sets have characters in their external IDs that are not valid in space identifiers. "
-                    "Do you want to automatically fix this by replacing these invalid character / truncating the external ID? (Datasets with invalid characters will be skipped if No)",
+                    "Do you want to automatically fix this by replacing these invalid characters / truncating the external ID? (Datasets with invalid characters will be skipped if No)",
                     default=auto_fix,
                 ).unsafe_ask()
             dry_run = questionary.confirm("Do you want to perform a dry run?", default=dry_run).unsafe_ask()

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -115,7 +115,9 @@ class InstanceSpaceCreator(MigrationCreator):
         linage_nodes: list[NodeRequest] = []
         for dataset in self.datasets:
             data_set_external_id = cast(str, dataset.external_id)
-            space_id = space_id_by_dataset[data_set_external_id]
+            space_id = space_id_by_dataset.get(data_set_external_id)
+            if space_id is None:
+                continue
             space = SpaceRequest(
                 space=space_id,
                 name=dataset.name,
@@ -169,8 +171,9 @@ class InstanceSpaceCreator(MigrationCreator):
                 ).print_warning(console=self.client.console)
             elif warning_message:
                 HighSeverityWarning(
-                    f"{warning_message}\nRun command with `--auto-fix` to automatically make the data set external ID a valid space ID."
+                    f"{warning_message}\nSkipping dataset. Run command with `--auto-fix` to automatically make the data set external ID a valid space ID."
                 ).print_warning(console=self.client.console)
+                continue
 
             result[data_set_external_id] = space_id
             space_id_to_external_ids.setdefault(space_id, []).append(data_set_external_id)

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator.py
@@ -114,12 +114,12 @@ class TestCreator:
         creator = InstanceSpaceCreator(toolkit_client_approval.client, [invalid_dataset], auto_fix=auto_fix)
         created = list(creator.create_resources())
         assert len(created) == 1
-        created_space = created[0].resources[0].resource
-        assert isinstance(created_space, SpaceRequest)
         if auto_fix:
+            created_space = created[0].resources[0].resource
+            assert isinstance(created_space, SpaceRequest)
             assert created_space.space == "invaliddatasetnamewithspaces"
         else:
-            assert created_space.space == "invalid dataset name with spaces"
+            assert created[0].resources == []
 
     def test_create_instance_spaces_duplicate_space_ids(
         self, toolkit_client_approval: ApprovalToolkitClient, tmp_path: Path


### PR DESCRIPTION
# Description

`cdf migrate data-sets` uses data set external IDs to create resulting space IDs. When an external ID is not a valid space identifier (e.g. contained spaces) and `--auto-fix` is not set, the command previously warned but continued and then crashed on `spaces.retrieve()` with a 400 from CDF.

This change skips those data sets with a clear warning instead of failing, and additionally prompts interactively to enable `--auto-fix` when any selected data sets have invalid external IDs.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- [alpha] Fix `cdf migrate data-sets` crashing when a data set external ID is not a valid space identifier and `--auto-fix` is not used.