### PR TITLE
Add agent exampleQuestions validation to toolkit

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/agent.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/agent.py
@@ -226,6 +226,16 @@ class SubagentConfig(AgentObject):
     agent_external_id: str = Field(min_length=1, max_length=255)
 
 
+class ExampleMessage(AgentObject):
+    role: str
+    content: str
+
+
+class ExampleQuestion(AgentObject):
+    question: str
+    expected_messages: list[ExampleMessage] = Field(default_factory=list)
+
+
 class Agent(AgentObject):
     external_id: str
     name: str
@@ -236,6 +246,7 @@ class Agent(AgentObject):
     subagents: list[SubagentConfig] | None = None
     skills: list[str] | None = None
     labels: list[str] | None = None
+    example_questions: list[ExampleQuestion] | None = None
 
     def as_id(self) -> ExternalId:
         return ExternalId(external_id=self.external_id)

--- a/cognite_toolkit/_cdf_tk/yaml_classes/agent.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/agent.py
@@ -412,9 +412,7 @@ class AgentYAML(ToolkitResource):
         if not self.example_questions:
             return self
         payload = {
-            "questions": [
-                question.model_dump(by_alias=True, exclude_unset=True) for question in self.example_questions
-            ]
+            "questions": [question.model_dump(by_alias=True, exclude_unset=True) for question in self.example_questions]
         }
         serialized_size = len(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
         if serialized_size > EXAMPLE_QUESTIONS_MAX_SERIALIZED_SIZE:

--- a/cognite_toolkit/_cdf_tk/yaml_classes/agent.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/agent.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from typing import Annotated, Any, Literal
 
@@ -14,6 +15,8 @@ else:
     from typing_extensions import Self
 
 MAX_SUB_AGENTS_PER_AGENT = 20
+EXAMPLE_QUESTIONS_MAX_LENGTH = 5
+EXAMPLE_QUESTIONS_MAX_SERIALIZED_SIZE = 40960
 RUNTIME_VERSIONS_SUPPORTING_SUBAGENTS = frozenset({"1.3.0", "1.4.0"})
 
 
@@ -243,6 +246,19 @@ class SubagentConfig(BaseModelResource):
     )
 
 
+class ExampleMessage(BaseModelResource):
+    role: str = Field(description="The role of the expected message, e.g. 'function'.", min_length=1)
+    content: str = Field(description="The content of the expected message.", min_length=1)
+
+
+class ExampleQuestion(BaseModelResource):
+    question: str = Field(description="An example question for the agent.", min_length=1)
+    expected_messages: list[ExampleMessage] = Field(
+        default_factory=list,
+        description="Optional expected messages, such as tool-call hints.",
+    )
+
+
 Model = Literal[
     # Legacy model names without the azure/model naming convention
     "gpt-35-turbo",
@@ -350,6 +366,11 @@ class AgentYAML(ToolkitResource):
     )
     labels: list[str] | None = Field(None, description="Labels for the agent, e.g. 'published'.")
     runtime_version: str | None = Field(None, description="The runtime version")
+    example_questions: list[ExampleQuestion] | None = Field(
+        None,
+        description="Example questions shown to users to help them understand what the agent can do.",
+        max_length=EXAMPLE_QUESTIONS_MAX_LENGTH,
+    )
 
     @field_validator("subagents")
     @classmethod
