### PR TITLE
[CDF-28201] Add AppExternalIdScope for AppHostingAcl

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
@@ -19,6 +19,7 @@ from .scopes import (
     AgentExternalIdScope,
     AllScope,
     AppConfigScope,
+    AppExternalIdScope,
     AssetRootIDScope,
     CurrentUserScope,
     DataSetScope,
@@ -113,7 +114,7 @@ class AppHostingAcl(Acl):
 
     acl_name: Literal["appHostingAcl"] = Field("appHostingAcl", exclude=True)
     actions: Sequence[Literal["READ", "WRITE", "RUN"]]
-    scope: AllScope
+    scope: AllScope | AppExternalIdScope
 
 
 class AssetsAcl(Acl):

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/group/scopes.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/group/scopes.py
@@ -44,6 +44,11 @@ class AgentExternalIdScope(ScopeDefinition):
     external_ids: list[str]
 
 
+class AppExternalIdScope(ScopeDefinition):
+    scope_name: Literal["appExternalIdScope"] = Field("appExternalIdScope", exclude=True)
+    external_ids: list[str]
+
+
 class AllScope(ScopeDefinition):
     """Scope that applies to all resources."""
 
@@ -215,6 +220,7 @@ Scope: TypeAlias = Annotated[
         | AppConfigScope
         | PostgresGatewayUsersScope
         | AgentExternalIdScope
+        | AppExternalIdScope
         | UnknownScope
     ),
     BeforeValidator(_handle_unknown_scope),

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/group/scopes.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/group/scopes.py
@@ -45,6 +45,8 @@ class AgentExternalIdScope(ScopeDefinition):
 
 
 class AppExternalIdScope(ScopeDefinition):
+    """Scope limited to specific Custom Apps by External ID."""
+
     scope_name: Literal["appExternalIdScope"] = Field("appExternalIdScope", exclude=True)
     external_ids: list[str]
 

--- a/cognite_toolkit/_cdf_tk/yaml_classes/capabilities.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/capabilities.py
@@ -58,6 +58,11 @@ class AppConfigScope(Scope):
     apps: list[Literal["SEARCH"]]
 
 
+class AppExternalIdScope(Scope):
+    _scope_name = "appExternalIdScope"
+    external_ids: list[str]
+
+
 class CurrentUserScope(Scope):
     _scope_name = "currentuserscope"
 
@@ -200,7 +205,7 @@ class AppConfigAcl(Capability):
 class AppHostingAcl(Capability):
     _capability_name = "appHostingAcl"
     actions: list[Literal["READ", "WRITE", "RUN"]]
-    scope: AllScope
+    scope: AllScope | AppExternalIdScope
 
 
 class AssetsAcl(Capability):

--- a/tests/test_unit/test_cdf_tk/test_client/test_group_api_classes.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_group_api_classes.py
@@ -16,6 +16,13 @@ def all_acls() -> Iterable[tuple]:
         {"annotationsAcl": {"actions": ["WRITE", "READ", "SUGGEST", "REVIEW"], "scope": {"all": {}}}},
         {"appConfigAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"appConfigAcl": {"actions": ["READ", "WRITE"], "scope": {"appScope": {"apps": ["SEARCH"]}}}},
+        {"appHostingAcl": {"actions": ["READ", "RUN"], "scope": {"all": {}}}},
+        {
+            "appHostingAcl": {
+                "actions": ["READ", "RUN"],
+                "scope": {"appExternalIdScope": {"externalIds": ["my-special-app"]}},
+            }
+        },
         {"assetsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"assetsAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": [123]}}}},
         {"auditlogAcl": {"actions": ["READ"], "scope": {"all": {}}}},

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
@@ -20,6 +20,13 @@ def all_acls() -> Iterable:
         {"annotationsAcl": {"actions": ["WRITE", "READ", "SUGGEST", "REVIEW"], "scope": {"all": {}}}},
         {"appConfigAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"appConfigAcl": {"actions": ["READ", "WRITE"], "scope": {"appScope": {"apps": ["SEARCH"]}}}},
+        {"appHostingAcl": {"actions": ["READ", "RUN"], "scope": {"all": {}}}},
+        {
+            "appHostingAcl": {
+                "actions": ["READ", "RUN"],
+                "scope": {"appExternalIdScope": {"externalIds": ["my-special-app"]}},
+            }
+        },
         {"assetsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"assetsAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": ["myDataSet"]}}}},
         {"auditlogAcl": {"actions": ["READ"], "scope": {"all": {}}}},


### PR DESCRIPTION
# Description

Add `AppExternalIdScope` Pydantic class and add it as a scope option to the `AppHostingAcl` Pydantic class so groups can restrict app hosting access to specific apps by external ID without seeing an error during build.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Added

- Support scoping the `appHostingAcl` capability to specific apps via `appExternalIdScope`.