### PR TITLE
[CDF-28094] Improve cdf data download instances CLI interface for multiple instance spaces

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -865,8 +865,8 @@ class DownloadApp(typer.Typer):
                 "--instance-space",
                 "-s",
                 help="Instance space(s) to download instances from. Can be specified multiple times. "
-                "When used without --schema-space and --view, it downloads all instances in the given space(s) without any view properties. "
-                "Required when --schema-space and --view are also provided.",
+                "When used without --schema-space and --view, downloads all instances in the given space(s) without any properties from views. "
+                "When used with --schema-space and --view, limits the download to those spaces.",
             ),
         ] = None,
         schema_space: Annotated[
@@ -1021,17 +1021,15 @@ class DownloadApp(typer.Typer):
                 output_dir, file_format, InstanceFormats, compression, limit, "instances", "view"
             )
         elif schema_space is not None and view_external_ids is not None:
-            if not instance_spaces:
-                raise typer.BadParameter(
-                    "--instance-space is required when using --schema-space and --view.",
-                    param_hint="--instance-space",
+            selected_instance_spaces = tuple(instance_spaces) if instance_spaces else None
+            if selected_instance_spaces:
+                download_dir_name = (
+                    selected_instance_spaces[0]
+                    if len(selected_instance_spaces) == 1
+                    else sanitize_filename("_".join(selected_instance_spaces))
                 )
-            selected_instance_spaces = tuple(instance_spaces)
-            download_dir_name = (
-                selected_instance_spaces[0]
-                if len(selected_instance_spaces) == 1
-                else sanitize_filename("_".join(selected_instance_spaces))
-            )
+            else:
+                download_dir_name = sanitize_filename(schema_space)
             selectors = [
                 InstanceViewSelector(
                     view=SelectedView(

--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -39,6 +39,7 @@ from cognite_toolkit._cdf_tk.dataio.selectors import (
     DataSetSelector,
     FileMetadataFilesSelectorV2,
     InstanceSelector,
+    InstanceSpaceSelector,
     InstanceViewSelector,
     InternalWithNameId,
     NodeWithNameId,
@@ -863,8 +864,9 @@ class DownloadApp(typer.Typer):
             typer.Option(
                 "--instance-space",
                 "-s",
-                help="Instance space(s) to download instances from. Can be specified multiple times to download instances from multiple spaces. "
-                "If --schema-space and --view are not also provided, an interactive selection will be made.",
+                help="Instance space(s) to download instances from. Can be specified multiple times. "
+                "When used without --schema-space and --view, it downloads all instances in the given space(s) without any view properties. "
+                "Required when --schema-space and --view are also provided.",
             ),
         ] = None,
         schema_space: Annotated[
@@ -872,7 +874,7 @@ class DownloadApp(typer.Typer):
             typer.Option(
                 "--schema-space",
                 "-c",
-                help="The schema space where the views are located. Must be provided if --view is also provided.",
+                help="The schema space where the views are located. Required when --view is also provided.",
             ),
         ] = None,
         view_external_ids: Annotated[
@@ -881,7 +883,8 @@ class DownloadApp(typer.Typer):
                 "--view",
                 "-w",
                 help="View external ID(s) to read through when downloading properties for the "
-                "instances. Can be specified multiple times to download from multiple views. To specify version use a forward slash, e.g. viewExternalId/v1.",
+                "instances. Can be specified multiple times to download from multiple views. To specify version use a forward slash, e.g. viewExternalId/v1. "
+                "Required when --schema-space is also provided.",
             ),
         ] = None,
         instance_type: Annotated[
@@ -947,7 +950,16 @@ class DownloadApp(typer.Typer):
         cmd = DownloadCommand(client=client)
 
         selectors: list[InstanceSelector]
-        if schema_space is None and view_external_ids is None:
+        if instance_spaces and schema_space is None and view_external_ids is None:
+            selectors = [
+                InstanceSpaceSelector(
+                    instance_space=space,
+                    instance_type=instance_type.value,
+                    download_dir_name=space,
+                )
+                for space in instance_spaces
+            ]
+        elif schema_space is None and view_external_ids is None:
             selector = DataModelingSelect(client, "download instances")
             data_model = selector.select_data_model(
                 inline_views=True,
@@ -963,17 +975,13 @@ class DownloadApp(typer.Typer):
                     data_model=data_model.as_id(),
                 ),
             )
-            selected_instance_spaces: tuple[str, ...] | None
-            if instance_spaces:
-                selected_instance_spaces = tuple(instance_spaces)
-            else:
-                select_instance_space = questionary.confirm(
-                    "Do you want to select an instance space to download from? If no, all instances from the selected views will be downloaded.",
-                    default=False,
-                ).unsafe_ask()
-                selected_instance_spaces = None
-                if select_instance_space:
-                    selected_instance_spaces = tuple(selector.select_instance_space(multiselect=True))
+            select_instance_space = questionary.confirm(
+                "Do you want to select an instance space to download from? If no, all instances from the selected views will be downloaded.",
+                default=False,
+            ).unsafe_ask()
+            selected_instance_spaces: tuple[str, ...] | None = None
+            if select_instance_space:
+                selected_instance_spaces = tuple(selector.select_instance_space(multiselect=True))
             edge_type_ids_by_view_id: dict[ViewId, set[EdgeTypeId]] = {}
             if Flags.EXTEND_DOWNLOAD.EXTEND_DOWNLOAD.is_enabled():
                 include_edges = questionary.confirm(

--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -39,7 +39,6 @@ from cognite_toolkit._cdf_tk.dataio.selectors import (
     DataSetSelector,
     FileMetadataFilesSelectorV2,
     InstanceSelector,
-    InstanceSpaceSelector,
     InstanceViewSelector,
     InternalWithNameId,
     NodeWithNameId,
@@ -859,13 +858,13 @@ class DownloadApp(typer.Typer):
     def download_instances_cmd(
         cls,
         ctx: typer.Context,
-        instance_space: Annotated[
-            str | None,
+        instance_spaces: Annotated[
+            list[str] | None,
             typer.Option(
                 "--instance-space",
                 "-s",
-                help="The instance space to download instances from. If not provided, an interactive "
-                "selection will be made.",
+                help="Instance space(s) to download instances from. Can be specified multiple times to download instances from multiple spaces. "
+                "If --schema-space and --view are not also provided, an interactive selection will be made.",
             ),
         ] = None,
         schema_space: Annotated[
@@ -873,7 +872,7 @@ class DownloadApp(typer.Typer):
             typer.Option(
                 "--schema-space",
                 "-c",
-                help="The schema space where the views are located.",
+                help="The schema space where the views are located. Must be provided if --view is also provided.",
             ),
         ] = None,
         view_external_ids: Annotated[
@@ -881,8 +880,8 @@ class DownloadApp(typer.Typer):
             typer.Option(
                 "--view",
                 "-w",
-                help="List of view external IDs to download properties for the "
-                "instances. To specify version use a forward slash, e.g. viewExternalId/v1.",
+                help="View external ID(s) to read through when downloading properties for the "
+                "instances. Can be specified multiple times to download from multiple views. To specify version use a forward slash, e.g. viewExternalId/v1.",
             ),
         ] = None,
         instance_type: Annotated[
@@ -948,7 +947,7 @@ class DownloadApp(typer.Typer):
         cmd = DownloadCommand(client=client)
 
         selectors: list[InstanceSelector]
-        if instance_space is None:
+        if schema_space is None and view_external_ids is None:
             selector = DataModelingSelect(client, "download instances")
             data_model = selector.select_data_model(
                 inline_views=True,
@@ -964,13 +963,17 @@ class DownloadApp(typer.Typer):
                     data_model=data_model.as_id(),
                 ),
             )
-            select_instance_space = questionary.confirm(
-                "Do you want to select an instance space to download from? If no, all instances from the selected views will be downloaded.",
-                default=False,
-            ).unsafe_ask()
-            instance_spaces: tuple[str, ...] | None = None
-            if select_instance_space:
-                instance_spaces = tuple(selector.select_instance_space(multiselect=True))
+            selected_instance_spaces: tuple[str, ...] | None
+            if instance_spaces:
+                selected_instance_spaces = tuple(instance_spaces)
+            else:
+                select_instance_space = questionary.confirm(
+                    "Do you want to select an instance space to download from? If no, all instances from the selected views will be downloaded.",
+                    default=False,
+                ).unsafe_ask()
+                selected_instance_spaces = None
+                if select_instance_space:
+                    selected_instance_spaces = tuple(selector.select_instance_space(multiselect=True))
             edge_type_ids_by_view_id: dict[ViewId, set[EdgeTypeId]] = {}
             if Flags.EXTEND_DOWNLOAD.EXTEND_DOWNLOAD.is_enabled():
                 include_edges = questionary.confirm(
@@ -1000,7 +1003,7 @@ class DownloadApp(typer.Typer):
                             external_id=view.external_id,
                             version=view.version,
                         ),
-                        instance_spaces=instance_spaces,
+                        instance_spaces=selected_instance_spaces,
                         instance_type=view_instance_type,
                         download_dir_name=download_dir_name,
                         edge_types=tuple(edge_types) if edge_types else None,
@@ -1009,25 +1012,28 @@ class DownloadApp(typer.Typer):
             output_dir, file_format, compression, limit = cls._interactive_select_shared(  # type: ignore[assignment]
                 output_dir, file_format, InstanceFormats, compression, limit, "instances", "view"
             )
-        elif schema_space is None and view_external_ids is None:
-            selectors = [
-                InstanceSpaceSelector(
-                    instance_space=instance_space,
-                    instance_type=instance_type.value,
-                    download_dir_name=instance_space,
-                )
-            ]
         elif schema_space is not None and view_external_ids is not None:
+            if not instance_spaces:
+                raise typer.BadParameter(
+                    "--instance-space is required when using --schema-space and --view.",
+                    param_hint="--instance-space",
+                )
+            selected_instance_spaces = tuple(instance_spaces)
+            download_dir_name = (
+                selected_instance_spaces[0]
+                if len(selected_instance_spaces) == 1
+                else sanitize_filename("_".join(selected_instance_spaces))
+            )
             selectors = [
-                InstanceSpaceSelector(
-                    instance_space=instance_space,
+                InstanceViewSelector(
                     view=SelectedView(
                         space=schema_space,
                         external_id=view_id_str.split("/", maxsplit=1)[0],
                         version=view_id_str.split("/", maxsplit=1)[1] if "/" in view_id_str else None,
                     ),
+                    instance_spaces=selected_instance_spaces,
                     instance_type=instance_type.value,
-                    download_dir_name=instance_space,
+                    download_dir_name=download_dir_name,
                 )
                 for view_id_str in view_external_ids
             ]

--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -1022,14 +1022,7 @@ class DownloadApp(typer.Typer):
             )
         elif schema_space is not None and view_external_ids is not None:
             selected_instance_spaces = tuple(instance_spaces) if instance_spaces else None
-            if selected_instance_spaces:
-                download_dir_name = (
-                    selected_instance_spaces[0]
-                    if len(selected_instance_spaces) == 1
-                    else sanitize_filename("_".join(selected_instance_spaces))
-                )
-            else:
-                download_dir_name = sanitize_filename(schema_space)
+            download_dir_name = sanitize_filename(schema_space)
             selectors = [
                 InstanceViewSelector(
                     view=SelectedView(


### PR DESCRIPTION
# Description

`cdf data download instances` in non-interactive mode has some unnecessary strict ergonomics. With this change, `--instance-space` / `-s` can be specified multiple times, matching the `--view` parameter which already supported this, and reflecting how multiple instance spaces can be selected in interactive mode. This also enables the command to be run with _only_ `--view` and `--schema-space` defined, which now means all instance spaces will be included in the query. The current user-facing behavior is preserved as this would not work in a CI-environment (it would previously fall back to interactive mode in this case), and the `--instance-space` property itself still supports just providing a single space to the command.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Improved

- Allow specifying multiple `--instance-space` values in `cdf data download instances` to download instances from several spaces in one command.