### PR TITLE
[prep CDF-27311] Add 3D DM migration feature-flag probe for hybrid projects.

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -45,6 +45,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.migration_io import (
     RecordsMigrationIO,
     ThreeDAssetMappingMigrationIO,
     ThreeDMigrationIO,
+    verify_threed_dm_migration_enabled,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import (
     AssetCentricMigrationSelector,
@@ -1295,7 +1296,7 @@ class MigrateApp(typer.Typer):
         id: Annotated[
             list[int] | None,
             typer.Argument(
-                help="The ID of the 3D Model to migrate. If not provided, an interactive selection will be "
+                help="The IDs of the 3D Models to migrate. If not provided, an interactive selection will be "
                 "performed to select the 3D Models to migrate."
             ),
         ] = None,
@@ -1332,6 +1333,7 @@ class MigrateApp(typer.Typer):
         is populated with the mapping from Asset-Centric resources to the new data modeling resources.
         """
         client = EnvironmentVariables.create_from_environment().get_client()
+        verify_threed_dm_migration_enabled(client)
         selected_ids: list[int]
         if id:
             selected_ids = id
@@ -1358,8 +1360,8 @@ class MigrateApp(typer.Typer):
         model_id: Annotated[
             list[int] | None,
             typer.Argument(
-                help="The IDs of the 3D model to migrate asset mappings for. If not provided, an interactive selection will be "
-                "performed to select the."
+                help="The IDs of the 3D models to migrate asset mappings for. If not provided, an interactive selection will be "
+                "performed to select the 3D models to migrate asset mappings for."
             ),
         ] = None,
         object_3D_space: Annotated[
@@ -1408,6 +1410,7 @@ class MigrateApp(typer.Typer):
         This command expects that the selected 3D model has already been migrated to data modeling.
         """
         client = EnvironmentVariables.create_from_environment().get_client()
+        verify_threed_dm_migration_enabled(client)
         selected_ids: list[int]
         if model_id is not None:
             selected_ids = model_id

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
@@ -3,9 +3,9 @@ from typing import ClassVar, Literal
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.http_client import (
+    FailedResponse,
     HTTPClient,
     RequestMessage,
-    ToolkitAPIError,
 )
 from cognite_toolkit._cdf_tk.client.http_client._item_classes import (
     ItemsFailedRequest,
@@ -43,7 +43,7 @@ from cognite_toolkit._cdf_tk.dataio.selectors import (
     ThreeDModelIdSelector,
     ThreeDSelector,
 )
-from cognite_toolkit._cdf_tk.exceptions import ToolkitNotImplementedError, ToolkitValueError
+from cognite_toolkit._cdf_tk.exceptions import ToolkitMigrationError, ToolkitNotImplementedError, ToolkitValueError
 from cognite_toolkit._cdf_tk.resource_ios._resource_ios.streams import StreamIO
 from cognite_toolkit._cdf_tk.tk_warnings import MediumSeverityWarning
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence, humanize_collection
@@ -546,6 +546,35 @@ class AnnotationMigrationIO(
         raise NotImplementedError("Serializing Annotation Migrations to JSON is not supported.")
 
 
+_THREED_DM_MIGRATION_PROBE_ENDPOINT = "/3d/migrate/models"
+_THREED_DM_MIGRATION_NOT_ENABLED_MESSAGE = "Migration endpoint not enabled"
+_THREED_DM_MIGRATION_FEATURE_FLAG_ERROR = (
+    "You need to have the 3D migration feature flag enabled on your CDF project to proceed with this "
+    "operation. Please contact your Cognite representative to get this enabled."
+)
+
+
+def verify_threed_dm_migration_enabled(client: ToolkitClient) -> None:
+    """Probe /3d/migrate/models to check the THREED_Enable_DM_Migration toggle on hybrid projects."""
+    if client.project.status().this_project.data_modeling_status == "DATA_MODELING_ONLY":
+        return
+
+    with HTTPClient(config=client.config) as http_client:
+        response = http_client.request_single_retries(
+            RequestMessage(
+                endpoint_url=client.config.create_api_url(_THREED_DM_MIGRATION_PROBE_ENDPOINT),
+                method="POST",
+                body_content={"items": []},
+            )
+        )
+    if (
+        isinstance(response, FailedResponse)
+        and response.status_code == 400
+        and response.error.message == _THREED_DM_MIGRATION_NOT_ENABLED_MESSAGE
+    ):
+        raise ToolkitMigrationError(_THREED_DM_MIGRATION_FEATURE_FLAG_ERROR)
+
+
 class ThreeDMigrationIO(UploadableDataIO[ThreeDSelector, ThreeDModelClassicResponse, ThreeDMigrationRequest]):
     """IO class for downloading and migrating 3D models.
 
@@ -638,11 +667,6 @@ class ThreeDMigrationIO(UploadableDataIO[ThreeDSelector, ThreeDModelClassicRespo
                 items=data_chunk.items,
             )
         )
-        if (
-            failed_response := next((res for res in responses if isinstance(res, ItemsFailedResponse)), None)
-        ) and failed_response.status_code == 400:
-            raise ToolkitAPIError("3D model migration failed. You need to enable the 3D migration alpha feature flag.")
-
         results.extend(responses)
         success_ids = {id for res in responses if isinstance(res, ItemsSuccessResponse) for id in res.ids}
         for data in data_chunk.items:

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
@@ -546,23 +546,19 @@ class AnnotationMigrationIO(
         raise NotImplementedError("Serializing Annotation Migrations to JSON is not supported.")
 
 
-_THREED_DM_MIGRATION_PROBE_ENDPOINT = "/3d/migrate/models"
-_THREED_DM_MIGRATION_NOT_ENABLED_MESSAGE = "Migration endpoint not enabled"
-_THREED_DM_MIGRATION_FEATURE_FLAG_ERROR = (
-    "You need to have the 3D migration feature flag enabled on your CDF project to proceed with this "
-    "operation. Please contact your Cognite representative to get this enabled."
-)
-
-
 def verify_threed_dm_migration_enabled(client: ToolkitClient) -> None:
-    """Probe /3d/migrate/models to check the THREED_Enable_DM_Migration toggle on hybrid projects."""
+    """
+    Probe /3d/migrate/models to check if the 3D DM migration feature flag is
+    enabled on hybrid projects. If the flag is not enabled, this API will always
+    return a 400 error with the message "Migration endpoint not enabled".
+    """
     if client.project.status().this_project.data_modeling_status == "DATA_MODELING_ONLY":
         return
 
     with HTTPClient(config=client.config) as http_client:
         response = http_client.request_single_retries(
             RequestMessage(
-                endpoint_url=client.config.create_api_url(_THREED_DM_MIGRATION_PROBE_ENDPOINT),
+                endpoint_url=client.config.create_api_url("/3d/migrate/models"),
                 method="POST",
                 body_content={"items": []},
             )
@@ -570,9 +566,12 @@ def verify_threed_dm_migration_enabled(client: ToolkitClient) -> None:
     if (
         isinstance(response, FailedResponse)
         and response.status_code == 400
-        and response.error.message == _THREED_DM_MIGRATION_NOT_ENABLED_MESSAGE
+        and response.error.message == "Migration endpoint not enabled"
     ):
-        raise ToolkitMigrationError(_THREED_DM_MIGRATION_FEATURE_FLAG_ERROR)
+        raise ToolkitMigrationError(
+            "You need to have the 3D migration feature flag enabled on your CDF project to proceed with this "
+            "operation. Please contact your Cognite representative to get this enabled."
+        )
 
 
 class ThreeDMigrationIO(UploadableDataIO[ThreeDSelector, ThreeDModelClassicResponse, ThreeDMigrationRequest]):

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
@@ -552,9 +552,6 @@ def verify_threed_dm_migration_enabled(client: ToolkitClient) -> None:
     enabled on hybrid projects. If the flag is not enabled, this API will always
     return a 400 error with the message "Migration endpoint not enabled".
     """
-    if client.project.status().this_project.data_modeling_status == "DATA_MODELING_ONLY":
-        return
-
     with HTTPClient(config=client.config) as http_client:
         response = http_client.request_single_retries(
             RequestMessage(


### PR DESCRIPTION
# Description

Replace the in-flight HTTP 400 check during 3D model upload with a pre-flight probe towards `/3d/migrate/models` with an empty items payload. This ensures that users get a clear error upfront when the relevant feature flag in Fusion is disabled. The probe runs at the start of `cdf migrate 3d` and `cdf migrate 3d-mappings` and will be extended to be used for the upcoming `cdf migrate 360-images` and `cdf migrate 360-image-annotations`.
## Bump

- [ ] Patch
- [x] Skip