### PR TITLE
Improve Neat validation message when installed without credentials

### DIFF
--- a/cognite_toolkit/_cdf_tk/rules/_neat.py
+++ b/cognite_toolkit/_cdf_tk/rules/_neat.py
@@ -25,25 +25,21 @@ class NeatRuleSet(ToolkitGlobalRuleSet):
     DISPLAY_NAME = "Neat (data modeling)"
 
     def get_status(self) -> RuleSetStatus:
-        is_installed = self.installed()
-        if is_installed and self.client:
-            return RuleSetStatus(
-                code="ready",
-                message="Neat is installed and will be used to validate data models. This validation may take a while since it needs to fetch the entire CDF snapshot.",
-            )
-        if is_installed and not self.client:
+        if self.installed():
+            if self.client:
+                return RuleSetStatus(
+                    code="ready",
+                    message="Neat is installed and will validate data models. Fetching the full CDF snapshot may take a while.",
+                )
             return RuleSetStatus(
                 code="unavailable",
-                message=(
-                    "Neat is installed, but the Toolkit client isn't authenticated. "
-                    "Run `cdf auth init` to set up credentials."
-                ),
+                message="Neat is installed, but the Toolkit client is not authenticated. Run `cdf auth init` to authenticate.",
             )
-        message = (
-            f"Neat is unavailable. Neat is not installed. Install with `{package_install_command('cognite-neat')}`."
-        )
+
+        install_command = package_install_command("cognite-neat")
+        message = f"Neat is not installed. Install with `{install_command}`."
         if not self.client:
-            message += " Neat requires a client. Provide client credentials to use Neat for validation."
+            message += " Then run `cdf auth init` to authenticate the Toolkit client."
         return RuleSetStatus(code="unavailable", message=message)
 
     def validate(self) -> Iterable[Insight | FailedValidation]:

--- a/cognite_toolkit/_cdf_tk/rules/_neat.py
+++ b/cognite_toolkit/_cdf_tk/rules/_neat.py
@@ -31,12 +31,19 @@ class NeatRuleSet(ToolkitGlobalRuleSet):
                 code="ready",
                 message="Neat is installed and will be used to validate data models. This validation may take a while since it needs to fetch the entire CDF snapshot.",
             )
-        missing: list[str] = []
-        if not is_installed:
-            missing.append(f"Neat is not installed. Install with `{package_install_command('cognite-neat')}`.")
+        if is_installed and not self.client:
+            return RuleSetStatus(
+                code="unavailable",
+                message=(
+                    "Neat is installed, but the Toolkit client isn't authenticated. "
+                    "Run `cdf auth init` to set up credentials."
+                ),
+            )
+        message = (
+            f"Neat is unavailable. Neat is not installed. Install with `{package_install_command('cognite-neat')}`."
+        )
         if not self.client:
-            missing.append("Neat requires a client. Provide client credentials to use Neat for validation.")
-        message = "Neat is unavailable. " + " ".join(missing)
+            message += " Neat requires a client. Provide client credentials to use Neat for validation."
         return RuleSetStatus(code="unavailable", message=message)
 
     def validate(self) -> Iterable[Insight | FailedValidation]:

--- a/tests/test_unit/test_cdf_tk/test_rules/test_neat.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_neat.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -6,6 +6,23 @@ from cognite_toolkit._cdf_tk.rules._neat import NeatRuleSet
 
 
 class TestNeatRuleSetStatus:
+    @patch.object(NeatRuleSet, "installed", return_value=True)
+    def test_get_status_unavailable_when_installed_without_client(self, _installed: object) -> None:
+        status = NeatRuleSet(modules=[]).get_status()
+
+        assert status.code == "unavailable"
+        assert status.message is not None
+        assert "Neat is installed" in status.message
+        assert "cdf auth init" in status.message
+
+    @patch.object(NeatRuleSet, "installed", return_value=True)
+    def test_get_status_ready_when_installed_with_client(self, _installed: object) -> None:
+        status = NeatRuleSet(modules=[], client=MagicMock()).get_status()
+
+        assert status.code == "ready"
+        assert status.message is not None
+        assert "Neat is installed" in status.message
+
     @patch.object(NeatRuleSet, "installed", return_value=False)
     def test_get_status_suggests_uv_when_running_under_uv(
         self, _installed: object, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
# Description

When Neat is installed but the Toolkit client is not authenticated, the build planning validation now shows a clearer message pointing users to `cdf auth init` instead of incorrectly reporting Neat as unavailable.

Not installed and not authenticated
<img width="942" height="43" alt="Screenshot 2026-06-26 at 10 54 22" src="https://github.com/user-attachments/assets/ea727ab4-b598-42ec-87b8-62c18a9d7944" />

Installed, but not authenticated
<img width="942" height="43" alt="Screenshot 2026-06-26 at 10 55 53" src="https://github.com/user-attachments/assets/73415baf-eed1-4489-b273-80abe33c54d4" />

Good to go!
<img width="942" height="43" alt="Screenshot 2026-06-26 at 10 55 32" src="https://github.com/user-attachments/assets/1d6add21-0842-4c12-8977-60b44e860922" />





## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Improved

- Neat validation status message when Neat is installed but credentials are missing