### PR TITLE
[CDF-28203] Improvements to migration logging

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -325,9 +325,7 @@ class MigrationCommand(ToolkitCommand):
             responses: ItemsResultList = ItemsResultList()
             for chunk in chunker_sequence(page.items, target.CHUNK_SIZE):
                 chunk_page = page.create_from(list(chunk))
-                chunk_results = target.upload_items(
-                    data_chunk=chunk_page, http_client=write_client, selector=selected
-                )
+                chunk_results = target.upload_items(data_chunk=chunk_page, http_client=write_client, selector=selected)
                 responses.extend(chunk_results)
 
                 for item in chunk_results:

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -325,49 +325,48 @@ class MigrationCommand(ToolkitCommand):
             responses: ItemsResultList = ItemsResultList()
             for chunk in chunker_sequence(page.items, target.CHUNK_SIZE):
                 chunk_page = page.create_from(list(chunk))
-                chunk_results = target.upload_items(data_chunk=chunk_page, http_client=write_client, selector=selected)
-                responses.extend(chunk_results)
+                responses.extend(
+                    target.upload_items(data_chunk=chunk_page, http_client=write_client, selector=selected)
+                )
 
-                for item in chunk_results:
-                    if isinstance(item, ItemsSuccessResponse):
-                        continue
-                    if isinstance(item, ItemsFailedResponse):
-                        error = item.error
-                        for id_ in item.ids:
-                            target.logger.log(
-                                MigrationEntryV2(
-                                    id=id_,
-                                    severity=Severity.failure,
-                                    label=f"Failed to write to CDF: {error.code}",
-                                    message=error.message,
-                                    source=str(selected),
-                                    destination=target.KIND,
-                                )
+            for item in responses:
+                if isinstance(item, ItemsSuccessResponse):
+                    continue
+                if isinstance(item, ItemsFailedResponse):
+                    error = item.error
+                    for id_ in item.ids:
+                        target.logger.log(
+                            MigrationEntryV2(
+                                id=id_,
+                                severity=Severity.failure,
+                                label=f"Failed to write to CDF: {error.code}",
+                                message=error.message,
+                                source=str(selected),
+                                destination=target.KIND,
                             )
-                    elif isinstance(item, ItemsFailedRequest):
-                        for id_ in item.ids:
-                            target.logger.log(
-                                MigrationEntryV2(
-                                    id=id_,
-                                    severity=Severity.failure,
-                                    label="Failed to write to CDF: Request failed",
-                                    message=item.error_message,
-                                    source=str(selected),
-                                    destination=target.KIND,
-                                )
+                        )
+                elif isinstance(item, ItemsFailedRequest):
+                    for id_ in item.ids:
+                        target.logger.log(
+                            MigrationEntryV2(
+                                id=id_,
+                                severity=Severity.failure,
+                                label="Failed to write to CDF: Request failed",
+                                message=item.error_message,
+                                source=str(selected),
+                                destination=target.KIND,
                             )
+                        )
 
-                if chunk_results and all(
-                    isinstance(result, ItemsFailedResponse | ItemsFailedRequest) for result in chunk_results
-                ):
-                    target.logger.apply_to_all_unprocessed(
-                        label="Early termination of migration",
-                        severity=Severity.skipped,
-                    )
-                    target.logger.force_write()
-                    raise ToolkitRuntimeError(
-                        f"Migration was stopped due to repeatedly failed uploads. Check the log files in {log_dir}."
-                    )
+            if responses and all(isinstance(result, ItemsFailedResponse | ItemsFailedRequest) for result in responses):
+                target.logger.apply_to_all_unprocessed(
+                    label="Early termination of migration",
+                    severity=Severity.skipped,
+                )
+                target.logger.force_write()
+                raise ToolkitRuntimeError(
+                    f"Migration was stopped due to repeatedly failed uploads. Check the log files in {log_dir}."
+                )
 
             migrate_count += sum(len(response.ids) for response in responses)
             ProgressYAML(

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -42,6 +42,7 @@ from cognite_toolkit._cdf_tk.dataio.logger import (
 from cognite_toolkit._cdf_tk.dataio.progress import Bookmark, CursorBookmark, ProgressYAML
 from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitMigrationError,
+    ToolkitRuntimeError,
     ToolkitValueError,
 )
 from cognite_toolkit._cdf_tk.resource_ios import ResourceWorker
@@ -324,38 +325,51 @@ class MigrationCommand(ToolkitCommand):
             responses: ItemsResultList = ItemsResultList()
             for chunk in chunker_sequence(page.items, target.CHUNK_SIZE):
                 chunk_page = page.create_from(list(chunk))
-                responses.extend(
-                    target.upload_items(data_chunk=chunk_page, http_client=write_client, selector=selected)
+                chunk_results = target.upload_items(
+                    data_chunk=chunk_page, http_client=write_client, selector=selected
                 )
+                responses.extend(chunk_results)
 
-            for item in responses:
-                if isinstance(item, ItemsSuccessResponse):
-                    continue
-                if isinstance(item, ItemsFailedResponse):
-                    error = item.error
-                    for id_ in item.ids:
-                        target.logger.log(
-                            MigrationEntryV2(
-                                id=id_,
-                                severity=Severity.failure,
-                                label=f"Failed to write to CDF: {error.code}",
-                                message=error.message,
-                                source=str(selected),
-                                destination=target.KIND,
+                for item in chunk_results:
+                    if isinstance(item, ItemsSuccessResponse):
+                        continue
+                    if isinstance(item, ItemsFailedResponse):
+                        error = item.error
+                        for id_ in item.ids:
+                            target.logger.log(
+                                MigrationEntryV2(
+                                    id=id_,
+                                    severity=Severity.failure,
+                                    label=f"Failed to write to CDF: {error.code}",
+                                    message=error.message,
+                                    source=str(selected),
+                                    destination=target.KIND,
+                                )
                             )
-                        )
-                elif isinstance(item, ItemsFailedRequest):
-                    for id_ in item.ids:
-                        target.logger.log(
-                            MigrationEntryV2(
-                                id=id_,
-                                severity=Severity.failure,
-                                label="Failed to write to CDF: Request failed",
-                                message=item.error_message,
-                                source=str(selected),
-                                destination=target.KIND,
+                    elif isinstance(item, ItemsFailedRequest):
+                        for id_ in item.ids:
+                            target.logger.log(
+                                MigrationEntryV2(
+                                    id=id_,
+                                    severity=Severity.failure,
+                                    label="Failed to write to CDF: Request failed",
+                                    message=item.error_message,
+                                    source=str(selected),
+                                    destination=target.KIND,
+                                )
                             )
-                        )
+
+                if chunk_results and all(
+                    isinstance(result, ItemsFailedResponse | ItemsFailedRequest) for result in chunk_results
+                ):
+                    target.logger.apply_to_all_unprocessed(
+                        label="Early termination of migration",
+                        severity=Severity.skipped,
+                    )
+                    target.logger.force_write()
+                    raise ToolkitRuntimeError(
+                        f"Migration was stopped due to repeatedly failed uploads. Check the log files in {log_dir}."
+                    )
 
             migrate_count += sum(len(response.ids) for response in responses)
             ProgressYAML(

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -851,16 +851,20 @@ class ConnectionCreator:
 
     def create_direct_relation(
         self, value: Any, dm_prop: DirectNodeRelation, source_prop_id: str, source_view_id: ViewId
-    ) -> tuple[NodeId | list[NodeId], list[str]]:
+    ) -> tuple[NodeId | list[NodeId] | None, list[str]]:
         targets, target_issues = self._create_targets(value, source_prop_id, source_view_id)
         relations, relation_issues = self._targets_to_direct_relation(
-            targets, dm_prop, f"{source_view_id!s}.{source_prop_id!s}"
+            targets, dm_prop, f"{source_view_id!s}.{source_prop_id!s}", known_issues=target_issues
         )
         return relations, target_issues + relation_issues
 
     def _targets_to_direct_relation(
-        self, targets: list[NodeId], dm_prop: DirectNodeRelation, source_display_name: str
-    ) -> tuple[NodeId | list[NodeId], list[str]]:
+        self,
+        targets: list[NodeId],
+        dm_prop: DirectNodeRelation,
+        source_display_name: str,
+        known_issues: Sequence[str] = (),
+    ) -> tuple[NodeId | list[NodeId] | None, list[str]]:
         errors: list[str] = []
         if dm_prop.list:
             if dm_prop.max_list_size and len(targets) > dm_prop.max_list_size:
@@ -872,6 +876,10 @@ class ConnectionCreator:
         elif len(targets) == 1:
             return targets[0], errors
         elif len(targets) == 0:
+            if known_issues:
+                # The reason no target could be resolved is already captured in known_issues,
+                # so we skip raising a generic error that would otherwise hide it.
+                return None, errors
             raise ValueError(
                 f"No targets for items relation property {source_display_name!s}: expected exactly 1, got 0"
             )
@@ -897,7 +905,7 @@ class ConnectionCreator:
 
     def create_direct_relation_from_edges(
         self, edges: list[EdgeOtherSide], dm_prop: DirectNodeRelation, source_edge_type: EdgeTypeId
-    ) -> tuple[NodeId | list[NodeId], list[str]]:
+    ) -> tuple[NodeId | list[NodeId] | None, list[str]]:
         if not dm_prop.list:
             edges = self._tiebreak_direct_relation_edges(edges, source_edge_type)
         targets: list[NodeId] = []
@@ -909,7 +917,9 @@ class ConnectionCreator:
                 issues.append(str(error))
                 continue
             targets.append(target)
-        result, relation_issues = self._targets_to_direct_relation(targets, dm_prop, str(source_edge_type))
+        result, relation_issues = self._targets_to_direct_relation(
+            targets, dm_prop, str(source_edge_type), known_issues=issues
+        )
         return result, issues + relation_issues
 
     def create_edges_from_edges(
@@ -1206,7 +1216,8 @@ def convert_container_properties(
                 )
                 continue
             errors.extend(issues)
-            created_properties[dest_prop_id] = created_connection
+            if created_connection is not None:
+                created_properties[dest_prop_id] = created_connection
         elif isinstance(dm_prop, ViewCorePropertyResponse):
             try:
                 created_value = convert_to_primary_property_with_special_cases(
@@ -1261,7 +1272,8 @@ def convert_edges(
                 )
                 continue
             errors.extend(issues)
-            created_properties[dest_prop_id] = created_connection
+            if created_connection is not None:
+                created_properties[dest_prop_id] = created_connection
         elif isinstance(dm_prop, ViewCorePropertyResponse):
             # Todo: If json or text we can potentially convert to a string representation of the edge targets, but for now we just log an error.
             errors.append(f"Cannot map edge property {source_type!s} to non-connection property {dm_prop.type.type!s}.")

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -748,14 +748,13 @@ class ConnectionCreator:
             try:
                 targets.append(self._create_target(item, source_prop_id, source_view_id))
             except ValueError as error:
-                issues.append(
-                    f"Failed to create direct relation for property {source_prop_id!r} with value {item!r}: {error}"
-                )
-            except KeyError:
-                issues.append(
-                    f"Failed to create direct relation for property {source_prop_id!r} with value {item!r}: "
-                    "no migrated instance found for reference"
-                )
+                issues.append(f"Failed to create direct relation for property {source_prop_id!r}: {error}")
+            except KeyError as error:
+                raise RuntimeError(
+                    f"Bug in Toolkit: {source_view_id!s}.{source_prop_id!s} value {item!r} was not registered via "
+                    "CustomConnectionMapping.update() before being used to create a direct relation. "
+                    "Did you forget to call update_cache()?"
+                ) from error
         return targets, issues
 
     def _create_target(self, value: Any, source_prop_id: str, source_view_id: ViewId) -> NodeId:
@@ -767,12 +766,12 @@ class ConnectionCreator:
         elif self._is_timeseries_reference(source_view_id, source_prop_id) and isinstance(value, str):
             if value not in self._timeseries_reference_cache:
                 raise ValueError(
-                    f"No migrated CogniteTimeSeries instance found for classic timeseries external ID {value!r}"
+                    f"No migrated CogniteTimeSeries instance found for classic timeseries with external ID {value!r}"
                 )
             return self._timeseries_reference_cache[value]
         elif self._is_file_reference(source_view_id, source_prop_id) and isinstance(value, str):
             if value not in self._file_reference_cache:
-                raise ValueError(f"No migrated CogniteFile instance found for classic file external ID {value!r}")
+                raise ValueError(f"No migrated CogniteFile instance found for classic file with external ID {value!r}")
             return self._file_reference_cache[value]
         elif (
             self._is_direct_relation(source_view_id, source_prop_id)
@@ -1133,7 +1132,9 @@ class InFieldAssetMapping(CustomConnectionMapping[NodeId]):
         # the external ID classic.
         result = self._node_id_by_external_id[item.external_id]
         if result is None:
-            raise KeyError(f"No mapping found for {item!r}")
+            raise ValueError(
+                f"No migrated CogniteAsset instance found for classic asset with external ID {item.external_id!r}"
+            )
         return result
 
     def update(self, items: Iterable[NodeId]) -> None:

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.yaml
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.yaml
@@ -74,23 +74,23 @@
 #   containerMapping:
 #     node.createdTime: sourceCreatedTime
 #     node.lastUpdatedTime: sourceUpdatedTime
-- externalId: InFieldMeasurementReadingMapping
-  sourceView:
-    space: cdf_apm
-    externalId: MeasurementReading
-    version: v4
-    type: view
-  destinationView:
-    space: cdf_infield
-    externalId: MeasurementReading
-    version: v1
-    type: view
-  mapIdenticalIdProperties: true
-  containerMapping:
-    node.createdTime: sourceCreatedTime
-    node.lastUpdatedTime: sourceUpdatedTime
-  edgeMapping:
-    cdf_apm:referenceMeasurements(direction=inwards): item
+# - externalId: InFieldMeasurementReadingMapping
+#   sourceView:
+#     space: cdf_apm
+#     externalId: MeasurementReading
+#     version: v4
+#     type: view
+#   destinationView:
+#     space: cdf_infield
+#     externalId: MeasurementReading
+#     version: v1
+#     type: view
+#   mapIdenticalIdProperties: true
+#   containerMapping:
+#     node.createdTime: sourceCreatedTime
+#     node.lastUpdatedTime: sourceUpdatedTime
+#   edgeMapping:
+#     cdf_apm:referenceMeasurements(direction=inwards): item
 # - externalId: InFieldTemplateMapping
 #   sourceView:
 #     space: cdf_apm
@@ -136,24 +136,24 @@
 #   containerMapping:
 #     node.createdTime: sourceCreatedTime
 #     node.lastUpdatedTime: sourceUpdatedTime
-# - externalId: InFieldChecklistItemMapping
-#   sourceView:
-#     space: cdf_apm
-#     externalId: ChecklistItem
-#     version: v7
-#     type: view
-#   destinationView:
-#     space: cdf_infield
-#     externalId: ChecklistItem
-#     version: v1
-#     type: view
-#   mapIdenticalIdProperties: true
-#   containerMapping:
-#     node.createdTime: sourceCreatedTime
-#     node.lastUpdatedTime: sourceUpdatedTime
-#   edgeMapping:
-#     cdf_apm:referenceChecklistItems(direction=inwards): checklist
-#     cdf_apm:referenceObservations(direction=outwards): observations
+- externalId: InFieldChecklistItemMapping
+  sourceView:
+    space: cdf_apm
+    externalId: ChecklistItem
+    version: v7
+    type: view
+  destinationView:
+    space: cdf_infield
+    externalId: ChecklistItem
+    version: v1
+    type: view
+  mapIdenticalIdProperties: true
+  containerMapping:
+    node.createdTime: sourceCreatedTime
+    node.lastUpdatedTime: sourceUpdatedTime
+  edgeMapping:
+    cdf_apm:referenceChecklistItems(direction=inwards): checklist
+    cdf_apm:referenceObservations(direction=outwards): observations
 # - externalId: InFieldTemplateItemMapping
 #   sourceView:
 #     space: cdf_apm

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.yaml
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.yaml
@@ -1,79 +1,79 @@
 # The mapping definitions are topological ordered based on the container constraints of the
 # destination views. This is to ensure that data can be uploaded without violating any constraints.
-- externalId: InFieldCogniteSolutionTagMapping
-  sourceView:
-    space: cdf_apps_shared
-    externalId: CogniteSolutionTag
-    version: v1
-    type: view
-  destinationView:
-    space: cdf_apps_shared
-    externalId: CogniteSolutionTag
-    version: v1
-    type: view
-  mapIdenticalIdProperties: true
-  containerMapping: {}
-- externalId: InFieldConditionalActionMapping
-  sourceView:
-    space: cdf_apm
-    externalId: ConditionalAction
-    version: v1
-    type: view
-  destinationView:
-    space: cdf_infield
-    externalId: ConditionalAction
-    version: v1
-    type: view
-  mapIdenticalIdProperties: true
-  containerMapping:
-    node.createdTime: sourceCreatedTime
-    node.lastUpdatedTime: sourceUpdatedTime
-- externalId: InfieldObservationMapping
-  sourceView:
-    space: cdf_apm
-    externalId: Observation
-    version: v5
-    type: view
-  destinationView:
-    space: cdf_infield
-    externalId: FieldObservation
-    version: v1
-    type: view
-  containerMapping:
-    node.createdTime: sourceCreatedTime
-    node.lastUpdatedTime: sourceUpdatedTime
-    source: source
-    description: description
-    title: name
-    createdBy: sourceCreatedUser
-    updatedBy: sourceUpdatedUser
-    status: status
-    asset: assets
-    files: files
-    troubleshooting: troubleshooting
-    priority: priority
-    type: type
-  ignoreSourceProperties:
-    - sourceId
-    - rootLocation
-    - sourceCreatedTime
-    - isArchived
-    - solutionTags
-- externalId: InFieldChecklistMapping
-  sourceView:
-    space: cdf_apm
-    externalId: Checklist
-    version: v7
-    type: view
-  destinationView:
-    space: cdf_infield
-    externalId: Checklist
-    version: v1
-    type: view
-  mapIdenticalIdProperties: true
-  containerMapping:
-    node.createdTime: sourceCreatedTime
-    node.lastUpdatedTime: sourceUpdatedTime
+# - externalId: InFieldCogniteSolutionTagMapping
+#   sourceView:
+#     space: cdf_apps_shared
+#     externalId: CogniteSolutionTag
+#     version: v1
+#     type: view
+#   destinationView:
+#     space: cdf_apps_shared
+#     externalId: CogniteSolutionTag
+#     version: v1
+#     type: view
+#   mapIdenticalIdProperties: true
+#   containerMapping: {}
+# - externalId: InFieldConditionalActionMapping
+#   sourceView:
+#     space: cdf_apm
+#     externalId: ConditionalAction
+#     version: v1
+#     type: view
+#   destinationView:
+#     space: cdf_infield
+#     externalId: ConditionalAction
+#     version: v1
+#     type: view
+#   mapIdenticalIdProperties: true
+#   containerMapping:
+#     node.createdTime: sourceCreatedTime
+#     node.lastUpdatedTime: sourceUpdatedTime
+# - externalId: InfieldObservationMapping
+#   sourceView:
+#     space: cdf_apm
+#     externalId: Observation
+#     version: v5
+#     type: view
+#   destinationView:
+#     space: cdf_infield
+#     externalId: FieldObservation
+#     version: v1
+#     type: view
+#   containerMapping:
+#     node.createdTime: sourceCreatedTime
+#     node.lastUpdatedTime: sourceUpdatedTime
+#     source: source
+#     description: description
+#     title: name
+#     createdBy: sourceCreatedUser
+#     updatedBy: sourceUpdatedUser
+#     status: status
+#     asset: assets
+#     files: files
+#     troubleshooting: troubleshooting
+#     priority: priority
+#     type: type
+#   ignoreSourceProperties:
+#     - sourceId
+#     - rootLocation
+#     - sourceCreatedTime
+#     - isArchived
+#     - solutionTags
+# - externalId: InFieldChecklistMapping
+#   sourceView:
+#     space: cdf_apm
+#     externalId: Checklist
+#     version: v7
+#     type: view
+#   destinationView:
+#     space: cdf_infield
+#     externalId: Checklist
+#     version: v1
+#     type: view
+#   mapIdenticalIdProperties: true
+#   containerMapping:
+#     node.createdTime: sourceCreatedTime
+#     node.lastUpdatedTime: sourceUpdatedTime
 - externalId: InFieldMeasurementReadingMapping
   sourceView:
     space: cdf_apm
@@ -91,86 +91,86 @@
     node.lastUpdatedTime: sourceUpdatedTime
   edgeMapping:
     cdf_apm:referenceMeasurements(direction=inwards): item
-- externalId: InFieldTemplateMapping
-  sourceView:
-    space: cdf_apm
-    externalId: Template
-    version: v8
-    type: view
-  destinationView:
-    space: cdf_infield
-    externalId: Template
-    version: v1
-    type: view
-  mapIdenticalIdProperties: true
-  containerMapping:
-    node.createdTime: sourceCreatedTime
-    node.lastUpdatedTime: sourceUpdatedTime
-- externalId: InFieldActionMapping
-  sourceView:
-    space: cdf_apm
-    externalId: Action
-    version: v1
-    type: view
-  destinationView:
-    space: cdf_infield
-    externalId: Action
-    version: v1
-    type: view
-  mapIdenticalIdProperties: true
-  containerMapping:
-    node.createdTime: sourceCreatedTime
-    node.lastUpdatedTime: sourceUpdatedTime
-- externalId: InFieldConditionMapping
-  sourceView:
-    space: cdf_apm
-    externalId: Condition
-    version: v1
-    type: view
-  destinationView:
-    space: cdf_infield
-    externalId: Condition
-    version: v1
-    type: view
-  mapIdenticalIdProperties: true
-  containerMapping:
-    node.createdTime: sourceCreatedTime
-    node.lastUpdatedTime: sourceUpdatedTime
-- externalId: InFieldChecklistItemMapping
-  sourceView:
-    space: cdf_apm
-    externalId: ChecklistItem
-    version: v7
-    type: view
-  destinationView:
-    space: cdf_infield
-    externalId: ChecklistItem
-    version: v1
-    type: view
-  mapIdenticalIdProperties: true
-  containerMapping:
-    node.createdTime: sourceCreatedTime
-    node.lastUpdatedTime: sourceUpdatedTime
-  edgeMapping:
-    cdf_apm:referenceChecklistItems(direction=inwards): checklist
-    cdf_apm:referenceObservations(direction=outwards): observations
-- externalId: InFieldTemplateItemMapping
-  sourceView:
-    space: cdf_apm
-    externalId: TemplateItem
-    version: v7
-    type: view
-  destinationView:
-    space: cdf_infield
-    externalId: TemplateItem
-    version: v1
-    type: view
-  mapIdenticalIdProperties: true
-  containerMapping:
-    node.createdTime: sourceCreatedTime
-    node.lastUpdatedTime: sourceUpdatedTime
-  edgeMapping:
-    cdf_apm:referenceTemplateItems(direction=inwards): template
+# - externalId: InFieldTemplateMapping
+#   sourceView:
+#     space: cdf_apm
+#     externalId: Template
+#     version: v8
+#     type: view
+#   destinationView:
+#     space: cdf_infield
+#     externalId: Template
+#     version: v1
+#     type: view
+#   mapIdenticalIdProperties: true
+#   containerMapping:
+#     node.createdTime: sourceCreatedTime
+#     node.lastUpdatedTime: sourceUpdatedTime
+# - externalId: InFieldActionMapping
+#   sourceView:
+#     space: cdf_apm
+#     externalId: Action
+#     version: v1
+#     type: view
+#   destinationView:
+#     space: cdf_infield
+#     externalId: Action
+#     version: v1
+#     type: view
+#   mapIdenticalIdProperties: true
+#   containerMapping:
+#     node.createdTime: sourceCreatedTime
+#     node.lastUpdatedTime: sourceUpdatedTime
+# - externalId: InFieldConditionMapping
+#   sourceView:
+#     space: cdf_apm
+#     externalId: Condition
+#     version: v1
+#     type: view
+#   destinationView:
+#     space: cdf_infield
+#     externalId: Condition
+#     version: v1
+#     type: view
+#   mapIdenticalIdProperties: true
+#   containerMapping:
+#     node.createdTime: sourceCreatedTime
+#     node.lastUpdatedTime: sourceUpdatedTime
+# - externalId: InFieldChecklistItemMapping
+#   sourceView:
+#     space: cdf_apm
+#     externalId: ChecklistItem
+#     version: v7
+#     type: view
+#   destinationView:
+#     space: cdf_infield
+#     externalId: ChecklistItem
+#     version: v1
+#     type: view
+#   mapIdenticalIdProperties: true
+#   containerMapping:
+#     node.createdTime: sourceCreatedTime
+#     node.lastUpdatedTime: sourceUpdatedTime
+#   edgeMapping:
+#     cdf_apm:referenceChecklistItems(direction=inwards): checklist
+#     cdf_apm:referenceObservations(direction=outwards): observations
+# - externalId: InFieldTemplateItemMapping
+#   sourceView:
+#     space: cdf_apm
+#     externalId: TemplateItem
+#     version: v7
+#     type: view
+#   destinationView:
+#     space: cdf_infield
+#     externalId: TemplateItem
+#     version: v1
+#     type: view
+#   mapIdenticalIdProperties: true
+#   containerMapping:
+#     node.createdTime: sourceCreatedTime
+#     node.lastUpdatedTime: sourceUpdatedTime
+#   edgeMapping:
+#     cdf_apm:referenceTemplateItems(direction=inwards): template
 - externalId: InFieldScheduleMapping
   sourceView:
     space: cdf_apm

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.yaml
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.yaml
@@ -1,141 +1,141 @@
 # The mapping definitions are topological ordered based on the container constraints of the
 # destination views. This is to ensure that data can be uploaded without violating any constraints.
-# - externalId: InFieldCogniteSolutionTagMapping
-#   sourceView:
-#     space: cdf_apps_shared
-#     externalId: CogniteSolutionTag
-#     version: v1
-#     type: view
-#   destinationView:
-#     space: cdf_apps_shared
-#     externalId: CogniteSolutionTag
-#     version: v1
-#     type: view
-#   mapIdenticalIdProperties: true
-#   containerMapping: {}
-# - externalId: InFieldConditionalActionMapping
-#   sourceView:
-#     space: cdf_apm
-#     externalId: ConditionalAction
-#     version: v1
-#     type: view
-#   destinationView:
-#     space: cdf_infield
-#     externalId: ConditionalAction
-#     version: v1
-#     type: view
-#   mapIdenticalIdProperties: true
-#   containerMapping:
-#     node.createdTime: sourceCreatedTime
-#     node.lastUpdatedTime: sourceUpdatedTime
-# - externalId: InfieldObservationMapping
-#   sourceView:
-#     space: cdf_apm
-#     externalId: Observation
-#     version: v5
-#     type: view
-#   destinationView:
-#     space: cdf_infield
-#     externalId: FieldObservation
-#     version: v1
-#     type: view
-#   containerMapping:
-#     node.createdTime: sourceCreatedTime
-#     node.lastUpdatedTime: sourceUpdatedTime
-#     source: source
-#     description: description
-#     title: name
-#     createdBy: sourceCreatedUser
-#     updatedBy: sourceUpdatedUser
-#     status: status
-#     asset: assets
-#     files: files
-#     troubleshooting: troubleshooting
-#     priority: priority
-#     type: type
-#   ignoreSourceProperties:
-#     - sourceId
-#     - rootLocation
-#     - sourceCreatedTime
-#     - isArchived
-#     - solutionTags
-# - externalId: InFieldChecklistMapping
-#   sourceView:
-#     space: cdf_apm
-#     externalId: Checklist
-#     version: v7
-#     type: view
-#   destinationView:
-#     space: cdf_infield
-#     externalId: Checklist
-#     version: v1
-#     type: view
-#   mapIdenticalIdProperties: true
-#   containerMapping:
-#     node.createdTime: sourceCreatedTime
-#     node.lastUpdatedTime: sourceUpdatedTime
-# - externalId: InFieldMeasurementReadingMapping
-#   sourceView:
-#     space: cdf_apm
-#     externalId: MeasurementReading
-#     version: v4
-#     type: view
-#   destinationView:
-#     space: cdf_infield
-#     externalId: MeasurementReading
-#     version: v1
-#     type: view
-#   mapIdenticalIdProperties: true
-#   containerMapping:
-#     node.createdTime: sourceCreatedTime
-#     node.lastUpdatedTime: sourceUpdatedTime
-#   edgeMapping:
-#     cdf_apm:referenceMeasurements(direction=inwards): item
-# - externalId: InFieldTemplateMapping
-#   sourceView:
-#     space: cdf_apm
-#     externalId: Template
-#     version: v8
-#     type: view
-#   destinationView:
-#     space: cdf_infield
-#     externalId: Template
-#     version: v1
-#     type: view
-#   mapIdenticalIdProperties: true
-#   containerMapping:
-#     node.createdTime: sourceCreatedTime
-#     node.lastUpdatedTime: sourceUpdatedTime
-# - externalId: InFieldActionMapping
-#   sourceView:
-#     space: cdf_apm
-#     externalId: Action
-#     version: v1
-#     type: view
-#   destinationView:
-#     space: cdf_infield
-#     externalId: Action
-#     version: v1
-#     type: view
-#   mapIdenticalIdProperties: true
-#   containerMapping:
-#     node.createdTime: sourceCreatedTime
-#     node.lastUpdatedTime: sourceUpdatedTime
-# - externalId: InFieldConditionMapping
-#   sourceView:
-#     space: cdf_apm
-#     externalId: Condition
-#     version: v1
-#     type: view
-#   destinationView:
-#     space: cdf_infield
-#     externalId: Condition
-#     version: v1
-#     type: view
-#   mapIdenticalIdProperties: true
-#   containerMapping:
-#     node.createdTime: sourceCreatedTime
-#     node.lastUpdatedTime: sourceUpdatedTime
+- externalId: InFieldCogniteSolutionTagMapping
+  sourceView:
+    space: cdf_apps_shared
+    externalId: CogniteSolutionTag
+    version: v1
+    type: view
+  destinationView:
+    space: cdf_apps_shared
+    externalId: CogniteSolutionTag
+    version: v1
+    type: view
+  mapIdenticalIdProperties: true
+  containerMapping: {}
+- externalId: InFieldConditionalActionMapping
+  sourceView:
+    space: cdf_apm
+    externalId: ConditionalAction
+    version: v1
+    type: view
+  destinationView:
+    space: cdf_infield
+    externalId: ConditionalAction
+    version: v1
+    type: view
+  mapIdenticalIdProperties: true
+  containerMapping:
+    node.createdTime: sourceCreatedTime
+    node.lastUpdatedTime: sourceUpdatedTime
+- externalId: InfieldObservationMapping
+  sourceView:
+    space: cdf_apm
+    externalId: Observation
+    version: v5
+    type: view
+  destinationView:
+    space: cdf_infield
+    externalId: FieldObservation
+    version: v1
+    type: view
+  containerMapping:
+    node.createdTime: sourceCreatedTime
+    node.lastUpdatedTime: sourceUpdatedTime
+    source: source
+    description: description
+    title: name
+    createdBy: sourceCreatedUser
+    updatedBy: sourceUpdatedUser
+    status: status
+    asset: assets
+    files: files
+    troubleshooting: troubleshooting
+    priority: priority
+    type: type
+  ignoreSourceProperties:
+    - sourceId
+    - rootLocation
+    - sourceCreatedTime
+    - isArchived
+    - solutionTags
+- externalId: InFieldChecklistMapping
+  sourceView:
+    space: cdf_apm
+    externalId: Checklist
+    version: v7
+    type: view
+  destinationView:
+    space: cdf_infield
+    externalId: Checklist
+    version: v1
+    type: view
+  mapIdenticalIdProperties: true
+  containerMapping:
+    node.createdTime: sourceCreatedTime
+    node.lastUpdatedTime: sourceUpdatedTime
+- externalId: InFieldMeasurementReadingMapping
+  sourceView:
+    space: cdf_apm
+    externalId: MeasurementReading
+    version: v4
+    type: view
+  destinationView:
+    space: cdf_infield
+    externalId: MeasurementReading
+    version: v1
+    type: view
+  mapIdenticalIdProperties: true
+  containerMapping:
+    node.createdTime: sourceCreatedTime
+    node.lastUpdatedTime: sourceUpdatedTime
+  edgeMapping:
+    cdf_apm:referenceMeasurements(direction=inwards): item
+- externalId: InFieldTemplateMapping
+  sourceView:
+    space: cdf_apm
+    externalId: Template
+    version: v8
+    type: view
+  destinationView:
+    space: cdf_infield
+    externalId: Template
+    version: v1
+    type: view
+  mapIdenticalIdProperties: true
+  containerMapping:
+    node.createdTime: sourceCreatedTime
+    node.lastUpdatedTime: sourceUpdatedTime
+- externalId: InFieldActionMapping
+  sourceView:
+    space: cdf_apm
+    externalId: Action
+    version: v1
+    type: view
+  destinationView:
+    space: cdf_infield
+    externalId: Action
+    version: v1
+    type: view
+  mapIdenticalIdProperties: true
+  containerMapping:
+    node.createdTime: sourceCreatedTime
+    node.lastUpdatedTime: sourceUpdatedTime
+- externalId: InFieldConditionMapping
+  sourceView:
+    space: cdf_apm
+    externalId: Condition
+    version: v1
+    type: view
+  destinationView:
+    space: cdf_infield
+    externalId: Condition
+    version: v1
+    type: view
+  mapIdenticalIdProperties: true
+  containerMapping:
+    node.createdTime: sourceCreatedTime
+    node.lastUpdatedTime: sourceUpdatedTime
 - externalId: InFieldChecklistItemMapping
   sourceView:
     space: cdf_apm
@@ -154,23 +154,23 @@
   edgeMapping:
     cdf_apm:referenceChecklistItems(direction=inwards): checklist
     cdf_apm:referenceObservations(direction=outwards): observations
-# - externalId: InFieldTemplateItemMapping
-#   sourceView:
-#     space: cdf_apm
-#     externalId: TemplateItem
-#     version: v7
-#     type: view
-#   destinationView:
-#     space: cdf_infield
-#     externalId: TemplateItem
-#     version: v1
-#     type: view
-#   mapIdenticalIdProperties: true
-#   containerMapping:
-#     node.createdTime: sourceCreatedTime
-#     node.lastUpdatedTime: sourceUpdatedTime
-#   edgeMapping:
-#     cdf_apm:referenceTemplateItems(direction=inwards): template
+- externalId: InFieldTemplateItemMapping
+  sourceView:
+    space: cdf_apm
+    externalId: TemplateItem
+    version: v7
+    type: view
+  destinationView:
+    space: cdf_infield
+    externalId: TemplateItem
+    version: v1
+    type: view
+  mapIdenticalIdProperties: true
+  containerMapping:
+    node.createdTime: sourceCreatedTime
+    node.lastUpdatedTime: sourceUpdatedTime
+  edgeMapping:
+    cdf_apm:referenceTemplateItems(direction=inwards): template
 - externalId: InFieldScheduleMapping
   sourceView:
     space: cdf_apm

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -68,6 +68,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.streams import (
     StreamSettings,
 )
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
+from cognite_toolkit._cdf_tk.client.http_client import ItemsFailedRequest
 from cognite_toolkit._cdf_tk.commands._migrate.command import MigrationCommand
 from cognite_toolkit._cdf_tk.commands._migrate.data_mapper import (
     AssetCentricToInstanceMapper,
@@ -95,8 +96,9 @@ from cognite_toolkit._cdf_tk.commands._migrate.migration_io import (
 )
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import MigrationCSVFileSelector
 from cognite_toolkit._cdf_tk.dataio import CanvasIO, ChartIO, DataItem, Page
-from cognite_toolkit._cdf_tk.dataio.logger import ItemsResult
+from cognite_toolkit._cdf_tk.dataio.logger import ItemsResult, Severity
 from cognite_toolkit._cdf_tk.dataio.progress import CursorBookmark, ProgressYAML
+from cognite_toolkit._cdf_tk.exceptions import ToolkitRuntimeError
 from cognite_toolkit._cdf_tk.dataio.selectors import (
     CanvasExternalIdSelector,
     ChartExternalIdSelector,
@@ -260,6 +262,22 @@ class _ChunkTrackingUploadIO:
     def upload_items(self, data_chunk: Page, http_client: object, selector: object | None = None) -> list:
         self.upload_chunk_sizes.append(len(data_chunk))
         return []
+
+
+class _FailingUploadIO:
+    CHUNK_SIZE = 1000
+    KIND = "Instances"
+
+    def __init__(self) -> None:
+        self.logger = MagicMock()
+
+    def upload_items(self, data_chunk: Page, http_client: object, selector: object | None = None) -> list:
+        return [
+            ItemsFailedRequest(
+                ids=[item.tracking_id for item in data_chunk.items],
+                error_message="Aborting further splitting of requests after 50 failed attempts.",
+            )
+        ]
 
 
 @pytest.mark.usefixtures("disable_gzip", "disable_pypi_check")
@@ -1161,6 +1179,31 @@ class TestMigrationCommand:
         upload(page)
 
         assert target.upload_chunk_sizes == [1000, 1]
+
+    def test_abort_when_all_items_in_chunk_fail(self, tmp_path: Path) -> None:
+        command = MigrationCommand(silent=True)
+        target = _FailingUploadIO()
+        page = Page(
+            worker_id="main",
+            items=[DataItem(tracking_id=f"item-{index}", item=index) for index in range(2)],
+        )
+        upload = command._upload(
+            selected=MagicMock(__str__=lambda self: "ChecklistItem_v7_node"),
+            write_client=MagicMock(),
+            target=target,  # type: ignore[arg-type]
+            dry_run=False,
+            log_dir=tmp_path,
+            total_item_count=2,
+            start_item=0,
+        )
+        with pytest.raises(ToolkitRuntimeError, match="Migration was stopped due to repeatedly failed uploads"):
+            upload(page)
+
+        target.logger.apply_to_all_unprocessed.assert_called_once_with(
+            label="Early termination of migration",
+            severity=Severity.skipped,
+        )
+        target.logger.force_write.assert_called_once()
 
     def test_validate_migration_model_available(self) -> None:
         with monkeypatch_toolkit_client() as client:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -20,6 +20,7 @@ from cognite.client.data_classes.data_modeling import (
 from cognite.client.data_classes.data_modeling.statistics import InstanceStatistics, ProjectStatistics
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
+from cognite_toolkit._cdf_tk.client.http_client import ItemsFailedRequest
 from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, InternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.annotation import (
     AnnotationResponse,
@@ -68,7 +69,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.streams import (
     StreamSettings,
 )
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
-from cognite_toolkit._cdf_tk.client.http_client import ItemsFailedRequest
 from cognite_toolkit._cdf_tk.commands._migrate.command import MigrationCommand
 from cognite_toolkit._cdf_tk.commands._migrate.data_mapper import (
     AssetCentricToInstanceMapper,
@@ -98,12 +98,11 @@ from cognite_toolkit._cdf_tk.commands._migrate.selectors import MigrationCSVFile
 from cognite_toolkit._cdf_tk.dataio import CanvasIO, ChartIO, DataItem, Page
 from cognite_toolkit._cdf_tk.dataio.logger import ItemsResult, Severity
 from cognite_toolkit._cdf_tk.dataio.progress import CursorBookmark, ProgressYAML
-from cognite_toolkit._cdf_tk.exceptions import ToolkitRuntimeError
 from cognite_toolkit._cdf_tk.dataio.selectors import (
     CanvasExternalIdSelector,
     ChartExternalIdSelector,
 )
-from cognite_toolkit._cdf_tk.exceptions import ToolkitMigrationError, ToolkitValueError
+from cognite_toolkit._cdf_tk.exceptions import ToolkitMigrationError, ToolkitRuntimeError, ToolkitValueError
 
 
 def _migration_status_totals(results: Sequence[ItemsResult]) -> dict[str, int]:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
@@ -51,6 +51,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.conversion import (
     ConversionContext,
     DirectRelationCache,
     EdgeOtherSide,
+    InFieldAssetMapping,
     InstanceMappingError,
     SpaceMappingInstanceIdMapper,
     asset_centric_to_dm,
@@ -1770,6 +1771,18 @@ class TestInstanceIdMapper:
         mapper = SpaceMappingInstanceIdMapper({"source_space": "target_space"})
         result = mapper.map_instance_id(NodeId(space="source_space", external_id="node1"))
         assert result == NodeId(space="target_space", external_id="node1")
+
+
+class TestInFieldAssetMapping:
+    def test_getitem_raises_descriptive_value_error_for_unmigrated_asset(self) -> None:
+        mapping = InFieldAssetMapping(MagicMock(spec=ToolkitClient))
+        mapping._node_id_by_external_id["AI29531"] = None
+
+        with pytest.raises(
+            ValueError,
+            match="No migrated CogniteAsset instance found for classic asset with external ID 'AI29531'",
+        ):
+            mapping[NodeId(space="APM_SourceData", external_id="AI29531")]
 
 
 class TestAssetCentricToRecord:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
@@ -1519,6 +1519,16 @@ class TestInstanceToInstanceConversion:
                 id="Missing classic file reference in list direct relation",
             ),
             pytest.param(
+                {"sensorTs": "missing_ts_ext_id"},
+                {},
+                [
+                    "Failed to create direct relation for property 'sensorTs' with value "
+                    "'missing_ts_ext_id': No migrated CogniteTimeSeries instance found for classic "
+                    "timeseries external ID 'missing_ts_ext_id'"
+                ],
+                id="Missing classic timeseries reference in single-valued direct relation",
+            ),
+            pytest.param(
                 {"epoch": 1700000000000},
                 {"timestamp": "2023-11-14T22:13:20Z"},
                 [],
@@ -1680,6 +1690,25 @@ class TestInstanceToInstanceConversion:
                     "Cannot map edge property src_space:textEdge(direction=outwards) to non-connection property text.",
                 ],
                 id="List relation, multi-target single, edge creation (inwards), non-connection error, and duplicate mapping",
+            ),
+            pytest.param(
+                {
+                    EdgeTypeId(type=NodeId(space="src_space", external_id="relatesTo"), direction="outwards"): [
+                        EdgeOtherSide(
+                            edge_id=IGNORED_EDGE_ID,
+                            other_side=NodeId(space="unmapped_space", external_id="asset_X"),
+                        )
+                    ],
+                },
+                {},
+                [],
+                [
+                    "No source-to-destination space mapping applies to space 'unmapped_space'. This migration is "
+                    "only configured to map instances from the following source space(s): dst_space and "
+                    "src_space. Instances (or direct-relation/edge targets) outside these spaces cannot be "
+                    "migrated. To fix this, re-run the migration with 'unmapped_space' included as a source space."
+                ],
+                id="Unmapped edge target space surfaces the specific mapping error instead of a generic one",
             ),
         ],
     )

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
@@ -1513,9 +1513,8 @@ class TestInstanceToInstanceConversion:
                 {"files": ["2c2a5867-a7f8-4eb2-9bd4-724776b4be9d"]},
                 {"files": []},
                 [
-                    "Failed to create direct relation for property 'files' with value "
-                    "'2c2a5867-a7f8-4eb2-9bd4-724776b4be9d': No migrated CogniteFile instance found for classic "
-                    "file external ID '2c2a5867-a7f8-4eb2-9bd4-724776b4be9d'"
+                    "Failed to create direct relation for property 'files': No migrated CogniteFile instance "
+                    "found for classic file with external ID '2c2a5867-a7f8-4eb2-9bd4-724776b4be9d'"
                 ],
                 id="Missing classic file reference in list direct relation",
             ),
@@ -1523,9 +1522,8 @@ class TestInstanceToInstanceConversion:
                 {"sensorTs": "missing_ts_ext_id"},
                 {},
                 [
-                    "Failed to create direct relation for property 'sensorTs' with value "
-                    "'missing_ts_ext_id': No migrated CogniteTimeSeries instance found for classic "
-                    "timeseries external ID 'missing_ts_ext_id'"
+                    "Failed to create direct relation for property 'sensorTs': No migrated CogniteTimeSeries "
+                    "instance found for classic timeseries with external ID 'missing_ts_ext_id'"
                 ],
                 id="Missing classic timeseries reference in single-valued direct relation",
             ),


### PR DESCRIPTION
# Description

Fixes FDM-CDM migration direct-relation conversion errors being swallowed and replaced by generic messages (e.g. "expected exactly 1, got 0") when the real cause was already known, such as a missing migrated files/timeseries/asset reference. 

Additionally, add an early-abort circuit breaker to the migrate upload step — mirroring the existing `upload` command — such that a systemic write failure stops the run after the first all-failed chunk instead of repeating the expensive split-and-retry cycle for every subsequent page. This reflects user feedback that it's easy for some migrations like `cdf migrate infield-data` to run for long periods of time and then subsequently discover that a specific exception has occurred that makes it pointless to continue (e.g. like having CogniteEquipment populated instead of CogniteAsset).

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- [alpha] When running `cdf migrate infield-data` the migration logs will not show more specific failure reasons when there are errors with direct relations.
- [alpha] When running `cdf migrate` commands, the migration will now stop early in case of repeated critical errors.