### PR TITLE
Fix InField migration edge tiebreaking and improve missing reference error messages

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -48,9 +48,9 @@ from cognite_toolkit._cdf_tk.commands._migrate.image_360_mappings import (
     create_360_image_selectors,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.infield_data_mappings import (
+    DIRECT_RELATION_EDGE_TIEBREAKERS,
     create_infield_data_mappings,
     create_infield_schedule_selector,
-    DIRECT_RELATION_EDGE_TIEBREAKERS,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.migration_io import (
     AnnotationMigrationIO,

--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -48,9 +48,9 @@ from cognite_toolkit._cdf_tk.commands._migrate.image_360_mappings import (
     create_360_image_selectors,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.infield_data_mappings import (
-    DIRECT_RELATION_EDGE_TIEBREAKERS,
     create_infield_data_mappings,
     create_infield_schedule_selector,
+    DIRECT_RELATION_EDGE_TIEBREAKERS,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.migration_io import (
     AnnotationMigrationIO,

--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -48,6 +48,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.image_360_mappings import (
     create_360_image_selectors,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.infield_data_mappings import (
+    DIRECT_RELATION_EDGE_TIEBREAKERS,
     create_infield_data_mappings,
     create_infield_schedule_selector,
 )
@@ -1695,6 +1696,7 @@ class MigrateApp(typer.Typer):
             client,
             instance_id_mapper=SpaceMappingInstanceIdMapper(space_mapping),
             custom_mappings=[InFieldAssetMapping(client)],
+            direct_relation_edge_tiebreakers=DIRECT_RELATION_EDGE_TIEBREAKERS,
         )
         mapper = FDMtoCDMMapper(
             client,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -747,14 +747,17 @@ class ConnectionCreator:
             for item in value:
                 try:
                     targets.append(self._create_target(item, source_prop_id, source_view_id))
+                except ValueError as error:
+                    issues.append(
+                        f"Failed to create direct relation for property {source_prop_id!r} with value {item!r}: {error}"
+                    )
                 except KeyError:
-                    issues.append(f"Failed to create target for value {item!s}")
+                    issues.append(
+                        f"Failed to create direct relation for property {source_prop_id!r} with value {item!r}: "
+                        "no migrated instance found for reference"
+                    )
             return targets, issues
-        else:
-            try:
-                return [self._create_target(value, source_prop_id, source_view_id)], []
-            except KeyError:
-                return [], [f"Failed to create target for value {value!s}"]
+        return [self._create_target(value, source_prop_id, source_view_id)], []
 
     def _create_target(self, value: Any, source_prop_id: str, source_view_id: ViewId) -> NodeId:
         if custom_case_cache := self._custom_mapping_caches.get((source_view_id, source_prop_id)):
@@ -763,8 +766,14 @@ class ConnectionCreator:
             node_id = self._as_node_id(value)
             return custom_case_cache[node_id] if node_id else custom_case_cache[value]
         elif self._is_timeseries_reference(source_view_id, source_prop_id) and isinstance(value, str):
+            if value not in self._timeseries_reference_cache:
+                raise ValueError(
+                    f"No migrated CogniteTimeSeries instance found for classic timeseries external ID {value!r}"
+                )
             return self._timeseries_reference_cache[value]
         elif self._is_file_reference(source_view_id, source_prop_id) and isinstance(value, str):
+            if value not in self._file_reference_cache:
+                raise ValueError(f"No migrated CogniteFile instance found for classic file external ID {value!r}")
             return self._file_reference_cache[value]
         elif (
             self._is_direct_relation(source_view_id, source_prop_id)

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from collections.abc import Hashable, Iterable, Mapping, Sequence, Set
+from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence, Set
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from functools import cache
@@ -544,6 +544,9 @@ class EdgeOtherSide:
     other_side: NodeId
 
 
+DirectRelationEdgeTiebreaker = Callable[[list[EdgeOtherSide]], list[EdgeOtherSide]]
+
+
 class CustomConnectionMapping(ABC, Generic[T_ID]):
     """
     This class is used for special mapping cases in the instance to instance conversion.
@@ -620,6 +623,7 @@ class ConnectionCreator:
         client: ToolkitClient,
         instance_id_mapper: InstanceIdMapper,
         custom_mappings: Sequence[CustomConnectionMapping] | None = None,
+        direct_relation_edge_tiebreakers: Mapping[str, DirectRelationEdgeTiebreaker] | None = None,
     ) -> None:
         self._client = client
         self._instance_id_mapper = instance_id_mapper
@@ -628,6 +632,7 @@ class ConnectionCreator:
         self._custom_mapping_caches = self._create_custom_case_caches(custom_mappings or [])
         self._timeseries_reference_cache: dict[str, NodeId] = {}
         self._file_reference_cache: dict[str, NodeId] = {}
+        self._direct_relation_edge_tiebreakers = direct_relation_edge_tiebreakers or {}
 
     def _create_custom_case_caches(
         self, custom_mappings: Sequence[CustomConnectionMapping]
@@ -868,9 +873,25 @@ class ConnectionCreator:
             )
             return targets[0], errors
 
+    def _tiebreak_direct_relation_edges(
+        self, edges: list[EdgeOtherSide], source_edge_type: EdgeTypeId
+    ) -> list[EdgeOtherSide]:
+        """
+        Tiebreaker function for when the target is a non-list direct relation and we need a method
+        to reduce a set of potentially N edges connected to a node to 1.
+        """
+        if len(edges) < 2:
+            return edges
+        tiebreaker = self._direct_relation_edge_tiebreakers.get(source_edge_type.type.external_id)
+        if tiebreaker is None:
+            return edges
+        return tiebreaker(edges)
+
     def create_direct_relation_from_edges(
         self, edges: list[EdgeOtherSide], dm_prop: DirectNodeRelation, source_edge_type: EdgeTypeId
     ) -> tuple[NodeId | list[NodeId], list[str]]:
+        if not dm_prop.list:
+            edges = self._tiebreak_direct_relation_edges(edges, source_edge_type)
         targets: list[NodeId] = []
         issues: list[str] = []
         for edge in edges:

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -741,33 +741,22 @@ class ConnectionCreator:
     def _create_targets(
         self, value: Any, source_prop_id: str, source_view_id: ViewId
     ) -> tuple[list[NodeId], list[str]]:
-        if isinstance(value, list):
-            targets: list[NodeId] = []
-            issues: list[str] = []
-            for item in value:
-                try:
-                    targets.append(self._create_target(item, source_prop_id, source_view_id))
-                except ValueError as error:
-                    issues.append(
-                        f"Failed to create direct relation for property {source_prop_id!r} with value {item!r}: {error}"
-                    )
-                except KeyError:
-                    issues.append(
-                        f"Failed to create direct relation for property {source_prop_id!r} with value {item!r}: "
-                        "no migrated instance found for reference"
-                    )
-            return targets, issues
-        try:
-            return [self._create_target(value, source_prop_id, source_view_id)], []
-        except ValueError as error:
-            return [], [
-                f"Failed to create direct relation for property {source_prop_id!r} with value {value!r}: {error}"
-            ]
-        except KeyError:
-            return [], [
-                f"Failed to create direct relation for property {source_prop_id!r} with value {value!r}: "
-                "no migrated instance found for reference"
-            ]
+        items = value if isinstance(value, list) else [value]
+        targets: list[NodeId] = []
+        issues: list[str] = []
+        for item in items:
+            try:
+                targets.append(self._create_target(item, source_prop_id, source_view_id))
+            except ValueError as error:
+                issues.append(
+                    f"Failed to create direct relation for property {source_prop_id!r} with value {item!r}: {error}"
+                )
+            except KeyError:
+                issues.append(
+                    f"Failed to create direct relation for property {source_prop_id!r} with value {item!r}: "
+                    "no migrated instance found for reference"
+                )
+        return targets, issues
 
     def _create_target(self, value: Any, source_prop_id: str, source_view_id: ViewId) -> NodeId:
         if custom_case_cache := self._custom_mapping_caches.get((source_view_id, source_prop_id)):

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -757,7 +757,17 @@ class ConnectionCreator:
                         "no migrated instance found for reference"
                     )
             return targets, issues
-        return [self._create_target(value, source_prop_id, source_view_id)], []
+        try:
+            return [self._create_target(value, source_prop_id, source_view_id)], []
+        except ValueError as error:
+            return [], [
+                f"Failed to create direct relation for property {source_prop_id!r} with value {value!r}: {error}"
+            ]
+        except KeyError:
+            return [], [
+                f"Failed to create direct relation for property {source_prop_id!r} with value {value!r}: "
+                "no migrated instance found for reference"
+            ]
 
     def _create_target(self, value: Any, source_prop_id: str, source_view_id: ViewId) -> NodeId:
         if custom_case_cache := self._custom_mapping_caches.get((source_view_id, source_prop_id)):

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -16,9 +17,17 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     QuerySortSpec,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.view_to_view_mapping import ViewToViewMapping
+from cognite_toolkit._cdf_tk.commands._migrate.conversion import EdgeOtherSide
 from cognite_toolkit._cdf_tk.constants import SUBSELECTION_LIMIT_QUERY_ENDPOINT
 from cognite_toolkit._cdf_tk.dataio.selectors import InstanceQuerySelector
 from cognite_toolkit._cdf_tk.utils.file import read_yaml_content, safe_read
+
+DIRECT_RELATION_EDGE_TIEBREAKERS: dict[str, Callable[[list[EdgeOtherSide]], list[EdgeOtherSide]]] = {
+    # This was observed as a potential artifact from previous Infield migrations.
+    "referenceChecklistItems": lambda edges: (
+        [edge for edge in edges if edge.edge_id.external_id.endswith("_relation")][:1] or edges
+    ),
+}
 
 
 def create_infield_data_mappings(extra: ExtraValues | None = None) -> list[ViewToViewMapping]:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
@@ -1323,6 +1323,12 @@ class TestInstanceToInstanceConversion:
             type=FileCDFExternalIdReference(),
             **DEFAULT_ARGS,
         ),
+        "files": ViewCorePropertyResponse(
+            container=CONTAINER_ID,
+            container_property_identifier="files",
+            type=FileCDFExternalIdReference(list=True),
+            **DEFAULT_ARGS,
+        ),
         "epoch": ViewCorePropertyResponse(
             container=CONTAINER_ID,
             container_property_identifier="epoch",
@@ -1394,6 +1400,12 @@ class TestInstanceToInstanceConversion:
             type=DirectNodeRelation(),
             **DEFAULT_ARGS,
         ),
+        "files": ViewCorePropertyResponse(
+            container=CONTAINER_ID,
+            container_property_identifier="files",
+            type=DirectNodeRelation(list=True),
+            **DEFAULT_ARGS,
+        ),
         "timestamp": ViewCorePropertyResponse(
             container=CONTAINER_ID,
             container_property_identifier="timestamp",
@@ -1454,6 +1466,7 @@ class TestInstanceToInstanceConversion:
         container_mapping={
             "epoch": "timestamp",
             "jsonVal": "jsonDestination",
+            "files": "files",
         },
         edge_mapping={
             EdgeTypeId(type=NodeId(space="src_space", external_id="relatesTo"), direction="outwards"): "relatedAsset",
@@ -1494,6 +1507,16 @@ class TestInstanceToInstanceConversion:
                     " Cannot convert not-a-number to int64.",
                 ],
                 id="File reference, date formatting, conversion error, and reverse relation skip",
+            ),
+            pytest.param(
+                {"files": ["2c2a5867-a7f8-4eb2-9bd4-724776b4be9d"]},
+                {"files": []},
+                [
+                    "Failed to create direct relation for property 'files' with value "
+                    "'2c2a5867-a7f8-4eb2-9bd4-724776b4be9d': No migrated CogniteFile instance found for classic "
+                    "file external ID '2c2a5867-a7f8-4eb2-9bd4-724776b4be9d'"
+                ],
+                id="Missing classic file reference in list direct relation",
             ),
             pytest.param(
                 {"epoch": 1700000000000},

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
@@ -59,6 +59,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.conversion import (
     convert_edges,
     create_properties,
 )
+from cognite_toolkit._cdf_tk.commands._migrate.infield_data_mappings import DIRECT_RELATION_EDGE_TIEBREAKERS
 from cognite_toolkit._cdf_tk.commands._migrate.issues import (
     ConversionIssue,
     FailedConversion,
@@ -1679,6 +1680,32 @@ class TestInstanceToInstanceConversion:
         assert results.container_properties == expected_relations
         assert [edge.model_dump() for edge in results.edges] == [edge.model_dump() for edge in expected_edges]
         assert results.errors == expected_errors
+
+
+class TestDirectRelationEdgeTiebreakers:
+    def test_reference_checklist_items_prefers_relation_suffix(self) -> None:
+        stale_edge = EdgeOtherSide(
+            edge_id=EdgeId(space="src", external_id="a:b"),
+            other_side=NodeId(space="src", external_id="checklist_a"),
+        )
+        native_edge = EdgeOtherSide(
+            edge_id=EdgeId(space="src", external_id="a_b_relation"),
+            other_side=NodeId(space="src", external_id="checklist_b"),
+        )
+        tiebreaker = DIRECT_RELATION_EDGE_TIEBREAKERS["referenceChecklistItems"]
+
+        assert tiebreaker([stale_edge, native_edge]) == [native_edge]
+
+    def test_reference_checklist_items_returns_input_when_no_suffix_match(self) -> None:
+        edges = [
+            EdgeOtherSide(
+                edge_id=EdgeId(space="src", external_id="a:b"),
+                other_side=NodeId(space="src", external_id="checklist_a"),
+            )
+        ]
+        tiebreaker = DIRECT_RELATION_EDGE_TIEBREAKERS["referenceChecklistItems"]
+
+        assert tiebreaker(edges) == edges
 
 
 class TestInstanceIdMapper:


### PR DESCRIPTION
# Description

Two bugfixes for the `cdf migrate infield` command. Adds a configurable tiebreaker mechanism to `ConnectionCreator` for resolving ambiguous direct-relation edges, and wires in a concrete tiebreaker discovered in one project for `referenceChecklistItems` edges that were duplicated by earlier InField migrations. Also improves the error messages surfaced when a classic timeseries or file external ID cannot be resolved to a migrated instance to make them more human-readable.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- [alpha] Fix incorrect edge resolution during InField migration when `referenceChecklistItems` edges and checklists are duplicated.
- Improve error messages when a referenced classic timeseries or file cannot be matched to a migrated instance.