### PR TITLE
feat(infield): update the observation validation to accept the new config structure

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
@@ -403,40 +403,61 @@ class InFieldCDMLocationConfigIO(ResourceIO[NodeId, InFieldCDMLocationConfigRequ
 
     @classmethod
     def get_dependencies(cls, resource: InFieldCDMLocationConfigYAML) -> Iterable[tuple[type[ResourceIO], Identifier]]:
-        if resource.data_exploration_config is None:
-            return
-        for card_attr in INFIELD_CDM_CARD_VIEW_ATTR_TO_JSON_KEY:
-            card_mapping = getattr(resource.data_exploration_config, card_attr, None)
-            if card_mapping is None:
-                continue
-            yield (
-                ViewIO,
-                ViewId(
-                    space=card_mapping.space,
-                    external_id=card_mapping.external_id,
-                    version=card_mapping.version,
-                ),
-            )
+        if resource.data_exploration_config is not None:
+            for card_attr in INFIELD_CDM_CARD_VIEW_ATTR_TO_JSON_KEY:
+                card_mapping = getattr(resource.data_exploration_config, card_attr, None)
+                if card_mapping is None:
+                    continue
+                yield (
+                    ViewIO,
+                    ViewId(
+                        space=card_mapping.space,
+                        external_id=card_mapping.external_id,
+                        version=card_mapping.version,
+                    ),
+                )
+        if resource.view_mappings and resource.view_mappings.observation:
+            for obs_config in resource.view_mappings.observation:
+                yield (ViewIO, obs_config.view.as_id())
 
     @classmethod
     def get_dependent_items(cls, item: dict) -> Iterable[tuple[type[ResourceIO], Hashable]]:
         data_exploration_config = item.get("dataExplorationConfig")
-        if not isinstance(data_exploration_config, dict):
-            return
-        for json_key in INFIELD_CDM_CARD_VIEW_ATTR_TO_JSON_KEY.values():
-            card_mapping = data_exploration_config.get(json_key)
-            if not isinstance(card_mapping, dict):
-                continue
-            if not in_dict(("space", "externalId", "version"), card_mapping):
-                continue
-            yield (
-                ViewIO,
-                ViewId(
-                    space=card_mapping["space"],
-                    external_id=card_mapping["externalId"],
-                    version=str(card_mapping["version"]),
-                ),
-            )
+        if isinstance(data_exploration_config, dict):
+            for json_key in INFIELD_CDM_CARD_VIEW_ATTR_TO_JSON_KEY.values():
+                card_mapping = data_exploration_config.get(json_key)
+                if not isinstance(card_mapping, dict):
+                    continue
+                if not in_dict(("space", "externalId", "version"), card_mapping):
+                    continue
+                yield (
+                    ViewIO,
+                    ViewId(
+                        space=card_mapping["space"],
+                        external_id=card_mapping["externalId"],
+                        version=str(card_mapping["version"]),
+                    ),
+                )
+        view_mappings = item.get("viewMappings")
+        if isinstance(view_mappings, dict):
+            observations = view_mappings.get("observation")
+            if isinstance(observations, list):
+                for obs_config in observations:
+                    if not isinstance(obs_config, dict):
+                        continue
+                    view = obs_config.get("view")
+                    if not isinstance(view, dict):
+                        continue
+                    if not in_dict(("space", "externalId", "version"), view):
+                        continue
+                    yield (
+                        ViewIO,
+                        ViewId(
+                            space=view["space"],
+                            external_id=view["externalId"],
+                            version=str(view["version"]),
+                        ),
+                    )
 
     @cached_property
     def _legacy_instance_spaces(self) -> set[str]:

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
@@ -408,14 +408,7 @@ class InFieldCDMLocationConfigIO(ResourceIO[NodeId, InFieldCDMLocationConfigRequ
                 card_mapping = getattr(resource.data_exploration_config, card_attr, None)
                 if card_mapping is None:
                     continue
-                yield (
-                    ViewIO,
-                    ViewId(
-                        space=card_mapping.space,
-                        external_id=card_mapping.external_id,
-                        version=card_mapping.version,
-                    ),
-                )
+                yield (ViewIO, card_mapping.as_id())
         if resource.view_mappings and resource.view_mappings.observation:
             for obs_config in resource.view_mappings.observation:
                 yield (ViewIO, obs_config.view.as_id())

--- a/cognite_toolkit/_cdf_tk/rules/_infield.py
+++ b/cognite_toolkit/_cdf_tk/rules/_infield.py
@@ -12,8 +12,8 @@ from cognite_toolkit._cdf_tk.utils.file import read_yaml_file
 from cognite_toolkit._cdf_tk.yaml_classes import InFieldCDMLocationConfigYAML
 from cognite_toolkit._cdf_tk.yaml_classes.infield_cdm_location_config import (
     INFIELD_CDM_CARD_VIEW_ATTR_TO_JSON_KEY,
-    ViewMapping,
 )
+from cognite_toolkit._cdf_tk.yaml_classes.view_field_definitions import ViewReference
 
 _REQUIRED_PROPERTIES: dict[str, frozenset[str]] = {
     "assetActivitiesCardView": frozenset(
@@ -82,10 +82,10 @@ class InFieldCDMViewPropertiesRuleSet(ToolkitGlobalRuleSet):
 
         refs: list[_CardViewRef] = []
         for attr, card_key in INFIELD_CDM_CARD_VIEW_ATTR_TO_JSON_KEY.items():
-            mapping: ViewMapping | None = getattr(config.data_exploration_config, attr, None)
+            mapping: ViewReference | None = getattr(config.data_exploration_config, attr, None)
             if mapping is None:
                 continue
-            view_id = ViewId(space=mapping.space, external_id=mapping.external_id, version=mapping.version)
+            view_id = mapping.as_id()
             required = _REQUIRED_PROPERTIES[card_key]
             refs.append((resource, card_key, view_id, required))
         return refs

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
@@ -6,6 +6,7 @@ from cognite_toolkit._cdf_tk.client.identifiers import NodeId
 from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 
 from .base import BaseModelResource, ToolkitResource
+from .view_field_definitions import ViewReference
 
 
 class FeatureToggles(BaseModelResource):
@@ -72,6 +73,20 @@ class ViewMapping(BaseModelResource):
     type: Literal["view"] = "view"
 
 
+class ObservationViewWriteBack(BaseModelResource):
+    """Write-back configuration for an observation view."""
+
+    notifications_endpoint_external_id: str = Field(min_length=1)
+    attachments_endpoint_external_id: str | None = Field(None, min_length=1)
+
+
+class ObservationViewConfig(BaseModelResource):
+    """Observation view configuration."""
+
+    view: ViewReference
+    write_back: ObservationViewWriteBack | None = None
+
+
 class ViewMappings(BaseModelResource):
     """View mappings configuration."""
 
@@ -87,7 +102,7 @@ class ViewMappings(BaseModelResource):
     file: ViewMapping | None = None
     # As of 27/04-26, observation only supported for one view,
     # but we keep the list for future flexibility.
-    observation: list[ViewMapping] | None = Field(None, min_length=1, max_length=1)
+    observation: list[ObservationViewConfig] | None = Field(None, min_length=1, max_length=1)
 
 
 class DataExplorationConfig(BaseModelResource):

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
@@ -1,5 +1,3 @@
-from typing import Literal
-
 from pydantic import Field
 
 from cognite_toolkit._cdf_tk.client.identifiers import NodeId
@@ -64,15 +62,6 @@ class DataStorage(BaseModelResource):
     app_instance_space: str | None = Field(None, min_length=1, max_length=43, pattern=SPACE_FORMAT_PATTERN)
 
 
-class ViewMapping(BaseModelResource):
-    """View mapping configuration."""
-
-    space: str = Field(min_length=1, max_length=43, pattern=SPACE_FORMAT_PATTERN)
-    version: str
-    external_id: str
-    type: Literal["view"] = "view"
-
-
 class ObservationViewWriteBack(BaseModelResource):
     """Write-back configuration for an observation view."""
 
@@ -90,16 +79,16 @@ class ObservationViewConfig(BaseModelResource):
 class ViewMappings(BaseModelResource):
     """View mappings configuration."""
 
-    asset: ViewMapping | None = None
-    operation: ViewMapping | None = None
-    notification: ViewMapping | None = None
+    asset: ViewReference | None = None
+    operation: ViewReference | None = None
+    notification: ViewReference | None = None
     # As of 26/04-26, activity is supported,
     # but InField will likely rename it ot maintenance_order, thus we keep
     # both for now to avoid complaining to the user of either.
-    maintenance_order: ViewMapping | None = None
-    activity: ViewMapping | None = None
+    maintenance_order: ViewReference | None = None
+    activity: ViewReference | None = None
 
-    file: ViewMapping | None = None
+    file: ViewReference | None = None
     # As of 27/04-26, observation only supported for one view,
     # but we keep the list for future flexibility.
     observation: list[ObservationViewConfig] | None = Field(None, min_length=1, max_length=1)
@@ -108,9 +97,9 @@ class ViewMappings(BaseModelResource):
 class DataExplorationConfig(BaseModelResource):
     """Data exploration configuration."""
 
-    asset_properties_card_view: ViewMapping | None = None
-    asset_activities_card_view: ViewMapping | None = None
-    asset_notifications_card_view: ViewMapping | None = None
+    asset_properties_card_view: ViewReference | None = None
+    asset_activities_card_view: ViewReference | None = None
+    asset_notifications_card_view: ViewReference | None = None
 
 
 # Pydantic attribute name -> YAML/API key for card views used in build dependency and validation rules.

--- a/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InFieldCDMLocationConfig.yaml
+++ b/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InFieldCDMLocationConfig.yaml
@@ -66,9 +66,10 @@ viewMappings:
     version: v1
     externalId: MaintenanceOrder
   observation:
-  - space: sp_observations_space
-    version: v1
-    externalId: FieldObservation
+  - view:
+      space: sp_observations_space
+      version: v1
+      externalId: FieldObservation
 disciplines:
 - name: Electrical
   externalId: discipline_electrical

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_fieldops.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_fieldops.py
@@ -108,6 +108,66 @@ class TestInFieldCDMLocationConfigCRUD:
             ),
         }
 
+    def test_get_dependencies_includes_observation_view(self) -> None:
+        config = InFieldCDMLocationConfigYAML.model_validate(
+            {
+                "space": "sp_instance",
+                "externalId": "my_location_config",
+                "viewMappings": {
+                    "observation": [
+                        {
+                            "view": {
+                                "space": "customer_idm_extention",
+                                "version": "v2",
+                                "externalId": "ObservationView",
+                            },
+                        },
+                    ],
+                },
+            }
+        )
+        actual = {
+            (loader_cls.__name__, identifier)
+            for loader_cls, identifier in InFieldCDMLocationConfigIO.get_dependencies(config)
+        }
+        assert actual == {
+            (ViewIO.__name__, ViewId(space="customer_idm_extention", external_id="ObservationView", version="v2")),
+        }
+
+    def test_get_dependencies_includes_card_views_and_observation_view(self) -> None:
+        config = InFieldCDMLocationConfigYAML.model_validate(
+            {
+                "space": "sp_instance",
+                "externalId": "my_location_config",
+                "dataExplorationConfig": {
+                    "assetActivitiesCardView": {
+                        "space": "customer_idm_extention",
+                        "version": "v2",
+                        "externalId": "ActivitiesCard",
+                    },
+                },
+                "viewMappings": {
+                    "observation": [
+                        {
+                            "view": {
+                                "space": "customer_idm_extention",
+                                "version": "v2",
+                                "externalId": "ObservationView",
+                            },
+                        },
+                    ],
+                },
+            }
+        )
+        actual = {
+            (loader_cls.__name__, identifier)
+            for loader_cls, identifier in InFieldCDMLocationConfigIO.get_dependencies(config)
+        }
+        assert actual == {
+            (ViewIO.__name__, ViewId(space="customer_idm_extention", external_id="ActivitiesCard", version="v2")),
+            (ViewIO.__name__, ViewId(space="customer_idm_extention", external_id="ObservationView", version="v2")),
+        }
+
     def test_get_dependencies_without_data_exploration_config(self) -> None:
         config = InFieldCDMLocationConfigYAML.model_validate(
             {"space": "sp_instance", "externalId": "my_location_config"}
@@ -157,6 +217,30 @@ class TestInFieldCDMLocationConfigCRUD:
                 ViewIO.__name__,
                 ViewId(space="customer_idm_extention", external_id="NotificationsCard", version="v2"),
             ),
+        }
+
+    def test_get_dependent_items_includes_observation_view(self) -> None:
+        item = {
+            "space": "sp_instance",
+            "externalId": "my_location_config",
+            "viewMappings": {
+                "observation": [
+                    {
+                        "view": {
+                            "space": "customer_idm_extention",
+                            "version": "v2",
+                            "externalId": "ObservationView",
+                        },
+                    },
+                ],
+            },
+        }
+        actual = {
+            (loader_cls.__name__, identifier)
+            for loader_cls, identifier in InFieldCDMLocationConfigIO.get_dependent_items(item)
+        }
+        assert actual == {
+            (ViewIO.__name__, ViewId(space="customer_idm_extention", external_id="ObservationView", version="v2")),
         }
 
     def test_skip_illegal_configuration(self) -> None:

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
@@ -169,6 +169,24 @@ def invalid_test_cases() -> Iterable:
             "externalId": "my_config",
             "space": "my_space",
             "viewMappings": {
+                "asset": {
+                    "space": "my_space",
+                    "version": "v1",
+                    "externalId": "123invalid",
+                },
+            },
+        },
+        {
+            "In viewMappings.asset.externalId string should match pattern "
+            "'^[a-zA-Z]([a-zA-Z0-9_]{0,253}[a-zA-Z0-9])?$'"
+        },
+        id="Invalid externalId pattern in viewMappings.asset",
+    )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
+            "viewMappings": {
                 "observation": [
                     {
                         "view": {

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
@@ -176,10 +176,7 @@ def invalid_test_cases() -> Iterable:
                 },
             },
         },
-        {
-            "In viewMappings.asset.externalId string should match pattern "
-            "'^[a-zA-Z]([a-zA-Z0-9_]{0,253}[a-zA-Z0-9])?$'"
-        },
+        {"In viewMappings.asset.externalId string should match pattern '^[a-zA-Z]([a-zA-Z0-9_]{0,253}[a-zA-Z0-9])?$'"},
         id="Invalid externalId pattern in viewMappings.asset",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
@@ -126,13 +126,124 @@ def invalid_test_cases() -> Iterable:
             "space": "my_space",
             "viewMappings": {
                 "observation": [
-                    {"space": "my_space", "version": "v1", "externalId": "ObsA"},
-                    {"space": "my_space", "version": "v1", "externalId": "ObsB"},
+                    {
+                        "view": {
+                            "space": "my_space",
+                            "version": "v1",
+                            "externalId": "ObsA",
+                        },
+                    },
+                    {
+                        "view": {
+                            "space": "my_space",
+                            "version": "v1",
+                            "externalId": "ObsB",
+                        },
+                    },
                 ],
             },
         },
         {"In viewMappings.observation list should have at most 1 item after validation, not 2"},
         id="Multiple observations in viewMappings not supported",
+    )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
+            "viewMappings": {
+                "observation": [
+                    {"space": "my_space", "version": "v1", "externalId": "ObsA"},
+                ],
+            },
+        },
+        {
+            "In viewMappings.observation[1] missing required field: 'view'",
+            "In viewMappings.observation[1] unknown field: 'externalId'",
+            "In viewMappings.observation[1] unknown field: 'space'",
+            "In viewMappings.observation[1] unknown field: 'version'",
+        },
+        id="Flat legacy ViewMapping shape in viewMappings.observation",
+    )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
+            "viewMappings": {
+                "observation": [
+                    {
+                        "view": {
+                            "space": "my_space",
+                            "version": "v1",
+                        },
+                    },
+                ],
+            },
+        },
+        {"In viewMappings.observation[1].view missing required field: 'externalId'"},
+        id="Missing required field in viewMappings.observation view",
+    )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
+            "viewMappings": {
+                "observation": [
+                    {
+                        "view": {
+                            "space": "my_space",
+                            "version": "v1",
+                            "externalId": "ObsView",
+                        },
+                        "unknownField": "bad_value",
+                    },
+                ],
+            },
+        },
+        {"In viewMappings.observation[1] unknown field: 'unknownField'"},
+        id="Unknown field in viewMappings.observation",
+    )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
+            "viewMappings": {
+                "observation": [
+                    {
+                        "view": {
+                            "space": "my_space",
+                            "version": "v1",
+                            "externalId": "ObsView",
+                        },
+                        "writeBack": {
+                            "notificationsEndpointExternalId": "notif-endpoint",
+                            "unknownField": "bad_value",
+                        },
+                    },
+                ],
+            },
+        },
+        {"In viewMappings.observation[1].writeBack unknown field: 'unknownField'"},
+        id="Unknown field in viewMappings.observation.writeBack",
+    )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
+            "viewMappings": {
+                "observation": [
+                    {
+                        "view": {
+                            "space": "my_space",
+                            "version": "v1",
+                            "externalId": "ObsView",
+                        },
+                        "writeBack": {},
+                    },
+                ],
+            },
+        },
+        {"In viewMappings.observation[1].writeBack missing required field: 'notificationsEndpointExternalId'"},
+        id="Missing notificationsEndpointExternalId in viewMappings.observation.writeBack",
     )
     yield pytest.param(
         {
@@ -217,3 +328,26 @@ class TestInfieldCDMLocationConfigYAML:
         assert isinstance(format_warning, ResourceFormatWarning)
 
         assert set(format_warning.errors) == expected_errors
+
+    def test_load_valid_observation_view_config(self) -> None:
+        data = {
+            "externalId": "my_config",
+            "space": "my_space",
+            "viewMappings": {
+                "observation": [
+                    {
+                        "view": {
+                            "space": "my_space",
+                            "version": "v1",
+                            "externalId": "ObsView",
+                        },
+                        "writeBack": {
+                            "notificationsEndpointExternalId": "notif-endpoint",
+                        },
+                    },
+                ],
+            },
+        }
+        loaded = InFieldCDMLocationConfigYAML.model_validate(data)
+        dumped = loaded.model_dump(exclude_unset=True, by_alias=True)
+        assert dumped == data

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags.yaml
@@ -236,9 +236,10 @@ InFieldCDMLocationConfigResponse:
           space: sp_notifications_space
           version: v1
         observation:
-        - externalId: FieldObservation
-          space: sp_observations_space
-          version: v1
+        - view:
+            externalId: FieldObservation
+            space: sp_observations_space
+            version: v1
         operation:
           externalId: Operation
           space: sp_operations_space

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags_v2.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags_v2.yaml
@@ -226,9 +226,10 @@ InFieldCDMLocationConfigResponse:
           space: sp_notifications_space
           version: v1
         observation:
-        - externalId: FieldObservation
-          space: sp_observations_space
-          version: v1
+        - view:
+            externalId: FieldObservation
+            space: sp_observations_space
+            version: v1
         operation:
           externalId: Operation
           space: sp_operations_space


### PR DESCRIPTION
# Description

This updates validation for `InFieldCDMLocationConfig` to match the new observation view configuration format and tightens view reference validation across the config.

`viewMappings.observation` now expects a list of observation view configs (still limited to one item for now). Each entry can include a `view` reference and an optional `writeBack` section for notification and attachment endpoints. The toolkit also checks that the referenced observation view exists before deploy.

View references in `viewMappings` and `dataExplorationConfig` now use the same `ViewReference` validation used elsewhere in the toolkit, so invalid view IDs and versions are caught earlier.

closes: https://cognitedata.atlassian.net/browse/FO-3804

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- `InFieldCDMLocationConfig`: `viewMappings.observation` entries now support an optional `writeBack` section for configuring the notifications and attachments endpoints used when writing observation data back to CDF.
- `InFieldCDMLocationConfig`: Toolkit now verifies that the view referenced under `viewMappings.observation` exists in the project before deploying.

### Changed

- `InFieldCDMLocationConfig`: `viewMappings.observation` entries must now be specified with the view reference nested under a `view` key (e.g. `observation: [{view: {space: ..., externalId: ..., version: ...}}]`) instead of specifying the view fields directly on the list item. Existing configs using the old flat format will need to be updated.
- `InFieldCDMLocationConfig`: view references under `viewMappings` and `dataExplorationConfig` are now validated more strictly (consistent with view references elsewhere in the toolkit), so invalid `space`, `externalId`, or `version` values are now caught at build time instead of failing later at deploy.
