### PR TITLE
[CDF-28175] Fix location filter asset subtree key compatibility

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/location.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/location.py
@@ -98,6 +98,13 @@ class LocationFilterIO(ResourceIO[ExternalId, LocationFilterRequest, LocationFil
         return id.external_id
 
     def load_resource(self, resource: dict[str, Any], is_dry_run: bool = False) -> LocationFilterRequest:
+        def _normalize_asset_subtree_ids(asset_filter: dict[str, Any]) -> None:
+            subtree_external_ids = asset_filter.pop("assetSubtreeExternalIds", None)
+            if subtree_external_ids is None:
+                return
+            if "assetSubtreeIds" not in asset_filter:
+                asset_filter["assetSubtreeIds"] = subtree_external_ids
+
         if parent_external_id := resource.pop("parentExternalId", None):
             # This is a workaround: when the parentExternalId cannot be resolved because the parent
             # hasn't been created yet, we save it so that we can try again "later"
@@ -115,6 +122,7 @@ class LocationFilterIO(ResourceIO[ExternalId, LocationFilterRequest, LocationFil
             asset_centric["dataSetIds"] = self.client.lookup.data_sets.id(
                 data_set_external_ids, is_dry_run, allow_empty=True
             )
+        _normalize_asset_subtree_ids(asset_centric)
         for subfilter_name in self.subfilter_names:
             subfilter = asset_centric.get(subfilter_name, {})
             if data_set_external_ids := subfilter.pop("dataSetExternalIds", []):
@@ -123,6 +131,7 @@ class LocationFilterIO(ResourceIO[ExternalId, LocationFilterRequest, LocationFil
                     is_dry_run,
                     allow_empty=True,
                 )
+            _normalize_asset_subtree_ids(subfilter)
 
         return LocationFilterRequest.model_validate(resource)
 
@@ -232,14 +241,14 @@ class LocationFilterIO(ResourceIO[ExternalId, LocationFilterRequest, LocationFil
             asset_centric = item["assetCentric"]
             for data_set_external_id in asset_centric.get("dataSetExternalIds", []):
                 yield DataSetsIO, ExternalId(external_id=data_set_external_id)
-            for asset in asset_centric.get("assetSubtreeIds", []):
+            for asset in [*asset_centric.get("assetSubtreeIds", []), *asset_centric.get("assetSubtreeExternalIds", [])]:
                 if "externalId" in asset:
                     yield AssetIO, ExternalId(external_id=asset["externalId"])
             for subfilter_name in cls.subfilter_names:
                 subfilter = asset_centric.get(subfilter_name, {})
                 for data_set_external_id in subfilter.get("dataSetExternalIds", []):
                     yield DataSetsIO, ExternalId(external_id=data_set_external_id)
-                for asset in subfilter.get("assetSubtreeIds", []):
+                for asset in [*subfilter.get("assetSubtreeIds", []), *subfilter.get("assetSubtreeExternalIds", [])]:
                     if "externalId" in asset:
                         yield AssetIO, ExternalId(external_id=asset["externalId"])
         for view in item.get("views", []):

--- a/cognite_toolkit/_cdf_tk/yaml_classes/location.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/location.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import Field
+from pydantic import AliasChoices, Field
 
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
@@ -46,7 +46,9 @@ class LocationFilterViewId(BaseModelResource):
 class AssetCentricFields(BaseModelResource):
     data_set_external_ids: list[str] | None = Field(default=None, description="The list of data set external IDs")
     asset_subtree_external_ids: list[dict[Literal["externalId"], str]] | None = Field(
-        default=None, description="External IDs of the asset."
+        default=None,
+        description="External IDs of the asset.",
+        validation_alias=AliasChoices("assetSubtreeExternalIds", "assetSubtreeIds"),
     )
     external_id_prefix: str | None = Field(default=None, description="The external ID prefix")
 

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_locations.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_locations.py
@@ -65,6 +65,29 @@ class TestLocationFilterLoader:
             external_id="event-subtree-id-678"
         )
 
+    @pytest.mark.parametrize("subtree_field", ["assetSubtreeIds", "assetSubtreeExternalIds"])
+    def test_load_asset_subtree_aliases(
+        self,
+        env_vars_with_client: EnvironmentVariables,
+        subtree_field: str,
+    ) -> None:
+        loader = LocationFilterIO.create_loader(env_vars_with_client.get_client())
+        loaded = loader.load_resource(
+            {
+                "externalId": "my-location",
+                "name": "My Location",
+                "assetCentric": {
+                    "assets": {
+                        subtree_field: [{"externalId": "GE"}],
+                    }
+                },
+            },
+            is_dry_run=True,
+        )
+        assert loaded.asset_centric is not None
+        assert loaded.asset_centric.assets is not None
+        assert loaded.asset_centric.assets.asset_subtree_ids == [ExternalId(external_id="GE")]
+
     def test_topological_sort_success(self) -> None:
         # Create location filters with parent-child relationships
         # Structure: grandparent -> parent -> child

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_location.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_location.py
@@ -155,6 +155,21 @@ class TestLocationYAML:
         location = LocationYAML.model_validate(test_input)
         assert location.model_dump(by_alias=True, exclude_unset=True) == test_input
 
+    def test_asset_subtree_ids_alias_is_accepted(self) -> None:
+        payload = {
+            "externalId": "loc-010",
+            "name": "Location alias check",
+            "assetCentric": {
+                "assets": {
+                    "assetSubtreeIds": [{"externalId": "asset-001"}],
+                }
+            },
+        }
+
+        location = LocationYAML.model_validate(payload)
+        dumped = location.model_dump(by_alias=True, exclude_unset=True)
+        assert dumped["assetCentric"]["assets"]["assetSubtreeExternalIds"] == [{"externalId": "asset-001"}]
+
     @pytest.mark.parametrize("data, expected_errors", list(invalid_location_filters_test_cases()))
     def test_invalid_location_filters_error_messages(self, data: dict | list, expected_errors: set[str]) -> None:
         warning_list = validate_resource_yaml_pydantic(data, LocationYAML, Path("some_file.yaml"))


### PR DESCRIPTION
# Description

We introduced an error with Pydantic classes for location filters, mixing `assetSubtreeIds` (correct) and `assetSubtreeExternalIds` (wrong). This change keeps compatibility by accepting both in location YAML and normalizing deploy payloads to API-compatible subtree IDs.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Fixed location filter asset subtree key handling so build and deploy accept compatible syntax.