### PR TITLE
[CDF-28124] fix(deploy): handle UTF-8 BOM and whitespace in CSV key-column detection

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -1249,7 +1249,8 @@ class DeployV2Command(ToolkitCommand):
                     and isinstance(resource.identifier, RawTableId)
                 ):
                     for file_type in ["csv", "parquet"]:
-                        if (data_file := resource.source_file.with_suffix(f".{file_type}")).is_file():
+                        data_file = resource.source_file.with_suffix(f".{file_type}")
+                        if data_file.is_file():
                             key_col = cls._detect_key_column(data_file)
                             selections[
                                 RawTableSelector(
@@ -1273,9 +1274,9 @@ class DeployV2Command(ToolkitCommand):
         """
         if data_file.suffix == ".csv":
             try:
-                with data_file.open(encoding="utf-8", newline="") as fh:
+                with data_file.open(encoding="utf-8-sig", newline="") as fh:
                     header = next(csv.reader(fh), [])
-                if header and header[0] == "key":
+                if header and header[0].strip() == "key":
                     return "key"
             except (OSError, csv.Error):
                 pass

--- a/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
@@ -633,3 +633,22 @@ class TestDetectKeyColumn:
         txt_file = tmp_path / "my_table.txt"
         txt_file.write_text("key,name\n1,foo\n", encoding="utf-8")
         assert DeployV2Command._detect_key_column(txt_file) is None
+
+    def test_csv_with_utf8_bom_returns_key(self, tmp_path: Path) -> None:
+        csv_file = tmp_path / "bom_table.csv"
+        csv_file.write_text("key,name,value\n1,foo,bar\n", encoding="utf-8-sig")
+        assert DeployV2Command._detect_key_column(csv_file) == "key"
+
+    def test_csv_with_whitespace_around_key_returns_key(self, tmp_path: Path) -> None:
+        csv_file = tmp_path / "spaced_table.csv"
+        csv_file.write_bytes(b" key ,name,value\n1,foo,bar\n")
+        assert DeployV2Command._detect_key_column(csv_file) == "key"
+
+    def test_csv_windows_excel_format_returns_key(self, tmp_path: Path) -> None:
+        """Reproduce the Windows hypothesis: Excel saves CSV with a UTF-8 BOM and
+        CRLF line endings.  Without utf-8-sig + newline='' the first column would
+        be read as '\\ufeffkey' and detection would silently return None."""
+        windows_csv = b"\xef\xbb\xbfkey,name,value\r\n4b254a48,Oslo Shipping harbor,OSH\r\n"
+        csv_file = tmp_path / "excel_export.csv"
+        csv_file.write_bytes(windows_csv)
+        assert DeployV2Command._detect_key_column(csv_file) == "key"


### PR DESCRIPTION
# Description

Follow-up to #3063. The `_detect_key_column` helper used `encoding="utf-8"`, which leaves a UTF-8 BOM (`\ufeff`) in place when a CSV was created on Windows or exported from Excel. The first column would be read as `"\ufeffkey"` instead of `"key"`, silently bypassing key detection and falling back to UUID-per-row behaviour.

Also strips surrounding whitespace from the header value to cover CSVs where column names have accidental leading/trailing spaces.

Also narrows the broad `except Exception` clauses (carried over from the initial commit) to specific exception types (`OSError`, `csv.Error`, `ImportError`, `ArrowException`) per Gemini's review suggestions on #3063.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- When deploying raw tables via `cdf deploy`, key-column detection now correctly handles UTF-8 BOM (Excel/Windows CSVs) and leading/trailing whitespace in column headers.