### PR TITLE
[CDF-28012] Interactive prompt to auto-enable required plugins

### DIFF
--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -9,10 +9,7 @@ from typing import NoReturn
 
 import typer
 from cognite.client.config import global_config
-from rich.markup import escape
 from rich.panel import Panel
-
-from cognite_toolkit._cdf_tk.hints import Hint
 
 # Do not warn the user about feature previews from the Cognite-SDK we use in Toolkit
 global_config.disable_pypi_version_check = True
@@ -38,12 +35,11 @@ from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 from cognite_toolkit._cdf_tk.commands import (
     AboutCommand,
 )
-from cognite_toolkit._cdf_tk.constants import HINT_LEAD_TEXT, URL, USE_SENTRY
+from cognite_toolkit._cdf_tk.constants import HINT_LEAD_TEXT, USE_SENTRY
 from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitError,
 )
 from cognite_toolkit._cdf_tk.feature_flags import Flags
-from cognite_toolkit._cdf_tk.plugins import Plugins
 from cognite_toolkit._cdf_tk.utils import (
     sentry_exception_filter,
 )
@@ -90,15 +86,11 @@ _app.add_typer(AuthApp(**default_typer_kws), name="auth")
 _app.add_typer(RepoApp(**default_typer_kws), name="repo")
 
 
-if Plugins.run.value.is_enabled():
-    _app.add_typer(RunApp(**default_typer_kws), name="run")
-
-if Plugins.dump.value.is_enabled():
-    _app.add_typer(DumpApp(**default_typer_kws), name="dump")
-
-
-if Plugins.dev.value.is_enabled():
-    _app.add_typer(DevApp(**default_typer_kws), name="dev")
+# Plugin apps are always registered so they can intercept invocation at the command level and
+# offer to enable themselves (see `Plugins.ensure_enabled`), rather than being hidden when disabled.
+_app.add_typer(RunApp(**default_typer_kws), name="run")
+_app.add_typer(DumpApp(**default_typer_kws), name="dump")
+_app.add_typer(DevApp(**default_typer_kws), name="dev")
 
 if Flags.PROFILE.is_enabled():
     _app.add_typer(ProfileApp(**default_typer_kws), name="profile")
@@ -109,8 +101,7 @@ if Flags.MIGRATE.is_enabled():
 if Flags.IMPORT_CMD.is_enabled():
     _app.add_typer(ImportApp(**default_typer_kws), name="import")
 
-if Plugins.data.value.is_enabled():
-    _app.add_typer(DataApp(**default_typer_kws), name="data")
+_app.add_typer(DataApp(**default_typer_kws), name="data")
 
 
 _app.add_typer(ModulesApp(**default_typer_kws), name="modules")
@@ -154,6 +145,11 @@ def _get_subcommand_map() -> dict[str, list[str]]:
     return subcommand_map
 
 
+# Click raises either `UsageError` or its `NoSuchCommand` subclass depending on the version,
+# so we match on the message text rather than the exception class name in the traceback.
+NO_SUCH_COMMAND_PATTERN = re.compile(r"No such command '(\w+)'\.")
+
+
 def _suggest_command(unknown_cmd: str) -> str | None:
     """Check if the unknown command exists as a subcommand and return a suggestion."""
     subcommand_map = _get_subcommand_map()
@@ -182,17 +178,9 @@ def app() -> NoReturn:
         print(f"  [bold red]ERROR ([/][red]{type(err).__name__}[/][bold red]):[/] {err}")
         raise SystemExit(1)
     except SystemExit:
-        if result := re.search(r"click.exceptions.UsageError: No such command '(\w+)'.", traceback.format_exc()):
+        if result := NO_SUCH_COMMAND_PATTERN.search(traceback.format_exc()):
             cmd = result.group(1)
-            if cmd in Plugins.list():
-                plugin = r"[plugins]"
-                print(
-                    f"{HINT_LEAD_TEXT} The plugin [bold]{cmd}[/bold] is not enabled."
-                    f"\nEnable it in the [bold]cdf.toml[/bold] file by setting '{cmd} = true' in the "
-                    f"[bold]{escape(plugin)}[/bold] section."
-                    f"\nDocs to learn more: {Hint.link(URL.plugins, URL.plugins)}"
-                )
-            elif suggestion := _suggest_command(cmd):
+            if suggestion := _suggest_command(cmd):
                 print(f"{HINT_LEAD_TEXT} {suggestion}")
         raise
 

