### PR TITLE
Fix wrong docs URL in cdf --help output

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_core_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_core_app.py
@@ -89,8 +89,8 @@ class CoreApp(typer.Typer):
         ] = False,
     ) -> None:
         """
-        Docs: https://docs.cognite.com/cdf/deploy/cdf_toolkit/references/resource_library\n
-        Template reference documentation: https://developer.cognite.com/sdks/toolkit/references/configs
+        Docs: https://docs.cognite.com/cdf/deploy/cdf_toolkit/guides/usage\n
+        Resource reference: https://docs.cognite.com/cdf/deploy/cdf_toolkit/references/resource_library
         """
         ctx.obj = Common(override_env=override_env)
         if ctx.invoked_subcommand is None:

--- a/cognite_toolkit/_cdf_tk/apps/_core_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_core_app.py
@@ -89,7 +89,7 @@ class CoreApp(typer.Typer):
         ] = False,
     ) -> None:
         """
-        Docs: https://docs.cognite.com/cdf/deploy/cdf_toolkit/\n
+        Docs: https://docs.cognite.com/cdf/deploy/cdf_toolkit/references/resource_library\n
         Template reference documentation: https://developer.cognite.com/sdks/toolkit/references/configs
         """
         ctx.obj = Common(override_env=override_env)


### PR DESCRIPTION
# Description

Updating links in `cdf --help` output

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Corrected the docs URL shown in `cdf --help` to point to the correct docs