### PR TITLE
[CDF-28146] Fix migration upload chunking and tracking ID propagation in FDM-to-CDM mapper

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/http_client/__init__.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/__init__.py
@@ -12,6 +12,7 @@ from ._item_classes import (
     ItemsFailedRequest,
     ItemsFailedResponse,
     ItemsRequest,
+    ItemsResultList,
     ItemsResultMessage,
     ItemsSuccessResponse,
 )
@@ -25,6 +26,7 @@ __all__ = [
     "ItemsFailedRequest",
     "ItemsFailedResponse",
     "ItemsRequest",
+    "ItemsResultList",
     "ItemsResultMessage",
     "ItemsSuccessResponse",
     "RequestMessage",

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -293,7 +293,7 @@ class MigrationCommand(ToolkitCommand):
         mapper: DataMapper[T_Selector, T_DataResponse, T_DataRequest],
     ) -> Callable[[Page[T_DataResponse]], Page[T_DataRequest]]:
         def track_mapping(source: Page[T_DataResponse]) -> Page[T_DataRequest]:
-            return mapper.map_page(source)
+            return source.create_from(mapper.map(source.items))
 
         return track_mapping
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -177,6 +177,10 @@ class MigrationCommand(ToolkitCommand):
 
             action = "Would migrate" if dry_run else "Migrating"
             target = "records" if isinstance(data, RecordsMigrationIO) else "instances"
+            # Here we use logger totals instead of the actual number of downladed items. For some selectors,
+            # download pages can include auxiliary edges that are, for example, converted to direct relations
+            # on a node after being migrated, alongside the nodes to migrate themselves. It would be confusing
+            # to a user if those edges were counted and displayed, since the initial estimate only counts the nodes to migrate.
             total = sum(result.count for result in items_results)
             console.print(f"{action} {total:,} {selected.display_name} to {target}.")
         return results_by_selector

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -26,7 +26,6 @@ from cognite_toolkit._cdf_tk.data_classes import DeployResults
 from cognite_toolkit._cdf_tk.data_classes._tracking_info import DataTracking
 from cognite_toolkit._cdf_tk.dataio import (
     ChartIO,
-    DataItem,
     Page,
     T_DataRequest,
     T_DataResponse,
@@ -294,17 +293,7 @@ class MigrationCommand(ToolkitCommand):
         mapper: DataMapper[T_Selector, T_DataResponse, T_DataRequest],
     ) -> Callable[[Page[T_DataResponse]], Page[T_DataRequest]]:
         def track_mapping(source: Page[T_DataResponse]) -> Page[T_DataRequest]:
-            raw_items = [di.item for di in source.items]
-            mapped = mapper.map(raw_items)
-            return Page(
-                worker_id=source.worker_id,
-                items=[
-                    DataItem(tracking_id=item.tracking_id, item=target)
-                    for target, item in zip(mapped, source.items)
-                    if target is not None
-                ],
-                bookmark=source.bookmark,
-            )
+            return mapper.map_page(source)
 
         return track_mapping
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -160,7 +160,6 @@ class MigrationCommand(ToolkitCommand):
             )
 
             executor.run(start_item=step.completed_count)
-            total = executor.downloaded_items
 
             items_results = logger.finalize(dry_run)
             results_by_selector[str(selected)] = items_results
@@ -178,6 +177,7 @@ class MigrationCommand(ToolkitCommand):
 
             action = "Would migrate" if dry_run else "Migrating"
             target = "records" if isinstance(data, RecordsMigrationIO) else "instances"
+            total = sum(result.count for result in items_results)
             console.print(f"{action} {total:,} {selected.display_name} to {target}.")
         return results_by_selector
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -13,6 +13,7 @@ from cognite_toolkit._cdf_tk.client.http_client import (
     HTTPClient,
     ItemsFailedRequest,
     ItemsFailedResponse,
+    ItemsResultList,
     ItemsSuccessResponse,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.streams import StreamResponse
@@ -316,7 +317,7 @@ class MigrationCommand(ToolkitCommand):
             if dry_run:
                 return None
 
-            responses: list = []
+            responses: ItemsResultList = ItemsResultList()
             for chunk in chunker_sequence(page.items, target.CHUNK_SIZE):
                 chunk_page = page.create_from(list(chunk))
                 responses.extend(

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -46,6 +46,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
 )
 from cognite_toolkit._cdf_tk.resource_ios import ResourceWorker
 from cognite_toolkit._cdf_tk.utils import humanize_collection, safe_write, sanitize_filename
+from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 from cognite_toolkit._cdf_tk.utils.file import yaml_safe_dump
 from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter, Uncompressed
 from cognite_toolkit._cdf_tk.utils.producer_worker import ProducerWorkerExecutor
@@ -326,7 +327,12 @@ class MigrationCommand(ToolkitCommand):
             if dry_run:
                 return None
 
-            responses = target.upload_items(data_chunk=page, http_client=write_client, selector=selected)
+            responses: list = []
+            for chunk in chunker_sequence(page.items, target.CHUNK_SIZE):
+                chunk_page = page.create_from(list(chunk))
+                responses.extend(
+                    target.upload_items(data_chunk=chunk_page, http_client=write_client, selector=selected)
+                )
 
             for item in responses:
                 if isinstance(item, ItemsSuccessResponse):

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1372,12 +1372,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
         ):
             if len(intersecting_view_ids) == 1:
                 intersection_view_id = next(iter(intersecting_view_ids))
-                custom_mapper = self._custom_instance_mappings[intersection_view_id]
-                if isinstance(custom_mapper, InFieldLegacyToCDMScheduleMapper):
-                    return custom_mapper.map_page(source)
-                raise NotImplementedError(
-                    f"Custom instance mapper {type(custom_mapper).__name__} does not support tracked mapping."
-                )
+                return self._custom_instance_mappings[intersection_view_id].map_page(source)
             raise NotImplementedError(
                 "Bug in Toolkit: There should be at most one intersecting view when using custom mapping of instances."
             )

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -99,7 +99,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.issues import (
     instance_conversion_issue_as_migration_entry,
 )
 from cognite_toolkit._cdf_tk.constants import MISSING_INSTANCE_SPACE
