### PR TITLE
fix(test): register SkillsAPI in generic CDF resource smoke CRUDL tests

### DIFF
--- a/tests_smoke/test_client/test_cdf_resource_api.py
+++ b/tests_smoke/test_client/test_cdf_resource_api.py
@@ -185,6 +185,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.signal_subscription import 
     SignalSubscriptionRequest,
     SignalSubscriptionResponse,
 )
+from cognite_toolkit._cdf_tk.client.resource_classes.skill import SkillResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.streamlit_ import StreamlitResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.streams import StreamRequest, StreamResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.three_d import (
@@ -543,6 +544,22 @@ def get_examples_minimum_requests(request_cls: type[ResponseResource]) -> list[d
                 "externalId": "smoke-test-signal-subscription",
                 "sink": {"type": "email", "externalId": "smoke-test-signal-sink"},
                 "filter": {"topic": "cognite_workflows", "resource": "smoke-test-workflow"},
+            }
+        ],
+        SkillResponse: [
+            {
+                "externalId": "smoke-test-skill",
+                "name": "smoke-test-skill",
+                "description": "Smoke test skill",
+                "content": """---
+name: smoke-test-skill
+description: Smoke test skill
+---
+
+# Smoke test skill
+
+Used by toolkit smoke tests.
+""",
             }
         ],
         SequenceResponse: [


### PR DESCRIPTION
## Description

`SkillsAPI` was added as a `CDFResourceAPI` subclass but had no entry in the smoke test registry (`get_examples_minimum_requests`), causing `test_all_cdf_resource_apis_registered` to fail.

Add `SkillResponse` example data so `SkillsAPI` is covered by the generic `test_crudl` parametrized smoke tests.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Register `SkillsAPI` in generic CDF resource smoke CRUDL tests.