--- a/cognite_toolkit/_cdf_tk/apps/_data_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_data_app.py
@@ -3,6 +3,8 @@ from typing import Any
 import typer
 from rich import print
 
+from cognite_toolkit._cdf_tk.plugins import Plugins
+
 from ._download_app import DownloadApp
 from ._purge import PurgeApp
 from ._upload_app import UploadApp
@@ -19,6 +21,7 @@ class DataApp(typer.Typer):
     @staticmethod
     def main(ctx: typer.Context) -> None:
         """Plugin to work with data in CDF"""
+        Plugins.data.ensure_enabled()
         if ctx.invoked_subcommand is None:
             print("Use [bold yellow]cdf data --help[/] for more information.")
         return None

--- a/cognite_toolkit/_cdf_tk/apps/_dev_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dev_app.py
@@ -9,6 +9,7 @@ from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.commands import ResourcesCommand
 from cognite_toolkit._cdf_tk.feature_flags import FeatureFlag, Flags
+from cognite_toolkit._cdf_tk.plugins import Plugins
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 
 from ._entity_matching_app import EntityMatchingApp
@@ -30,6 +31,7 @@ class DevApp(typer.Typer):
     @staticmethod
     def main(ctx: typer.Context) -> None:
         """Commands to work with development."""
+        Plugins.dev.ensure_enabled()
         if ctx.invoked_subcommand is None:
             print("Use [bold yellow]cdf dev --help[/] for more information.")
         return None

--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -30,6 +30,7 @@ from cognite_toolkit._cdf_tk.commands.dump_resource import (
 )
 from cognite_toolkit._cdf_tk.exceptions import ToolkitRequiredValueError
 from cognite_toolkit._cdf_tk.feature_flags import Flags
+from cognite_toolkit._cdf_tk.plugins import Plugins
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 
 
@@ -59,6 +60,7 @@ class DumpApp(typer.Typer):
     @staticmethod
     def dump_main(ctx: typer.Context) -> None:
         """Commands to dump resource configurations from CDF into a temporary directory."""
+        Plugins.dump.ensure_enabled()
         if ctx.invoked_subcommand is None:
             print("Use [bold yellow]cdf dump --help[/] for more information.")
         return None

--- a/cognite_toolkit/_cdf_tk/apps/_run.py
+++ b/cognite_toolkit/_cdf_tk/apps/_run.py
@@ -10,6 +10,7 @@ from cognite_toolkit._cdf_tk.commands import (
     RunTransformationCommand,
     RunWorkflowCommand,
 )
+from cognite_toolkit._cdf_tk.plugins import Plugins
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 
 CDF_TOML = CDFToml.load(Path.cwd())
@@ -31,7 +32,10 @@ class RunApp(typer.Typer):
     @staticmethod
     def main(ctx: typer.Context) -> None:
         """Commands to execute processes in CDF."""
+        # When nested under `cdf dev`, the `dev` plugin guards access; only the top-level
+        # `cdf run` requires the `run` plugin to be enabled.
         if ctx.parent is None or ctx.parent.info_name != "dev":
+            Plugins.run.ensure_enabled()
             RunApp._print_deprecation_warning()
         if ctx.invoked_subcommand is None:
             print("Use [bold yellow]cdf run --help[/] for more information.")

--- a/cognite_toolkit/_cdf_tk/cdf_toml.py
+++ b/cognite_toolkit/_cdf_tk/cdf_toml.py
@@ -183,6 +183,29 @@ class CDFToml:
         return cls.load(cwd=RESOURCES_PATH, use_singleton=False)
 
     @classmethod
