### PR TITLE
Add x-request-id capture and instance download --debug flag

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -944,6 +944,14 @@ class DownloadApp(typer.Typer):
                 help="Turn on to get more verbose output when running the command",
             ),
         ] = False,
+        debug: Annotated[
+            bool,
+            typer.Option(
+                "--debug",
+                help="Turn on query debugging: requests server-side query profiling and logs per-page "
+                "diagnostics (page size, cursor, elapsed time, x-request-id) to help investigate 408 timeouts.",
+            ),
+        ] = False,
     ) -> None:
         """This command will download Instances from CDF into a temporary directory."""
         client = EnvironmentVariables.create_from_environment().get_client()
@@ -1045,7 +1053,7 @@ class DownloadApp(typer.Typer):
         cmd.run(
             lambda: cmd.download(
                 selectors=selectors,
-                io=InstanceIO(client, api_format=api_format.value),
+                io=InstanceIO(client, api_format=api_format.value, debug=debug),
                 output_dir=output_dir,
                 file_format=f".{file_format.value}",
                 compression=compression.value,

--- a/cognite_toolkit/_cdf_tk/client/api/instances.py
+++ b/cognite_toolkit/_cdf_tk/client/api/instances.py
@@ -6,6 +6,7 @@ from itertools import zip_longest
 from typing import Generic, Literal, TypeAlias, TypeVar, overload
 
 from pydantic import JsonValue
+from rich.console import Console
 
 from cognite_toolkit._cdf_tk.client.cdf_client import CDFResourceAPI, PagedResponse, ResponseItems
 from cognite_toolkit._cdf_tk.client.cdf_client.api import APIMethod, Endpoint
@@ -76,6 +77,9 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
             /instances/query and /instances/sync endpoints.
 
     """
+
+    # Lazily created stderr console used for --debug diagnostics when the HTTP client has no console.
+    _debug_console: "Console | None" = None
 
     def __init__(self, http_client: HTTPClient, consecutive_success_count_increase: int = 100) -> None:
         super().__init__(http_client=http_client, method_endpoint_map=METHOD_MAP)
@@ -491,9 +495,12 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
                     f"(page size {query.with_[query.root].limit}, x-request-id: "
                     f"{response.error.request_id or 'unknown'})."
                 )
+            # Always surface the x-request-id so the timeout can be traced against server-side logs,
+            # even when the download is not run with --debug.
+            request_id_suffix = f" (x-request-id: {response.error.request_id})" if response.error.request_id else ""
             raise ReduceLoadException(
                 source_exception=ToolkitAPIError(
-                    f"Request failed with status code {response.status_code}: {response.error.message}",
+                    f"Request failed with status code {response.status_code}: {response.error.message}{request_id_suffix}",
                     missing=response.error.missing,  # type: ignore[arg-type]
                     duplicated=response.error.duplicated,  # type: ignore[arg-type]
                     code=response.error.code,
@@ -527,9 +534,17 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         return f"{cursor[:12]}…" if len(cursor) > 12 else cursor
 
     def _debug_log(self, message: str) -> None:
-        console = self._http_client._console
-        if console is not None:
-            console.print(f"[dim cyan]\\[instances debug][/dim cyan] {message}")
+        # Prefer the HTTP client console when available. In the CLI download path the client is
+        # created without a console, so fall back to a stderr console. Using stderr keeps the
+        # diagnostics visible even while a rich progress display owns stdout.
+        console = self._http_client._console or self._get_debug_console()
+        console.print(f"[dim cyan]\\[instances debug][/dim cyan] {message}")
+
+    @classmethod
+    def _get_debug_console(cls) -> Console:
+        if cls._debug_console is None:
+            cls._debug_console = Console(stderr=True)
+        return cls._debug_console
 
     def _get_endpoint(self, endpoint: QueryEndpoint) -> Endpoint:
         if endpoint == "query":

--- a/cognite_toolkit/_cdf_tk/client/api/instances.py
+++ b/cognite_toolkit/_cdf_tk/client/api/instances.py
@@ -1,3 +1,5 @@
+import json
+import time
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from itertools import zip_longest
@@ -28,6 +30,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._instance import InstanceSlimDefinition
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._query import (
+    QueryDebugParameters,
     QueryEdgeExpression,
     QueryEdgeTableExpression,
     QueryNodeExpression,
@@ -131,6 +134,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         limit: int = 100,
         cursor: str | None = None,
         endpoint: QueryEndpoint = "query",
+        debug: bool = False,
     ) -> PagedResponse[InstanceResponse]:
         """Iterate over all instances in CDF.
 
@@ -139,12 +143,16 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
             limit: Maximum number of items to return.
             cursor: Cursor for pagination.
             endpoint: Which endpoint to use
+            debug: If True, request server-side query profiling and log per-page diagnostics
+                (page size, cursor, elapsed time, x-request-id) to the client console.
 
         Returns:
             PagedResponse of InstanceResponse objects.
         """
         request = self._create_query(filter, limit, cursor)
-        response = self.query(request, type_results=True, endpoint=endpoint, exhaust_sub_selections=False)
+        response = self.query(
+            request, type_results=True, endpoint=endpoint, exhaust_sub_selections=False, debug=debug
+        )
         return PagedResponse(items=response.items["root"], nextCursor=response.root_cursor)
 
     def _create_query(
@@ -202,6 +210,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         limit: int | None = 100,
         endpoint: QueryEndpoint = "query",
         init_cursor: str | None = None,
+        debug: bool = False,
     ) -> Iterable[list[InstanceResponse]]:
         """Iterate over all instances in CDF.
 
@@ -210,6 +219,8 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
             limit: Maximum number of items to return per page.
             endpoint: Which endpoint to use
             init_cursor: Which cursor to use
+            debug: If True, request server-side query profiling and log per-page diagnostics
+                (page size, cursor, elapsed time, x-request-id) to the client console.
 
         Returns:
             Iterable of lists of InstanceResponse objects.
@@ -218,7 +229,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         chunk_limit = endpoint_prop.item_limit if limit is None else min(limit, endpoint_prop.item_limit)
         query = self._create_query(filter, chunk_limit, init_cursor)
         for response in self.query_iterate(
-            query, type_results=True, endpoint=endpoint, exhaust_sub_selections=False, limit=limit
+            query, type_results=True, endpoint=endpoint, exhaust_sub_selections=False, limit=limit, debug=debug
         ):
             yield response.items[response.root]
 
@@ -239,6 +250,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         type_results: Literal[True] = True,
         endpoint: QueryEndpoint = "query",
         exhaust_sub_selections: bool = False,
+        debug: bool = False,
     ) -> QueryResponseTyped: ...
 
     @overload
@@ -248,6 +260,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         type_results: Literal[False],
         endpoint: QueryEndpoint = "query",
         exhaust_sub_selections: bool = False,
+        debug: bool = False,
     ) -> QueryResponseUntyped: ...
 
     def query(
@@ -256,6 +269,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         type_results: bool = True,
         endpoint: QueryEndpoint = "query",
         exhaust_sub_selections: bool = False,
+        debug: bool = False,
     ) -> QueryResponseTyped | QueryResponseUntyped:
         """Execute a query against the instances query endpoint.
 
@@ -282,6 +296,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
             endpoint,
             exhaust_sub_selections,
             limit,
+            debug,
         ):
             results.append(batch)
         if not results:
@@ -310,6 +325,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         endpoint: QueryEndpoint = "query",
         exhaust_sub_selections: bool = False,
         limit: int | None = None,
+        debug: bool = False,
     ) -> Iterable[QueryResponseTyped]: ...
 
     @overload
@@ -320,6 +336,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         endpoint: QueryEndpoint = "query",
         exhaust_sub_selections: bool = False,
         limit: int | None = None,
+        debug: bool = False,
     ) -> Iterable[QueryResponseUntyped]: ...
 
     def query_iterate(
@@ -329,6 +346,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         endpoint: QueryEndpoint = "query",
         exhaust_sub_selections: bool = False,
         limit: int | None = None,
+        debug: bool = False,
     ) -> Iterable[QueryResponseTyped | QueryResponseUntyped]:
         """Iterate over the results of a query against the instances query/sync endpoint."""
         yield from self._query_iterate(
@@ -338,6 +356,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
             endpoint,
             exhaust_sub_selections,
             limit,
+            debug,
         )
 
     def _query_iterate(
@@ -347,9 +366,14 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         endpoint: QueryEndpoint = "query",
         exhaust_sub_selections: bool = False,
         limit: int | None = None,
+        debug: bool = False,
     ) -> Iterable[QueryResponseTyped | QueryResponseUntyped]:
         endpoint_prop = self._get_endpoint(endpoint)
         response_cls = QueryResponseTyped if type_results else QueryResponseUntyped
+
+        # Profiling is only supported by the query endpoint, not sync.
+        if debug and endpoint == "query" and query.debug is None:
+            query.debug = QueryDebugParameters(profile=True)
 
         max_chunk_size = query.with_[query.root].limit or endpoint_prop.item_limit
         current_chunk_size = max_chunk_size
@@ -358,13 +382,22 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         total = 0
         while True:
             try:
-                batch = self._query(query, response_cls, endpoint_prop, exhaust_sub_selections, endpoint_name=endpoint)
+                batch = self._query(
+                    query, response_cls, endpoint_prop, exhaust_sub_selections, endpoint_name=endpoint, debug=debug
+                )
             except ReduceLoadException as e:
                 if current_chunk_size <= 1:
                     raise e.source_exception
                 min_failed_chunk_size = min(current_chunk_size, min_failed_chunk_size)
                 success_request_count = 0
-                current_chunk_size = current_chunk_size // 2
+                new_chunk_size = current_chunk_size // 2
+                if debug:
+                    request_id = getattr(e.source_exception, "request_id", None)
+                    self._debug_log(
+                        f"Graph query timed out (408) at page size {current_chunk_size} "
+                        f"(x-request-id: {request_id or 'unknown'}). Reducing page size to {new_chunk_size}."
+                    )
+                current_chunk_size = new_chunk_size
                 page_limit = current_chunk_size if limit is None else min(current_chunk_size, max(limit - total, 0))
                 query.with_[query.root].limit = page_limit
                 continue
@@ -400,10 +433,11 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         endpoint: Endpoint,
         exhaust_sub_selections: bool,
         endpoint_name: QueryEndpoint,
+        debug: bool = False,
     ) -> _T_QueryResponse:
         first: _T_QueryResponse | None = None
         while True:
-            response = self._make_query(endpoint, query, response_cls, endpoint_name)
+            response = self._make_query(endpoint, query, response_cls, endpoint_name, debug=debug)
             if first is None:
                 first = response
             else:
@@ -437,6 +471,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         query: QueryRequest,
         response_cls: type[_T_QueryResponse],
         endpoint_name: QueryEndpoint,
+        debug: bool = False,
     ) -> _T_QueryResponse:
         request = RequestMessage(
             endpoint_url=self._http_client.config.create_api_url(endpoint.path),
@@ -445,9 +480,17 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
             # We do not retry 408 as that is an indication we should reduce load.
             retry_status_codes={429, 502, 503, 504},
         )
+        start = time.perf_counter()
         response = self._http_client.request_single_retries(request)
+        elapsed = time.perf_counter() - start
         if isinstance(response, FailedResponse) and response.status_code == 408:
             # Graph query timed out. Reduce load or contention, or optimise your query.
+            if debug:
+                self._debug_log(
+                    f"{endpoint_name} page failed with 408 after {elapsed:.1f}s "
+                    f"(page size {query.with_[query.root].limit}, x-request-id: "
+                    f"{response.error.request_id or 'unknown'})."
+                )
             raise ReduceLoadException(
                 source_exception=ToolkitAPIError(
                     f"Request failed with status code {response.status_code}: {response.error.message}",
@@ -455,6 +498,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
                     duplicated=response.error.duplicated,  # type: ignore[arg-type]
                     code=response.error.code,
                     request=request,
+                    request_id=response.error.request_id,
                 )
             )
 
@@ -464,7 +508,28 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         query_response: _T_QueryResponse = response_cls.model_validate_json(success.body)  # type: ignore[assignment]
         # We persist the root from the query. This is for convenience.
         query_response.root = query.root
+        if debug:
+            cursor = (query.cursors or {}).get(query.root)
+            self._debug_log(
+                f"{endpoint_name} page OK in {elapsed:.1f}s "
+                f"(page size {query.with_[query.root].limit}, "
+                f"cursor {self._truncate_cursor(cursor)}, "
+                f"x-request-id: {success.request_id or 'unknown'})."
+            )
+            if query_response.debug:
+                self._debug_log(f"Query profile: {json.dumps(query_response.debug, default=str)}")
         return query_response
+
+    @staticmethod
+    def _truncate_cursor(cursor: str | None) -> str:
+        if not cursor:
+            return "<start>"
+        return f"{cursor[:12]}…" if len(cursor) > 12 else cursor
+
+    def _debug_log(self, message: str) -> None:
+        console = self._http_client._console
+        if console is not None:
+            console.print(f"[dim cyan]\\[instances debug][/dim cyan] {message}")
 
     def _get_endpoint(self, endpoint: QueryEndpoint) -> Endpoint:
         if endpoint == "query":

--- a/cognite_toolkit/_cdf_tk/client/http_client/_client.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_client.py
@@ -201,6 +201,7 @@ class HTTPClient:
                 status_code=response.status_code,
                 body=response.text,
                 content=response.content,
+                request_id=response.headers.get("x-request-id"),
             )
         error_details = ErrorDetails.from_response(response)
         if retry_request := self._retry_request(response, request, error_details):

--- a/cognite_toolkit/_cdf_tk/client/http_client/_data_classes.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_data_classes.py
@@ -25,13 +25,15 @@ class HTTPResult(HTTPBaseModel):
         if isinstance(self, SuccessResponse):
             return self
         elif isinstance(self, FailedResponse):
+            request_id_suffix = f" (x-request-id: {self.error.request_id})" if self.error.request_id else ""
             raise ToolkitAPIError(
-                f"Request failed with status code {self.status_code}: {self.error.message}",
+                f"Request failed with status code {self.status_code}: {self.error.message}{request_id_suffix}",
                 missing=self.error.missing,  # type: ignore[arg-type]
                 duplicated=self.error.duplicated,  # type: ignore[arg-type]
                 code=self.error.code,
                 request=request,
                 response=self,
+                request_id=self.error.request_id,
             )
         elif isinstance(self, FailedRequest):
             raise ToolkitAPIError(f"Request failed with error: {self.error}", request=request)
@@ -61,6 +63,7 @@ class HTTPResult(HTTPBaseModel):
                     missing=self.error.missing,
                     duplicated=self.error.duplicated,
                     is_auto_retryable=self.error.is_auto_retryable,
+                    request_id=self.error.request_id,
                 ),
             )
         elif isinstance(self, FailedRequest):
@@ -77,6 +80,8 @@ class SuccessResponse(HTTPResult):
     status_code: int
     body: str
     content: bytes
+    # The x-request-id response header, useful for correlating with server-side logs.
+    request_id: str | None = None
 
     @property
     def body_json(self) -> dict[str, Any]:
@@ -92,15 +97,21 @@ class ErrorDetails(HTTPBaseModel):
     missing: list[JsonValue] | None = None
     duplicated: list[JsonValue] | None = None
     is_auto_retryable: bool | None = None
+    # The x-request-id response header, useful for correlating a failure with server-side logs.
+    request_id: str | None = None
 
     @classmethod
     def from_response(cls, response: httpx.Response) -> "ErrorDetails":
         """Populate the error details from a httpx response."""
+        request_id = response.headers.get("x-request-id")
         try:
             res = TypeAdapter(dict[Literal["error"], ErrorDetails]).validate_json(response.text)
         except ValueError:
-            return cls(code=response.status_code, message=response.text)
-        return res["error"]
+            return cls(code=response.status_code, message=response.text, request_id=request_id)
+        error = res["error"]
+        if error.request_id is None:
+            error.request_id = request_id
+        return error
 
 
 class FailedResponse(HTTPResult):

--- a/cognite_toolkit/_cdf_tk/client/http_client/_exception.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_exception.py
@@ -16,6 +16,7 @@ class ToolkitAPIError(Exception):
         is_auto_retryable: bool | None = None,
         request: "RequestMessage | None " = None,
         response: "FailedResponse | None " = None,
+        request_id: str | None = None,
     ) -> None:
         super().__init__(message)
         self.message = message
@@ -25,6 +26,7 @@ class ToolkitAPIError(Exception):
         self.is_auto_retryable = is_auto_retryable
         self.request = request
         self.response = response
+        self.request_id = request_id
 
     def as_debug_dict(self) -> dict[str, Any]:
         debug_info: dict[str, Any] = {}
@@ -38,6 +40,8 @@ class ToolkitAPIError(Exception):
             elif self.request.data_content:
                 debug_info["requestBody"] = "<bytes>"
         debug_info["errorMessage"] = self.message
+        if self.request_id:
+            debug_info["requestId"] = self.request_id
         if self.code:
             debug_info["statusCode"] = self.code
         if self.is_auto_retryable is not None:

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -83,9 +83,11 @@ class InstanceIO(
         client: ToolkitClient,
         remove_existing_version: bool = True,
         api_format: Literal["request", "response"] = "request",
+        debug: bool = False,
     ) -> None:
         super().__init__(client, api_format=api_format)
         self._remove_existing_version = remove_existing_version
+        self._debug = debug
         # Cache for view to read-only properties mapping
         self._view_readonly_properties_cache: dict[ViewId, set[str]] = {}
         self._view_crud = ViewIO.create_loader(self.client)
@@ -391,6 +393,7 @@ class InstanceIO(
             exhaust_sub_selections=True,
             limit=limit,
             endpoint=endpoint,
+            debug=self._debug,
         ):
             wrapped_items = [
                 DataItem(tracking_id=f"{item.space}:{item.external_id}", item=item)
@@ -418,7 +421,7 @@ class InstanceIO(
         while cursor is not None or total == 0:
             page_limit = min(self.CHUNK_SIZE, limit - total) if limit is not None else self.CHUNK_SIZE
             page = self.client.tool.instances.paginate(
-                instance_filter, limit=page_limit, cursor=cursor, endpoint=selector.endpoint
+                instance_filter, limit=page_limit, cursor=cursor, endpoint=selector.endpoint, debug=self._debug
             )
             total += len(page.items)
             if page:

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_instance_io.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_instance_io.py
@@ -11,6 +11,7 @@ from cognite_toolkit._cdf_tk.client.http_client import (
     HTTPClient,
     ItemsFailedResponse,
     ItemsSuccessResponse,
+    ToolkitAPIError,
 )
 from cognite_toolkit._cdf_tk.client.identifiers import EdgeTypeId, NodeId
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
@@ -49,6 +50,24 @@ class TestInstanceIO:
 
         assert captured, "Expected the query endpoint to be called."
         assert captured[0].get("debug") == {"profile": True}
+
+    @pytest.mark.usefixtures("disable_gzip")
+    def test_408_error_includes_request_id(
+        self, respx_mock: respx.MockRouter, toolkit_config: ToolkitClientConfig
+    ) -> None:
+        client = ToolkitClient(config=toolkit_config)
+        respx_mock.post(toolkit_config.create_api_url("/models/instances/query")).respond(
+            status_code=408,
+            json={"error": {"code": 408, "message": "Graph query timed out."}},
+            headers={"x-request-id": "req-timeout-789"},
+        )
+
+        with pytest.raises(ToolkitAPIError) as exc_info:
+            # limit=1 makes the reduce-load loop reach page size 1 and re-raise on the first 408.
+            client.tool.instances.paginate(limit=1)
+
+        assert "req-timeout-789" in str(exc_info.value)
+        assert exc_info.value.request_id == "req-timeout-789"
 
     def test_download_instance_ids(self, respx_mock: respx.MockRouter, toolkit_config: ToolkitClientConfig) -> None:
         client = ToolkitClient(config=toolkit_config)

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_instance_io.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_instance_io.py
@@ -32,6 +32,24 @@ from tests.test_unit.approval_client import ApprovalToolkitClient
 
 
 class TestInstanceIO:
+    @pytest.mark.usefixtures("disable_gzip")
+    def test_paginate_debug_requests_profiling(
+        self, respx_mock: respx.MockRouter, toolkit_config: ToolkitClientConfig
+    ) -> None:
+        client = ToolkitClient(config=toolkit_config)
+        captured: list[dict] = []
+
+        def query_callback(request: httpx.Request) -> httpx.Response:
+            captured.append(json.loads(request.content))
+            return httpx.Response(status_code=200, json={"items": {"root": []}, "nextCursor": {"root": None}})
+
+        respx_mock.post(toolkit_config.create_api_url("/models/instances/query")).mock(side_effect=query_callback)
+
+        client.tool.instances.paginate(limit=10, debug=True)
+
+        assert captured, "Expected the query endpoint to be called."
+        assert captured[0].get("debug") == {"profile": True}
+
     def test_download_instance_ids(self, respx_mock: respx.MockRouter, toolkit_config: ToolkitClientConfig) -> None:
         client = ToolkitClient(config=toolkit_config)
         url = toolkit_config.create_api_url("/models/instances/query")

--- a/tests/test_unit/test_cdf_tk/test_utils/test_http_client.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_http_client.py
@@ -79,6 +79,28 @@ class TestHTTPClient2:
         assert response.status_code == 400
         assert response.error.message == "bad request"
 
+    def test_failed_request_captures_request_id(self, rsps: respx.MockRouter, http_client: HTTPClient) -> None:
+        rsps.get("https://example.com/api/resource").respond(
+            json={"error": {"message": "bad request", "code": 400}},
+            status_code=400,
+            headers={"x-request-id": "req-abc-123"},
+        )
+        response = http_client.request_single(
+            RequestMessage(endpoint_url="https://example.com/api/resource", method="GET")
+        )
+        assert isinstance(response, FailedResponse)
+        assert response.error.request_id == "req-abc-123"
+
+    def test_success_request_captures_request_id(self, rsps: respx.MockRouter, http_client: HTTPClient) -> None:
+        rsps.get("https://example.com/api/resource").respond(
+            json={"key": "value"}, status_code=200, headers={"x-request-id": "req-ok-456"}
+        )
+        response = http_client.request_single(
+            RequestMessage(endpoint_url="https://example.com/api/resource", method="GET")
+        )
+        assert isinstance(response, SuccessResponse)
+        assert response.request_id == "req-ok-456"
+
     @pytest.mark.usefixtures("disable_gzip")
     def test_retry_then_success(self, rsps: respx.MockRouter, http_client: HTTPClient) -> None:
         url = "https://example.com/api/resource"


### PR DESCRIPTION
## Summary
- Capture the `x-request-id` response header into `ErrorDetails`/`SuccessResponse` and surface it on `ToolkitAPIError` (message + `as_debug_dict`), so 408 graph-query timeouts can be correlated with server-side/PG3 logs.
- Add a `--debug` flag to `cdf data download instances` that, behind one flag:
  - requests server-side query profiling via `QueryDebugParameters(profile=True)` (query endpoint only), logging the returned plan, and
  - logs per-page diagnostics (endpoint, page size, truncated cursor, elapsed time, `x-request-id`), including on the 408 reduce-load path where the page size is halved.
- Threaded a `debug` parameter through `InstanceIO` → `InstancesAPI.paginate/iterate/query/query_iterate` down to `_make_query`.

## Context
Investigating intermittent 408s while paging a view that maps multiple containers (multi-container joins in PG3 under IOPS contention). The reduce-load-on-408 behavior already exists on the query endpoint; this PR adds the observability needed to attribute and trace those timeouts.

## Test plan
- [x] `mypy` clean on changed modules
- [x] `test_http_client.py`: request-id captured on success and failure responses
- [x] `test_instance_io.py`: `--debug` injects `{"debug": {"profile": true}}` into the query body
- [ ] Manual: run an instance download with `--debug` against a project and confirm profiling/log output