### PR TITLE
fix(test): update CogniteCore dump counts and unblock patch release

### DIFF
--- a/tests/test_integration/test_commands/test_dump_data_model.py
+++ b/tests/test_integration/test_commands/test_dump_data_model.py
@@ -55,8 +55,8 @@ class TestDumpResource:
         data_model_folder = output_dir / DataModelIO.folder_name
         assert data_model_folder.exists()
         assert sum(1 for _ in data_model_folder.glob(f"*{DataModelIO.kind}.yaml")) == 1
-        assert sum(1 for _ in data_model_folder.glob(f"**/*{ViewIO.kind}.yaml")) == 33
-        assert sum(1 for _ in data_model_folder.glob(f"**/*{ContainerCRUD.kind}.yaml")) == 29
+        assert sum(1 for _ in data_model_folder.glob(f"**/*{ViewIO.kind}.yaml")) == 34
+        assert sum(1 for _ in data_model_folder.glob(f"**/*{ContainerCRUD.kind}.yaml")) == 30
         assert sum(1 for _ in data_model_folder.glob(f"**/*{SpaceCRUD.kind}.yaml")) == 2
 
     @pytest.mark.skip("Failing likely due to changes in the SchemaService validation.")


### PR DESCRIPTION
# Description

Updates the CogniteCore dump integration test after Cognite added view to CDM (34 views and 30 containers). Unblocks the Release Toolkit workflow that has been failing since #3061, #3064, and #3051.

This patch release carries over changelog entries from those unreleased merges.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- Toolkit support for Atlas AI Skills (`agent/` folder, `Skill` kind) and agent `skills` references.

### Fixed

- CogniteCore dump integration test counts after changes to CDM.