### PR TITLE
Add agent subagents validation and sync LLM models with cog-ai

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/agent.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/agent.py
@@ -222,6 +222,10 @@ AgentTool = Annotated[
 ]
 
 
+class SubagentConfig(AgentObject):
+    agent_external_id: str = Field(min_length=1, max_length=255)
+
+
 class Agent(AgentObject):
     external_id: str
     name: str
@@ -229,6 +233,7 @@ class Agent(AgentObject):
     instructions: str | None = None
     model: str | None = None
     tools: list[AgentTool] | None = None
+    subagents: list[SubagentConfig] | None = None
     labels: list[str] | None = None
 
     def as_id(self) -> ExternalId:

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/agent.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/agent.py
@@ -101,7 +101,7 @@ class AgentIO(ResourceIO[ExternalId, AgentRequest, AgentResponse]):
 
     @classmethod
     def get_dependent_items(cls, item: dict) -> Iterable[tuple[type[ResourceIO], Hashable]]:
-        for subagent in item.get("subagents", []):
+        for subagent in item.get("subagents") or []:
             if isinstance(subagent, dict) and (agent_external_id := subagent.get("agentExternalId")):
                 yield AgentIO, ExternalId(external_id=agent_external_id)
         for tool in item.get("tools", []):

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/agent.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/agent.py
@@ -101,6 +101,9 @@ class AgentIO(ResourceIO[ExternalId, AgentRequest, AgentResponse]):
 
     @classmethod
     def get_dependent_items(cls, item: dict) -> Iterable[tuple[type[ResourceIO], Hashable]]:
+        for subagent in item.get("subagents", []):
+            if isinstance(subagent, dict) and (agent_external_id := subagent.get("agentExternalId")):
+                yield AgentIO, ExternalId(external_id=agent_external_id)
         for tool in item.get("tools", []):
             if tool.get("type") == "callFunction":
                 if ext_id := tool.get("configuration", {}).get("externalId"):
@@ -114,6 +117,8 @@ class AgentIO(ResourceIO[ExternalId, AgentRequest, AgentResponse]):
 
     @classmethod
     def get_dependencies(cls, resource: AgentYAML) -> Iterable[tuple[type[ResourceIO], Identifier]]:
+        for subagent in resource.subagents or []:
+            yield AgentIO, ExternalId(external_id=subagent.agent_external_id)
         for tool in resource.tools or []:
             match tool:
                 case CallFunction():
@@ -191,5 +196,11 @@ class AgentIO(ResourceIO[ExternalId, AgentRequest, AgentResponse]):
         elif json_path == ("exampleQuestions",):
             return diff_list_identifiable(
                 local, cdf, get_identifier=lambda q: q.get("question", "") if isinstance(q, dict) else str(q)
+            )
+        elif json_path == ("subagents",):
+            return diff_list_identifiable(
+                local,
+                cdf,
+                get_identifier=lambda ref: ref.get("agentExternalId", "") if isinstance(ref, dict) else "",
             )
         return super().diff_list(local, cdf, json_path)

--- a/cognite_toolkit/_cdf_tk/yaml_classes/agent.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/agent.py
@@ -342,6 +342,7 @@ class AgentYAML(ToolkitResource):
         None,
         description="List of agents to expose as subagents on this agent.",
         max_length=MAX_SUB_AGENTS_PER_AGENT,