-from cognite_toolkit._cdf_tk.dataio import T_DataRequest, T_DataResponse, T_Selector
+from cognite_toolkit._cdf_tk.dataio import DataItem, Page, T_DataRequest, T_DataResponse, T_Selector
 from cognite_toolkit._cdf_tk.dataio.logger import DataLogger, NoOpLogger, Severity
 from cognite_toolkit._cdf_tk.dataio.selectors import (
     CanvasSelector,
@@ -147,6 +147,17 @@ class DataMapper(Generic[T_Selector, T_DataResponse, T_DataRequest], ABC):
 
         """
         raise NotImplementedError("Subclasses must implement this method.")
+
+    def map_page(self, source: Page[T_DataResponse]) -> Page[T_DataRequest]:
+        raw_items = [data_item.item for data_item in source.items]
+        mapped = self.map(raw_items)
+        return source.create_from(
+            [
+                DataItem(tracking_id=data_item.tracking_id, item=target)
+                for target, data_item in zip(mapped, source.items)
+                if target is not None
+            ]
+        )
 
 
 class AssetCentricMapper(
@@ -1348,16 +1359,40 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
         ):
             if len(intersecting_view_ids) == 1:
                 intersection_view_id = next(iter(intersecting_view_ids))
-                return self._custom_instance_mappings[intersection_view_id].map(source)
-            else:
-                # This is caused by the selector used to download the instance responses not matching the expectation in
-                # the mapper.
+                custom_mapper = self._custom_instance_mappings[intersection_view_id]
+                if isinstance(custom_mapper, InFieldLegacyToCDMScheduleMapper):
+                    return custom_mapper.map(source)
                 raise NotImplementedError(
-                    "Bug in Toolkit: There should be at most one intersecting view when using custom mapping of instances."
+                    f"Custom instance mapper {type(custom_mapper).__name__} does not support tracked mapping."
                 )
+            raise NotImplementedError(
+                "Bug in Toolkit: There should be at most one intersecting view when using custom mapping of instances."
+            )
+        return [data_item.item for data_item in self._map_nodes_to_data_items(source)]
+
+    def map_page(self, source: Page[NodeOrEdgeResponse]) -> Page[NodeOrEdgeRequest]:
+        raw_items = [data_item.item for data_item in source.items]
+        if self._custom_instance_mappings and (
+            intersecting_view_ids := (self._get_view_ids(raw_items) & set(self._custom_instance_mappings))
+        ):
+            if len(intersecting_view_ids) == 1:
+                intersection_view_id = next(iter(intersecting_view_ids))
+                custom_mapper = self._custom_instance_mappings[intersection_view_id]
+                if isinstance(custom_mapper, InFieldLegacyToCDMScheduleMapper):
+                    return custom_mapper.map_page(source)
+                raise NotImplementedError(
+                    f"Custom instance mapper {type(custom_mapper).__name__} does not support tracked mapping."
+                )
+            raise NotImplementedError(
+                "Bug in Toolkit: There should be at most one intersecting view when using custom mapping of instances."
+            )
+        return source.create_from(self._map_nodes_to_data_items(raw_items))
+
+    def _map_nodes_to_data_items(self, source: Sequence[NodeOrEdgeResponse]) -> list[DataItem[NodeOrEdgeRequest]]:
         self._connection_creator.update_cache(source)
         nodes, other_side_by_edge_type_and_direction_by_source = self._as_nodes_and_edges(source)
-        mapped_instances: list[NodeOrEdgeRequest | None] = []
+        mapped_items: list[DataItem[NodeOrEdgeRequest]] = []
+        mapped_instances: list[NodeOrEdgeRequest] = []
         issue_by_source_node_id: dict[NodeId, InstanceConversionIssue] = {}
         source_id_by_target_id: dict[NodeId, NodeId] = {}
         target_view_ids: set[ViewId] = set()
@@ -1381,8 +1416,11 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
                 for source_view_id in (node.properties or {}).keys()
                 if isinstance(source_view_id, ViewId)
             )
+            mapped_items.append(DataItem(tracking_id=str(node.as_id()), item=mapped_node))
             mapped_instances.append(mapped_node)
-            mapped_instances.extend(edges)
+            for edge in edges:
+                mapped_items.append(DataItem(tracking_id=str(edge.as_id()), item=edge))
+                mapped_instances.append(edge)
 
         # Post Validation - check that all direct relation with constraints exists.
         self._connection_creator.update_view_cache(view_ids=target_view_ids)
@@ -1404,7 +1442,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
                     for issue in issue_by_source_node_id.values()
                 ]
             )
-        return mapped_instances
+        return mapped_items
 
     def _get_view_ids(self, source: Sequence[NodeOrEdgeResponse]) -> set[ViewId]:
         return {
@@ -1730,8 +1768,15 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, NodeOrEdgeRe
         self._connection_creator.update_view_cache(retrieved)
 
     def map(self, source: Sequence[NodeOrEdgeResponse]) -> Sequence[NodeOrEdgeRequest | None]:
+        return [data_item.item for data_item in self._map_schedules_to_data_items(source)]
+
+    def map_page(self, source: Page[NodeOrEdgeResponse]) -> Page[NodeOrEdgeRequest]:
+        raw_items = [data_item.item for data_item in source.items]
+        return source.create_from(self._map_schedules_to_data_items(raw_items))
+
+    def _map_schedules_to_data_items(self, source: Sequence[NodeOrEdgeResponse]) -> list[DataItem[NodeOrEdgeRequest]]:
         schedules, template_edges, template_id_edges, issues = self._as_schedules_and_edges(source)
-        output: list[NodeOrEdgeRequest | None] = []
+        mapped_items: list[DataItem[NodeOrEdgeRequest]] = []
         for duplicated_schedules in schedules.values():
             # Sort for deterministic output.
             duplicated_schedules.sort(key=lambda item: item.external_id)
@@ -1740,7 +1785,10 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, NodeOrEdgeRe
                 issues.append(issue)
             elif mapped_item is None:
                 issues.append(issue)
-            output.append(mapped_item)
+            if mapped_item is not None:
+                mapped_items.append(
+                    DataItem(tracking_id=str(duplicated_schedules[0].as_id()), item=mapped_item)
+                )
         if issues:
             self.logger.log(
                 [
@@ -1750,7 +1798,7 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, NodeOrEdgeRe
                     for issue in issues
                 ]
             )
-        return output
+        return mapped_items
 
     def _as_schedules_and_edges(
         self, source: Sequence[NodeOrEdgeResponse]

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1227,7 +1227,9 @@ class ThreeDMapper(DataMapper[ThreeDSelector, ThreeDModelClassicResponse, ThreeD
 
 
 class ThreeDAssetMapper(DataMapper[ThreeDSelector, AssetMappingClassicResponse, AssetMappingDMRequestId]):
-    def map(self, source: Sequence[DataItem[AssetMappingClassicResponse]]) -> Sequence[DataItem[AssetMappingDMRequestId]]:
+    def map(
+        self, source: Sequence[DataItem[AssetMappingClassicResponse]]
+    ) -> Sequence[DataItem[AssetMappingDMRequestId]]:
         output: list[DataItem[AssetMappingDMRequestId]] = []
         log_entries: list[MigrationEntryV2] = []
         raw_items = [data_item.item for data_item in source]

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1766,7 +1766,7 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, NodeOrEdgeRe
 
     def _map_schedules_to_data_items(self, source: Sequence[NodeOrEdgeResponse]) -> list[DataItem[NodeOrEdgeRequest]]:
         schedules, template_edges, template_id_edges, issues = self._as_schedules_and_edges(source)
-        mapped_items: list[DataItem[NodeOrEdgeRequest]] = []
+        output: list[DataItem[NodeOrEdgeRequest]] = []
         for duplicated_schedules in schedules.values():
             # Sort for deterministic output.
             duplicated_schedules.sort(key=lambda item: item.external_id)
@@ -1776,9 +1776,7 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, NodeOrEdgeRe
             elif mapped_item is None:
                 issues.append(issue)
             if mapped_item is not None:
-                mapped_items.append(
-                    DataItem(tracking_id=str(duplicated_schedules[0].as_id()), item=mapped_item)
-                )
+                output.append(DataItem(tracking_id=str(mapped_item.as_id()), item=mapped_item))
         if issues:
             self.logger.log(
                 [
@@ -1788,7 +1786,7 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, NodeOrEdgeRe
                     for issue in issues
                 ]
             )
-        return mapped_items
+        return output
 
     def _as_schedules_and_edges(
         self, source: Sequence[NodeOrEdgeResponse]

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1359,12 +1359,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
         ):
             if len(intersecting_view_ids) == 1:
                 intersection_view_id = next(iter(intersecting_view_ids))
-                custom_mapper = self._custom_instance_mappings[intersection_view_id]
-                if isinstance(custom_mapper, InFieldLegacyToCDMScheduleMapper):
-                    return custom_mapper.map(source)
-                raise NotImplementedError(
-                    f"Custom instance mapper {type(custom_mapper).__name__} does not support tracked mapping."
-                )
+                return self._custom_instance_mappings[intersection_view_id].map(source)
             raise NotImplementedError(
                 "Bug in Toolkit: There should be at most one intersecting view when using custom mapping of instances."
             )

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1415,7 +1415,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
             output.append(DataItem(tracking_id=str(node.as_id()), item=mapped_node))
             mapped_instances.append(mapped_node)
             for edge in edges:
-                output.append(DataItem(tracking_id=str(edge.as_id()), item=edge))
+                output.append(DataItem(tracking_id=str(node.as_id()), item=edge))
                 mapped_instances.append(edge)
 
         # Post Validation - check that all direct relation with constraints exists.

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -56,6 +56,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     ViewResponse,
     ViewResponseProperty,
 )
+from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._instance import NodeOrEdgeRequest
 from cognite_toolkit._cdf_tk.client.resource_classes.group import AllScope
 from cognite_toolkit._cdf_tk.client.resource_classes.group.acls import ChartsAdminAcl
 from cognite_toolkit._cdf_tk.client.resource_classes.record_property_mapping import RecordPropertyMapping
@@ -136,28 +137,22 @@ class DataMapper(Generic[T_Selector, T_DataResponse, T_DataRequest], ABC):
         pass
 
     @abstractmethod
-    def map(self, source: Sequence[T_DataResponse]) -> Sequence[T_DataRequest | None]:
+    def map(self, source: Sequence[DataItem[T_DataResponse]]) -> Sequence[DataItem[T_DataRequest]]:
         """Map a chunk of source data to the target format.
 
         Args:
-            source: The source data chunk to be mapped.
+            source: The source data items to be mapped. Each DataItem carries a tracking_id
+                that should be propagated (or replaced) in the returned DataItems.
 
         Returns:
-            A sequence of mapped target data.
+            A sequence of mapped target DataItems. Items that cannot be mapped are omitted
+            (rather than returning None), so the output length may differ from the input.
 
         """
         raise NotImplementedError("Subclasses must implement this method.")
 
     def map_page(self, source: Page[T_DataResponse]) -> Page[T_DataRequest]:
-        raw_items = [data_item.item for data_item in source.items]
-        mapped = self.map(raw_items)
-        return source.create_from(
-            [
-                DataItem(tracking_id=data_item.tracking_id, item=target)
-                for target, data_item in zip(mapped, source.items)
-                if target is not None
-            ]
-        )
+        return source.create_from(self.map(source.items))
 
 
 class AssetCentricMapper(
@@ -299,17 +294,18 @@ class AssetCentricMapper(
         return entries
 
     def map(
-        self, source: Sequence[AssetCentricMapping[T_AssetCentricResourceExtended]]
-    ) -> Sequence[T_DataRequest | None]:
-        self._direct_relation_cache.update(item.resource for item in source)
-        output: list[T_DataRequest | None] = []
+        self, source: Sequence[DataItem[AssetCentricMapping[T_AssetCentricResourceExtended]]]
+    ) -> Sequence[DataItem[T_DataRequest]]:
+        self._direct_relation_cache.update(data_item.item.resource for data_item in source)
+        output: list[DataItem[T_DataRequest]] = []
         log_entries: list[MigrationEntryV2] = []
-        for item in source:
-            result, conversion_issue = self._map_single_item(item)
+        for data_item in source:
+            result, conversion_issue = self._map_single_item(data_item.item)
             log_entries.extend(
-                self._migration_entries_for_conversion(item, conversion_issue, result is None),
+                self._migration_entries_for_conversion(data_item.item, conversion_issue, result is None),
             )
-            output.append(result)
+            if result is not None:
+                output.append(DataItem(tracking_id=data_item.tracking_id, item=result))
         if log_entries:
             self.logger.log(log_entries)
         return output
@@ -463,13 +459,15 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
         ):
             raise self.client.tool.token.create_error(missing_acl, action="migrate charts")
 
-    def map(self, source: Sequence[ChartResponse]) -> Sequence[ChartRequest | None]:
-        event_ids_by_chart_external_id = self._populate_cache(source)
-        output: list[ChartRequest | None] = []
+    def map(self, source: Sequence[DataItem[ChartResponse]]) -> Sequence[DataItem[ChartRequest]]:
+        raw_items = [data_item.item for data_item in source]
+        event_ids_by_chart_external_id = self._populate_cache(raw_items)
+        output: list[DataItem[ChartRequest]] = []
         log_entries: list[MigrationEntryV2] = []
         chart_src = "Charts"
         chart_dest = "Charts (data modeling)"
-        for item in source:
+        for data_item in source:
+            item = data_item.item
             identifier = item.external_id
 
             if not item.data.time_series_collection and not self._has_legacy_backend_refs(item):
@@ -483,7 +481,6 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
                         destination=chart_dest,
                     )
                 )
-                output.append(None)
                 continue
             mapped_item, issue = self._map_single_item(
                 item, event_ids_by_chart_external_id.get(item.external_id, set())
@@ -551,7 +548,8 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
                         destination=chart_dest,
                     )
                 )
-            output.append(mapped_item)
+            if mapped_item is not None:
+                output.append(DataItem(tracking_id=data_item.tracking_id, item=mapped_item))
         if log_entries:
             self.logger.log(log_entries)
         return output
@@ -940,14 +938,16 @@ class CanvasMapper(DataMapper[CanvasSelector, IndustrialCanvasResponse, Industri
         self.dry_run = dry_run
         self.skip_on_missing_ref = skip_on_missing_ref
 
-    def map(self, source: Sequence[IndustrialCanvasResponse]) -> Sequence[IndustrialCanvasRequest | None]:
-        file_node_ids = self._populate_cache(source)
+    def map(self, source: Sequence[DataItem[IndustrialCanvasResponse]]) -> Sequence[DataItem[IndustrialCanvasRequest]]:
+        raw_items = [data_item.item for data_item in source]
+        file_node_ids = self._populate_cache(raw_items)
         cognite_file_by_id = {file.as_id(): file for file in self.client.tool.cognite_files.retrieve(file_node_ids)}
-        output: list[IndustrialCanvasRequest | None] = []
+        output: list[DataItem[IndustrialCanvasRequest]] = []
         log_entries: list[MigrationEntryV2] = []
         canvas_src = "Industrial Canvas"
         canvas_dest = "Industrial Canvas (data modeling)"
-        for item in source:
+        for data_item in source:
+            item = data_item.item
             mapped_item, issue = self._map_single_item(item, cognite_file_by_id)
             identifier = item.external_id
 
@@ -989,8 +989,8 @@ class CanvasMapper(DataMapper[CanvasSelector, IndustrialCanvasResponse, Industri
                         destination=canvas_dest,
                     )
                 )
-
-            output.append(mapped_item)
+            else:
+                output.append(DataItem(tracking_id=data_item.tracking_id, item=mapped_item))
         if log_entries:
             self.logger.log(log_entries)
         return output
@@ -1123,13 +1123,15 @@ class CanvasMapper(DataMapper[CanvasSelector, IndustrialCanvasResponse, Industri
 
 
 class ThreeDMapper(DataMapper[ThreeDSelector, ThreeDModelClassicResponse, ThreeDMigrationRequest]):
-    def map(self, source: Sequence[ThreeDModelClassicResponse]) -> Sequence[ThreeDMigrationRequest | None]:
-        self._populate_cache(source)
-        output: list[ThreeDMigrationRequest | None] = []
+    def map(self, source: Sequence[DataItem[ThreeDModelClassicResponse]]) -> Sequence[DataItem[ThreeDMigrationRequest]]:
+        raw_items = [data_item.item for data_item in source]
+        self._populate_cache(raw_items)
+        output: list[DataItem[ThreeDMigrationRequest]] = []
         log_entries: list[MigrationEntryV2] = []
         src_3d = "3D models"
         dest_3d = "3D models (data modeling)"
-        for item in source:
+        for data_item in source:
+            item = data_item.item
             mapped_item, issue = self._map_single_item(item)
             identifier = item.name
             if mapped_item is None:
@@ -1156,7 +1158,8 @@ class ThreeDMapper(DataMapper[ThreeDSelector, ThreeDModelClassicResponse, ThreeD
                         destination=dest_3d,
                     )
                 )
-            output.append(mapped_item)
+            if mapped_item is not None:
+                output.append(DataItem(tracking_id=data_item.tracking_id, item=mapped_item))
         if log_entries:
             self.logger.log(log_entries)
         return output
@@ -1227,13 +1230,15 @@ class ThreeDMapper(DataMapper[ThreeDSelector, ThreeDModelClassicResponse, ThreeD
 
 
 class ThreeDAssetMapper(DataMapper[ThreeDSelector, AssetMappingClassicResponse, AssetMappingDMRequestId]):
-    def map(self, source: Sequence[AssetMappingClassicResponse]) -> Sequence[AssetMappingDMRequestId | None]:
-        output: list[AssetMappingDMRequestId | None] = []
+    def map(self, source: Sequence[DataItem[AssetMappingClassicResponse]]) -> Sequence[DataItem[AssetMappingDMRequestId]]:
+        output: list[DataItem[AssetMappingDMRequestId]] = []
         log_entries: list[MigrationEntryV2] = []
-        self._populate_cache(source)
+        raw_items = [data_item.item for data_item in source]
+        self._populate_cache(raw_items)
         src_map = "3D asset mappings"
         dest_map = "3D asset mappings (data modeling)"
-        for item in source:
+        for data_item in source:
+            item = data_item.item
             mapped_item, issue = self._map_single_item(item)
             identifier = f"AssetMapping_{item.model_id!s}_{item.revision_id!s}_{item.asset_id!s}"
             if mapped_item is None:
@@ -1260,8 +1265,8 @@ class ThreeDAssetMapper(DataMapper[ThreeDSelector, AssetMappingClassicResponse, 
                         destination=dest_map,
                     )
                 )
-
-            output.append(mapped_item)
+            if mapped_item is not None:
+                output.append(DataItem(tracking_id=data_item.tracking_id, item=mapped_item))
         if log_entries:
             self.logger.log(log_entries)
         return output
@@ -1353,9 +1358,10 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
         views = self.client.tool.views.retrieve(list(view_ids))
         self._connection_creator.update_view_cache(views)
 
-    def map(self, source: Sequence[NodeOrEdgeResponse]) -> Sequence[NodeOrEdgeRequest | None]:
+    def map(self, source: Sequence[DataItem[NodeOrEdgeResponse]]) -> Sequence[DataItem[NodeOrEdgeRequest]]:
+        raw_items = [data_item.item for data_item in source]
         if self._custom_instance_mappings and (
-            intersecting_view_ids := (self._get_view_ids(source) & set(self._custom_instance_mappings))
+            intersecting_view_ids := (self._get_view_ids(raw_items) & set(self._custom_instance_mappings))
         ):
             if len(intersecting_view_ids) == 1:
                 intersection_view_id = next(iter(intersecting_view_ids))
@@ -1363,25 +1369,9 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
             raise NotImplementedError(
                 "Bug in Toolkit: There should be at most one intersecting view when using custom mapping of instances."
             )
-        return [data_item.item for data_item in self._map_nodes_to_data_items(source)]
-
-    def map_page(self, source: Page[NodeOrEdgeResponse]) -> Page[NodeOrEdgeRequest]:
-        raw_items = [data_item.item for data_item in source.items]
-        if self._custom_instance_mappings and (
-            intersecting_view_ids := (self._get_view_ids(raw_items) & set(self._custom_instance_mappings))
-        ):
-            if len(intersecting_view_ids) == 1:
-                intersection_view_id = next(iter(intersecting_view_ids))
-                return self._custom_instance_mappings[intersection_view_id].map_page(source)
-            raise NotImplementedError(
-                "Bug in Toolkit: There should be at most one intersecting view when using custom mapping of instances."
-            )
-        return source.create_from(self._map_nodes_to_data_items(raw_items))
-
-    def _map_nodes_to_data_items(self, source: Sequence[NodeOrEdgeResponse]) -> list[DataItem[NodeOrEdgeRequest]]:
-        self._connection_creator.update_cache(source)
-        nodes, other_side_by_edge_type_and_direction_by_source = self._as_nodes_and_edges(source)
-        mapped_items: list[DataItem[NodeOrEdgeRequest]] = []
+        self._connection_creator.update_cache(raw_items)
+        nodes, other_side_by_edge_type_and_direction_by_source = self._as_nodes_and_edges(raw_items)
+        output: list[DataItem[NodeOrEdgeRequest]] = []
         mapped_instances: list[NodeOrEdgeRequest] = []
         issue_by_source_node_id: dict[NodeId, InstanceConversionIssue] = {}
         source_id_by_target_id: dict[NodeId, NodeId] = {}
@@ -1406,10 +1396,10 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
                 for source_view_id in (node.properties or {}).keys()
                 if isinstance(source_view_id, ViewId)
             )
-            mapped_items.append(DataItem(tracking_id=str(node.as_id()), item=mapped_node))
+            output.append(DataItem(tracking_id=str(node.as_id()), item=mapped_node))
             mapped_instances.append(mapped_node)
             for edge in edges:
-                mapped_items.append(DataItem(tracking_id=str(edge.as_id()), item=edge))
+                output.append(DataItem(tracking_id=str(edge.as_id()), item=edge))
                 mapped_instances.append(edge)
 
         # Post Validation - check that all direct relation with constraints exists.
@@ -1432,7 +1422,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
                     for issue in issue_by_source_node_id.values()
                 ]
             )
-        return mapped_items
+        return output
 
     def _get_view_ids(self, source: Sequence[NodeOrEdgeResponse]) -> set[ViewId]:
         return {
@@ -1757,15 +1747,9 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, NodeOrEdgeRe
         retrieved = self.client.tool.views.retrieve([self._mapping.destination_view])
         self._connection_creator.update_view_cache(retrieved)
 
-    def map(self, source: Sequence[NodeOrEdgeResponse]) -> Sequence[NodeOrEdgeRequest | None]:
-        return [data_item.item for data_item in self._map_schedules_to_data_items(source)]
-
-    def map_page(self, source: Page[NodeOrEdgeResponse]) -> Page[NodeOrEdgeRequest]:
-        raw_items = [data_item.item for data_item in source.items]
-        return source.create_from(self._map_schedules_to_data_items(raw_items))
-
-    def _map_schedules_to_data_items(self, source: Sequence[NodeOrEdgeResponse]) -> list[DataItem[NodeOrEdgeRequest]]:
-        schedules, template_edges, template_id_edges, issues = self._as_schedules_and_edges(source)
+    def map(self, source: Sequence[DataItem[NodeOrEdgeResponse]]) -> Sequence[DataItem[NodeOrEdgeRequest]]:
+        raw_items = [data_item.item for data_item in source]
+        schedules, template_edges, template_id_edges, issues = self._as_schedules_and_edges(raw_items)
         output: list[DataItem[NodeOrEdgeRequest]] = []
         for duplicated_schedules in schedules.values():
             # Sort for deterministic output.

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -2052,8 +2052,9 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
     ViewToViewMapping path for Image360Collection source nodes.
     """
 
-    def map(self, source: Sequence[NodeOrEdgeResponse]) -> Sequence[NodeOrEdgeRequest | None]:
-        collection_nodes = [node for node in source if isinstance(node, NodeResponse)]
+    def map(self, source: Sequence[DataItem[NodeOrEdgeResponse]]) -> Sequence[DataItem[NodeOrEdgeRequest]]:
+        raw_items = [data_item.item for data_item in source]
+        collection_nodes = [node for node in raw_items if isinstance(node, NodeResponse)]
         migrated_ids = [
             NodeId(space=node.space, external_id=sanitize_instance_external_id(node.external_id, "_cdm"))
             for node in collection_nodes
@@ -2068,8 +2069,9 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
             else {}
         )
 
-        results: list[NodeRequest | None] = []
-        for node in source:
+        results: list[DataItem[NodeOrEdgeRequest]] = []
+        for data_item in source:
+            node = data_item.item
             instance_space = node.space
             collection_ext_id = sanitize_instance_external_id(node.external_id, "_cdm")
             migrated_id = NodeId(space=instance_space, external_id=collection_ext_id)
@@ -2095,28 +2097,31 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
                     model_external_id = f"cog_3d_model_{created_model.id}"
 
             results.append(
-                NodeRequest(
-                    space=instance_space,
-                    external_id=collection_ext_id,
-                    sources=[
-                        InstanceSource(
-                            source=ContainerId(space="cdf_cdm_3d", external_id="Cognite3DRevision"),
-                            properties={
-                                "model3D": {"space": instance_space, "externalId": model_external_id},
-                                "status": "Done",
-                                "published": True,
-                                "type": "Image360",
-                            },
-                        ),
-                        InstanceSource(
-                            source=ContainerId(space="cdf_cdm", external_id="CogniteDescribable"),
-                            properties={
-                                "name": ((node.properties or {}).get(LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW) or {}).get(
-                                    "label"
-                                )
-                            },
-                        ),
-                    ],
+                DataItem(
+                    tracking_id=data_item.tracking_id,
+                    item=NodeRequest(
+                        space=instance_space,
+                        external_id=collection_ext_id,
+                        sources=[
+                            InstanceSource(
+                                source=ContainerId(space="cdf_cdm_3d", external_id="Cognite3DRevision"),
+                                properties={
+                                    "model3D": {"space": instance_space, "externalId": model_external_id},
+                                    "status": "Done",
+                                    "published": True,
+                                    "type": "Image360",
+                                },
+                            ),
+                            InstanceSource(
+                                source=ContainerId(space="cdf_cdm", external_id="CogniteDescribable"),
+                                properties={
+                                    "name": ((node.properties or {}).get(LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW) or {}).get(
+                                        "label"
+                                    )
+                                },
+                            ),
+                        ],
+                    ),
                 )
             )
         return results

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -2115,9 +2115,9 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
                             InstanceSource(
                                 source=ContainerId(space="cdf_cdm", external_id="CogniteDescribable"),
                                 properties={
-                                    "name": ((node.properties or {}).get(LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW) or {}).get(
-                                        "label"
-                                    )
+                                    "name": (
+                                        (node.properties or {}).get(LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW) or {}
+                                    ).get("label")
                                 },
                             ),
                         ],

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -56,7 +56,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     ViewResponse,
     ViewResponseProperty,
 )
