### PR TITLE
fix: handle list[dict] variable values in BuildVariable hash

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -785,12 +785,12 @@ class ModulesCommand(ToolkitCommand):
             return
 
         table = Table(title=f"{effective_build_env} {organization_dir.name} modules")
-        table.add_column("Module Name", style="bold")
-        table.add_column("Resource Folders", style="bold")
-        table.add_column("Resources", style="bold")
-        table.add_column("Build Warnings", style="bold")
-        table.add_column("Build Result", style="bold")
-        table.add_column("Location", style="bold")
+        table.add_column("Module Name", style="bold", min_width=20, no_wrap=True)
+        table.add_column("Resource\nFolders", style="bold", justify="right", min_width=8)
+        table.add_column("Resources", style="bold", justify="right", min_width=9)
+        table.add_column("Build\nWarnings", style="bold", justify="right", min_width=8)
+        table.add_column("Build Result", style="bold", min_width=13)
+        table.add_column("Location", style="bold", min_width=40, no_wrap=True)
 
         for module in module_list:
             if module.status == "Success":

--- a/cognite_toolkit/_cdf_tk/data_classes/_build_variables.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_build_variables.py
@@ -18,6 +18,21 @@ else:
     from typing_extensions import Self
 
 
+def _to_hashable(v: Any) -> Any:
+    """Recursively convert lists and dicts to hashable nested tuples.
+
+    BuildVariable is a frozen dataclass so its value must be hashable for set()
+    comparisons in compare_modules(). Simple lists of scalars are already handled
+    by the existing tuple() conversion, but list[dict] values (e.g. site_readiness)
+    would still contain unhashable dicts inside the tuple.
+    """
+    if isinstance(v, list):
+        return tuple(_to_hashable(i) for i in v)
+    if isinstance(v, dict):
+        return tuple(sorted((k, _to_hashable(val)) for k, val in v.items()))
+    return v
+
+
 @dataclass(frozen=True)
 class BuildVariable:
     """This is an internal representation of a  build variable in a config.[env].file
@@ -55,11 +70,7 @@ class BuildVariable:
 
     @classmethod
     def load(cls, data: dict[str, Any]) -> Self:
-        if isinstance(data["value"], list):
-            # Convert the list to a tuple to make it hashable
-            value = tuple(data["value"])
-        else:
-            value = data["value"]
+        value = _to_hashable(data["value"])
         return cls(data["key"], value, data["is_selected"], Path(data["location"]))
 
 
@@ -110,7 +121,7 @@ class BuildVariables(tuple, Sequence[BuildVariable]):
                     # Remove this check to support variables with dictionary values.
                     continue
                 else:
-                    hashable_values = tuple(value) if isinstance(value, list) else value
+                    hashable_values = _to_hashable(value)
                     is_selected = selected_modules is None or path in selected_modules
                     variables.append(BuildVariable(key, hashable_values, is_selected, path, iteration))
 

--- a/tests/test_unit/test_cdf_tk/test_data_classes/test_build_variables.py
+++ b/tests/test_unit/test_cdf_tk/test_data_classes/test_build_variables.py
@@ -180,6 +180,46 @@ query: >-
         # Tags should be a YAML list, not SQL tuple
         assert loaded["tags"] == ["tag1", "tag2"]
 
+    def test_load_raw_list_of_dicts_is_hashable(self) -> None:
+        """Variables with list[dict] values (e.g. site_readiness) must be hashable.
+
+        BuildVariable is a frozen dataclass; set() comparisons in compare_modules()
+        call __hash__ on each instance. A list[dict] value wrapped in tuple() still
+        contains unhashable dicts — _to_hashable() must recurse into the dicts.
+        """
+        variables = BuildVariables.load_raw(
+            {
+                "site_readiness": [
+                    {"site_name_lower": "clov", "site_name_upper": "CLOV", "site_prefix": "CLV"},
+                    {"site_name_lower": "egina", "site_name_upper": "EGINA", "site_prefix": "EGI"},
+                ],
+            },
+            available_modules=set(),
+            selected_modules=set(),
+        )
+
+        assert len(variables) == 1
+        # Must not raise TypeError: unhashable type: 'dict'
+        assert len({variables[0]}) == 1
+
+    def test_load_from_cache_list_of_dicts_is_hashable(self) -> None:
+        """BuildVariable.load() (used to read build_info.*.yaml cache) must also
+        produce hashable values when the cached value is a list[dict]."""
+        from cognite_toolkit._cdf_tk.data_classes._build_variables import BuildVariable
+
+        bv = BuildVariable.load(
+            {
+                "key": "site_readiness",
+                "value": [{"site_name_lower": "clov", "site_prefix": "CLV"}],
+                "is_selected": True,
+                "location": "modules",
+            }
+        )
+
+        # Must not raise TypeError: unhashable type: 'dict'
+        assert hash(bv) is not None
+        assert len({bv}) == 1
+
     def test_get_module_variables_variable_preference_order(self) -> None:
         source_yaml = """
 modules:


### PR DESCRIPTION
## Summary

`cdf modules list` (and any command that calls `compare_modules()`) crashes with:

```
TypeError: unhashable type: 'dict'
  File "_module_resources.py", line 163, in compare_modules
    if set(current_module_variables) != set(cached_module.build_variables):
```

when a config variable has a **list-of-dicts** value — for example:

```yaml
variables:
  modules:
    site_readiness:
      - site_name_lower: clov
        site_name_upper: CLOV
        site_prefix: CLV
      - site_name_lower: egina
        site_name_upper: EGINA
        site_prefix: EGI
```

## Root Cause

`BuildVariable` is a `frozen dataclass`, so Python auto-generates `__hash__` from all fields including `value`. Both `load_raw()` and `load()` converted list values with `tuple(value)`, but if the list contains dicts, those dicts end up inside the tuple and are still unhashable — causing `set()` to fail.

## Fix

Extract a `_to_hashable()` helper that **recursively** converts lists and dicts to nested tuples of sorted key-value pairs:

```python
def _to_hashable(v: Any) -> Any:
    if isinstance(v, list):
        return tuple(_to_hashable(i) for i in v)
    if isinstance(v, dict):
        return tuple(sorted((k, _to_hashable(val)) for k, val in v.items()))
    return v
```

Applied in both:
- `load_raw()` — live variables parsed from `config.*.yaml`
- `BuildVariable.load()` — variables read back from `build_info.*.yaml` cache

## Tests

Two new test cases in `test_build_variables.py`:
- `test_load_raw_list_of_dicts_is_hashable` — verifies `load_raw()` with a `list[dict]` variable produces a hashable `BuildVariable`
- `test_load_from_cache_list_of_dicts_is_hashable` — verifies `BuildVariable.load()` (cache read path) does the same

All 10 existing + new tests pass.