+    )
     skills: list[str] | None = Field(
         None,
         description="A list of skill external IDs available to the agent.",

--- a/cognite_toolkit/_cdf_tk/yaml_classes/agent.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/agent.py
@@ -1,11 +1,20 @@
+import sys
 from typing import Annotated, Any, Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator, model_validator
 
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.constants import DM_EXTERNAL_ID_PATTERN, DM_VERSION_PATTERN, SPACE_FORMAT_PATTERN
 
 from .base import BaseModelResource, ToolkitResource
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+MAX_SUB_AGENTS_PER_AGENT = 20
+RUNTIME_VERSIONS_SUPPORTING_SUBAGENTS = frozenset({"1.3.0", "1.4.0"})
 
 
 class AgentToolModelResource(BaseModelResource, extra="allow"): ...
@@ -226,9 +235,39 @@ AgentTool = Annotated[
 # --- Agent YAML resource ---
 
 
+class SubagentConfig(BaseModelResource):
+    agent_external_id: str = Field(
+        description="External ID of the agent to use as a subagent.",
+        min_length=1,
+        max_length=255,
+    )
+
+
 Model = Literal[
+    # Legacy model names without the azure/model naming convention
+    "gpt-35-turbo",
+    "gpt-35-turbo-16k",
+    "gpt-4",
+    "gpt-4-turbo",
+    "gpt-4-32k",
+    "gpt-4-vision",
+    "gpt-4o-2024-05-13",
+    "gpt-4o-2024-08-06",
+    "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "bedrock/anthropic.claude-3-haiku-20240307-v1:0",
+    "gpt-4o-mini",
+    "gemini-1.5-pro",
+    # Azure models
+    "azure/o1",
+    "azure/o3-mini",
     "azure/o3",
     "azure/o4-mini",
+    "azure/gpt-3.5-turbo",
+    "azure/gpt-3.5-turbo-16k",
+    "azure/gpt-4",
+    "azure/gpt-4-turbo",
+    "azure/gpt-4-32k",
+    "azure/gpt-4-vision",
     "azure/gpt-4o",
     "azure/gpt-4o-mini",
     "azure/gpt-4.1",
@@ -238,14 +277,34 @@ Model = Literal[
     "azure/gpt-5-mini",
     "azure/gpt-5-nano",
     "azure/gpt-5.1",
+    "azure/gpt-5.2",
+    "azure/gpt-5.4",
+    "azure/gpt-5.4-mini",
+    "azure/gpt-5.4-nano",
+    "azure/gpt-5.5",
+    # GCP models
+    "gcp/claude-4-sonnet",
     "gcp/claude-4.5-sonnet",
     "gcp/claude-4.5-haiku",
+    "gcp/claude-4-opus",
+    "gcp/gemini-1.5-pro",
+    "gcp/gemini-1.5-flash",
+    "gcp/gemini-2.0-flash",
     "gcp/gemini-2.5-pro",
     "gcp/gemini-2.5-flash",
+    "gcp/gemini-2.5-flash-lite",
+    "gcp/gemini-3-pro-preview",
+    "gcp/gemini-3.1-pro-preview",
+    # AWS models
+    "aws/claude-4.6-sonnet",
+    "aws/claude-4.7-opus",
     "aws/claude-4.5-sonnet",
     "aws/claude-4.5-haiku",
     "aws/claude-4-sonnet",
+    "aws/claude-4-opus",
+    "aws/claude-4.1-opus",
     "aws/claude-3.5-sonnet",
+    "aws/claude-3-haiku",
 ]
 
 
@@ -279,8 +338,48 @@ class AgentYAML(ToolkitResource):
         "azure/gpt-4o-mini", description="The name of the model to use. Defaults to your CDF project's default model."
     )
     tools: list[AgentTool] | None = Field(None, description="A list of tools available to the agent.", max_length=20)
+    subagents: list[SubagentConfig] | None = Field(
+        None,
+        description="List of agents to expose as subagents on this agent.",
+        max_length=MAX_SUB_AGENTS_PER_AGENT,
+    )
     labels: list[str] | None = Field(None, description="Labels for the agent, e.g. 'published'.")
     runtime_version: str | None = Field(None, description="The runtime version")
+
+    @field_validator("subagents")
+    @classmethod
+    def validate_subagents_unique(cls, subagents: list[SubagentConfig] | None) -> list[SubagentConfig] | None:
+        if not subagents:
+            return subagents
+        seen: set[str] = set()
+        duplicates: list[str] = []
+        for ref in subagents:
+            if ref.agent_external_id in seen:
+                duplicates.append(ref.agent_external_id)
+            seen.add(ref.agent_external_id)
+        if duplicates:
+            raise ValueError(
+                f"Duplicate subagent agentExternalId(s): {sorted(set(duplicates))}. "
+                "Each entry must reference a distinct agent."
+            )
+        return subagents
+
+    @model_validator(mode="after")
+    def validate_subagents_configuration(self) -> Self:
+        if not self.subagents:
+            return self
+        if any(ref.agent_external_id == self.external_id for ref in self.subagents):
+            raise ValueError("An agent cannot reference itself as a subagent.")
+        if self.runtime_version and self.runtime_version not in RUNTIME_VERSIONS_SUPPORTING_SUBAGENTS:
+            raise ValueError(
+                f"Runtime version '{self.runtime_version}' does not support subagents. "
+                "Use a runtime version where supports_subagents is enabled, or remove the 'subagents' field."
+            )
+        if self.tools and any(tool.name == "delegate_to_subagent" for tool in self.tools):
+            raise ValueError(
+                "Tool name 'delegate_to_subagent' is reserved for the system sub-agent delegate tool. Rename the tool."
+            )
+        return self
 
     def as_id(self) -> ExternalId:
         return ExternalId(external_id=self.external_id)

--- a/tests/test_unit/test_cdf_tk/test_client/test_api_data_classes.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_api_data_classes.py
@@ -190,6 +190,19 @@ class TestRequestUpdateable:
 
 
 class TestAgentRequest:
+    def test_subagents_roundtrip(self) -> None:
+        data = {
+            "externalId": "supervisor",
+            "name": "Supervisor",
+            "runtimeVersion": "1.3.0",
+            "subagents": [
+                {"agentExternalId": "weather-specialist"},
+                {"agentExternalId": "rca-specialist"},
+            ],
+        }
+        agent_request = AgentRequest.model_validate(data)
+        assert agent_request.dump() == data
+
     def test_allow_unknown_tool(self) -> None:
         data = {
             "externalId": "agent_1",

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_agent.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_agent.py
@@ -87,6 +87,7 @@ class TestAgentIODependencies:
             (AgentIO, ExternalId(external_id="weather-specialist")),
             (AgentIO, ExternalId(external_id="rca-specialist")),
         ]
+
     def test_skill_is_in_class_dependencies(self) -> None:
         if FeatureFlag.is_enabled(Flags.AGENT_SKILLS):
             assert SkillIO in AgentIO.dependencies

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_agent.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_agent.py
@@ -34,6 +34,30 @@ class TestAgentIODumpResource:
 
         assert dumped == local
 
+    def test_dump_resource_ignores_empty_subagents_when_omitted_locally(self) -> None:
+        client = ToolkitClientMock()
+        io = AgentIO(client, None, None)
+        local = {
+            "externalId": "my_agent",
+            "name": "My Agent",
+            "runtimeVersion": "1.3.0",
+        }
+        resource = AgentResponse.model_validate(
+            {
+                "externalId": "my_agent",
+                "name": "My Agent",
+                "createdTime": 0,
+                "lastUpdatedTime": 0,
+                "ownerId": "owner",
+                "runtimeVersion": "1.3.0",
+                "subagents": [],
+            }
+        )
+
+        dumped = io.dump_resource(resource, local)
+
+        assert dumped == local
+
 
 class TestAgentIODependencies:
     def test_datamodel_is_in_class_dependencies(self) -> None:
@@ -192,6 +216,20 @@ class TestAgentIODependencies:
                 {"externalId": "my_agent", "tools": []},
                 [],
                 id="agent with no tools yields no dependencies",
+            ),
+            pytest.param(
+                {
+                    "externalId": "supervisor",
+                    "subagents": [
+                        {"agentExternalId": "weather-specialist"},
+                        {"agentExternalId": "rca-specialist"},
+                    ],
+                },
+                [
+                    (AgentIO, ExternalId(external_id="weather-specialist")),
+                    (AgentIO, ExternalId(external_id="rca-specialist")),
+                ],
+                id="subagents yield AgentIO dependencies",
             ),
             pytest.param(
                 {

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_agent.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_agent.py
@@ -7,6 +7,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.agent import AgentResponse
 from cognite_toolkit._cdf_tk.client.testing import ToolkitClientMock
 from cognite_toolkit._cdf_tk.resource_ios import DataModelIO, FunctionIO, ResourceIO
 from cognite_toolkit._cdf_tk.resource_ios._resource_ios.agent import AgentIO
+from cognite_toolkit._cdf_tk.yaml_classes import AgentYAML
 
 
 class TestAgentIODumpResource:
@@ -65,6 +66,26 @@ class TestAgentIODependencies:
 
     def test_function_is_in_class_dependencies(self) -> None:
         assert FunctionIO in AgentIO.dependencies
+
+    def test_get_dependencies_yields_subagent_references(self) -> None:
+        resource = AgentYAML.model_validate(
+            {
+                "externalId": "supervisor",
+                "name": "Supervisor",
+                "runtimeVersion": "1.3.0",
+                "subagents": [
+                    {"agentExternalId": "weather-specialist"},
+                    {"agentExternalId": "rca-specialist"},
+                ],
+            }
+        )
+
+        actual = list(AgentIO.get_dependencies(resource))
+
+        assert actual == [
+            (AgentIO, ExternalId(external_id="weather-specialist")),
+            (AgentIO, ExternalId(external_id="rca-specialist")),
+        ]
 
     @pytest.mark.parametrize(
         "item, expected",
@@ -245,3 +266,44 @@ class TestAgentIODependencies:
         actual = list(AgentIO.get_dependent_items(item))
 
         assert actual == expected
+
+
+class TestAgentIODiffList:
+    def test_diff_list_subagents_matches_by_agent_external_id(self) -> None:
+        io = AgentIO(ToolkitClientMock(), None, None)
+        local = [
+            {"agentExternalId": "weather-specialist"},
+            {"agentExternalId": "rca-specialist"},
+        ]
+        cdf = [
+            {"agentExternalId": "weather-specialist"},
+            {"agentExternalId": "rca-specialist"},
+        ]
+
+        local_by_cdf, added = io.diff_list(local, cdf, ("subagents",))
+
+        assert local_by_cdf == {0: 0, 1: 1}
+        assert added == []
+
+    def test_diff_list_subagents_reports_cdf_only_subagents(self) -> None:
+        io = AgentIO(ToolkitClientMock(), None, None)
+        local = [{"agentExternalId": "weather-specialist"}]
+        cdf = [
+            {"agentExternalId": "weather-specialist"},
+            {"agentExternalId": "rca-specialist"},
+        ]
+
+        local_by_cdf, added = io.diff_list(local, cdf, ("subagents",))
+
+        assert local_by_cdf == {0: 0}
+        assert added == [1]
+
+    def test_diff_list_subagents_reports_no_match_when_external_ids_differ(self) -> None:
+        io = AgentIO(ToolkitClientMock(), None, None)
+        local = [{"agentExternalId": "weather-specialist"}]
+        cdf = [{"agentExternalId": "rca-specialist"}]
+
+        local_by_cdf, added = io.diff_list(local, cdf, ("subagents",))
+
+        assert local_by_cdf == {}
+        assert added == [0]

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_agents.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_agents.py
@@ -7,18 +7,27 @@ import pytest
 from cognite_toolkit._cdf_tk.constants import MODULES
 from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
 from cognite_toolkit._cdf_tk.utils import humanize_collection
-from cognite_toolkit._cdf_tk.utils._auxiliary import get_concrete_subclasses
+from cognite_toolkit._cdf_tk.utils._auxiliary import get_concrete_subclasses, literal_string_values_from_annotation
 from cognite_toolkit._cdf_tk.validation import validate_resource_yaml_pydantic
 from cognite_toolkit._cdf_tk.yaml_classes.agent import (
     KNOWN_TOOLS,
+    MAX_SUB_AGENTS_PER_AGENT,
     AgentInstanceSpaces,
     AgentInstanceSpacesDefinition,
     AgentTool,
     AgentToolDefinition,
     AgentYAML,
+    Model,
 )
 from tests.data import COMPLETE_ORG_ALPHA_FLAGS
 from tests.test_unit.utils import find_resources
+
+
+def _model_literal_error_message(invalid_value: object) -> str:
+    models = literal_string_values_from_annotation(Model)
+    quoted = ", ".join(f"'{model}'" for model in models[:-1])
+    options = f"{quoted} or '{models[-1]}'" if len(models) > 1 else f"'{models[0]}'"
+    return f"In field model input should be {options}. Got {invalid_value!r}."
 
 
 def invalid_test_cases() -> Iterable:
@@ -40,13 +49,7 @@ def invalid_test_cases() -> Iterable:
         {
             "In field description string should have at most 1024 characters",
             "In field externalId string should have at least 1 character",
-            "In field model input should be 'azure/o3', 'azure/o4-mini', 'azure/gpt-4o', "
-            "'azure/gpt-4o-mini', 'azure/gpt-4.1', 'azure/gpt-4.1-nano', "
-            "'azure/gpt-4.1-mini', 'azure/gpt-5', 'azure/gpt-5-mini', 'azure/gpt-5-nano', "
-            "'azure/gpt-5.1', 'gcp/claude-4.5-sonnet', 'gcp/claude-4.5-haiku', "
-            "'gcp/gemini-2.5-pro', 'gcp/gemini-2.5-flash', 'aws/claude-4.5-sonnet', "
-            "'aws/claude-4.5-haiku', 'aws/claude-4-sonnet' or 'aws/claude-3.5-sonnet'. Got "
-            "'invalid-model'.",
+            _model_literal_error_message("invalid-model"),
             "In field name string should have at least 1 character",
             "In field tools list should have at most 20 items after validation, not 21",
         },
@@ -149,13 +152,7 @@ def invalid_test_cases() -> Iterable:
             "Hint: Use double quotes to force string.",
             "In field instructions input should be a valid string. Got [] of type list. "
             "Hint: Use double quotes to force string.",
-            "In field model input should be 'azure/o3', 'azure/o4-mini', 'azure/gpt-4o', "
-            "'azure/gpt-4o-mini', 'azure/gpt-4.1', 'azure/gpt-4.1-nano', "
-            "'azure/gpt-4.1-mini', 'azure/gpt-5', 'azure/gpt-5-mini', 'azure/gpt-5-nano', "
-            "'azure/gpt-5.1', 'gcp/claude-4.5-sonnet', 'gcp/claude-4.5-haiku', "
-            "'gcp/gemini-2.5-pro', 'gcp/gemini-2.5-flash', 'aws/claude-4.5-sonnet', "
-            "'aws/claude-4.5-haiku', 'aws/claude-4-sonnet' or 'aws/claude-3.5-sonnet'. Got "
-            "True.",
+            _model_literal_error_message(True),
             "In field name input should be a valid string. Got None of type NoneType. "
             "Hint: Use double quotes to force string.",
             "In field tools input should be a valid list. Got 'not_a_list'.",
@@ -299,3 +296,104 @@ class TestAgentYAML:
         data = {"externalId": "my_agent", "name": "My Agent", "tools": [tool]}
         loaded = AgentYAML.model_validate(data)
         assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    def test_subagents_roundtrip(self) -> None:
+        data = {
+            "externalId": "supervisor",
+            "name": "Supervisor",
+            "runtimeVersion": "1.3.0",
+            "subagents": [
+                {"agentExternalId": "weather-specialist"},
+                {"agentExternalId": "rca-specialist"},
+            ],
+        }
+        loaded = AgentYAML.model_validate(data)
+        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    @pytest.mark.parametrize(
+        "data, expected_error",
+        [
+            pytest.param(
+                {
+                    "externalId": "supervisor",
+                    "name": "Supervisor",
+                    "runtimeVersion": "1.3.0",
+                    "subagents": [
+                        {"agentExternalId": "weather-specialist"},
+                        {"agentExternalId": "weather-specialist"},
+                    ],
+                },
+                "duplicate subagent agentExternalId(s): ['weather-specialist']. Each entry must reference a distinct agent.",
+                id="duplicate-subagents",
+            ),
+            pytest.param(
+                {
+                    "externalId": "supervisor",
+                    "name": "Supervisor",
+                    "runtimeVersion": "1.3.0",
+                    "subagents": [{"agentExternalId": ""}],
+                },
+                "In subagents[1].agentExternalId string should have at least 1 character",
+                id="empty-subagent-external-id",
+            ),
+            pytest.param(
+                {
+                    "externalId": "supervisor",
+                    "name": "Supervisor",
+                    "runtimeVersion": "1.0.0",
+                    "subagents": [{"agentExternalId": "weather-specialist"}],
+                },
+                "Runtime version '1.0.0' does not support subagents. "
+                "Use a runtime version where supports_subagents is enabled, or remove the 'subagents' field.",
+                id="unsupported-runtime-version",
+            ),
+            pytest.param(
+                {
+                    "externalId": "supervisor",
+                    "name": "Supervisor",
+                    "runtimeVersion": "1.3.0",
+                    "subagents": [{"agentExternalId": "supervisor"}],
+                },
+                "An agent cannot reference itself as a subagent.",
+                id="self-reference",
+            ),
+            pytest.param(
+                {
+                    "externalId": "supervisor",
+                    "name": "Supervisor",
+                    "runtimeVersion": "1.3.0",
+                    "tools": [
+                        {
+                            "type": "askDocument",
+                            "name": "delegate_to_subagent",
+                            "description": "A valid tool description for testing",
+                        }
+                    ],
+                    "subagents": [{"agentExternalId": "weather-specialist"}],
+                },
+                "Tool name 'delegate_to_subagent' is reserved for the system sub-agent delegate tool. Rename the tool.",
+                id="reserved-delegate-tool-name",
+            ),
+        ],
+    )
+    def test_subagents_validation_errors(self, data: dict, expected_error: str) -> None:
+        warning_list = validate_resource_yaml_pydantic(data, AgentYAML, Path("agent.yaml"))
+        assert len(warning_list) == 1
+        warning = warning_list[0]
+        assert isinstance(warning, ResourceFormatWarning)
+        assert any(expected_error in error for error in warning.errors)
+
+    def test_subagents_max_length_validation(self) -> None:
+        data = {
+            "externalId": "supervisor",
+            "name": "Supervisor",
+            "runtimeVersion": "1.3.0",
+            "subagents": [{"agentExternalId": f"agent-{index}"} for index in range(MAX_SUB_AGENTS_PER_AGENT + 1)],
+        }
+        warning_list = validate_resource_yaml_pydantic(data, AgentYAML, Path("agent.yaml"))
+        assert len(warning_list) == 1
+        warning = warning_list[0]
+        assert isinstance(warning, ResourceFormatWarning)
+        assert any(
+            f"list should have at most {MAX_SUB_AGENTS_PER_AGENT} items" in error for error in warning.errors
+        )

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_agents.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_agents.py
@@ -394,6 +394,4 @@ class TestAgentYAML:
         assert len(warning_list) == 1
         warning = warning_list[0]
         assert isinstance(warning, ResourceFormatWarning)
-        assert any(
-            f"list should have at most {MAX_SUB_AGENTS_PER_AGENT} items" in error for error in warning.errors
-        )
+        assert any(f"list should have at most {MAX_SUB_AGENTS_PER_AGENT} items" in error for error in warning.errors)


### PR DESCRIPTION
## Description

Update toolkit agent YAML validation with cog-ai for LLM models and subagents.  No more will toolkit complain that you're using invalid models or that you have a rogue subagents specification in your agent definitions.

- Expand the agent `model` literal to match cog-ai's `ValidLanguageModel` list (57 models), including legacy aliases and newer GPT-5.x / Claude / Gemini entries
- Add typed `subagents` support on agent YAML and API client models, with validation for unique references, max 20 entries, self-reference, reserved tool name, and supported runtime versions (1.3.0 / 1.4.0)
- Wire subagents into `AgentIO` dependency resolution, list diffing, and dump normalization

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- Agent `subagents` YAML validation.

### Improved

- Updated valid values for the agent `model` property.