@@ -383,6 +404,23 @@ class AgentYAML(ToolkitResource):
         if self.tools and any(tool.name == "delegate_to_subagent" for tool in self.tools):
             raise ValueError(
                 "Tool name 'delegate_to_subagent' is reserved for the system sub-agent delegate tool. Rename the tool."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_example_questions_serialized_size(self) -> Self:
+        if not self.example_questions:
+            return self
+        payload = {
+            "questions": [
+                question.model_dump(by_alias=True, exclude_unset=True) for question in self.example_questions
+            ]
+        }
+        serialized_size = len(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+        if serialized_size > EXAMPLE_QUESTIONS_MAX_SERIALIZED_SIZE:
+            raise ValueError(
+                f"Serialized exampleQuestions size is {serialized_size} bytes, which exceeds the maximum of "
+                f"{EXAMPLE_QUESTIONS_MAX_SERIALIZED_SIZE} bytes."
             )
         return self
 

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_agent.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_agent.py
@@ -60,6 +60,30 @@ class TestAgentIODumpResource:
 
         assert dumped == local
 
+    def test_dump_resource_ignores_empty_example_questions_when_omitted_locally(self) -> None:
+        client = ToolkitClientMock()
+        io = AgentIO(client, None, None)
+        local = {
+            "externalId": "my_agent",
+            "name": "My Agent",
+            "runtimeVersion": "0.9.9",
+        }
+        resource = AgentResponse.model_validate(
+            {
+                "externalId": "my_agent",
+                "name": "My Agent",
+                "createdTime": 0,
+                "lastUpdatedTime": 0,
+                "ownerId": "owner",
+                "runtimeVersion": "0.9.9",
+                "exampleQuestions": [],
+            }
+        )
+
+        dumped = io.dump_resource(resource, local)
+
+        assert dumped == local
+
 
 class TestAgentIODependencies:
     def test_datamodel_is_in_class_dependencies(self) -> None:
@@ -327,3 +351,38 @@ class TestAgentIODiffList:
 
         assert local_by_cdf == {}
         assert added == [0]
+
+    def test_diff_list_example_questions_matches_by_question(self) -> None:
+        io = AgentIO(ToolkitClientMock(), None, None)
+        local = [
+            {"question": "What can you do?"},
+            {
+                "question": "Can you show me all work orders concerning valves?",
+                "expectedMessages": [{"role": "function", "content": "Finding maintenance orders..."}],
+            },
+        ]
+        cdf = [
+            {"question": "What can you do?"},
+            {
+                "question": "Can you show me all work orders concerning valves?",
+                "expectedMessages": [{"role": "function", "content": "Finding maintenance orders..."}],
+            },
+        ]
+
+        local_by_cdf, added = io.diff_list(local, cdf, ("exampleQuestions",))
+
+        assert local_by_cdf == {0: 0, 1: 1}
+        assert added == []
+
+    def test_diff_list_example_questions_reports_cdf_only_questions(self) -> None:
+        io = AgentIO(ToolkitClientMock(), None, None)
+        local = [{"question": "What can you do?"}]
+        cdf = [
+            {"question": "What can you do?"},
+            {"question": "Give a summary of the last shift and action points"},
+        ]
+
+        local_by_cdf, added = io.diff_list(local, cdf, ("exampleQuestions",))
+
+        assert local_by_cdf == {0: 0}
+        assert added == [1]

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_agents.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_agents.py
@@ -10,6 +10,8 @@ from cognite_toolkit._cdf_tk.utils import humanize_collection
 from cognite_toolkit._cdf_tk.utils._auxiliary import get_concrete_subclasses, literal_string_values_from_annotation
 from cognite_toolkit._cdf_tk.validation import validate_resource_yaml_pydantic
 from cognite_toolkit._cdf_tk.yaml_classes.agent import (
+    EXAMPLE_QUESTIONS_MAX_LENGTH,
+    EXAMPLE_QUESTIONS_MAX_SERIALIZED_SIZE,
     KNOWN_TOOLS,
     MAX_SUB_AGENTS_PER_AGENT,
     AgentInstanceSpaces,
@@ -395,3 +397,141 @@ class TestAgentYAML:
         warning = warning_list[0]
         assert isinstance(warning, ResourceFormatWarning)
         assert any(f"list should have at most {MAX_SUB_AGENTS_PER_AGENT} items" in error for error in warning.errors)
+
+    def test_example_questions_roundtrip_question_only(self) -> None:
+        data = {
+            "externalId": "my_agent",
+            "name": "My Agent",
+            "exampleQuestions": [
+                {"question": "What can you do?"},
+                {"question": "Give a summary of the last shift and action points"},
+            ],
+        }
+        loaded = AgentYAML.model_validate(data)
+        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    def test_example_questions_roundtrip_with_expected_messages(self) -> None:
+        data = {
+            "externalId": "my_agent",
+            "name": "My Agent",
+            "exampleQuestions": [
+                {
+                    "question": "Can you show me all work orders concerning valves?",
+                    "expectedMessages": [
+                        {"role": "function", "content": "Finding maintenance orders..."},
+                    ],
+                },
+                {
+                    "question": "List all raw databases",
+                    "expectedMessages": [
+                        {"role": "function", "content": "Calling Rest Api..."},
+                        {"role": "function", "content": "Fetching results..."},
+                    ],
+                },
+            ],
+        }
+        loaded = AgentYAML.model_validate(data)
+        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    def test_example_questions_empty_list_roundtrip(self) -> None:
+        data = {
+            "externalId": "my_agent",
+            "name": "My Agent",
+            "exampleQuestions": [],
+        }
+        loaded = AgentYAML.model_validate(data)
+        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    @pytest.mark.parametrize(
+        "data, expected_error",
+        [
+            pytest.param(
+                {
+                    "externalId": "my_agent",
+                    "name": "My Agent",
+                    "exampleQuestions": ["What can you do?"],
+                },
+                "In exampleQuestions[1] input must be an object of type ExampleQuestion",
+                id="bare-string-shorthand",
+            ),
+            pytest.param(
+                {
+                    "externalId": "my_agent",
+                    "name": "My Agent",
+                    "exampleQuestions": [{}],
+                },
+                "In exampleQuestions[1] missing required field: 'question'",
+                id="missing-question",
+            ),
+            pytest.param(
+                {
+                    "externalId": "my_agent",
+                    "name": "My Agent",
+                    "exampleQuestions": [{"question": ""}],
+                },
+                "In exampleQuestions[1].question string should have at least 1 character",
+                id="empty-question",
+            ),
+            pytest.param(
+                {
+                    "externalId": "my_agent",
+                    "name": "My Agent",
+                    "exampleQuestions": [
+                        {
+                            "question": "Can you show me all work orders concerning valves?",
+                            "expectedMessages": [{"role": "function"}],
+                        }
+                    ],
+                },
+                "In exampleQuestions[1].expectedMessages[1] missing required field: 'content'",
+                id="expected-message-missing-content",
+            ),
+            pytest.param(
+                {
+                    "externalId": "my_agent",
+                    "name": "My Agent",
+                    "exampleQuestions": [
+                        {
+                            "question": "Can you show me all work orders concerning valves?",
+                            "expectedMessages": [{"content": "Finding maintenance orders..."}],
+                        }
+                    ],
+                },
+                "In exampleQuestions[1].expectedMessages[1] missing required field: 'role'",
+                id="expected-message-missing-role",
+            ),
+        ],
+    )
+    def test_example_questions_validation_errors(self, data: dict, expected_error: str) -> None:
+        warning_list = validate_resource_yaml_pydantic(data, AgentYAML, Path("agent.yaml"))
+        assert len(warning_list) == 1
+        warning = warning_list[0]
+        assert isinstance(warning, ResourceFormatWarning)
+        assert any(expected_error in error for error in warning.errors)
+
+    def test_example_questions_max_length_validation(self) -> None:
+        data = {
+            "externalId": "my_agent",
+            "name": "My Agent",
+            "exampleQuestions": [{"question": f"Question {index}"} for index in range(EXAMPLE_QUESTIONS_MAX_LENGTH + 1)],
+        }
+        warning_list = validate_resource_yaml_pydantic(data, AgentYAML, Path("agent.yaml"))
+        assert len(warning_list) == 1
+        warning = warning_list[0]
+        assert isinstance(warning, ResourceFormatWarning)
+        assert any(f"list should have at most {EXAMPLE_QUESTIONS_MAX_LENGTH} items" in error for error in warning.errors)
+
+    def test_example_questions_serialized_size_validation(self) -> None:
+        oversized_question = "x" * (EXAMPLE_QUESTIONS_MAX_SERIALIZED_SIZE - len('{"questions":[{"question":""}]}') + 1)
+        data = {
+            "externalId": "my_agent",
+            "name": "My Agent",
+            "exampleQuestions": [{"question": oversized_question}],
+        }
+        warning_list = validate_resource_yaml_pydantic(data, AgentYAML, Path("agent.yaml"))
+        assert len(warning_list) == 1
+        warning = warning_list[0]
+        assert isinstance(warning, ResourceFormatWarning)
+        assert any(
+            f"exceeds the maximum of {EXAMPLE_QUESTIONS_MAX_SERIALIZED_SIZE} bytes" in error for error in warning.errors
+        )

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_agents.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_agents.py
@@ -513,13 +513,17 @@ class TestAgentYAML:
         data = {
             "externalId": "my_agent",
             "name": "My Agent",
-            "exampleQuestions": [{"question": f"Question {index}"} for index in range(EXAMPLE_QUESTIONS_MAX_LENGTH + 1)],
+            "exampleQuestions": [
+                {"question": f"Question {index}"} for index in range(EXAMPLE_QUESTIONS_MAX_LENGTH + 1)
+            ],
         }
         warning_list = validate_resource_yaml_pydantic(data, AgentYAML, Path("agent.yaml"))
         assert len(warning_list) == 1
         warning = warning_list[0]
         assert isinstance(warning, ResourceFormatWarning)
-        assert any(f"list should have at most {EXAMPLE_QUESTIONS_MAX_LENGTH} items" in error for error in warning.errors)
+        assert any(
+            f"list should have at most {EXAMPLE_QUESTIONS_MAX_LENGTH} items" in error for error in warning.errors
+        )
 
     def test_example_questions_serialized_size_validation(self) -> None:
         oversized_question = "x" * (EXAMPLE_QUESTIONS_MAX_SERIALIZED_SIZE - len('{"questions":[{"question":""}]}') + 1)


### PR DESCRIPTION
# Description

Adds `exampleQuestions` support to agent YAML so toolkit users can declare example prompts when configuring agents. Each entry is validated as an object with a required `question` field and an optional `expectedMessages` list (`role` + `content`), matching the Atlas API format.

Validation enforces the same limits as the agents service: at most 5 questions, and the serialized DMS payload (`{"questions": [...]}`) must not exceed 40,960 bytes. Bare-string list items are rejected.

Also adds `ExampleQuestion` / `ExampleMessage` to the agent resource classes so API round-trip, dump, and diff behavior work consistently.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- Agent `exampleQuestions` field with YAML validation for `question` and optional `expectedMessages`