-from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._instance import NodeOrEdgeRequest
 from cognite_toolkit._cdf_tk.client.resource_classes.group import AllScope
 from cognite_toolkit._cdf_tk.client.resource_classes.group.acls import ChartsAdminAcl
 from cognite_toolkit._cdf_tk.client.resource_classes.record_property_mapping import RecordPropertyMapping

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -100,7 +100,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.issues import (
     instance_conversion_issue_as_migration_entry,
 )
 from cognite_toolkit._cdf_tk.constants import MISSING_INSTANCE_SPACE
-from cognite_toolkit._cdf_tk.dataio import DataItem, Page, T_DataRequest, T_DataResponse, T_Selector
+from cognite_toolkit._cdf_tk.dataio import DataItem, T_DataRequest, T_DataResponse, T_Selector
 from cognite_toolkit._cdf_tk.dataio.logger import DataLogger, NoOpLogger, Severity
 from cognite_toolkit._cdf_tk.dataio.selectors import (
     CanvasSelector,
@@ -150,9 +150,6 @@ class DataMapper(Generic[T_Selector, T_DataResponse, T_DataRequest], ABC):
 
         """
         raise NotImplementedError("Subclasses must implement this method.")
-
-    def map_page(self, source: Page[T_DataResponse]) -> Page[T_DataRequest]:
-        return source.create_from(self.map(source.items))
 
 
 class AssetCentricMapper(

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -91,9 +91,9 @@ class InstanceIO(
         self._view_crud = ViewIO.create_loader(self.client)
 
     def emit_registered_page(self, page: "Page[NodeOrEdgeResponse]") -> "Page[NodeOrEdgeResponse]":
-        node_ids = [item.tracking_id for item in page.items if item.item.instance_type == "node"]
-        if node_ids:
-            self.logger.register(node_ids)
+        ids = [item.tracking_id for item in page.items if not isinstance(item.item, EdgeResponse)]
+        if ids:
+            self.logger.register(ids)
         return page
 
     @staticmethod

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -90,6 +90,12 @@ class InstanceIO(
         self._view_readonly_properties_cache: dict[ViewId, set[str]] = {}
         self._view_crud = ViewIO.create_loader(self.client)
 
+    def emit_registered_page(self, page: "Page[NodeOrEdgeResponse]") -> "Page[NodeOrEdgeResponse]":
+        node_ids = [item.tracking_id for item in page.items if item.item.instance_type == "node"]
+        if node_ids:
+            self.logger.register(node_ids)
+        return page
+
     @staticmethod
     def _build_list_filter(selector: InstanceViewSelector | InstanceSpaceSelector) -> InstanceFilter:
         """Build an InstanceFilter from a selector.

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -21,6 +21,7 @@ from cognite.client.data_classes.data_modeling.statistics import InstanceStatist
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
 from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, InternalId
+from cognite_toolkit._cdf_tk.client.http_client import ItemsSuccessResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.annotation import (
     AnnotationResponse,
     AssetLinkData,
@@ -94,7 +95,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.migration_io import (
     RecordsMigrationIO,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import MigrationCSVFileSelector
-from cognite_toolkit._cdf_tk.dataio import CanvasIO, ChartIO
+from cognite_toolkit._cdf_tk.dataio import CanvasIO, ChartIO, DataItem, Page
 from cognite_toolkit._cdf_tk.dataio.logger import ItemsResult
 from cognite_toolkit._cdf_tk.dataio.progress import CursorBookmark, ProgressYAML
 from cognite_toolkit._cdf_tk.dataio.selectors import (
@@ -247,6 +248,21 @@ def _make_stream_response(
             ),
         ),
     )
+
+
+class _ChunkTrackingUploadIO:
+    CHUNK_SIZE = 1000
+    KIND = "Instances"
+
+    def __init__(self) -> None:
+        self.upload_chunk_sizes: list[int] = []
+        self.logger = MagicMock()
+
+    def upload_items(
+        self, data_chunk: Page, http_client: object, selector: object | None = None
+    ) -> list:
+        self.upload_chunk_sizes.append(len(data_chunk))
+        return []
 
 
 @pytest.mark.usefixtures("disable_gzip", "disable_pypi_check")
@@ -1128,6 +1144,26 @@ class TestMigrationCommand:
 
         has_existing_version = [item["externalId"] for item in created_instance if "existingVersion" in item]
         assert not has_existing_version, f"Expected no existingVersion field, but found in: {has_existing_version}"
+
+    def test_upload_chunks_pages_larger_than_chunk_size(self, tmp_path: Path) -> None:
+        command = MigrationCommand(silent=True)
+        target = _ChunkTrackingUploadIO()
+        page = Page(
+            worker_id="main",
+            items=[DataItem(tracking_id=f"item-{index}", item=index) for index in range(1001)],
+        )
+        upload = command._upload(
+            selected=MagicMock(),
+            write_client=MagicMock(),
+            target=target,  # type: ignore[arg-type]
+            dry_run=False,
+            log_dir=tmp_path,
+            total_item_count=1001,
+            start_item=0,
+        )
+        upload(page)
+
+        assert target.upload_chunk_sizes == [1000, 1]
 
     def test_validate_migration_model_available(self) -> None:
         with monkeypatch_toolkit_client() as client:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -21,7 +21,6 @@ from cognite.client.data_classes.data_modeling.statistics import InstanceStatist
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
 from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, InternalId
-from cognite_toolkit._cdf_tk.client.http_client import ItemsSuccessResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.annotation import (
     AnnotationResponse,
     AssetLinkData,
@@ -258,9 +257,7 @@ class _ChunkTrackingUploadIO:
         self.upload_chunk_sizes: list[int] = []
         self.logger = MagicMock()
 
-    def upload_items(
-        self, data_chunk: Page, http_client: object, selector: object | None = None
-    ) -> list:
+    def upload_items(self, data_chunk: Page, http_client: object, selector: object | None = None) -> list:
         self.upload_chunk_sizes.append(len(data_chunk))
         return []
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -85,7 +85,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.data_mapper import (
 )
 from cognite_toolkit._cdf_tk.commands._migrate.issues import MigrationEntryV2
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import MigrationCSVFileSelector
-from cognite_toolkit._cdf_tk.dataio import DataItem, Page
+from cognite_toolkit._cdf_tk.dataio import DataItem
 from cognite_toolkit._cdf_tk.dataio.logger import DataLogger, FileWithAggregationLogger, Severity
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 from tests.data import MIGRATION_DIR
@@ -939,20 +939,17 @@ class TestFDMtoCDMMapper:
             mapper = FDMtoCDMMapper(client, [mapping], connection_creator)
             mapper.prepare(MagicMock())
 
-            source_page = Page(
-                worker_id="main",
-                items=[
-                    DataItem(tracking_id=f"{self.SOURCE_SPACE}:node1", item=node),
-                    DataItem(tracking_id=f"{self.SOURCE_SPACE}:edge1", item=edge),
-                ],
-            )
-            mapped_page = mapper.map_page(source_page)
+            source_items = [
+                DataItem(tracking_id=f"{self.SOURCE_SPACE}:node1", item=node),
+                DataItem(tracking_id=f"{self.SOURCE_SPACE}:edge1", item=edge),
+            ]
+            mapped_items = mapper.map(source_items)
 
-        assert len(mapped_page.items) == 2
-        assert mapped_page.items[0].tracking_id == f"{self.SOURCE_SPACE}:node1"
-        assert isinstance(mapped_page.items[0].item, NodeRequest)
-        assert mapped_page.items[1].tracking_id == f"{self.TARGET_SPACE}:edge1"
-        assert isinstance(mapped_page.items[1].item, EdgeRequest)
+        assert len(mapped_items) == 2
+        assert mapped_items[0].tracking_id == f"{self.SOURCE_SPACE}:node1"
+        assert isinstance(mapped_items[0].item, NodeRequest)
+        assert mapped_items[1].tracking_id == f"{self.TARGET_SPACE}:edge1"
+        assert isinstance(mapped_items[1].item, EdgeRequest)
 
     @pytest.mark.parametrize(
         "dry_run, expected_log_calls",

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -965,7 +965,7 @@ class TestFDMtoCDMMapper:
         assert len(mapped_items) == 2
         assert mapped_items[0].tracking_id == f"{self.SOURCE_SPACE}:node1"
         assert isinstance(mapped_items[0].item, NodeRequest)
-        assert mapped_items[1].tracking_id == f"{self.TARGET_SPACE}:edge1"
+        assert mapped_items[1].tracking_id == f"{self.SOURCE_SPACE}:node1"
         assert isinstance(mapped_items[1].item, EdgeRequest)
 
     @pytest.mark.parametrize(

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -902,7 +902,7 @@ class TestFDMtoCDMMapper:
             actual = mapper.map([DataItem(tracking_id=str(i), item=inst) for i, inst in enumerate(instances)])
             assert [data_item.item.dump() for data_item in actual] == [item.dump() for item in expected]
 
-    def test_map_page_emits_all_mapped_items_with_tracking_ids(self) -> None:
+    def test_map_emits_all_mapped_items_with_tracking_ids(self) -> None:
         node = NodeResponse(
             space=self.SOURCE_SPACE,
             external_id="node1",

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -1147,7 +1147,7 @@ class TestFDMtoCDMMapper:
             mapper.logger = logger
             mapper.prepare(MagicMock())
 
-            actual = mapper.map([node])
+            actual = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:image1", item=node)])
 
         if expect_failure:
             assert actual == []
@@ -1161,9 +1161,9 @@ class TestFDMtoCDMMapper:
             assert f"{self.SOURCE_SPACE}:image1" == entry.id
         else:
             assert len(actual) == 1
-            assert isinstance(actual[0], NodeRequest)
-            assert actual[0].space == self.SOURCE_SPACE
-            assert actual[0].external_id == sanitize_instance_external_id("image1", "_cdm")
+            assert isinstance(actual[0].item, NodeRequest)
+            assert actual[0].item.space == self.SOURCE_SPACE
+            assert actual[0].item.external_id == sanitize_instance_external_id("image1", "_cdm")
             logger.log.assert_not_called()
 
     def test_image360_collection_mapper_uses_same_space_and_model3d_from_map(self) -> None:
@@ -1186,13 +1186,13 @@ class TestFDMtoCDMMapper:
             client.tool.instances.retrieve.return_value = []
             client.tool.three_d.models_classic.create.return_value = [created_model]
             mapper = Image360CollectionMapper(client)
-            actual = mapper.map([collection_node])
+            actual = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:collection1", item=collection_node)])
 
         client.tool.three_d.models_classic.create.assert_called_once_with(
             [ThreeDModelDMSRequest(name="My collection", space=self.SOURCE_SPACE, type="Image360")]
         )
         assert len(actual) == 1
-        collection_request = actual[0]
+        collection_request = actual[0].item
         assert isinstance(collection_request, NodeRequest)
         assert collection_request.space == self.SOURCE_SPACE
         assert collection_request.external_id == sanitize_instance_external_id("collection1", "_cdm")
@@ -1232,10 +1232,10 @@ class TestFDMtoCDMMapper:
         with monkeypatch_toolkit_client() as client:
             client.tool.instances.retrieve.return_value = [migrated_node]
             mapper = Image360CollectionMapper(client)
-            actual = mapper.map([collection_node])
+            actual = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:collection1", item=collection_node)])
 
         client.tool.three_d.models_classic.create.assert_not_called()
-        collection_request = actual[0]
+        collection_request = actual[0].item
         assert isinstance(collection_request, NodeRequest)
         model_source = next(
             source for source in collection_request.sources or [] if source.source.external_id == "Cognite3DRevision"
@@ -1357,17 +1357,17 @@ class TestFDMtoCDMMapper:
             )
             mapper.prepare(MagicMock())
 
-            collection_results = mapper.map([collection_node])
-            station_results = mapper.map([station_node])
-            image_results = mapper.map([image_node])
+            collection_results = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:collection1", item=collection_node)])
+            station_results = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:station1", item=station_node)])
+            image_results = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:image1", item=image_node)])
 
         assert len(collection_results) == 1
         assert len(station_results) == 1
         assert len(image_results) == 1
 
-        collection_request = collection_results[0]
-        station_request = station_results[0]
-        image_request = image_results[0]
+        collection_request = collection_results[0].item
+        station_request = station_results[0].item
+        image_request = image_results[0].item
         assert isinstance(collection_request, NodeRequest)
         assert isinstance(station_request, NodeRequest)
         assert isinstance(image_request, NodeRequest)

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -162,8 +162,8 @@ class TestAssetCentricToInstanceMapper:
             mapper.prepare(selected)
 
             mapped: list[InstanceApply] = []
-            for target, item in zip(mapper.map(source), source):
-                mapped.append(target)
+            for data_item in mapper.map([DataItem(tracking_id=str(i), item=s) for i, s in enumerate(source)]):
+                mapped.append(data_item.item)
 
             # We do not assert the exact content of mapped, as that is tested in the
             # tests for the asset_centric_to_dm function.
@@ -209,7 +209,7 @@ class TestAssetCentricToInstanceMapper:
                 RuntimeError,
                 match=r"Failed to lookup mapping or view for ingestion view 'cdf_asset_mapping'. Did you forget to call .prepare()?",
             ):
-                mapper.map([source])
+                mapper.map([DataItem(tracking_id="t", item=source)])
 
     def test_prepare_missing_view_source_raises_error(self, tmp_path: Path) -> None:
         """Test that prepare raises ToolkitValueError when view source is not found."""
@@ -335,8 +335,8 @@ class TestThreeDAssetMapper:
             mapper = ThreeDAssetMapper(client)
             logger = MagicMock(spec=DataLogger)
             mapper.logger = logger
-            mapped = mapper.map([response])[0]
-
+            result = mapper.map([DataItem(tracking_id="t", item=response)])
+            mapped = result[0].item if result else None
             if lookup_asset is not None:
                 # One for cache population, one for actual call
                 assert client.migration.lookup.assets.call_count == 2
@@ -397,7 +397,7 @@ class TestCanvasMapper:
             logger = MagicMock(spec=DataLogger)
             mapper.logger = logger
 
-            actual = mapper.map([input_canvas])[0]
+            actual = mapper.map([DataItem(tracking_id="t", item=input_canvas)])[0].item
 
         assert not actual.container_references
         assert len(actual.fdm_instance_container_references) == len(input_canvas.container_references)
@@ -461,9 +461,9 @@ class TestChartMapper:
             client.migration.lookup.events = event_lookup
 
             mapper = ChartMapper(client)
-            mapped_list = mapper.map([source])
+            mapped_list = mapper.map([DataItem(tracking_id="t", item=source)])
             assert len(mapped_list) == 1
-            mapped = mapped_list[0]
+            mapped = mapped_list[0].item
             assert isinstance(mapped, ChartRequest)
 
         dumped = mapped.dump()
@@ -588,9 +588,9 @@ class TestChartMapper:
             logger = FileWithAggregationLogger(MagicMock())
             logger.register([chart.external_id])
             mapper.logger = logger
-            result = mapper.map([chart])
+            result = mapper.map([DataItem(tracking_id="t", item=chart)])
 
-        assert result == [None]
+        assert result == []
 
         aggregations = logger.aggregations_by_ids[chart.external_id]
         assert len(aggregations) == 1
@@ -899,8 +899,8 @@ class TestFDMtoCDMMapper:
             mapper = FDMtoCDMMapper(client, [mapping], connection_creator)
             mapper.prepare(MagicMock())
 
-            actual = mapper.map(instances)
-            assert [item.dump() for item in actual] == [item.dump() for item in expected]
+            actual = mapper.map([DataItem(tracking_id=str(i), item=inst) for i, inst in enumerate(instances)])
+            assert [data_item.item.dump() for data_item in actual] == [item.dump() for item in expected]
 
     def test_map_page_emits_all_mapped_items_with_tracking_ids(self) -> None:
         node = NodeResponse(
@@ -1001,13 +1001,16 @@ class TestFDMtoCDMMapper:
             # First step: map the would-be target of the direct relation.
             mapper.map(
                 [
-                    NodeResponse(
-                        space=self.SOURCE_SPACE,
-                        external_id="first",
-                        last_updated_time=1,
-                        created_time=0,
-                        version=1,
-                        properties={self.SOURCE_VIEW_ID: {}},
+                    DataItem(
+                        tracking_id="t",
+                        item=NodeResponse(
+                            space=self.SOURCE_SPACE,
+                            external_id="first",
+                            last_updated_time=1,
+                            created_time=0,
+                            version=1,
+                            properties={self.SOURCE_VIEW_ID: {}},
+                        ),
                     )
                 ]
             )
@@ -1016,15 +1019,18 @@ class TestFDMtoCDMMapper:
             # Second step: map a node whose direct relation points at "first".
             mapper.map(
                 [
-                    NodeResponse(
-                        space=self.SOURCE_SPACE,
-                        external_id="second",
-                        last_updated_time=1,
-                        created_time=0,
-                        version=1,
-                        properties={
-                            self.SOURCE_VIEW_ID: {"sourceDirect": {"space": self.SOURCE_SPACE, "externalId": "first"}}
-                        },
+                    DataItem(
+                        tracking_id="t",
+                        item=NodeResponse(
+                            space=self.SOURCE_SPACE,
+                            external_id="second",
+                            last_updated_time=1,
+                            created_time=0,
+                            version=1,
+                            properties={
+                                self.SOURCE_VIEW_ID: {"sourceDirect": {"space": self.SOURCE_SPACE, "externalId": "first"}}
+                            },
+                        ),
                     )
                 ]
             )
@@ -1199,9 +1205,9 @@ class TestInFieldLegacyToCDMScheduleMapper:
             mapper = InFieldLegacyToCDMScheduleMapper(client, connection_creator, mapping)
             mapper.prepare(MagicMock())
 
-            result = mapper.map(schedule_instance_data)
+            result = mapper.map([DataItem(tracking_id=str(i), item=s) for i, s in enumerate(schedule_instance_data)])
 
-        mapped_schedules = [r for r in result if r is not None]
+        mapped_schedules = [data_item.item for data_item in result]
         assert len(mapped_schedules) == 2
 
         data_regression.check({"schedules": [s.dump() for s in mapped_schedules]})
@@ -1269,7 +1275,7 @@ class TestAssetCentricToRecordMapper:
             mapper = AssetCentricToRecordMapper(client, mappings_by_external_id={"mapping_a": mapping})
             mapper.prepare(MagicMock())
             with pytest.raises(ToolkitValueError, match="only supports Event"):
-                mapper.map([source])
+                mapper.map([DataItem(tracking_id="t", item=source)])
 
     def test_map_produces_record_request(self) -> None:
         container_id = ContainerId(space="my_space", external_id="EventContainer")
@@ -1289,9 +1295,9 @@ class TestAssetCentricToRecordMapper:
             client.tool.containers.retrieve.return_value = [_make_record_container_response(container_id)]
             mapper = AssetCentricToRecordMapper(client, mappings_by_external_id={"mapping_a": mapping})
             mapper.prepare(MagicMock())
-            results = mapper.map([source])
+            results = mapper.map([DataItem(tracking_id="t", item=source)])
         assert len(results) == 1
-        record = results[0]
+        record = results[0].item
         assert record is not None
         assert record.space == "my_space"
         assert record.external_id == "event_1"

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -1357,7 +1357,9 @@ class TestFDMtoCDMMapper:
             )
             mapper.prepare(MagicMock())
 
-            collection_results = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:collection1", item=collection_node)])
+            collection_results = mapper.map(
+                [DataItem(tracking_id=f"{self.SOURCE_SPACE}:collection1", item=collection_node)]
+            )
             station_results = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:station1", item=station_node)])
             image_results = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:image1", item=image_node)])
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -1025,7 +1025,9 @@ class TestFDMtoCDMMapper:
                             created_time=0,
                             version=1,
                             properties={
-                                self.SOURCE_VIEW_ID: {"sourceDirect": {"space": self.SOURCE_SPACE, "externalId": "first"}}
+                                self.SOURCE_VIEW_ID: {
+                                    "sourceDirect": {"space": self.SOURCE_SPACE, "externalId": "first"}
+                                }
                             },
                         ),
                     )

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -85,6 +85,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.data_mapper import (
 )
 from cognite_toolkit._cdf_tk.commands._migrate.issues import MigrationEntryV2
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import MigrationCSVFileSelector
+from cognite_toolkit._cdf_tk.dataio import DataItem, Page
 from cognite_toolkit._cdf_tk.dataio.logger import DataLogger, FileWithAggregationLogger, Severity
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 from tests.data import MIGRATION_DIR
@@ -900,6 +901,58 @@ class TestFDMtoCDMMapper:
 
             actual = mapper.map(instances)
             assert [item.dump() for item in actual] == [item.dump() for item in expected]
+
+    def test_map_page_emits_all_mapped_items_with_tracking_ids(self) -> None:
+        node = NodeResponse(
+            space=self.SOURCE_SPACE,
+            external_id="node1",
+            last_updated_time=1772522715000,
+            created_time=0,
+            version=1,
+            properties={self.SOURCE_VIEW_ID: {"textProp": "37"}},
+        )
+        edge = EdgeResponse(
+            space=self.SOURCE_SPACE,
+            external_id="edge1",
+            last_updated_time=1,
+            created_time=0,
+            version=1,
+            type=NodeId(space="schema_space1", external_id="sourceEdge1"),
+            start_node=NodeId(space=self.SOURCE_SPACE, external_id="node1"),
+            end_node=NodeId(space=self.SOURCE_SPACE, external_id="node2"),
+        )
+        with monkeypatch_toolkit_client() as client:
+            client.tool.views.retrieve.return_value = [self.SOURCE_VIEW, self.DESTINATION_VIEW]
+            mapping = self.VIEW_MAPPING.model_copy(
+                update={
+                    "container_mapping": {"textProp": "targetInt"},
+                    "edge_mapping": {
+                        EdgeTypeId(
+                            type=NodeId(space="schema_space1", external_id="sourceEdge1"), direction="outwards"
+                        ): "targetEdge1",
+                    },
+                }
+            )
+            connection_creator = ConnectionCreator(
+                client, instance_id_mapper=SpaceMappingInstanceIdMapper(self.SPACE_MAPPING)
+            )
+            mapper = FDMtoCDMMapper(client, [mapping], connection_creator)
+            mapper.prepare(MagicMock())
+
+            source_page = Page(
+                worker_id="main",
+                items=[
+                    DataItem(tracking_id=f"{self.SOURCE_SPACE}:node1", item=node),
+                    DataItem(tracking_id=f"{self.SOURCE_SPACE}:edge1", item=edge),
+                ],
+            )
+            mapped_page = mapper.map_page(source_page)
+
+        assert len(mapped_page.items) == 2
+        assert mapped_page.items[0].tracking_id == f"{self.SOURCE_SPACE}:node1"
+        assert isinstance(mapped_page.items[0].item, NodeRequest)
+        assert mapped_page.items[1].tracking_id == f"{self.TARGET_SPACE}:edge1"
+        assert isinstance(mapped_page.items[1].item, EdgeRequest)
 
     @pytest.mark.parametrize(
         "dry_run, expected_log_calls",

--- a/tests_smoke/test_commands/test_migrate_3D_model.py
+++ b/tests_smoke/test_commands/test_migrate_3D_model.py
@@ -232,12 +232,10 @@ class TestMigrate3D:
         mapper = ThreeDMapper(client)
 
         # Map the classic 3D model to data modeling format
-        mapped = mapper.map([model])
+        mapped = mapper.map([DataItem(tracking_id=str(model.id), item=model)])
         if len(mapped) != 1:
             raise AssertionError(f"{self.ERROR_HEADING}Failed to map classic 3D to data modeling format.")
-        migration_request = mapped[0]
-        if migration_request is None:
-            raise AssertionError(f"{self.ERROR_HEADING}Mapped migration request is None.")
+        migration_request = mapped[0].item
         io = ThreeDMigrationIO(client)
 
         # Call migration endpoint for 3D model and revision
@@ -297,12 +295,12 @@ class TestMigrate3D:
         mappings = list(mapping_io.stream_data(selector=selector))
         if not mappings:
             raise AssertionError(f"{self.ERROR_HEADING}No asset mappings found for migration.")
-        asset_mappings_dm = ThreeDAssetMapper(client).map([di.item for page in mappings for di in page.items])
+        asset_mappings_dm = ThreeDAssetMapper(client).map(
+            [DataItem(tracking_id=str(di.tracking_id), item=di.item) for page in mappings for di in page.items]
+        )
         if len(asset_mappings_dm) != 1:
             raise AssertionError(f"{self.ERROR_HEADING}Failed to map asset mappings for migration.")
-        asset_mapping = asset_mappings_dm[0]
-        if asset_mapping is None:
-            raise AssertionError(f"{self.ERROR_HEADING}Mapped asset mapping is None.")
+        asset_mapping = asset_mappings_dm[0].item
 
         with HTTPClient(config=client.config) as http_client:
             mapping_results = mapping_io.upload_items(


### PR DESCRIPTION
# Description

The migration command's `_upload` path passed entire pages to `upload_items` without splitting
them to each target's `CHUNK_SIZE`, causing a error to be thrown when a page contained more items than
the upload limit, which can happen during Infield migration when edges connected to nodes are being migrated as part of reading nodes through a view. This PR fixes the chunking at the upload layer.

It also fixes a latent bug where `FDMtoCDMMapper` (which fans out one source node into a node + edges) would silently drop or misassign tracking IDs via a `zip` with the shorter source list. The fix changes `DataMapper.map()` to take and return `DataItem`s directly, so each mapper owns its own tracking ID assignment rather than having them re-attached externally by the caller. For the fan-out mapper (currently only FDMtoCDMMapper), each output item can now get a tracking ID appropriately even if the destination list is larger than the source; for 1:1 mappers, the source tracking ID is propagated as before.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- [alpha] Fixes an issue where `cdf migrate infield-data` uploads could fail with a `ValueError` when migrating ChecklistItems