### PR TITLE
Mark all spaces used for schema resources as governed for Neat plugin in Toolkit

### DIFF
--- a/cognite_toolkit/_cdf_tk/rules/_neat.py
+++ b/cognite_toolkit/_cdf_tk/rules/_neat.py
@@ -16,6 +16,7 @@ from cognite_toolkit._cdf_tk.resource_ios import DataModelIO
 from ._base import FailedValidation, RuleSetStatus, ToolkitGlobalRuleSet
 
 if TYPE_CHECKING:
+    from cognite.neat._data_model.models.dms._schema import RequestSchema
     from cognite.neat._toolkit_adapter import NeatClient, NeatIssueList, SchemaLimits, SchemaSnapshot
 
 
@@ -57,6 +58,24 @@ class NeatRuleSet(ToolkitGlobalRuleSet):
         """Check if neat is installed"""
         return find_spec("cognite.neat") is not None
 
+    @classmethod
+    def _apply_all_schema_spaces_as_governed_spaces(cls, schema: "RequestSchema"):
+        """Mark all spaces in the loaded schema as governed for Neat rebuild validation.
+
+        Toolkit modules define the full desired state across multiple spaces (e.g. record
+        containers in companion spaces). In rebuild mode, Neat only checks governed spaces.
+        """
+        from cognite.neat._data_model.models.dms._space import SpaceRequest
+
+        spaces = {
+            schema.data_model.space,
+            *[container.space for container in schema.containers],
+            *[view.space for view in schema.views],
+            *[space.space for space in schema.spaces],
+            *[node_type.space for node_type in schema.node_types],
+        }
+        schema.extra.governed_spaces = [SpaceRequest(space=space) for space in sorted(spaces)]
+
     def _validate_model(self, data_model_dir: Path, data_model_file: Path) -> Iterable[Insight]:
         """Validates a data model using Neat and returns a list of insights.
 
@@ -72,13 +91,18 @@ class NeatRuleSet(ToolkitGlobalRuleSet):
             defined in Toolkit modules.
         """
 
+        from cognite.neat._config import AlphaFlagConfig
         from cognite.neat._toolkit_adapter import DMSAPIImporter, DmsDataModelRulesOrchestrator
 
         importer = DMSAPIImporter.from_yaml(yaml_file=data_model_dir, data_model_file=data_model_file)
         schema = importer.to_data_model()
+        self._apply_all_schema_spaces_as_governed_spaces(schema)
 
         orchestrator = DmsDataModelRulesOrchestrator(
-            cdf_snapshot=self._cdf_snapshot, limits=self._cdf_limits, modus_operandi="rebuild"
+            cdf_snapshot=self._cdf_snapshot,
+            limits=self._cdf_limits,
+            modus_operandi="rebuild",
+            alpha_flags=AlphaFlagConfig(enable_governed_spaces=True),
         )
         orchestrator.run(schema)
 

