### PR TITLE
[CDF-28125] Fix progress bar repeatedly printing new lines on Unix during migrate, upload, download, and purge

### DIFF
--- a/cognite_toolkit/_cdf_tk/utils/producer_worker.py
+++ b/cognite_toolkit/_cdf_tk/utils/producer_worker.py
@@ -352,7 +352,7 @@ def getch(timeout: float) -> str | None:
         fd = sys.stdin.fileno()
         old_settings = termios.tcgetattr(fd)
         try:
-            tty.setraw(fd)
+            tty.setcbreak(fd)
             rlist, _, _ = select.select([fd], [], [], timeout)
             if rlist:
                 ch = sys.stdin.read(1)

--- a/cognite_toolkit/_cdf_tk/utils/producer_worker.py
+++ b/cognite_toolkit/_cdf_tk/utils/producer_worker.py
@@ -142,7 +142,10 @@ class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
 
     def _user_input_listener(self, producer_thread: threading.Thread) -> None:
         while not self._error_event.is_set() and not self._stop_event.is_set():
-            key = getch(timeout=0.1)
+            try:
+                key = getch(timeout=0.1)
+            except EOFError:
+                break
             if key is None and not producer_thread.is_alive():
                 break
             elif key is None:
@@ -356,6 +359,8 @@ def getch(timeout: float) -> str | None:
             rlist, _, _ = select.select([fd], [], [], timeout)
             if rlist:
                 ch = sys.stdin.read(1)
+                if not ch:
+                    raise EOFError
                 return ch
             else:
                 return None


### PR DESCRIPTION
# Description

Fix the progress bar printing a new line on every refresh instead of updating in place on macOS/Linux. Root cause was `tty.setraw()` disabling output processing on the terminal, which broke Rich's in-place rendering. Switching to `tty.setcbreak()` fixes this. Also fixes `Ctrl+C`, which was previously swallowed — it now triggers a graceful shutdown, same as pressing `q`. Affects `cdf migrate`, `cdf upload`, `cdf download`, and `cdf purge`.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fix progress bar printing duplicate lines on every update during `cdf migrate`, `cdf data upload`, `cdf data download`, and `cdf purge` on macOS and Linux.
- Fix Ctrl+C being ignored during `cdf migrate`, `cdf upload`, `cdf download`, and `cdf purge` — it now stops the operation gracefully.