+    def enable_plugin(cls, plugin_name: str, cwd: Path | None = None) -> bool:
+        """Enables the given plugin in the cdf.toml file.
+
+        This sets ``<plugin_name> = true`` in the ``[plugins]`` section, creating the section
+        if it does not exist. The file is edited line-by-line so existing comments and formatting
+        are preserved. The in-memory singleton is reset so a subsequent ``CDFToml.load()`` reflects
+        the change.
+
+        Returns ``True`` if the plugin was enabled, ``False`` if no ``cdf.toml`` file was found.
+        """
+        global _CDF_TOML
+        cwd = cwd or Path.cwd()
+        file_path = cwd / cls.file_name
+        if not file_path.exists():
+            return False
+        content = file_path.read_text(encoding="utf-8")
+        new_content = _set_plugin_enabled(content, clean_name(plugin_name))
+        if new_content != content:
+            file_path.write_text(new_content, encoding="utf-8")
+        _CDF_TOML = None
+        return True
+
+    @classmethod
     def write(cls, organization_dir: Path, env: EnvType = "dev", version: str = _version.__version__) -> None:
         destination = Path.cwd() / CDFToml.file_name
         if destination.exists():
@@ -200,6 +223,49 @@ default_organization_dir = "{organization_dir.name}"''',
             cdf_toml_content = cdf_toml_content.replace("#<PLACEHOLDER>", "")
         cdf_toml_content = cdf_toml_content.replace("<DEFAULT_ENV_PLACEHOLDER>", env)
         destination.write_text(cdf_toml_content, encoding="utf-8")
+
+
+def _set_plugin_enabled(content: str, plugin_name: str) -> str:
+    """Returns ``content`` with ``<plugin_name> = true`` set in the ``[plugins]`` section.
+
+    The edit is done line-by-line to preserve existing comments and formatting:
+    - If the key already exists in ``[plugins]``, its assignment line is replaced.
+    - If the ``[plugins]`` section exists but the key does not, the key is inserted after the header.
+    - If there is no ``[plugins]`` section, one is appended to the end of the file.
+    """
+    assignment = f"{plugin_name} = true"
+    lines = content.splitlines()
+    key_pattern = re.compile(rf"^\s*{re.escape(plugin_name)}\s*=", re.IGNORECASE)
+
+    in_plugins = False
+    plugins_header_index: int | None = None
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_plugins = stripped == "[plugins]"
+            if in_plugins:
+                plugins_header_index = index
+            continue
+        if in_plugins and key_pattern.match(line):
+            lines[index] = assignment
+            return _join_lines(lines, content)
+
+    if plugins_header_index is not None:
+        lines.insert(plugins_header_index + 1, assignment)
+        return _join_lines(lines, content)
+
+    if lines and lines[-1].strip() != "":
+        lines.append("")
+    lines.append("[plugins]")
+    lines.append(assignment)
+    return _join_lines(lines, content)
+
+
+def _join_lines(lines: list[str], original: str) -> str:
+    text = "\n".join(lines)
+    if original.endswith("\n"):
+        text += "\n"
+    return text
 
 
 def _read_toml(file_path: Path) -> dict[str, Any]:

--- a/cognite_toolkit/_cdf_tk/plugins.py
+++ b/cognite_toolkit/_cdf_tk/plugins.py
@@ -1,8 +1,16 @@
+import os
+import sys
 from dataclasses import dataclass
 from enum import Enum
 
+import questionary
+import typer
+from rich import print
+from rich.markup import escape
+
 from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
-from cognite_toolkit._cdf_tk.constants import clean_name
+from cognite_toolkit._cdf_tk.constants import HINT_LEAD_TEXT, URL, clean_name
+from cognite_toolkit._cdf_tk.ui import QUESTIONARY_STYLE
 
 
 @dataclass
@@ -24,3 +32,54 @@ class Plugins(Enum):
     def list() -> dict[str, bool]:
         res = {plugin.name: Plugin.is_enabled(plugin.value) for plugin in Plugins}
         return res
+
+    def ensure_enabled(self) -> None:
+        """Ensure this plugin is enabled before running a command that requires it.
+
+        Returns immediately if the plugin is already enabled. Otherwise the user is prompted
+        to enable it. On confirmation the plugin is enabled in ``cdf.toml`` and execution
+        continues; otherwise the manual hint is printed and the command is aborted with
+        ``typer.Exit``. In non-interactive shells (e.g. CI) the command fails loudly by
+        default; set the ``CDF_ASSUME_YES`` environment variable to auto-enable instead.
+        """
+        plugin = self.value
+        if plugin.is_enabled():
+            return
+        name = clean_name(plugin.name)
+        if _confirm_enable(name) and CDFToml.enable_plugin(name):
+            print(f"{HINT_LEAD_TEXT} Enabled plugin [bold]{name}[/bold] in [bold]cdf.toml[/bold].")
+            return
+        _print_disabled_hint(name)
+        raise typer.Exit(code=1)
+
+
+def _confirm_enable(plugin_name: str) -> bool:
+    """Ask the user whether to enable the plugin.
+
+    Honours the ``CDF_ASSUME_YES`` environment variable for non-interactive/CI use, and
+    returns ``False`` in non-interactive shells so that CI fails loudly by default.
+    """
+    if os.environ.get("CDF_ASSUME_YES", "").strip().lower() in ("1", "true", "yes"):
+        return True
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return False
+    try:
+        return bool(
+            questionary.confirm(
+                f"The plugin '{plugin_name}' is required for this command but is not enabled. Enable it now?",
+                default=True,
+                style=QUESTIONARY_STYLE,
+            ).unsafe_ask()
+        )
+    except KeyboardInterrupt:
+        return False
+
+
+def _print_disabled_hint(plugin_name: str) -> None:
+    section = r"[plugins]"
+    print(
+        f"{HINT_LEAD_TEXT} The plugin [bold]{plugin_name}[/bold] is not enabled."
+        f"\nEnable it in the [bold]cdf.toml[/bold] file by setting '{plugin_name} = true' in the "
+        f"[bold]{escape(section)}[/bold] section."
+        f"\nDocs to learn more: [blue][link={URL.plugins}]{URL.plugins}[/link][/blue]"
+    )

--- a/tests/test_unit/test_cdf_tk/test_cdf_app.py
+++ b/tests/test_unit/test_cdf_tk/test_cdf_app.py
@@ -1,0 +1,111 @@
+import pytest
+import typer
+
+from cognite_toolkit import _cdf
+from cognite_toolkit._cdf_tk import plugins
+from cognite_toolkit._cdf_tk.plugins import Plugins
+
+
+class TestNoSuchCommandPattern:
+    @pytest.mark.parametrize(
+        "traceback_text",
+        [
+            # Newer Click/Typer raises the NoSuchCommand subclass.
+            "click.exceptions.NoSuchCommand: No such command 'data'.",
+            # Older Click raised the base UsageError.
+            "click.exceptions.UsageError: No such command 'data'.",
+        ],
+    )
+    def test_matches_known_traceback_formats(self, traceback_text: str) -> None:
+        match = _cdf.NO_SUCH_COMMAND_PATTERN.search(traceback_text)
+        assert match is not None
+        assert match.group(1) == "data"
+
+
+class TestEnsureEnabled:
+    def test_noop_when_already_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(plugins.Plugin, "is_enabled", lambda self: True)
+
+        def _fail_enable(name: str) -> bool:
+            raise AssertionError("enable_plugin should not be called when the plugin is already enabled")
+
+        monkeypatch.setattr(plugins.CDFToml, "enable_plugin", _fail_enable)
+
+        # Should not raise.
+        Plugins.data.ensure_enabled()
+
+    def test_assume_yes_env_enables_and_continues(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(plugins.Plugin, "is_enabled", lambda self: False)
+        monkeypatch.setenv("CDF_ASSUME_YES", "1")
+        enabled: list[str] = []
+
+        def _enable(name: str) -> bool:
+            enabled.append(name)
+            return True
+
+        monkeypatch.setattr(plugins.CDFToml, "enable_plugin", _enable)
+
+        Plugins.data.ensure_enabled()
+
+        assert enabled == ["data"]
+
+    def test_non_interactive_aborts_with_hint(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(plugins.Plugin, "is_enabled", lambda self: False)
+        monkeypatch.delenv("CDF_ASSUME_YES", raising=False)
+        monkeypatch.setattr(plugins.sys.stdin, "isatty", lambda: False)
+        monkeypatch.setattr(plugins.sys.stdout, "isatty", lambda: False)
+
+        def _fail_enable(name: str) -> bool:
+            raise AssertionError("enable_plugin should not be called when not confirmed")
+
+        monkeypatch.setattr(plugins.CDFToml, "enable_plugin", _fail_enable)
+
+        with pytest.raises(typer.Exit):
+            Plugins.data.ensure_enabled()
+
+        assert "is not enabled" in capsys.readouterr().out
+
+    def test_interactive_confirm_enables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(plugins.Plugin, "is_enabled", lambda self: False)
+        monkeypatch.delenv("CDF_ASSUME_YES", raising=False)
+        monkeypatch.setattr(plugins.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(plugins.sys.stdout, "isatty", lambda: True)
+
+        class _Confirm:
+            def unsafe_ask(self) -> bool:
+                return True
+
+        monkeypatch.setattr(plugins.questionary, "confirm", lambda *args, **kwargs: _Confirm())
+        enabled: list[str] = []
+
+        def _enable(name: str) -> bool:
+            enabled.append(name)
+            return True
+
+        monkeypatch.setattr(plugins.CDFToml, "enable_plugin", _enable)
+
+        Plugins.data.ensure_enabled()
+
+        assert enabled == ["data"]
+
+    def test_interactive_decline_aborts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(plugins.Plugin, "is_enabled", lambda self: False)
+        monkeypatch.delenv("CDF_ASSUME_YES", raising=False)
+        monkeypatch.setattr(plugins.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(plugins.sys.stdout, "isatty", lambda: True)
+
+        class _Confirm:
+            def unsafe_ask(self) -> bool:
+                return False
+
+        monkeypatch.setattr(plugins.questionary, "confirm", lambda *args, **kwargs: _Confirm())
+
+        def _fail_enable(name: str) -> bool:
+            raise AssertionError("enable_plugin should not be called when declined")
+
+        monkeypatch.setattr(plugins.CDFToml, "enable_plugin", _fail_enable)
+
+        with pytest.raises(typer.Exit):
+            Plugins.data.ensure_enabled()

--- a/tests/test_unit/test_cdf_tk/test_data_classes/test_cdf_toml.py
+++ b/tests/test_unit/test_cdf_tk/test_data_classes/test_cdf_toml.py
@@ -4,7 +4,8 @@ from pathlib import Path
 import pytest
 
 from cognite_toolkit import _version
-from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
+from cognite_toolkit._cdf_tk import cdf_toml as cdf_toml_module
+from cognite_toolkit._cdf_tk.cdf_toml import CDFToml, _set_plugin_enabled
 from cognite_toolkit._cdf_tk.constants import RESOURCES_PATH
 from cognite_toolkit._cdf_tk.exceptions import ToolkitTOMLFormatError
 from tests.constants import REPO_ROOT
@@ -70,14 +71,16 @@ class TestCDFToml:
             "invalid_zip",
         ],
     )
-    def test_load_invalid_toml_content(self, tmp_path: Path, invalid_toml_content: str, expected_error_message: str):
+    def test_load_invalid_toml_content(
+        self, tmp_path: Path, invalid_toml_content: str, expected_error_message: str
+    ) -> None:
         file_path = tmp_path / CDFToml.file_name
         file_path.write_text(invalid_toml_content)
 
         with pytest.raises(ToolkitTOMLFormatError, match=re.escape(expected_error_message)):
             CDFToml.load(cwd=tmp_path, use_singleton=False)
 
-    def test_load_package_url(self, tmp_path: Path):
+    def test_load_package_url(self, tmp_path: Path) -> None:
         valid_toml_content = """
         [cdf]
         [modules]
@@ -102,3 +105,68 @@ class TestCDFToml:
         # Verify the URL is a valid HTTPS URL pointing to cognite library
         assert library.url.startswith("https://github.com/cognitedata/library")
         assert library.url.endswith(".zip")
+
+
+class TestSetPluginEnabled:
+    def test_replaces_existing_false_assignment(self) -> None:
+        content = "[plugins]\ndump = false\ndev = false\n"
+
+        result = _set_plugin_enabled(content, "dump")
+
+        assert result == "[plugins]\ndump = true\ndev = false\n"
+
+    def test_preserves_comments_and_other_sections(self) -> None:
+        content = '[cdf]\ndefault_env = "dev"\n\n[plugins]\n# Toggle plugins here\ndump = false\n'
+
+        result = _set_plugin_enabled(content, "dump")
+
+        assert "# Toggle plugins here" in result
+        assert 'default_env = "dev"' in result
+        assert "dump = true" in result
+        assert "dump = false" not in result
+
+    def test_inserts_key_when_section_exists_without_key(self) -> None:
+        content = "[plugins]\ndev = false\n"
+
+        result = _set_plugin_enabled(content, "dump")
+
+        assert result == "[plugins]\ndump = true\ndev = false\n"
+
+    def test_appends_section_when_missing(self) -> None:
+        content = '[cdf]\ndefault_env = "dev"\n'
+
+        result = _set_plugin_enabled(content, "dump")
+
+        assert result.rstrip("\n").endswith("[plugins]\ndump = true")
+        assert "[cdf]" in result
+
+    def test_does_not_touch_key_outside_plugins_section(self) -> None:
+        content = "[other]\ndump = false\n\n[plugins]\ndev = false\n"
+
+        result = _set_plugin_enabled(content, "dump")
+
+        # The [other] section's dump must be left untouched; a new key added under [plugins].
+        assert "[other]\ndump = false" in result
+        assert "[plugins]\ndump = true\ndev = false" in result
+
+
+class TestEnablePlugin:
+    @pytest.mark.usefixtures("reset_cdf_toml_singleton")
+    def test_enable_plugin_updates_file_and_resets_singleton(self, tmp_path: Path) -> None:
+        file_path = tmp_path / CDFToml.file_name
+        file_path.write_text(
+            '[cdf]\ndefault_env = "dev"\n\n[modules]\nversion = "0.0.0"\n\n[plugins]\ndump = false\n',
+            encoding="utf-8",
+        )
+        # Prime the singleton so we can verify it is reset.
+        cdf_toml_module._CDF_TOML = CDFToml.load(cwd=tmp_path, use_singleton=False)
+
+        enabled = CDFToml.enable_plugin("dump", cwd=tmp_path)
+
+        assert enabled is True
+        assert cdf_toml_module._CDF_TOML is None
+        reloaded = CDFToml.load(cwd=tmp_path, use_singleton=False)
+        assert reloaded.plugins["dump"] is True
+
+    def test_enable_plugin_returns_false_when_no_file(self, tmp_path: Path) -> None:
+        assert CDFToml.enable_plugin("dump", cwd=tmp_path) is False


### PR DESCRIPTION
# Description

Implements [CDF-28012](https://cognitedata.atlassian.net/browse/CDF-28012). When a user runs a command that depends on a plugin that isn't enabled, the Toolkit now offers to enable it for them instead of printing a static "edit cdf.toml yourself" hint.

The enablement is **intercepted at the command level**: plugin apps (`run`, `dump`, `dev`, `data`) are always registered, and each one's callback calls `Plugins.ensure_enabled()`. If the plugin is disabled the user is prompted; on confirmation it is set in `cdf.toml` and execution continues **in the same process** (no re-exec). The line-based TOML edit preserves existing comments and formatting, and creates the `[plugins]` section if missing.

Behaviour:
- **Interactive**: prompts `Enable it now?`, then enables and proceeds.
- **Non-interactive (CI)**: fails loudly with the manual hint by default. Set `CDF_ASSUME_YES=1` to auto-enable.
- `cdf <plugin> --help` still works without enabling (help bypasses the callback).
- Nested `cdf dev run` is guarded by the `dev` plugin only; the `run` plugin is enforced only for top-level `cdf run`.

Also fixes a latent bug where the disabled-plugin/typo hint never showed, because the traceback regex matched `click.exceptions.UsageError` but current Click raises the `NoSuchCommand` subclass.

> [!NOTE]
> Draft — parked for review later.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- Interactive prompt to auto-enable a required-but-disabled plugin in `cdf.toml`, with `CDF_ASSUME_YES` for non-interactive use.

## Test plan

- [ ] Unit tests for the TOML editor, `CDFToml.enable_plugin`, and `Plugins.ensure_enabled` (interactive / env-var / non-interactive / decline paths)
- [ ] Manual: `cdf data download` (disabled) prompts/aborts; `CDF_ASSUME_YES=1 cdf data` enables and proceeds; `cdf --help` lists plugins; `cdf dev run` doesn't require the `run` plugin

[CDF-28012]: https://cognitedata.atlassian.net/browse/CDF-28012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