### PR TITLE
experiment: cdf . agent plugin

### DIFF
--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -21,6 +21,7 @@ global_config.silence_feature_preview_warnings = True
 from rich import print
 
 from cognite_toolkit._cdf_tk.apps import (
+    AgentApp,
     AuthApp,
     CoreApp,
     DataApp,
@@ -112,6 +113,9 @@ if Flags.IMPORT_CMD.is_enabled():
 if Plugins.data.value.is_enabled():
     _app.add_typer(DataApp(**default_typer_kws), name="data")
 
+if Plugins.agent.value.is_enabled():
+    _app.command(".", context_settings={"ignore_unknown_options": True})(AgentApp.agent)
+
 
 _app.add_typer(ModulesApp(**default_typer_kws), name="modules")
 _app.command("init")(landing_app.main_init)
@@ -182,13 +186,14 @@ def app() -> NoReturn:
         print(f"  [bold red]ERROR ([/][red]{type(err).__name__}[/][bold red]):[/] {err}")
         raise SystemExit(1)
     except SystemExit:
-        if result := re.search(r"click.exceptions.UsageError: No such command '(\w+)'.", traceback.format_exc()):
+        if result := re.search(r"click.exceptions.UsageError: No such command '([^']+)'.", traceback.format_exc()):
             cmd = result.group(1)
-            if cmd in Plugins.list():
+            plugin_name = "agent" if cmd == "." else cmd
+            if plugin_name in Plugins.list():
                 plugin = r"[plugins]"
                 print(
-                    f"{HINT_LEAD_TEXT} The plugin [bold]{cmd}[/bold] is not enabled."
-                    f"\nEnable it in the [bold]cdf.toml[/bold] file by setting '{cmd} = true' in the "
+                    f"{HINT_LEAD_TEXT} The plugin [bold]{plugin_name}[/bold] is not enabled."
+                    f"\nEnable it in the [bold]cdf.toml[/bold] file by setting '{plugin_name} = true' in the "
                     f"[bold]{escape(plugin)}[/bold] section."
                     f"\nDocs to learn more: {Hint.link(URL.plugins, URL.plugins)}"
                 )

--- a/cognite_toolkit/_cdf_tk/apps/__init__.py
+++ b/cognite_toolkit/_cdf_tk/apps/__init__.py
@@ -1,3 +1,4 @@
+from ._agent_app import AgentApp
 from ._auth_app import AuthApp
 from ._core_app import CoreApp
 from ._data_app import DataApp
@@ -16,6 +17,7 @@ from ._run import RunApp
 from ._upload_app import UploadApp
 
 __all__ = [
+    "AgentApp",
     "AuthApp",
     "CoreApp",
     "DataApp",

--- a/cognite_toolkit/_cdf_tk/apps/_agent_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_agent_app.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich import print
+
+from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
+from cognite_toolkit._cdf_tk.commands import AgentCommand
+from cognite_toolkit._cdf_tk.commands.agent import DEFAULT_AGENT_EXTERNAL_ID, DEFAULT_AGENT_MODEL, PERMISSION_MODES
+
+CDF_TOML = CDFToml.load(Path.cwd())
+
+
+class AgentApp:
+    """Holds the callback for the ``cdf .`` agent command."""
+
+    @staticmethod
+    def agent(
+        ctx: typer.Context,
+        prompt: Annotated[
+            list[str] | None,
+            typer.Argument(
+                help="Your request in natural language. Everything after 'cdf .' that is not an "
+                "option is treated as the prompt.",
+            ),
+        ] = None,
+        organization_dir: Annotated[
+            Path,
+            typer.Option(
+                "--organization-dir",
+                "-o",
+                help="Path to the Toolkit project directory the agent should work in.",
+            ),
+        ] = CDF_TOML.cdf.default_organization_dir,
+        env_name: Annotated[
+            str | None,
+            typer.Option(
+                "--env",
+                "-e",
+                help="The default build environment the agent should assume.",
+            ),
+        ] = CDF_TOML.cdf.default_env,
+        agent_external_id: Annotated[
+            str | None,
+            typer.Option(
+                "--agent",
+                help=f"Existing agent external ID to use. Defaults to {DEFAULT_AGENT_EXTERNAL_ID!r}.",
+            ),
+        ] = None,
+        model: Annotated[
+            str,
+            typer.Option(
+                "--model",
+                "-m",
+                help="Model to use when provisioning the default agent.",
+            ),
+        ] = DEFAULT_AGENT_MODEL,
+        permission_mode: Annotated[
+            str,
+            typer.Option(
+                "--permission-mode",
+                "-p",
+                help=f"How local tool use is confirmed. One of: {', '.join(PERMISSION_MODES)}.",
+            ),
+        ] = "acceptEdits",
+        max_steps: Annotated[
+            int,
+            typer.Option(
+                "--max-steps",
+                help="Maximum number of agent/tool iterations before stopping.",
+            ),
+        ] = 50,
+        new_session: Annotated[
+            bool,
+            typer.Option(
+                "--new",
+                help="Start a new conversation instead of continuing the previous one.",
+            ),
+        ] = False,
+        verbose: Annotated[
+            bool,
+            typer.Option(
+                "--verbose",
+                "-v",
+                help="Show tool input/output details.",
+            ),
+        ] = False,
+    ) -> None:
+        """Turn a natural-language prompt into Toolkit actions using a CDF agent session.
+
+        Example: cdf . create a data model for weather stations
+        """
+        words = list(prompt or [])
+        words.extend(ctx.args)
+        prompt_text = " ".join(words).strip()
+        if not prompt_text:
+            print(
+                "Usage: [bold yellow]cdf . <your request>[/]\n"
+                "Example: [bold yellow]cdf . add a transformation that loads assets[/]"
+            )
+            raise typer.Exit()
+
+        cmd = AgentCommand()
+        cmd.run(
+            lambda: cmd.execute(
+                prompt_text,
+                organization_dir,
+                env_name,
+                agent_external_id,
+                model,
+                permission_mode,
+                max_steps,
+                new_session,
+                verbose,
+            )
+        )

--- a/cognite_toolkit/_cdf_tk/client/api/agents.py
+++ b/cognite_toolkit/_cdf_tk/client/api/agents.py
@@ -7,11 +7,19 @@ Note: This is an alpha API and may change in future releases.
 """
 
 from collections.abc import Iterable, Sequence
+from typing import Any
 
 from cognite_toolkit._cdf_tk.client.cdf_client import CDFResourceAPI, Endpoint, PagedResponse
-from cognite_toolkit._cdf_tk.client.http_client import HTTPClient, ItemsSuccessResponse, SuccessResponse
+from cognite_toolkit._cdf_tk.client.http_client import HTTPClient, ItemsSuccessResponse, RequestMessage, SuccessResponse
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.agent import AgentRequest, AgentResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.agent_chat import (
+    AgentChatResponse,
+    ChatActionResult,
+    ChatMessage,
+    ClientToolAction,
+    ToolConfirmationResult,
+)
 
 
 class AgentsAPI(CDFResourceAPI[AgentResponse]):
@@ -104,3 +112,42 @@ class AgentsAPI(CDFResourceAPI[AgentResponse]):
             List of AgentResponse objects.
         """
         return self._list(limit=limit)
+
+    def chat(
+        self,
+        agent_external_id: str,
+        messages: ChatMessage
+        | ChatActionResult
+        | ToolConfirmationResult
+        | Sequence[ChatMessage | ChatActionResult | ToolConfirmationResult],
+        cursor: str | None = None,
+        actions: Sequence[ClientToolAction] | None = None,
+    ) -> AgentChatResponse:
+        """Start or continue a chat session with an agent.
+
+        See: https://api-docs.cognite.com/20230101-beta/tag/Agents/operation/agent_session_ai_agents_chat_post/
+        """
+        if isinstance(messages, (ChatMessage, ChatActionResult, ToolConfirmationResult)):
+            message_list: list[ChatMessage | ChatActionResult | ToolConfirmationResult] = [messages]
+        else:
+            message_list = list(messages)
+
+        body: dict[str, Any] = {
+            "agentExternalId": agent_external_id,
+            "messages": [message.dump() for message in message_list],
+        }
+        if cursor is not None:
+            body["cursor"] = cursor
+        if actions:
+            body["actions"] = [action.dump() for action in actions]
+
+        request = RequestMessage(
+            endpoint_url=self._make_url("/ai/agents/chat"),
+            method="POST",
+            body_content=body,
+            api_version=self._api_version,
+            disable_gzip=True,
+        )
+        result = self._http_client.request_single_retries(request)
+        response = result.get_success_or_raise(request)
+        return AgentChatResponse.model_validate_json(response.body)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/agent_chat.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/agent_chat.py
@@ -1,0 +1,188 @@
+import json
+import sys
+from typing import Annotated, Any, Literal
+
+from pydantic import BeforeValidator, ConfigDict, Field, model_validator
+
+from cognite_toolkit._cdf_tk.client._resource_base import BaseModelObject
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+
+class AgentChatObject(BaseModelObject):
+    model_config = ConfigDict(extra="allow")
+
+
+class TextContent(AgentChatObject):
+    type: Literal["text"] = "text"
+    text: str = ""
+
+
+def _normalize_text_content(value: Any) -> Any:
+    if isinstance(value, str):
+        return {"type": "text", "text": value}
+    return value
+
+
+MessageContent = Annotated[TextContent, BeforeValidator(_normalize_text_content)]
+
+
+class ChatMessage(AgentChatObject):
+    role: Literal["user"] = "user"
+    content: MessageContent
+
+    @classmethod
+    def from_text(cls, text: str) -> Self:
+        return cls(content=TextContent(text=text))
+
+
+class ClientToolActionDefinition(AgentChatObject):
+    name: str
+    description: str
+    parameters: dict[str, Any]
+
+
+class ClientToolAction(AgentChatObject):
+    type: Literal["clientTool"] = "clientTool"
+    client_tool: ClientToolActionDefinition = Field(alias="clientTool")
+
+
+class ChatActionResult(AgentChatObject):
+    role: Literal["action"] = "action"
+    type: Literal["clientTool"] = "clientTool"
+    action_id: str
+    content: MessageContent
+    data: list[Any] = Field(default_factory=list)
+
+    @classmethod
+    def from_text(cls, action_id: str, text: str) -> Self:
+        return cls(action_id=action_id, content=TextContent(text=text))
+
+
+class ClientToolCallSpec(AgentChatObject):
+    name: str
+    arguments: str | dict[str, Any]
+
+    def parsed_arguments(self) -> dict[str, Any]:
+        if isinstance(self.arguments, str):
+            return json.loads(self.arguments)
+        return self.arguments
+
+
+class ClientToolCall(AgentChatObject):
+    type: Literal["clientTool"] = "clientTool"
+    action_id: str
+    client_tool: ClientToolCallSpec = Field(alias="clientTool")
+
+    @property
+    def name(self) -> str:
+        return self.client_tool.name
+
+    @property
+    def arguments(self) -> dict[str, Any]:
+        return self.client_tool.parsed_arguments()
+
+
+class ToolConfirmationCall(AgentChatObject):
+    type: Literal["toolConfirmation"] = "toolConfirmation"
+    action_id: str
+    tool_name: str
+    tool_arguments: dict[str, Any] = Field(default_factory=dict)
+    tool_description: str = ""
+    tool_type: str = ""
+    content: MessageContent | None = None
+
+
+class ToolConfirmationResult(AgentChatObject):
+    role: Literal["action"] = "action"
+    type: Literal["toolConfirmation"] = "toolConfirmation"
+    action_id: str
+    status: Literal["ALLOW", "DENY"]
+
+
+def _parse_action_call(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    action_type = value.get("type")
+    if action_type == "clientTool":
+        return ClientToolCall.model_validate(value)
+    if action_type == "toolConfirmation":
+        return ToolConfirmationCall.model_validate(value)
+    return value
+
+
+ActionCall = Annotated[
+    ClientToolCall | ToolConfirmationCall | AgentChatObject,
+    BeforeValidator(_parse_action_call),
+]
+
+
+class AgentChatMessage(AgentChatObject):
+    role: Literal["agent"] = "agent"
+    content: MessageContent | None = None
+    actions: list[ActionCall] | None = None
+
+
+class AgentChatResponseBody(AgentChatObject):
+    type: str
+    cursor: str | None = None
+    messages: list[AgentChatMessage] = Field(default_factory=list)
+
+
+class AgentChatResponse(AgentChatObject):
+    agent_external_id: str
+    response: AgentChatResponseBody
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_flat_response(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        if "response" in data:
+            return data
+        if "messages" in data:
+            return {
+                "agentExternalId": data.get("agentExternalId", ""),
+                "response": {
+                    "type": data.get("type", "result"),
+                    "cursor": data.get("cursor"),
+                    "messages": data.get("messages", []),
+                },
+            }
+        return data
+
+    @property
+    def cursor(self) -> str | None:
+        return self.response.cursor
+
+    @property
+    def text(self) -> str | None:
+        for message in self.response.messages:
+            if message.content and message.content.text:
+                return message.content.text
+        return None
+
+    @property
+    def action_calls(self) -> list[ClientToolCall]:
+        calls: list[ClientToolCall] = []
+        for message in self.response.messages:
+            if not message.actions:
+                continue
+            for action in message.actions:
+                if isinstance(action, ClientToolCall):
+                    calls.append(action)
+        return calls
+
+    @property
+    def tool_confirmation_calls(self) -> list[ToolConfirmationCall]:
+        confirmations: list[ToolConfirmationCall] = []
+        for message in self.response.messages:
+            if not message.actions:
+                continue
+            for action in message.actions:
+                if isinstance(action, ToolConfirmationCall):
+                    confirmations.append(action)
+        return confirmations

--- a/cognite_toolkit/_cdf_tk/commands/__init__.py
+++ b/cognite_toolkit/_cdf_tk/commands/__init__.py
@@ -8,6 +8,7 @@ from ._purge import PurgeCommand
 from ._respace import RespaceCommand
 from ._upload import UploadCommand
 from .about import AboutCommand
+from .agent import AgentCommand
 from .auth import AuthCommand
 from .build_cmd import BuildCommand
 from .build_v2.build_v2 import BuildV2Command
@@ -26,6 +27,7 @@ from .run import RunFunctionCommand, RunTransformationCommand, RunWorkflowComman
 
 __all__ = [
     "AboutCommand",
+    "AgentCommand",
     "AuthCommand",
     "BuildCommand",
     "BuildV2Command",

--- a/cognite_toolkit/_cdf_tk/commands/agent.py
+++ b/cognite_toolkit/_cdf_tk/commands/agent.py
@@ -1,0 +1,580 @@
+import fnmatch
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import questionary
+from rich.console import Console
+from rich.markup import escape
+from rich.panel import Panel
+
+from cognite_toolkit._cdf_tk.client import ToolkitClient
+from cognite_toolkit._cdf_tk.client.http_client import ToolkitAPIError
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.client.resource_classes.agent import AgentRequest
+from cognite_toolkit._cdf_tk.client.resource_classes.agent_chat import (
+    AgentChatResponse,
+    ChatActionResult,
+    ChatMessage,
+    ClientToolAction,
+    ClientToolActionDefinition,
+    ClientToolCall,
+    ToolConfirmationCall,
+    ToolConfirmationResult,
+)
+from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
+from cognite_toolkit._cdf_tk.commands.agent_session import (
+    AgentSession,
+    clear_agent_session,
+    is_stale_session_error,
+    load_agent_session,
+    save_agent_session,
+    session_file_path,
+)
+from cognite_toolkit._cdf_tk.exceptions import AuthorizationError, ToolkitValueError
+from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
+
+DEFAULT_AGENT_EXTERNAL_ID = "toolkit_cli_agent"
+DEFAULT_AGENT_MODEL = "aws/claude-4.5-haiku"
+# CDF-reserved IDs cannot be created via the API; they may exist only when enabled in a project.
+RESERVED_AGENT_EXTERNAL_IDS = frozenset({"cdf_toolkit_cli"})
+PERMISSION_MODES = ("default", "acceptEdits", "readOnly")
+
+_AGENT_INSTRUCTIONS = """\
+You are an expert Cognite Data Fusion (CDF) Toolkit engineer working directly inside a
+user's Toolkit project from the command line. The user describes what they want in
+natural language and you make it happen using the files in this project and the `cdf` CLI.
+
+## Project layout
+
+A CDF Toolkit project is a directory tree of declarative YAML (plus SQL, Python and
+GraphQL) describing CDF resources. The `cdf.toml` file at the project root is the project
+marker. Toolkit modules and their resource directories live under `modules/<module_name>/`.
+
+## How to work
+
+1. Understand first — use list_dir, read_file, grep and glob to inspect the project before
+   changing anything. Match existing naming conventions, directory layout and formatting.
+2. Make focused changes — create or edit files under `modules/<module_name>/`. Never create
+   resource directories at the project root.
+3. Validate — run `cdf build --verbose` via run_cdf after changes. If the build fails, read
+   the error, fix the configuration and rebuild.
+4. Be transparent — briefly explain what you changed and why.
+
+## Safety
+
+- Read-only operations need no confirmation.
+- Before destructive CDF operations (`cdf deploy` without --dry-run, `cdf clean`), clearly
+  state what will happen. The client will ask the user to confirm.
+- Prefer `cdf deploy --dry-run` to preview changes.
+"""
+
+CLIENT_TOOLS: list[ClientToolAction] = [
+    ClientToolAction(
+        client_tool=ClientToolActionDefinition(
+            name="list_dir",
+            description="List files and directories under a path relative to the project root.",
+            parameters={
+                "type": "object",
+                "properties": {"path": {"type": "string", "description": "Relative directory path."}},
+                "required": ["path"],
+            },
+        )
+    ),
+    ClientToolAction(
+        client_tool=ClientToolActionDefinition(
+            name="read_file",
+            description="Read a text file relative to the project root.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Relative file path."},
+                    "start_line": {"type": "integer", "description": "Optional 1-based start line."},
+                    "end_line": {"type": "integer", "description": "Optional 1-based end line (inclusive)."},
+                },
+                "required": ["path"],
+            },
+        )
+    ),
+    ClientToolAction(
+        client_tool=ClientToolActionDefinition(
+            name="grep",
+            description="Search for a regex pattern in project files.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "pattern": {"type": "string", "description": "Regex pattern to search for."},
+                    "path": {"type": "string", "description": "Relative directory or file to search."},
+                    "glob": {"type": "string", "description": "Optional filename glob filter."},
+                },
+                "required": ["pattern"],
+            },
+        )
+    ),
+    ClientToolAction(
+        client_tool=ClientToolActionDefinition(
+            name="glob",
+            description="Find files matching a glob pattern under the project root.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "pattern": {"type": "string", "description": "Glob pattern, e.g. modules/**/*.yaml"},
+                },
+                "required": ["pattern"],
+            },
+        )
+    ),
+    ClientToolAction(
+        client_tool=ClientToolActionDefinition(
+            name="write_file",
+            description="Create or overwrite a text file relative to the project root.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Relative file path."},
+                    "content": {"type": "string", "description": "Full file content."},
+                },
+                "required": ["path", "content"],
+            },
+        )
+    ),
+    ClientToolAction(
+        client_tool=ClientToolActionDefinition(
+            name="edit_file",
+            description="Replace an exact string in a file (all occurrences).",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Relative file path."},
+                    "old_string": {"type": "string", "description": "Exact text to replace."},
+                    "new_string": {"type": "string", "description": "Replacement text."},
+                },
+                "required": ["path", "old_string", "new_string"],
+            },
+        )
+    ),
+    ClientToolAction(
+        client_tool=ClientToolActionDefinition(
+            name="run_cdf",
+            description=(
+                "Run a whitelisted cdf subcommand in the project directory. "
+                "Allowed: build, deploy (--dry-run), modules list, auth verify, clean (with confirmation)."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "cdf arguments without the 'cdf' prefix, e.g. 'build --verbose'.",
+                    },
+                },
+                "required": ["command"],
+            },
+        )
+    ),
+]
+
+_MUTATING_TOOLS = frozenset({"write_file", "edit_file", "run_cdf"})
+
+
+def build_instructions(project_root: Path, env_name: str | None) -> str:
+    lines = [
+        _AGENT_INSTRUCTIONS,
+        "## Session context",
+        f"- Toolkit project root: {project_root.resolve().as_posix()}",
+    ]
+    if env_name:
+        lines.append(f"- Default build environment: {env_name}")
+    return "\n".join(lines) + "\n"
+
+
+def ensure_agent(
+    client: ToolkitClient,
+    external_id: str,
+    instructions: str,
+    model: str | None,
+) -> str:
+    if external_id in RESERVED_AGENT_EXTERNAL_IDS:
+        existing = client.tool.agents.retrieve([ExternalId(external_id=external_id)], ignore_unknown_ids=True)
+        if existing:
+            return external_id
+        raise ToolkitValueError(
+            f"Built-in agent {external_id!r} is not available in this CDF project. "
+            "Omit --agent to use the auto-provisioned toolkit_cli_agent, or pass another agent external ID."
+        )
+    existing = client.tool.agents.retrieve([ExternalId(external_id=external_id)], ignore_unknown_ids=True)
+    if existing:
+        return external_id
+    resolved_model = model if model is not None else DEFAULT_AGENT_MODEL
+    request = AgentRequest(
+        external_id=external_id,
+        name="CDF Toolkit CLI agent",
+        instructions=instructions,
+        model=resolved_model,
+        tools=[],
+    )
+    try:
+        client.tool.agents.create([request])
+    except Exception as exc:
+        raise AuthorizationError(
+            "Could not create the default agent in CDF. Ensure you have agents:write capability, "
+            f"or pass --agent with an existing agent external ID. ({exc})"
+        ) from exc
+    return external_id
+
+
+class AgentCommand(ToolkitCommand):
+    def execute(
+        self,
+        prompt: str,
+        organization_dir: Path,
+        env_name: str | None,
+        agent_external_id: str | None,
+        model: str | None,
+        permission_mode: str,
+        max_steps: int,
+        new_session: bool,
+        verbose: bool,
+    ) -> None:
+        prompt = prompt.strip()
+        if not prompt:
+            raise ToolkitValueError("No prompt provided. Usage: cdf . <your request>")
+        if permission_mode not in PERMISSION_MODES:
+            raise ToolkitValueError(
+                f"Invalid permission mode {permission_mode!r}. Choose one of: {', '.join(PERMISSION_MODES)}."
+            )
+        if not organization_dir.is_dir():
+            raise ToolkitValueError(f"The project directory {organization_dir.as_posix()!r} does not exist.")
+
+        env_vars = EnvironmentVariables.create_from_environment()
+        client = env_vars.get_client()
+        project_root = organization_dir.resolve()
+        agent_id = agent_external_id or DEFAULT_AGENT_EXTERNAL_ID
+        instructions = build_instructions(project_root, env_name)
+        agent_id = ensure_agent(client, agent_id, instructions, model)
+
+        console = Console()
+        session_path = session_file_path(project_root)
+        if new_session:
+            clear_agent_session(session_path)
+
+        cursor: str | None = None
+        if not new_session:
+            stored_session = load_agent_session(session_path)
+            if stored_session:
+                if stored_session.matches(project_root, agent_id, client):
+                    cursor = stored_session.cursor
+                    console.print("[dim]Continuing previous conversation.[/dim]")
+                else:
+                    clear_agent_session(session_path)
+                    console.print("[dim]Starting a new conversation (project, agent or CDF target changed).[/dim]")
+
+        console.print(Panel(escape(prompt), title="Prompt", style="cyan", expand=False))
+
+        response = self._chat(client, agent_id, ChatMessage.from_text(prompt), cursor, session_path, console)
+        self._save_session(client, agent_id, project_root, session_path, response)
+        self._print_response_text(console, response)
+
+        for step in range(max_steps):
+            pending = self._collect_pending_actions(response)
+            if not pending:
+                return
+            results: list[ChatActionResult | ToolConfirmationResult] = []
+            for action in pending:
+                if isinstance(action, ToolConfirmationCall):
+                    if not self._confirm_tool_confirmation(console, action, permission_mode):
+                        results.append(ToolConfirmationResult(action_id=action.action_id, status="DENY"))
+                        continue
+                    results.append(ToolConfirmationResult(action_id=action.action_id, status="ALLOW"))
+                    continue
+                if isinstance(action, ClientToolCall):
+                    if not self._confirm_client_tool(console, action, permission_mode):
+                        results.append(ChatActionResult.from_text(action.action_id, "User denied this action."))
+                        continue
+                    console.print(f"[dim]→ {action.name}[/dim]")
+                    try:
+                        output = self._dispatch_tool(action, project_root, env_name)
+                    except Exception as exc:
+                        output = f"Tool error: {exc}"
+                        if verbose:
+                            console.print(f"[red]{escape(output)}[/red]")
+                    else:
+                        if verbose:
+                            preview = output if len(output) <= 500 else output[:497] + "..."
+                            console.print(f"[dim]{escape(preview)}[/dim]")
+                    results.append(ChatActionResult.from_text(action.action_id, output))
+
+            response = self._chat(client, agent_id, results, response.cursor, session_path, console)
+            self._save_session(client, agent_id, project_root, session_path, response)
+            self._print_response_text(console, response)
+        else:
+            console.print("[yellow]Stopped: reached --max-steps without finishing.[/yellow]")
+
+    @staticmethod
+    def _chat(
+        client: ToolkitClient,
+        agent_id: str,
+        messages: ChatMessage
+        | ChatActionResult
+        | ToolConfirmationResult
+        | list[ChatActionResult | ToolConfirmationResult],
+        cursor: str | None,
+        session_path: Path,
+        console: Console,
+    ) -> AgentChatResponse:
+        try:
+            return client.tool.agents.chat(agent_id, messages, cursor=cursor, actions=CLIENT_TOOLS)
+        except ToolkitAPIError as exc:
+            if cursor is None or not is_stale_session_error(str(exc)):
+                raise
+            clear_agent_session(session_path)
+            console.print("[yellow]Previous session expired; starting a new conversation.[/yellow]")
+            return client.tool.agents.chat(agent_id, messages, actions=CLIENT_TOOLS)
+
+    @staticmethod
+    def _save_session(
+        client: ToolkitClient,
+        agent_id: str,
+        project_root: Path,
+        session_path: Path,
+        response: AgentChatResponse,
+    ) -> None:
+        if not response.cursor:
+            return
+        config = client.config
+        save_agent_session(
+            session_path,
+            AgentSession(
+                cursor=response.cursor,
+                agent_external_id=agent_id,
+                project_dir=project_root.resolve().as_posix(),
+                cdf_project=config.project,
+                cdf_cluster=config.cdf_cluster or "",
+            ),
+        )
+
+    @staticmethod
+    def _collect_pending_actions(response: AgentChatResponse) -> list[ClientToolCall | ToolConfirmationCall]:
+        return [*response.action_calls, *response.tool_confirmation_calls]
+
+    @staticmethod
+    def _print_response_text(console: Console, response: AgentChatResponse) -> None:
+        if text := response.text:
+            console.print(text, markup=False, highlight=False)
+
+    @staticmethod
+    def _confirm_client_tool(console: Console, call: ClientToolCall, permission_mode: str) -> bool:
+        if permission_mode == "readOnly" and call.name in _MUTATING_TOOLS:
+            console.print(f"[yellow]Skipped {call.name}: read-only mode.[/yellow]")
+            return False
+        if permission_mode == "acceptEdits" and call.name in {"write_file", "edit_file"}:
+            return True
+        if call.name not in _MUTATING_TOOLS:
+            return True
+        if call.name == "run_cdf":
+            args = _parse_cdf_args(call.arguments.get("command", ""))
+            if not _is_destructive_cdf(args):
+                return True
+        summary = AgentCommand._summarize_tool_call(call)
+        return bool(questionary.confirm(f"Allow {summary}?", default=False).unsafe_ask())
+
+    @staticmethod
+    def _confirm_tool_confirmation(
+        console: Console,
+        call: ToolConfirmationCall,
+        permission_mode: str,
+    ) -> bool:
+        if permission_mode == "readOnly":
+            console.print(f"[yellow]Skipped server tool {call.tool_name}: read-only mode.[/yellow]")
+            return False
+        message = call.tool_description or f"Run server tool {call.tool_name}?"
+        return bool(questionary.confirm(message, default=False).unsafe_ask())
+
+    @staticmethod
+    def _summarize_tool_call(call: ClientToolCall) -> str:
+        args = call.arguments
+        for key in ("path", "pattern", "command"):
+            if isinstance(args.get(key), str):
+                value = args[key]
+                short = value if len(value) <= 80 else value[:77] + "..."
+                return f"{call.name} ({short})"
+        return call.name
+
+    @staticmethod
+    def _dispatch_tool(
+        call: ClientToolCall,
+        project_root: Path,
+        env_name: str | None,
+    ) -> str:
+        args = call.arguments
+        name = call.name
+        if name == "list_dir":
+            return _tool_list_dir(project_root, str(args.get("path", ".")))
+        if name == "read_file":
+            return _tool_read_file(
+                project_root,
+                str(args["path"]),
+                args.get("start_line"),
+                args.get("end_line"),
+            )
+        if name == "grep":
+            return _tool_grep(
+                project_root,
+                str(args["pattern"]),
+                str(args.get("path", ".")),
+                str(args.get("glob", "*")),
+            )
+        if name == "glob":
+            return _tool_glob(project_root, str(args["pattern"]))
+        if name == "write_file":
+            return _tool_write_file(project_root, str(args["path"]), str(args["content"]))
+        if name == "edit_file":
+            return _tool_edit_file(
+                project_root,
+                str(args["path"]),
+                str(args["old_string"]),
+                str(args["new_string"]),
+            )
+        if name == "run_cdf":
+            return _tool_run_cdf(project_root, str(args["command"]), env_name)
+        raise ToolkitValueError(f"Unknown tool {name!r}")
+
+
+def _resolve_path(project_root: Path, relative_path: str) -> Path:
+    target = (project_root / relative_path).resolve()
+    if not target.is_relative_to(project_root):
+        raise ToolkitValueError(f"Path {relative_path!r} escapes the project directory.")
+    return target
+
+
+def _tool_list_dir(project_root: Path, relative_path: str) -> str:
+    target = _resolve_path(project_root, relative_path)
+    if not target.is_dir():
+        raise ToolkitValueError(f"Not a directory: {relative_path!r}")
+    entries = sorted(target.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower()))
+    lines = []
+    for entry in entries[:200]:
+        suffix = "/" if entry.is_dir() else ""
+        rel = entry.relative_to(project_root).as_posix()
+        lines.append(f"{rel}{suffix}")
+    if len(entries) > 200:
+        lines.append(f"... and {len(entries) - 200} more")
+    return "\n".join(lines) or "(empty directory)"
+
+
+def _tool_read_file(
+    project_root: Path,
+    relative_path: str,
+    start_line: Any,
+    end_line: Any,
+) -> str:
+    target = _resolve_path(project_root, relative_path)
+    if not target.is_file():
+        raise ToolkitValueError(f"Not a file: {relative_path!r}")
+    lines = target.read_text(encoding="utf-8").splitlines()
+    start = int(start_line) if start_line else 1
+    end = int(end_line) if end_line else len(lines)
+    selected = lines[max(start - 1, 0) : end]
+    return "\n".join(selected)
+
+
+def _tool_grep(project_root: Path, pattern: str, relative_path: str, glob_pattern: str) -> str:
+    target = _resolve_path(project_root, relative_path)
+    regex = re.compile(pattern)
+    matches: list[str] = []
+    paths = [target] if target.is_file() else (p for p in target.rglob("*") if p.is_file())
+    for path in paths:
+        if target.is_dir() and not fnmatch.fnmatch(path.name, glob_pattern):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            if regex.search(line):
+                rel = path.relative_to(project_root).as_posix()
+                matches.append(f"{rel}:{line_no}:{line}")
+                if len(matches) >= 100:
+                    return "\n".join(matches) + "\n... (truncated)"
+    return "\n".join(matches) or "No matches."
+
+
+def _tool_glob(project_root: Path, pattern: str) -> str:
+    matches = sorted(project_root.glob(pattern))[:200]
+    lines = [path.relative_to(project_root).as_posix() for path in matches if path.is_file()]
+    if len(matches) > 200:
+        lines.append("... (truncated)")
+    return "\n".join(lines) or "No files matched."
+
+
+def _tool_write_file(project_root: Path, relative_path: str, content: str) -> str:
+    target = _resolve_path(project_root, relative_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    return f"Wrote {relative_path} ({len(content)} bytes)."
+
+
+def _tool_edit_file(project_root: Path, relative_path: str, old_string: str, new_string: str) -> str:
+    target = _resolve_path(project_root, relative_path)
+    if not target.is_file():
+        raise ToolkitValueError(f"Not a file: {relative_path!r}")
+    text = target.read_text(encoding="utf-8")
+    if old_string not in text:
+        raise ToolkitValueError(f"old_string not found in {relative_path!r}")
+    count = text.count(old_string)
+    target.write_text(text.replace(old_string, new_string), encoding="utf-8")
+    return f"Replaced {count} occurrence(s) in {relative_path}."
+
+
+def _parse_cdf_args(command: str) -> list[str]:
+    return shlex.split(command)
+
+
+def _is_allowed_cdf(args: list[str]) -> bool:
+    if not args:
+        return False
+    subcommand = args[0]
+    if subcommand in {"build", "auth"}:
+        return True
+    if subcommand == "modules" and len(args) > 1 and args[1] == "list":
+        return True
+    if subcommand == "deploy":
+        return True
+    if subcommand == "clean":
+        return True
+    return False
+
+
+def _is_destructive_cdf(args: list[str]) -> bool:
+    if not args:
+        return True
+    subcommand = args[0]
+    if subcommand == "deploy" and "--dry-run" not in args and "-r" not in args:
+        return True
+    if subcommand == "clean":
+        return True
+    return False
+
+
+def _tool_run_cdf(project_root: Path, command: str, env_name: str | None) -> str:
+    args = _parse_cdf_args(command)
+    if not _is_allowed_cdf(args):
+        raise ToolkitValueError(
+            f"Command not allowed: {command!r}. Allowed: build, deploy, modules list, auth verify, clean."
+        )
+    if env_name and "-e" not in args and "--env" not in args and args and args[0] == "build":
+        args.extend(["--env", env_name])
+    completed = subprocess.run(
+        [sys.executable, "-m", "cognite_toolkit._cdf", *args],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    output = (completed.stdout or "") + (completed.stderr or "")
+    if completed.returncode != 0:
+        return f"Exit code {completed.returncode}\n{output}".strip()
+    return output.strip() or "(command completed with no output)"

--- a/cognite_toolkit/_cdf_tk/commands/agent_session.py
+++ b/cognite_toolkit/_cdf_tk/commands/agent_session.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from cognite_toolkit._cdf_tk.client import ToolkitClient
+
+
+class AgentSession(BaseModel):
+    cursor: str
+    agent_external_id: str
+    project_dir: str
+    cdf_project: str
+    cdf_cluster: str = ""
+
+    def matches(self, project_root: Path, agent_external_id: str, client: ToolkitClient) -> bool:
+        config = client.config
+        return (
+            self.project_dir == project_root.resolve().as_posix()
+            and self.agent_external_id == agent_external_id
+            and self.cdf_project == config.project
+            and self.cdf_cluster == (config.cdf_cluster or "")
+        )
+
+
+def session_file_path(project_root: Path) -> Path:
+    return project_root / ".cdf" / "agent-session.json"
+
+
+def load_agent_session(path: Path) -> AgentSession | None:
+    if not path.is_file():
+        return None
+    try:
+        return AgentSession.model_validate_json(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def save_agent_session(path: Path, session: AgentSession) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(session.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+
+def clear_agent_session(path: Path) -> None:
+    if path.is_file():
+        path.unlink()
+
+
+def is_stale_session_error(message: str) -> bool:
+    lowered = message.lower()
+    return any(
+        token in lowered for token in ("cursor", "session", "expired", "invalid", "not found", "unknown conversation")
+    )

--- a/cognite_toolkit/_cdf_tk/plugins.py
+++ b/cognite_toolkit/_cdf_tk/plugins.py
@@ -19,6 +19,7 @@ class Plugins(Enum):
     dump = Plugin("dump", "plugin for Dump command to retrieve Asset resources from CDF")
     dev = Plugin("dev", "plugin for commands to develop modules in CDF")
     data = Plugin("data", "plugin for Data command to manage data in CDF")
+    agent = Plugin("agent", "plugin for the 'cdf .' agent that turns a prompt into Toolkit actions")
 
     @staticmethod
     def list() -> dict[str, bool]:

--- a/cognite_toolkit/_resources/cdf.toml
+++ b/cognite_toolkit/_resources/cdf.toml
@@ -12,6 +12,7 @@ dump = false
 dev = false
 data = false
 functions = false
+agent = false
 
 
 [library.cognite]

--- a/tests/test_unit/test_cdf_tk/test_client/test_agents_chat.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_agents_chat.py
@@ -1,0 +1,127 @@
+import json
+from unittest.mock import MagicMock
+
+import respx
+from httpx import Response
+from rich.console import Console
+
+from cognite_toolkit._cdf_tk.client import ToolkitClientConfig
+from cognite_toolkit._cdf_tk.client.api.agents import AgentsAPI
+from cognite_toolkit._cdf_tk.client.http_client import HTTPClient
+from cognite_toolkit._cdf_tk.client.resource_classes.agent_chat import (
+    AgentChatResponse,
+    ChatActionResult,
+    ChatMessage,
+    ClientToolAction,
+    ClientToolActionDefinition,
+)
+
+CHAT_RESPONSE_JSON = {
+    "agentExternalId": "cdf_toolkit_cli",
+    "response": {
+        "type": "result",
+        "cursor": "cursor-1",
+        "messages": [
+            {
+                "role": "agent",
+                "content": {"type": "text", "text": "Here is the answer."},
+                "actions": [
+                    {
+                        "type": "clientTool",
+                        "actionId": "call-1",
+                        "clientTool": {
+                            "name": "read_file",
+                            "arguments": json.dumps({"path": "cdf.toml"}),
+                        },
+                    }
+                ],
+            }
+        ],
+    },
+}
+
+
+class TestAgentChatModels:
+    def test_parse_chat_response(self) -> None:
+        response = AgentChatResponse.model_validate(CHAT_RESPONSE_JSON)
+        assert response.agent_external_id == "cdf_toolkit_cli"
+        assert response.cursor == "cursor-1"
+        assert response.text == "Here is the answer."
+        assert len(response.action_calls) == 1
+        call = response.action_calls[0]
+        assert call.name == "read_file"
+        assert call.arguments == {"path": "cdf.toml"}
+
+    def test_chat_message_dump(self) -> None:
+        dumped = ChatMessage.from_text("hello").dump()
+        assert dumped == {"role": "user", "content": {"type": "text", "text": "hello"}}
+
+    def test_action_result_dump(self) -> None:
+        dumped = ChatActionResult.from_text("call-1", "done").dump()
+        assert dumped["role"] == "action"
+        assert dumped["type"] == "clientTool"
+        assert dumped["actionId"] == "call-1"
+
+
+class TestAgentsAPIChat:
+    def test_chat_posts_expected_body(self, respx_mock: respx.MockRouter, toolkit_config: ToolkitClientConfig) -> None:
+        http_client = HTTPClient(toolkit_config, console=MagicMock(spec=Console))
+        api = AgentsAPI(http_client)
+        url = toolkit_config.create_api_url("/ai/agents/chat")
+
+        route = respx_mock.post(url).mock(return_value=Response(200, json=CHAT_RESPONSE_JSON))
+
+        action = ClientToolAction(
+            client_tool=ClientToolActionDefinition(
+                name="read_file",
+                description="Read a file",
+                parameters={"type": "object", "properties": {"path": {"type": "string"}}},
+            )
+        )
+        response = api.chat(
+            "cdf_toolkit_cli",
+            ChatMessage.from_text("list modules"),
+            actions=[action],
+        )
+
+        assert response.text == "Here is the answer."
+        assert route.called
+        request = route.calls.last.request
+        body = json.loads(request.content.decode())
+        assert body["agentExternalId"] == "cdf_toolkit_cli"
+        assert body["messages"][0]["content"]["text"] == "list modules"
+        assert body["actions"][0]["type"] == "clientTool"
+        assert body["actions"][0]["clientTool"]["name"] == "read_file"
+
+    def test_chat_continues_with_cursor(
+        self, respx_mock: respx.MockRouter, toolkit_config: ToolkitClientConfig
+    ) -> None:
+        http_client = HTTPClient(toolkit_config, console=MagicMock(spec=Console))
+        api = AgentsAPI(http_client)
+        url = toolkit_config.create_api_url("/ai/agents/chat")
+
+        final_response = {
+            "agentExternalId": "cdf_toolkit_cli",
+            "response": {
+                "type": "result",
+                "cursor": "cursor-2",
+                "messages": [
+                    {
+                        "role": "agent",
+                        "content": {"type": "text", "text": "Finished."},
+                    }
+                ],
+            },
+        }
+        route = respx_mock.post(url).mock(return_value=Response(200, json=final_response))
+
+        response = api.chat(
+            "cdf_toolkit_cli",
+            ChatActionResult.from_text("call-1", "file contents"),
+            cursor="cursor-1",
+        )
+
+        assert response.text == "Finished."
+        body = json.loads(route.calls.last.request.content.decode())
+        assert body["cursor"] == "cursor-1"
+        assert body["messages"][0]["role"] == "action"

--- a/tests/test_unit/test_cdf_tk/test_commands/test_agent.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_agent.py
@@ -1,0 +1,168 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from cognite_toolkit._cdf_tk.client.resource_classes.agent_chat import (
+    AgentChatResponse,
+    ClientToolCall,
+    ClientToolCallSpec,
+)
+from cognite_toolkit._cdf_tk.commands.agent import (
+    DEFAULT_AGENT_MODEL,
+    AgentCommand,
+    _resolve_path,
+    _tool_list_dir,
+    _tool_read_file,
+    build_instructions,
+    ensure_agent,
+)
+from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
+from cognite_toolkit._cdf_tk.plugins import Plugins
+
+
+def test_agent_plugin_is_registered() -> None:
+    assert "agent" in {plugin.value.name for plugin in Plugins}
+
+
+def test_build_instructions_includes_project_root(tmp_path: Path) -> None:
+    instructions = build_instructions(tmp_path, "dev")
+    assert tmp_path.resolve().as_posix() in instructions
+    assert "dev" in instructions
+
+
+class TestAgentCommandValidation:
+    def test_empty_prompt_raises(self, tmp_path: Path) -> None:
+        cmd = AgentCommand(skip_tracking=True)
+        with pytest.raises(ToolkitValueError, match="No prompt provided"):
+            cmd.execute("   ", tmp_path, "dev", None, None, "acceptEdits", 50, False, False)
+
+    def test_invalid_permission_mode_raises(self, tmp_path: Path) -> None:
+        cmd = AgentCommand(skip_tracking=True)
+        with pytest.raises(ToolkitValueError, match="Invalid permission mode"):
+            cmd.execute("do something", tmp_path, "dev", None, None, "yolo", 50, False, False)
+
+    def test_missing_project_dir_raises(self, tmp_path: Path) -> None:
+        cmd = AgentCommand(skip_tracking=True)
+        missing = tmp_path / "does-not-exist"
+        with pytest.raises(ToolkitValueError, match="does not exist"):
+            cmd.execute("do something", missing, "dev", None, None, "acceptEdits", 50, False, False)
+
+
+class TestLocalTools:
+    def test_resolve_path_rejects_escape(self, tmp_path: Path) -> None:
+        with pytest.raises(ToolkitValueError, match="escapes"):
+            _resolve_path(tmp_path, "../outside")
+
+    def test_list_and_read_file(self, tmp_path: Path) -> None:
+        (tmp_path / "modules").mkdir()
+        config = tmp_path / "cdf.toml"
+        config.write_text("x = 1\n", encoding="utf-8")
+        listing = _tool_list_dir(tmp_path, ".")
+        assert "cdf.toml" in listing
+        content = _tool_read_file(tmp_path, "cdf.toml", None, None)
+        assert content == "x = 1"
+
+
+class TestAgentCommandLoop:
+    def test_single_tool_round_trip(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / "cdf.toml").write_text("plugins = {}\n", encoding="utf-8")
+        first = AgentChatResponse.model_validate(
+            {
+                "agentExternalId": "cdf_toolkit_cli",
+                "response": {
+                    "type": "result",
+                    "cursor": "c1",
+                    "messages": [
+                        {
+                            "role": "agent",
+                            "content": {"type": "text", "text": "Reading config."},
+                            "actions": [
+                                {
+                                    "type": "clientTool",
+                                    "actionId": "a1",
+                                    "clientTool": {
+                                        "name": "read_file",
+                                        "arguments": '{"path": "cdf.toml"}',
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                },
+            }
+        )
+        second = AgentChatResponse.model_validate(
+            {
+                "agentExternalId": "cdf_toolkit_cli",
+                "response": {
+                    "type": "result",
+                    "cursor": None,
+                    "messages": [
+                        {
+                            "role": "agent",
+                            "content": {"type": "text", "text": "Your project has cdf.toml."},
+                        }
+                    ],
+                },
+            }
+        )
+
+        mock_client = MagicMock()
+        mock_client.tool.agents.chat.side_effect = [first, second]
+        mock_client.tool.agents.retrieve.return_value = [MagicMock()]
+        mock_client.config.project = "test-project"
+        mock_client.config.cdf_cluster = "api.cognitedata.com"
+
+        env_vars = MagicMock()
+        env_vars.get_client.return_value = mock_client
+
+        monkeypatch.setattr(
+            "cognite_toolkit._cdf_tk.commands.agent.EnvironmentVariables.create_from_environment",
+            lambda: env_vars,
+        )
+        monkeypatch.setattr(
+            "cognite_toolkit._cdf_tk.commands.agent.questionary.confirm",
+            lambda *args, **kwargs: MagicMock(unsafe_ask=lambda: True),
+        )
+
+        cmd = AgentCommand(skip_tracking=True)
+        cmd.execute(
+            "what config do I have?", tmp_path, "dev", "toolkit_cli_agent", None, "acceptEdits", 50, True, False
+        )
+
+        assert mock_client.tool.agents.chat.call_count == 2
+        second_call = mock_client.tool.agents.chat.call_args_list[1]
+        assert second_call.args[0] == "toolkit_cli_agent"
+        assert second_call.kwargs["cursor"] == "c1"
+
+    def test_reserved_agent_uses_existing(self) -> None:
+        client = MagicMock()
+        client.tool.agents.retrieve.return_value = [MagicMock()]
+        external_id = ensure_agent(client, "cdf_toolkit_cli", "instructions", None)
+        assert external_id == "cdf_toolkit_cli"
+        client.tool.agents.create.assert_not_called()
+
+    def test_reserved_agent_missing_raises(self) -> None:
+        client = MagicMock()
+        client.tool.agents.retrieve.return_value = []
+        with pytest.raises(ToolkitValueError, match="not available"):
+            ensure_agent(client, "cdf_toolkit_cli", "instructions", None)
+
+    def test_ensure_agent_creates_when_missing(self) -> None:
+        client = MagicMock()
+        client.tool.agents.retrieve.return_value = []
+        external_id = ensure_agent(client, "my_toolkit_agent", "instructions", None)
+        assert external_id == "my_toolkit_agent"
+        client.tool.agents.create.assert_called_once()
+        created = client.tool.agents.create.call_args[0][0][0]
+        assert created.model == DEFAULT_AGENT_MODEL
+
+    def test_summarize_tool_call(self) -> None:
+        call = ClientToolCall(
+            action_id="a1",
+            client_tool=ClientToolCallSpec(name="read_file", arguments={"path": "cdf.toml"}),
+        )
+        summary = AgentCommand._summarize_tool_call(call)
+        assert "read_file" in summary
+        assert "cdf.toml" in summary

--- a/tests/test_unit/test_cdf_tk/test_commands/test_agent_session.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_agent_session.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from cognite_toolkit._cdf_tk.commands.agent_session import (
+    AgentSession,
+    clear_agent_session,
+    load_agent_session,
+    save_agent_session,
+    session_file_path,
+)
+
+
+def test_session_roundtrip(tmp_path: Path) -> None:
+    path = session_file_path(tmp_path)
+    session = AgentSession(
+        cursor="cursor-abc",
+        agent_external_id="toolkit_cli_agent",
+        project_dir=tmp_path.resolve().as_posix(),
+        cdf_project="my-project",
+        cdf_cluster="api.cognitedata.com",
+    )
+    save_agent_session(path, session)
+    loaded = load_agent_session(path)
+    assert loaded == session
+
+
+def test_clear_session(tmp_path: Path) -> None:
+    path = session_file_path(tmp_path)
+    save_agent_session(
+        path,
+        AgentSession(
+            cursor="cursor-abc",
+            agent_external_id="toolkit_cli_agent",
+            project_dir=tmp_path.resolve().as_posix(),
+            cdf_project="my-project",
+        ),
+    )
+    clear_agent_session(path)
+    assert load_agent_session(path) is None
+
+
+def test_session_matches_project_and_agent(tmp_path: Path) -> None:
+    client = MagicMock()
+    client.config.project = "my-project"
+    client.config.cdf_cluster = "api.cognitedata.com"
+    session = AgentSession(
+        cursor="cursor-abc",
+        agent_external_id="toolkit_cli_agent",
+        project_dir=tmp_path.resolve().as_posix(),
+        cdf_project="my-project",
+        cdf_cluster="api.cognitedata.com",
+    )
+    assert session.matches(tmp_path, "toolkit_cli_agent", client)
+    assert not session.matches(tmp_path, "other_agent", client)


### PR DESCRIPTION
## Summary
- Adds an experimental `cdf .` command (behind `[plugins] agent = true`) that sends natural-language prompts to the CDF Agents chat API
- Implements a client-side tool harness (read/write files, grep, glob, run_cdf) with permission modes
- Persists conversation context between invocations via `.cdf/agent-session.json` and the chat API cursor (`--new` to reset)

## Test plan
- [ ] Enable `agent = true` in `cdf.toml` plugins
- [ ] `cdf . list modules in this project`
- [ ] `cdf . now add a transformation for assets` — should resume prior context
- [ ] `cdf . --new start over` — should start fresh
- [ ] Unit tests: `uv run pytest tests/test_unit/test_cdf_tk/test_commands/test_agent*.py tests/test_unit/test_cdf_tk/test_client/test_agents_chat.py`

**Do not merge** — experimental prototype for review and iteration only.