### PR TITLE
[CDF-28123] fix(build): update dml field in built YAML to renamed graphql filename

### DIFF
--- a/cognite_toolkit/_cdf_tk/builders/_datamodels.py
+++ b/cognite_toolkit/_cdf_tk/builders/_datamodels.py
@@ -75,8 +75,11 @@ class DataModelBuilder(Builder):
             expected_path = source_file.source.path.parent / Path(expected_filename)
 
             if expected_path in graphql_files:
-                shutil.copy(graphql_files[expected_path].source.path, destination_path.with_suffix(".graphql"))
+                dest_graphql = destination_path.with_suffix(".graphql")
+                shutil.copy(graphql_files[expected_path].source.path, dest_graphql)
                 extra_sources.append(graphql_files[expected_path].source)
+                # The build renames the .graphql file; update dml so deploy can locate it.
+                entry["dml"] = dest_graphql.name
             else:
                 raise ToolkitFileNotFoundError(
                     f"Failed to find GraphQL file. Expected {expected_filename} adjacent to {source_file.source.path.as_posix()}"

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -724,6 +724,13 @@ class BuildV2Command(ToolkitCommand):
                 filestem = f"{index}-{source_stem}-{identifier_filename}"
                 filename = f"{filestem}.{file.resource_type.kind}.yaml"
                 destination_path = folder / filename
+                # The build renames extra files (e.g. .graphql) with a long prefix; update
+                # the dml field so deploy can locate the renamed file instead of the original.
+                if (
+                    any(isinstance(ef, SuccessExtra) and ef.suffix == ".graphql" for ef in resource.extra_files)
+                    and "dml" in resource.raw
+                ):
+                    resource.raw["dml"] = f"{filestem}.graphql"
                 safe_write(destination_path, yaml_safe_dump(resource.raw), encoding=BUILD_FOLDER_ENCODING)
                 for extra_file in resource.extra_files:
                     if not isinstance(extra_file, SuccessExtra):

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_data_model.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_data_model.py
@@ -625,3 +625,49 @@ class TestGraphQLCRUDGetDependencies:
         deps = list(GraphQLCRUD.get_dependencies(graphql_model))
         assert len(deps) == 1
         assert deps[0] == (SpaceCRUD, SpaceId(space="my_space"))
+
+
+class TestDataModelBuilder:
+    """Regression tests for DataModelBuilder (build v1)."""
+
+    def test_dml_updated_to_renamed_graphql_in_build(self, tmp_path: Path) -> None:
+        # Regression test: build renames .graphql files with a long prefix, but deploy
+        # looks up the file via entry["dml"].  _copy_graphql_to_build must update "dml"
+        # so that deploy finds the renamed file instead of the original source name.
+        from cognite_toolkit._cdf_tk.builders._datamodels import DataModelBuilder
+        from cognite_toolkit._cdf_tk.data_classes._build_files import BuildSourceFile
+        from cognite_toolkit._cdf_tk.data_classes._built_resources import SourceLocationEager
+
+        source_dir = tmp_path / "source" / "data_modeling"
+        source_dir.mkdir(parents=True)
+        build_dir = tmp_path / "build"
+        build_dir.mkdir()
+
+        yaml_path = source_dir / "my_model.GraphQLSchema.yaml"
+        graphql_path = source_dir / "original_schema.graphql"
+        yaml_path.write_text("space: my_space\nexternalId: MyModel\nversion: v1\ndml: original_schema.graphql\n")
+        graphql_path.write_text("type Foo { name: String }")
+
+        entry: dict = {"space": "my_space", "externalId": "MyModel", "version": "v1", "dml": "original_schema.graphql"}
+        source_file = BuildSourceFile(
+            source=SourceLocationEager(path=yaml_path, _hash="abc"),
+            content=yaml_path.read_text(),
+            loaded=entry,
+        )
+        graphql_source = BuildSourceFile(
+            source=SourceLocationEager(path=graphql_path, _hash="def"),
+            content=graphql_path.read_text(),
+            loaded=None,
+        )
+
+        builder = DataModelBuilder(build_dir=build_dir)
+        destination_path = build_dir / "data_modeling" / "1-my_model-SPP-COR.my_model.GraphQLSchema.yaml"
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+
+        builder._copy_graphql_to_build(source_file, destination_path, {graphql_path: graphql_source})
+
+        # The "dml" field in the entry dict must be updated to the renamed build filename.
+        renamed_graphql = destination_path.with_suffix(".graphql").name
+        assert entry["dml"] == renamed_graphql, (
+            f"entry['dml'] was not updated after build rename: got {entry['dml']!r}, expected {renamed_graphql!r}"
+        )


### PR DESCRIPTION
# Description

During `cdf build`, `.graphql` files are renamed with a long index/identifier
prefix (e.g. `SPPDOM_2_7_0_data_model.graphql` →
`1-SPPDOM_2_7_0_data_model-SPP-COR-ALL-DMD.SPPDOM.2_7_0.graphql`), but the
`dml` field in the built YAML was not updated to reflect the rename. At deploy
time, `GraphQLCRUD._get_graphql_file` used the stale value and raised
`ToolkitFileNotFoundError`.

Fixed in both build v1 (`DataModelBuilder._copy_graphql_to_build`) and build v2
(`BuildV2Command._export_resources`), mirroring the existing pattern used for
transformation `queryFile`.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- `cdf build` + `cdf deploy` for GraphQL data models: the `dml` field in the
  built YAML is now updated to the renamed `.graphql` filename, preventing a
  `ToolkitFileNotFoundError` on deploy.