--- a/cognite_toolkit/_cdf_tk/rules/_neat.py
+++ b/cognite_toolkit/_cdf_tk/rules/_neat.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable
 from functools import cached_property
 from importlib.util import find_spec
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import ResourceType
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import (
@@ -16,7 +16,6 @@ from cognite_toolkit._cdf_tk.resource_ios import DataModelIO
 from ._base import FailedValidation, RuleSetStatus, ToolkitGlobalRuleSet
 
 if TYPE_CHECKING:
-    from cognite.neat._data_model.models.dms._schema import RequestSchema
     from cognite.neat._toolkit_adapter import NeatClient, NeatIssueList, SchemaLimits, SchemaSnapshot
 
 
@@ -59,7 +58,7 @@ class NeatRuleSet(ToolkitGlobalRuleSet):
         return find_spec("cognite.neat") is not None
 
     @classmethod
-    def _apply_all_schema_spaces_as_governed_spaces(cls, schema: "RequestSchema") -> None:
+    def _apply_all_schema_spaces_as_governed_spaces(cls, schema: Any) -> None:
         """Mark all spaces in the loaded schema as governed for Neat rebuild validation.
 
         Toolkit modules define the full desired state across multiple spaces (e.g. record

--- a/cognite_toolkit/_cdf_tk/rules/_neat.py
+++ b/cognite_toolkit/_cdf_tk/rules/_neat.py
@@ -59,7 +59,7 @@ class NeatRuleSet(ToolkitGlobalRuleSet):
         return find_spec("cognite.neat") is not None
 
     @classmethod
-    def _apply_all_schema_spaces_as_governed_spaces(cls, schema: "RequestSchema"):
+    def _apply_all_schema_spaces_as_governed_spaces(cls, schema: "RequestSchema") -> None:
         """Mark all spaces in the loaded schema as governed for Neat rebuild validation.
 
         Toolkit modules define the full desired state across multiple spaces (e.g. record

--- a/tests/test_unit/test_cdf_tk/test_rules/test_neat.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_neat.py
@@ -1,35 +1,30 @@
+from unittest.mock import patch
+
 import pytest
 
 from cognite_toolkit._cdf_tk.rules import NeatRuleSet
 
-pytest.importorskip("cognite.neat")
-
-from unittest.mock import patch
-
-import pytest
-from cognite.neat._data_model.models.dms._container import ContainerRequest
-from cognite.neat._data_model.models.dms._data_model import DataModelRequest
-from cognite.neat._data_model.models.dms._schema import RequestSchema
-from cognite.neat._data_model.models.dms._views import ViewRequest
-
-from cognite_toolkit._cdf_tk.rules._neat import NeatRuleSet
-
 
 class TestApplyToolkitGovernedSpaces:
     def test_collects_spaces_from_schema_resources(self) -> None:
+        pytest.importorskip("cognite.neat")
+        from cognite.neat._data_model.models.dms._container import ContainerRequest
+        from cognite.neat._data_model.models.dms._data_model import DataModelRequest
+        from cognite.neat._data_model.models.dms._schema import RequestSchema
+        from cognite.neat._data_model.models.dms._views import ViewRequest
+
         schema = RequestSchema(
-            dataModel=DataModelRequest(space="dm_space", externalId="MyModel", version="1"),
+            data_model=DataModelRequest(space="dm_space", external_id="MyModel", version="1"),
             containers=[
-                ContainerRequest(space="records_space", externalId="Record", properties={}),
+                ContainerRequest(space="records_space", external_id="Record", properties={}),
             ],
             views=[
-                ViewRequest(space="view_space", externalId="MyView", version="1", properties={}),
+                ViewRequest(space="view_space", external_id="MyView", version="1", properties={}),
             ],
         )
-
         NeatRuleSet._apply_all_schema_spaces_as_governed_spaces(schema)
-
         assert schema.governed_space_set() == {"dm_space", "records_space", "view_space"}
+
 
 class TestNeatRuleSetStatus:
     @patch.object(NeatRuleSet, "installed", return_value=False)

--- a/tests/test_unit/test_cdf_tk/test_rules/test_neat.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_neat.py
@@ -14,12 +14,12 @@ class TestApplyToolkitGovernedSpaces:
         from cognite.neat._data_model.models.dms._views import ViewRequest
 
         schema = RequestSchema(
-            data_model=DataModelRequest(space="dm_space", external_id="MyModel", version="1"),
+            dataModel=DataModelRequest(space="dm_space", externalId="MyModel", version="1"),
             containers=[
-                ContainerRequest(space="records_space", external_id="Record", properties={}),
+                ContainerRequest(space="records_space", externalId="Record", properties={}),
             ],
             views=[
-                ViewRequest(space="view_space", external_id="MyView", version="1", properties={}),
+                ViewRequest(space="view_space", externalId="MyView", version="1", properties={}),
             ],
         )
         NeatRuleSet._apply_all_schema_spaces_as_governed_spaces(schema)

--- a/tests/test_unit/test_cdf_tk/test_rules/test_neat.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_neat.py
@@ -1,0 +1,27 @@
+import pytest
+
+from cognite_toolkit._cdf_tk.rules import NeatRuleSet
+
+pytest.importorskip("cognite.neat")
+
+from cognite.neat._data_model.models.dms._container import ContainerRequest
+from cognite.neat._data_model.models.dms._data_model import DataModelRequest
+from cognite.neat._data_model.models.dms._schema import RequestSchema
+from cognite.neat._data_model.models.dms._views import ViewRequest
+
+
+class TestApplyToolkitGovernedSpaces:
+    def test_collects_spaces_from_schema_resources(self) -> None:
+        schema = RequestSchema(
+            dataModel=DataModelRequest(space="dm_space", externalId="MyModel", version="1"),
+            containers=[
+                ContainerRequest(space="records_space", externalId="Record", properties={}),
+            ],
+            views=[
+                ViewRequest(space="view_space", externalId="MyView", version="1", properties={}),
+            ],
+        )
+
+        NeatRuleSet._apply_all_schema_spaces_as_governed_spaces(schema)
+
+        assert schema.governed_space_set() == {"dm_space", "records_space", "view_space"}


### PR DESCRIPTION
# Description

When Neat is run as a plugin in Toolkit, it uses `rebuild` mode, whose validation only checks governed spaces (which is an alpha-flagged feature in Neat).  Toolkit data model modules often span multiple spaces (e.g. record containers that are stored in companion spaces). This change marks every space referenced in the loaded schema as 'governed' and enables Neat's governed-spaces alpha flag before running the orchestrator.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Improved

- Improve Neat plugin data model validation to not fail when resources are stored in a different space from data models themselves.