### PR TITLE
[CDF-28158] Fix Streamlit dataSetExternalId not applied on deploy

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/industrial_tool.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/industrial_tool.py
@@ -157,17 +157,14 @@ class StreamlitIO(ResourceIO[ExternalId, StreamlitRequest, StreamlitResponse]):
         )
         try:
             streamlit_request = StreamlitRequest.model_validate(item)
-            file_metadata_fields: dict[str, Any] = {
-                "externalId": streamlit_request.external_id,
-                "name": f"{streamlit_request.name}-source.json",
-                "directory": STREAMLIT_DIRECTORY,
-                "metadata": streamlit_request._as_metadata(),
-            }
-            if data_set_external_id := item.get("dataSetExternalId"):
-                file_metadata_fields["dataSetExternalId"] = data_set_external_id
-            file_metadata = yaml_safe_dump(
-                FileMetadataYAML.model_validate(file_metadata_fields).model_dump(by_alias=True, exclude_unset=True)
+            file_metadata_yaml = FileMetadataYAML(
+                externalId=streamlit_request.external_id,
+                name=f"{streamlit_request.name}-source.json",
+                directory=STREAMLIT_DIRECTORY,
+                metadata=streamlit_request._as_metadata(),
+                dataSetExternalId=item.get("dataSetExternalId"),
             )
+            file_metadata = yaml_safe_dump(file_metadata_yaml.model_dump(by_alias=True, exclude_unset=True))
         except ValidationError as e:
             # avoid circular import
             from cognite_toolkit._cdf_tk.validation import humanize_validation_error

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/industrial_tool.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/industrial_tool.py
@@ -20,7 +20,11 @@ from cognite_toolkit._cdf_tk.client.resource_classes.group import (
     FilesAcl,
     ScopeDefinition,
 )
-from cognite_toolkit._cdf_tk.client.resource_classes.streamlit_ import StreamlitRequest, StreamlitResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.streamlit_ import (
+    STREAMLIT_DIRECTORY,
+    StreamlitRequest,
+    StreamlitResponse,
+)
 from cognite_toolkit._cdf_tk.exceptions import (
     ResourceCreationError,
     ResourceUpdateError,
@@ -35,7 +39,7 @@ from cognite_toolkit._cdf_tk.utils import (
 from cognite_toolkit._cdf_tk.utils.acl_helper import dataset_scoped_resource
 from cognite_toolkit._cdf_tk.utils.file import yaml_safe_dump
 from cognite_toolkit._cdf_tk.utils.hashing import calculate_directory_hash, calculate_hash
-from cognite_toolkit._cdf_tk.yaml_classes import StreamlitYAML
+from cognite_toolkit._cdf_tk.yaml_classes import FileMetadataYAML, StreamlitYAML
 
 from .auth import GroupAllScopedCRUD
 from .data_organization import DataSetsIO
@@ -152,7 +156,18 @@ class StreamlitIO(ResourceIO[ExternalId, StreamlitRequest, StreamlitResponse]):
             description="Streamlit application code",
         )
         try:
-            file_metadata = yaml_safe_dump(StreamlitRequest.model_validate(item).dump(context="api"))
+            streamlit_request = StreamlitRequest.model_validate(item)
+            file_metadata_fields: dict[str, Any] = {
+                "externalId": streamlit_request.external_id,
+                "name": f"{streamlit_request.name}-source.json",
+                "directory": STREAMLIT_DIRECTORY,
+                "metadata": streamlit_request._as_metadata(),
+            }
+            if data_set_external_id := item.get("dataSetExternalId"):
+                file_metadata_fields["dataSetExternalId"] = data_set_external_id
+            file_metadata = yaml_safe_dump(
+                FileMetadataYAML.model_validate(file_metadata_fields).model_dump(by_alias=True, exclude_unset=True)
+            )
         except ValidationError as e:
             # avoid circular import
             from cognite_toolkit._cdf_tk.validation import humanize_validation_error

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_industrial_tool.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_industrial_tool.py
@@ -5,10 +5,14 @@ import pytest
 from cognite.client import _version as CogniteSDKVersion
 from packaging.requirements import Requirement
 
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.streamlit_ import StreamlitRequest
+from cognite_toolkit._cdf_tk.resource_ios._base_ios import SuccessExtra
+from cognite_toolkit._cdf_tk.resource_ios._resource_ios.file import FileMetadataCRUD
 from cognite_toolkit._cdf_tk.resource_ios._resource_ios.industrial_tool import StreamlitIO
 from cognite_toolkit._cdf_tk.tk_warnings import StreamlitRequirementsWarning
+from cognite_toolkit._cdf_tk.utils.file import read_yaml_content
 
 
 class TestStreamlitLoader:
@@ -96,3 +100,31 @@ class TestStreamlitUpdateWithFileio:
             loader._update_with_fileio([item])
 
         assert mock_client.tool.filemetadata.upload_file.called == expect_upload
+
+
+class TestStreamlitIOGetExtraFiles:
+    def test_file_metadata_includes_data_set_external_id(self, tmp_path: Path) -> None:
+        external_id = "my-streamlit-app"
+        app_dir = tmp_path / external_id
+        app_dir.mkdir()
+        (app_dir / "app.py").write_text("import streamlit as st\nst.title('Hello')\n")
+
+        yaml_file = tmp_path / "my-app.Streamlit.yaml"
+        item = {
+            "externalId": external_id,
+            "name": "My App",
+            "creator": "tester",
+            "entrypoint": "app.py",
+            "dataSetExternalId": "my_dataset",
+        }
+
+        extras = list(StreamlitIO.get_extra_files(yaml_file, ExternalId(external_id=external_id), item))
+
+        file_metadata_extra = next(
+            extra
+            for extra in extras
+            if isinstance(extra, SuccessExtra) and extra.suffix == f".{FileMetadataCRUD.kind}.yaml"
+        )
+        file_metadata = read_yaml_content(file_metadata_extra.content)
+        assert file_metadata["dataSetExternalId"] == "my_dataset"
+        assert "dataSetId" not in file_metadata

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_v2.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_v2.yaml
@@ -307,7 +307,7 @@ FileMetadataResponse:
     cognite-toolkit-hash: zipfil-hash-not-supported
   mimeType: application/zip
   name: first_example_function.zip
-- dataSetId: null
+- dataSetId: 7982613576047462211
   directory: /streamlit-apps/
   externalId: myapp
   metadata:


### PR DESCRIPTION
# Description

Fixes a bug where setting `dataSetExternalId` in `*.Streamlit.yaml` had no effect after `cdf deploy`. The Streamlit manifest looked correct after build, but the generated `*.FileMetadata.yaml` sidecar contained `dataSetId: null`. Deploy uses the FileMetadata/fileio path, so the dataset was cleared on every deploy.

`StreamlitIO.get_extra_files()` now generates the FileMetadata sidecar via `FileMetadataYAML` with `dataSetExternalId` preserved from the Streamlit manifest, matching the pattern already used by `FunctionIO`.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Streamlit apps losing their dataset association on deploy when `dataSetExternalId` is set in the manifest