### PR TITLE
feat(infield): updated config viewMappings name

### DIFF
--- a/cognite_toolkit/_cdf_tk/rules/_infield.py
+++ b/cognite_toolkit/_cdf_tk/rules/_infield.py
@@ -16,10 +16,10 @@ from cognite_toolkit._cdf_tk.yaml_classes.infield_cdm_location_config import (
 )
 
 _REQUIRED_PROPERTIES: dict[str, frozenset[str]] = {
-    "assetActivitiesCard": frozenset(
+    "assetActivitiesCardView": frozenset(
         {"sourceId", "name", "status", "type", "mainAsset", "scheduledEndTime", "scheduledStartTime"}
     ),
-    "assetNotificationsCard": frozenset(
+    "assetNotificationsCardView": frozenset(
         {"name", "sourceId", "type", "status", "description", "asset", "createdDate", "priority"}
     ),
 }

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
@@ -93,15 +93,15 @@ class ViewMappings(BaseModelResource):
 class DataExplorationConfig(BaseModelResource):
     """Data exploration configuration."""
 
-    asset_properties_card: ViewMapping | None = None
-    asset_activities_card: ViewMapping | None = None
-    asset_notifications_card: ViewMapping | None = None
+    asset_properties_card_view: ViewMapping | None = None
+    asset_activities_card_view: ViewMapping | None = None
+    asset_notifications_card_view: ViewMapping | None = None
 
 
 # Pydantic attribute name -> YAML/API key for card views used in build dependency and validation rules.
 INFIELD_CDM_CARD_VIEW_ATTR_TO_JSON_KEY: dict[str, str] = {
-    "asset_activities_card": "assetActivitiesCard",
-    "asset_notifications_card": "assetNotificationsCard",
+    "asset_activities_card_view": "assetActivitiesCardView",
+    "asset_notifications_card_view": "assetNotificationsCardView",
 }
 
 

--- a/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InFieldCDMLocationConfig.yaml
+++ b/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InFieldCDMLocationConfig.yaml
@@ -79,15 +79,15 @@ disciplines:
 - name: Civil
   externalId: discipline_civil
 dataExplorationConfig:
-  assetPropertiesCard:
+  assetPropertiesCardView:
     space: customer_idm_extention
-    version: v2
+    version: v3
     externalId: AssetPropertiesCard
-  assetActivitiesCard:
+  assetActivitiesCardView:
     space: customer_idm_extention
     version: v4
     externalId: InfieldActivitiesCardView
-  assetNotificationsCard:
+  assetNotificationsCardView:
     space: customer_idm_extention
     version: v2
     externalId: InfieldNotificationsCardView

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_fieldops.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_fieldops.py
@@ -83,12 +83,12 @@ class TestInFieldCDMLocationConfigCRUD:
                 "space": "sp_instance",
                 "externalId": "my_location_config",
                 "dataExplorationConfig": {
-                    "assetActivitiesCard": {
+                    "assetActivitiesCardView": {
                         "space": "customer_idm_extention",
                         "version": "v2",
                         "externalId": "ActivitiesCard",
                     },
-                    "assetNotificationsCard": {
+                    "assetNotificationsCardView": {
                         "space": "customer_idm_extention",
                         "version": "v2",
                         "externalId": "NotificationsCard",
@@ -120,7 +120,7 @@ class TestInFieldCDMLocationConfigCRUD:
                 "space": "sp_instance",
                 "externalId": "my_location_config",
                 "dataExplorationConfig": {
-                    "assetPropertiesCard": {
+                    "assetPropertiesCardView": {
                         "space": "customer_idm_extention",
                         "version": "v2",
                         "externalId": "PropertiesCard",
@@ -135,12 +135,12 @@ class TestInFieldCDMLocationConfigCRUD:
             "space": "sp_instance",
             "externalId": "my_location_config",
             "dataExplorationConfig": {
-                "assetActivitiesCard": {
+                "assetActivitiesCardView": {
                     "space": "customer_idm_extention",
                     "version": "v2",
                     "externalId": "ActivitiesCard",
                 },
-                "assetNotificationsCard": {
+                "assetNotificationsCardView": {
                     "space": "customer_idm_extention",
                     "version": "v2",
                     "externalId": "NotificationsCard",

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
@@ -99,15 +99,15 @@ def invalid_test_cases() -> Iterable:
             "externalId": "my_config",
             "space": "my_space",
             "dataExplorationConfig": {
-                "assetPropertiesCard": {
+                "assetPropertiesCardView": {
                     "space": "my_space",
                     "version": "v1",
                     # Missing externalId
                 },
             },
         },
-        {"In dataExplorationConfig.assetPropertiesCard missing required field: 'externalId'"},
-        id="Missing required field in dataExplorationConfig.assetPropertiesCard",
+        {"In dataExplorationConfig.assetPropertiesCardView missing required field: 'externalId'"},
+        id="Missing required field in dataExplorationConfig.assetPropertiesCardView",
     )
     yield pytest.param(
         {
@@ -139,7 +139,7 @@ def invalid_test_cases() -> Iterable:
             "externalId": "my_config",
             "space": "my_space",
             "dataExplorationConfig": {
-                "assetActivitiesCard": {
+                "assetActivitiesCardView": {
                     "space": "my_space",
                     "version": "v1",
                     "externalId": "MyActivityView",
@@ -147,29 +147,29 @@ def invalid_test_cases() -> Iterable:
                 },
             },
         },
-        {"In dataExplorationConfig.assetActivitiesCard unknown field: 'unknownNested'"},
-        id="Unknown field in dataExplorationConfig.assetActivitiesCard",
+        {"In dataExplorationConfig.assetActivitiesCardView unknown field: 'unknownNested'"},
+        id="Unknown field in dataExplorationConfig.assetActivitiesCardView",
     )
     yield pytest.param(
         {
             "externalId": "my_config",
             "space": "my_space",
             "dataExplorationConfig": {
-                "assetActivitiesCard": {
+                "assetActivitiesCardView": {
                     "space": "my_space",
                     "version": "v1",
                 },
             },
         },
-        {"In dataExplorationConfig.assetActivitiesCard missing required field: 'externalId'"},
-        id="Missing required field in dataExplorationConfig.assetActivitiesCard",
+        {"In dataExplorationConfig.assetActivitiesCardView missing required field: 'externalId'"},
+        id="Missing required field in dataExplorationConfig.assetActivitiesCardView",
     )
     yield pytest.param(
         {
             "externalId": "my_config",
             "space": "my_space",
             "dataExplorationConfig": {
-                "assetNotificationsCard": {
+                "assetNotificationsCardView": {
                     "space": "my_space",
                     "version": "v1",
                     "externalId": "MyNotificationView",
@@ -177,22 +177,22 @@ def invalid_test_cases() -> Iterable:
                 },
             },
         },
-        {"In dataExplorationConfig.assetNotificationsCard unknown field: 'extraProp'"},
-        id="Unknown field in dataExplorationConfig.assetNotificationsCard",
+        {"In dataExplorationConfig.assetNotificationsCardView unknown field: 'extraProp'"},
+        id="Unknown field in dataExplorationConfig.assetNotificationsCardView",
     )
     yield pytest.param(
         {
             "externalId": "my_config",
             "space": "my_space",
             "dataExplorationConfig": {
-                "assetNotificationsCard": {
+                "assetNotificationsCardView": {
                     "space": "my_space",
                     "version": "v1",
                 },
             },
         },
-        {"In dataExplorationConfig.assetNotificationsCard missing required field: 'externalId'"},
-        id="Missing required field in dataExplorationConfig.assetNotificationsCard",
+        {"In dataExplorationConfig.assetNotificationsCardView missing required field: 'externalId'"},
+        id="Missing required field in dataExplorationConfig.assetNotificationsCardView",
     )
 
 

--- a/tests/test_unit/test_cdf_tk/test_rules/test_infield.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_infield.py
@@ -36,12 +36,12 @@ def both_cards_config() -> dict:
         "space": "sp_instance",
         "externalId": "my_location_config",
         "dataExplorationConfig": {
-            "assetActivitiesCard": {
+            "assetActivitiesCardView": {
                 "space": "customer_idm",
                 "version": "v2",
                 "externalId": "ActivitiesCard",
             },
-            "assetNotificationsCard": {
+            "assetNotificationsCardView": {
                 "space": "customer_idm",
                 "version": "v2",
                 "externalId": "NotificationsCard",
@@ -125,8 +125,8 @@ class TestInFieldCDMViewPropertiesRuleSet:
         activities_id = ViewId(space="customer_idm", external_id="ActivitiesCard", version="v2")
         notifications_id = ViewId(space="customer_idm", external_id="NotificationsCard", version="v2")
         view_map = {
-            activities_id: mock_view(activities_id, _REQUIRED_PROPERTIES["assetActivitiesCard"]),
-            notifications_id: mock_view(notifications_id, _REQUIRED_PROPERTIES["assetNotificationsCard"]),
+            activities_id: mock_view(activities_id, _REQUIRED_PROPERTIES["assetActivitiesCardView"]),
+            notifications_id: mock_view(notifications_id, _REQUIRED_PROPERTIES["assetNotificationsCardView"]),
         }
 
         mock_client = MagicMock()
@@ -151,7 +151,7 @@ class TestInFieldCDMViewPropertiesRuleSet:
                 "space": "sp_instance",
                 "externalId": "my_location_config",
                 "dataExplorationConfig": {
-                    "assetActivitiesCard": {
+                    "assetActivitiesCardView": {
                         "space": "customer_idm",
                         "version": "v2",
                         "externalId": "ActivitiesCard",
@@ -162,7 +162,7 @@ class TestInFieldCDMViewPropertiesRuleSet:
         resource = create_built_resource(yaml_file, yaml_file)
         module = create_module(tmp_path, [resource])
         activities_id = ViewId(space="customer_idm", external_id="ActivitiesCard", version="v2")
-        activities_required = _REQUIRED_PROPERTIES["assetActivitiesCard"]
+        activities_required = _REQUIRED_PROPERTIES["assetActivitiesCardView"]
         mock_client = MagicMock()
         mock_client.tool.views.retrieve.return_value = [mock_view(activities_id, activities_required - {"mainAsset"})]
         rule = InFieldCDMViewPropertiesRuleSet(modules=[module], client=mock_client)
@@ -185,7 +185,7 @@ class TestInFieldCDMViewPropertiesRuleSet:
                 "space": "sp_instance",
                 "externalId": "my_location_config",
                 "dataExplorationConfig": {
-                    "assetActivitiesCard": {
+                    "assetActivitiesCardView": {
                         "space": "customer_idm",
                         "version": "v2",
                         "externalId": "ActivitiesCard",
@@ -223,8 +223,8 @@ class TestInFieldCDMViewPropertiesRuleSet:
         notifications_id = ViewId(space="customer_idm", external_id="NotificationsCard", version="v2")
         mock_client = MagicMock()
         mock_client.tool.views.retrieve.return_value = [
-            mock_view(activities_id, _REQUIRED_PROPERTIES["assetActivitiesCard"]),
-            mock_view(notifications_id, _REQUIRED_PROPERTIES["assetNotificationsCard"]),
+            mock_view(activities_id, _REQUIRED_PROPERTIES["assetActivitiesCardView"]),
+            mock_view(notifications_id, _REQUIRED_PROPERTIES["assetNotificationsCardView"]),
         ]
         rule = InFieldCDMViewPropertiesRuleSet(modules=[module], client=mock_client)
         list(rule.validate())

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags_v2.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags_v2.yaml
@@ -150,18 +150,18 @@ InFieldCDMLocationConfigResponse:
         - gp_infield_template_admins
         - gp_location_admins
       dataExplorationConfig:
-        assetActivitiesCard:
+        assetActivitiesCardView:
           externalId: InfieldActivitiesCardView
           space: customer_idm_extention
           version: v4
-        assetNotificationsCard:
+        assetNotificationsCardView:
           externalId: InfieldNotificationsCardView
           space: customer_idm_extention
           version: v2
-        assetPropertiesCard:
+        assetPropertiesCardView:
           externalId: AssetPropertiesCard
           space: customer_idm_extention
-          version: v2
+          version: v3
       dataFilters:
         assets:
           instanceSpaces:


### PR DESCRIPTION
# Description

Renames InField CDM dataExplorationConfig card view keys to match the DM:

- assetPropertiesCard → assetPropertiesCardView
- assetActivitiesCard → assetActivitiesCardView
- assetNotificationsCard → assetNotificationsCardView

<img width="568" height="454" alt="image" src="https://github.com/user-attachments/assets/f5ef5e29-39bd-465c-bb65-0f1686bda4ab" />


Tasks:

- https://cognitedata.atlassian.net/browse/FO-3688?atlOrigin=eyJpIjoiZjgwNDIzYTIzMTAwNDQzY2FjYjY5NjA3YzMwZWIzNzYiLCJwIjoiaiJ9

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Changed

- Renamed `dataExplorationConfig` card view keys to `assetPropertiesCardView`, `assetActivitiesCardView`, and `assetNotificationsCardView` (replacing `assetPropertiesCard`, `assetActivitiesCard`, and `assetNotificationsCard`).
