### PR TITLE
[CDF-28127] Add SAP writeback support when migrating InField Observations to custom CDM views

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -21,6 +21,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.conversion import (
     ConnectionCreator,
     InFieldAssetMapping,
     InFieldConditionMapping,
+    InFieldObservationSapStatusMapping,
     InFieldUserMapping,
     SpaceMappingInstanceIdMapper,
     SuffixInstanceIdMapper,
@@ -52,6 +53,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.infield_data_mappings import (
     DIRECT_RELATION_EDGE_TIEBREAKERS,
     create_infield_data_mappings,
     create_infield_schedule_selector,
+    resolve_observation_view_id,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.migration_io import (
     AnnotationMigrationIO,
@@ -1578,8 +1580,10 @@ class MigrateApp(typer.Typer):
             bool,
             typer.Option(
                 "--skip-observations",
-                help="Skip migrating Observation data to the default cdf_infield/FieldObservation view. "
-                "Only use this when you intend to migrate observations to a custom observation view manually.",
+                help="Skip migrating Observation data. If not specified, toolkit will automatically migrate data "
+                "to the default cdf_infield/FieldObservation view. If a custom Observation view is configured, "
+                "toolkit will attempt a best-effort migration to this custom view. Only use this flag "
+                "when you intend to migrate observations manually yourself, for example if you need custom logic.",
             ),
         ] = False,
     ) -> None:
@@ -1672,6 +1676,17 @@ class MigrateApp(typer.Typer):
             # If this skip is not done, users will end up with observations both in the custom observation view and the default FieldObservation view,
             # which can lead to the wrong view being rendered for migrated observations in Infield since it relies on the instances/inspect endpoint.
             infield_mappings = [m for m in infield_mappings if m.destination_view.external_id != "FieldObservation"]
+        else:
+            # If a custom observation view is configured for the target space (e.g. to support SAP writeback),
+            # migrate Observations onto it instead of the default FieldObservation view.
+            custom_observation_view = resolve_observation_view_id(infield_cdm_configs, target_space)
+            if custom_observation_view is not None:
+                infield_mappings = [
+                    m.model_copy(update={"destination_view": custom_observation_view})
+                    if m.source_view.external_id == "Observation"
+                    else m
+                    for m in infield_mappings
+                ]
         schedule_selector = create_infield_schedule_selector(instance_space=source_space)
         selectors: list[InstanceViewSelector | InstanceQuerySelector] = []
         schedule_mapping: ViewToViewMapping | None = None
@@ -1705,7 +1720,11 @@ class MigrateApp(typer.Typer):
             client,
             infield_mappings,
             connection_creator=connection_creator,
-            custom_properties_mappings=[InFieldConditionMapping(infield_mappings), InFieldUserMapping()],
+            custom_properties_mappings=[
+                InFieldConditionMapping(infield_mappings),
+                InFieldUserMapping(),
+                InFieldObservationSapStatusMapping(),
+            ],
             custom_instance_mappings={
                 InFieldLegacyToCDMScheduleMapper.SCHEDULE_VIEW: InFieldLegacyToCDMScheduleMapper(
                     client, connection_creator, schedule_mapping

--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -1583,7 +1583,7 @@ class MigrateApp(typer.Typer):
                 help="Skip migrating Observation data. If not specified, toolkit will automatically migrate data "
                 "to the default cdf_infield/FieldObservation view. If a custom Observation view is configured, "
                 "toolkit will attempt a best-effort migration to this custom view. Only use this flag "
-                "when you intend to migrate observations manually yourself, for example if you need custom logic.",
+                "when you intend to migrate observations using custom logic.",
             ),
         ] = False,
     ) -> None:

--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -1580,10 +1580,10 @@ class MigrateApp(typer.Typer):
             bool,
             typer.Option(
                 "--skip-observations",
-                help="Skip migrating Observation data. If not specified, toolkit will automatically migrate data "
-                "to the default cdf_infield/FieldObservation view. If a custom Observation view is configured, "
-                "toolkit will attempt a best-effort migration to this custom view. Only use this flag "
-                "when you intend to migrate observations using custom logic.",
+                help="Skip migrating Observation data. You need to use this flag if you are using a custom observation view with "
+                "significantly different or renamed properties from the default cdf_infield/FieldObservation, which requires custom "
+                "migration logic. By default, without this flag, Toolkit will migrate data to whatever observation view is configured "
+                "in the Infield location(s) that uses the relevant target space. ",
             ),
         ] = False,
     ) -> None:

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -1108,8 +1108,9 @@ class InFieldObservationSapStatusMapping(CustomContainerPropertiesMapping):
 
     APM's single ``status`` field conflates business workflow and SAP send-state. For CDM migrations, we map
     SAP-related values to separate ``sapStatus``/``notificationIdInSap`` fields, collapsing the business 'status'
-    field to "Completed" in all cases (regardless of whether the destination view supports writeback). "Draft"
-    and "Completed" are business-only statuses and are left for the generic container mapping to pass through.
+    field to "Completed" (or "Draft" for "Pending", which is still awaiting SAP) regardless of whether the
+    destination view supports writeback. "Draft" and "Completed" themselves are business-only statuses and are
+    left for the generic container mapping to pass through.
 
     The destination view is only written to if it actually has the ``sapStatus``/``notificationIdInSap``
     properties (detected dynamically from the resolved destination view, mirroring how InField itself
@@ -1120,30 +1121,37 @@ class InFieldObservationSapStatusMapping(CustomContainerPropertiesMapping):
 
     VIEW_IDS: ClassVar[Set[ViewId]] = frozenset({ViewId(space="cdf_apm", external_id="Observation", version="v5")})
 
-    _SAP_STATUS_BY_APM_STATUS: ClassVar[dict[str, str]] = {
-        "sent": "sent",
-        "not sent": "notSent",
-        "file not sent": "fileNotSent",
+    # APM status (lowercased) -> (sapStatus, business status).
+    _SAP_STATUS_BY_APM_STATUS: ClassVar[dict[str, tuple[str, str]]] = {
+        "sent": ("sent", "Completed"),
+        "not sent": ("notSent", "Completed"),
+        "file not sent": ("fileNotSent", "Completed"),
+        # "Pending" is still awaiting SAP, so the business status stays "Draft" rather than "Completed".
+        "pending": ("pending", "Draft"),
+        # "Failed" is not its own sapStatus enum value; it is folded into "notSent".
+        "failed": ("notSent", "Completed"),
     }
+    # sapStatus values for which there is no SAP notification ID to write back yet.
+    _SAP_STATUSES_WITHOUT_NOTIFICATION_ID: ClassVar[frozenset[str]] = frozenset({"notSent", "pending"})
 
     def convert(
         self, source_properties: dict[str, JsonValue | NodeId | list[NodeId]], context: ConversionContext
     ) -> ConversionResult:
         status = source_properties.get("status")
-        sap_status = self._SAP_STATUS_BY_APM_STATUS.get(status.lower()) if isinstance(status, str) else None
-        if sap_status is None:  # Skip and use default handling if not a SAP writeback status
+        status_mapping = self._SAP_STATUS_BY_APM_STATUS.get(status.lower()) if isinstance(status, str) else None
+        if status_mapping is None:  # Skip and use default handling if not a SAP writeback status
             return ConversionResult(container_properties={})
+        sap_status, business_status = status_mapping
 
-        # SAP writeback-related statuses always convert to a "Completed" status in the new  business logic-only
-        # 'status' field. We overwrite the source value in-place so the generic container mapping which runs
-        # after this doesn't separately fail to convert e.g. "Sent" and raise a redundant/confusing error.
-        source_properties["status"] = "Completed"
+        # We overwrite the source value in-place so the generic container mapping which runs after this
+        # doesn't separately fail to convert e.g. "Sent" and raise a redundant/confusing error.
+        source_properties["status"] = business_status
 
         supports_writeback = "sapStatus" in context.destination_properties and (
             "notificationIdInSap" in context.destination_properties
         )
         if not supports_writeback:
-            # We cannot migrate SAP writeback status, but the business status is still migrated to "completed".
+            # We cannot migrate SAP writeback status, but the business status above is still migrated.
             issues = [
                 f"Observation has SAP writeback status {status!r} but the configured observation view "
                 f"{context.mapping.destination_view!s} does not have the required target 'sapStatus' "
@@ -1157,7 +1165,7 @@ class InFieldObservationSapStatusMapping(CustomContainerPropertiesMapping):
             "sapStatus": sap_status,
         }
         if source_id := source_properties.get("sourceId"):
-            if sap_status != "notSent":
+            if sap_status not in self._SAP_STATUSES_WITHOUT_NOTIFICATION_ID:
                 created_properties["notificationIdInSap"] = source_id
         return ConversionResult(container_properties=created_properties)
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -1092,6 +1092,62 @@ class InFieldUserMapping(CustomContainerPropertiesMapping):
         return ConversionResult(container_properties=created_properties, errors=issues)
 
 
+class InFieldObservationSapStatusMapping(CustomContainerPropertiesMapping):
+    """Splits the APM Observation ``status`` field into CDM's separate ``status`` (business workflow)
+    and ``sapStatus``/``notificationIdInSap`` (SAP writeback state) fields, per the "SAP writeback on CDM
+    custom observation views" ADR.
+
+    The destination view is only written to if it actually has the ``sapStatus``/``notificationIdInSap``
+    properties (detected dynamically from the resolved destination view, mirroring how InField itself
+    detects writeback capability). This means the same logic works whether Observations are migrated to
+    the default ``cdf_infield/FieldObservation`` view or to a customer's custom observation view that
+    includes these two writeback fields.
+    """
+
+    VIEW_IDS: ClassVar[Set[ViewId]] = frozenset({ViewId(space="cdf_apm", external_id="Observation", version="v5")})
+
+    # APM's single `status` field conflates business workflow and SAP send-state for SAP-enabled clients.
+    # This maps the SAP-related values to CDM's separate `sapStatus`/`notificationIdInSap` fields, collapsing
+    # the business status to "Completed" in all cases. "Draft" and "Completed" are business-only statuses and
+    # are left for the generic container mapping to pass through unchanged.
+    _SAP_STATUS_BY_APM_STATUS: ClassVar[dict[str, str]] = {
+        "Sent": "Sent",
+        "Not sent": "Not sent",
+        "File not sent": "File not sent",
+    }
+
+    def convert(
+        self, source_properties: dict[str, JsonValue | NodeId | list[NodeId]], context: ConversionContext
+    ) -> ConversionResult:
+        status = source_properties.get("status")
+        sap_status = self._SAP_STATUS_BY_APM_STATUS.get(status) if isinstance(status, str) else None
+        if sap_status is None:
+            # "Draft", "Completed" or an unrecognized value: leave it to the generic identity mapping.
+            return ConversionResult(container_properties={})
+
+        supports_writeback = "sapStatus" in context.destination_properties and (
+            "notificationIdInSap" in context.destination_properties
+        )
+        if not supports_writeback:
+            # The destination view cannot represent SAP writeback state at all, so we leave this
+            # property alone rather than guessing a business status for it.
+            issues = [
+                f"Observation has SAP writeback status {status!r} but the configured Observation view "
+                f"{context.mapping.destination_view!s} does not have the required target 'sapStatus' "
+                "and/or 'notificationIdInSap' properties required to migrate this status value."
+            ]
+            return ConversionResult(container_properties={}, errors=issues)
+
+        created_properties: dict[str, JsonValue | NodeId | list[NodeId]] = {
+            "status": "Completed",
+            "sapStatus": sap_status,
+        }
+        if source_id := source_properties.get("sourceId"):
+            if sap_status != "Not sent":
+                created_properties["notificationIdInSap"] = source_id
+        return ConversionResult(container_properties=created_properties)
+
+
 class InFieldAssetMapping(CustomConnectionMapping[NodeId]):
     """Custom cases in the InField data migration
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -1106,6 +1106,11 @@ class InFieldObservationSapStatusMapping(CustomContainerPropertiesMapping):
     and ``sapStatus``/``notificationIdInSap`` (SAP writeback state) fields, per the "SAP writeback on CDM
     custom observation views" ADR.
 
+    APM's single ``status`` field conflates business workflow and SAP send-state. For CDM migrations, we map
+    SAP-related values to separate ``sapStatus``/``notificationIdInSap`` fields, collapsing the business 'status'
+    field to "Completed" in all cases (regardless of whether the destination view supports writeback). "Draft"
+    and "Completed" are business-only statuses and are left for the generic container mapping to pass through.
+
     The destination view is only written to if it actually has the ``sapStatus``/``notificationIdInSap``
     properties (detected dynamically from the resolved destination view, mirroring how InField itself
     detects writeback capability). This means the same logic works whether Observations are migrated to
@@ -1115,11 +1120,6 @@ class InFieldObservationSapStatusMapping(CustomContainerPropertiesMapping):
 
     VIEW_IDS: ClassVar[Set[ViewId]] = frozenset({ViewId(space="cdf_apm", external_id="Observation", version="v5")})
 
-    # APM's single `status` field conflates business workflow and SAP send-state for SAP-enabled clients.
-    # This maps the SAP-related values to CDM's separate `sapStatus`/`notificationIdInSap` fields, collapsing
-    # the business status to "Completed" in all cases (regardless of whether the destination view supports
-    # writeback). "Draft" and "Completed" are business-only statuses and are left for the generic container
-    # mapping to pass through unchanged.
     _SAP_STATUS_BY_APM_STATUS: ClassVar[dict[str, str]] = {
         "Sent": "Sent",
         "Not sent": "Not sent",
@@ -1131,22 +1131,19 @@ class InFieldObservationSapStatusMapping(CustomContainerPropertiesMapping):
     ) -> ConversionResult:
         status = source_properties.get("status")
         sap_status = self._SAP_STATUS_BY_APM_STATUS.get(status) if isinstance(status, str) else None
-        if sap_status is None:
-            # "Draft", "Completed" or an unrecognized value: leave it to the generic identity mapping.
+        if sap_status is None:  # Skip and use default handling if not a SAP writeback status
             return ConversionResult(container_properties={})
 
-        # SAP writeback statuses always collapse to a "Completed" business status. We overwrite the
-        # source value in-place so the generic container mapping (which runs after us on this same
-        # dict) maps 'status' to "Completed" too, instead of separately failing to convert e.g. "Sent"
-        # to the business 'status' enum and raising a redundant/confusing error alongside ours.
+        # SAP writeback-related statuses always convert to a "Completed" status in the new  business logic-only
+        # 'status' field. We overwrite the source value in-place so the generic container mapping which runs
+        # after this doesn't separately fail to convert e.g. "Sent" and raise a redundant/confusing error.
         source_properties["status"] = "Completed"
 
         supports_writeback = "sapStatus" in context.destination_properties and (
             "notificationIdInSap" in context.destination_properties
         )
         if not supports_writeback:
-            # The destination view cannot represent SAP writeback state at all, so we do not set the
-            # writeback-specific properties, but the business status above is still migrated to "Completed".
+            # We cannot migrate SAP writeback status, but the business status is still migrated to "Completed".
             issues = [
                 f"Observation has SAP writeback status {status!r} but the configured Observation view "
                 f"{context.mapping.destination_view!s} does not have the required target 'sapStatus' "
@@ -1155,8 +1152,7 @@ class InFieldObservationSapStatusMapping(CustomContainerPropertiesMapping):
             return ConversionResult(container_properties={}, errors=issues)
 
         # 'status' itself is intentionally left out here: the generic container mapping (running after
-        # us on the mutated source_properties above) already converts it to the destination view's
-        # "Completed" business status enum value with the correct casing.
+        # this mapping on the mutated source_properties above) handles conversion of this field.
         created_properties: dict[str, JsonValue | NodeId | list[NodeId]] = {
             "sapStatus": sap_status,
         }

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -1117,8 +1117,9 @@ class InFieldObservationSapStatusMapping(CustomContainerPropertiesMapping):
 
     # APM's single `status` field conflates business workflow and SAP send-state for SAP-enabled clients.
     # This maps the SAP-related values to CDM's separate `sapStatus`/`notificationIdInSap` fields, collapsing
-    # the business status to "Completed" in all cases. "Draft" and "Completed" are business-only statuses and
-    # are left for the generic container mapping to pass through unchanged.
+    # the business status to "Completed" in all cases (regardless of whether the destination view supports
+    # writeback). "Draft" and "Completed" are business-only statuses and are left for the generic container
+    # mapping to pass through unchanged.
     _SAP_STATUS_BY_APM_STATUS: ClassVar[dict[str, str]] = {
         "Sent": "Sent",
         "Not sent": "Not sent",
@@ -1134,12 +1135,18 @@ class InFieldObservationSapStatusMapping(CustomContainerPropertiesMapping):
             # "Draft", "Completed" or an unrecognized value: leave it to the generic identity mapping.
             return ConversionResult(container_properties={})
 
+        # SAP writeback statuses always collapse to a "Completed" business status. We overwrite the
+        # source value in-place so the generic container mapping (which runs after us on this same
+        # dict) maps 'status' to "Completed" too, instead of separately failing to convert e.g. "Sent"
+        # to the business 'status' enum and raising a redundant/confusing error alongside ours.
+        source_properties["status"] = "Completed"
+
         supports_writeback = "sapStatus" in context.destination_properties and (
             "notificationIdInSap" in context.destination_properties
         )
         if not supports_writeback:
-            # The destination view cannot represent SAP writeback state at all, so we leave this
-            # property alone rather than guessing a business status for it.
+            # The destination view cannot represent SAP writeback state at all, so we do not set the
+            # writeback-specific properties, but the business status above is still migrated to "Completed".
             issues = [
                 f"Observation has SAP writeback status {status!r} but the configured Observation view "
                 f"{context.mapping.destination_view!s} does not have the required target 'sapStatus' "
@@ -1147,8 +1154,10 @@ class InFieldObservationSapStatusMapping(CustomContainerPropertiesMapping):
             ]
             return ConversionResult(container_properties={}, errors=issues)
 
+        # 'status' itself is intentionally left out here: the generic container mapping (running after
+        # us on the mutated source_properties above) already converts it to the destination view's
+        # "Completed" business status enum value with the correct casing.
         created_properties: dict[str, JsonValue | NodeId | list[NodeId]] = {
-            "status": "Completed",
             "sapStatus": sap_status,
         }
         if source_id := source_properties.get("sourceId"):

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -1121,16 +1121,16 @@ class InFieldObservationSapStatusMapping(CustomContainerPropertiesMapping):
     VIEW_IDS: ClassVar[Set[ViewId]] = frozenset({ViewId(space="cdf_apm", external_id="Observation", version="v5")})
 
     _SAP_STATUS_BY_APM_STATUS: ClassVar[dict[str, str]] = {
-        "Sent": "Sent",
-        "Not sent": "Not sent",
-        "File not sent": "File not sent",
+        "sent": "sent",
+        "not sent": "notSent",
+        "file not sent": "fileNotSent",
     }
 
     def convert(
         self, source_properties: dict[str, JsonValue | NodeId | list[NodeId]], context: ConversionContext
     ) -> ConversionResult:
         status = source_properties.get("status")
-        sap_status = self._SAP_STATUS_BY_APM_STATUS.get(status) if isinstance(status, str) else None
+        sap_status = self._SAP_STATUS_BY_APM_STATUS.get(status.lower()) if isinstance(status, str) else None
         if sap_status is None:  # Skip and use default handling if not a SAP writeback status
             return ConversionResult(container_properties={})
 
@@ -1143,9 +1143,9 @@ class InFieldObservationSapStatusMapping(CustomContainerPropertiesMapping):
             "notificationIdInSap" in context.destination_properties
         )
         if not supports_writeback:
-            # We cannot migrate SAP writeback status, but the business status is still migrated to "Completed".
+            # We cannot migrate SAP writeback status, but the business status is still migrated to "completed".
             issues = [
-                f"Observation has SAP writeback status {status!r} but the configured Observation view "
+                f"Observation has SAP writeback status {status!r} but the configured observation view "
                 f"{context.mapping.destination_view!s} does not have the required target 'sapStatus' "
                 "and/or 'notificationIdInSap' properties required to migrate this status value."
             ]
@@ -1157,7 +1157,7 @@ class InFieldObservationSapStatusMapping(CustomContainerPropertiesMapping):
             "sapStatus": sap_status,
         }
         if source_id := source_properties.get("sourceId"):
-            if sap_status != "Not sent":
+            if sap_status != "notSent":
                 created_properties["notificationIdInSap"] = source_id
         return ConversionResult(container_properties=created_properties)
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.py
@@ -71,7 +71,7 @@ def resolve_observation_view_id(
         observations = view_mappings.get("observation")
         if not isinstance(observations, list) or not observations:
             continue
-        view = observations[0].get("view") if isinstance(observations[0], dict) else None
+        view = observations[0]
         if not isinstance(view, dict) or not all(key in view for key in ("space", "externalId", "version")):
             continue
         view_id_by_location[config.external_id] = ViewId(

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -16,10 +16,13 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     QuerySelectSource,
     QuerySortSpec,
 )
+from cognite_toolkit._cdf_tk.client.resource_classes.infield import InFieldCDMLocationConfigResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.view_to_view_mapping import ViewToViewMapping
 from cognite_toolkit._cdf_tk.commands._migrate.conversion import EdgeOtherSide
 from cognite_toolkit._cdf_tk.constants import SUBSELECTION_LIMIT_QUERY_ENDPOINT
 from cognite_toolkit._cdf_tk.dataio.selectors import InstanceQuerySelector
+from cognite_toolkit._cdf_tk.exceptions import ToolkitMigrationError
+from cognite_toolkit._cdf_tk.utils import humanize_collection
 from cognite_toolkit._cdf_tk.utils.file import read_yaml_content, safe_read
 
 DIRECT_RELATION_EDGE_TIEBREAKERS: dict[str, Callable[[list[EdgeOtherSide]], list[EdgeOtherSide]]] = {
@@ -38,6 +41,57 @@ def create_infield_data_mappings(extra: ExtraValues | None = None) -> list[ViewT
     if not isinstance(mappings_dict, list):
         raise ValueError(f"Expected a list of mappings in the YAML file, but got {type(mappings_dict).__name__}")
     return TypeAdapter(list[ViewToViewMapping]).validate_python(mappings_dict, extra=extra)
+
+
+def resolve_observation_view_id(
+    configs: Sequence[InFieldCDMLocationConfigResponse], target_space: str
+) -> ViewId | None:
+    """Determine which custom observation view, if any, Observations should be migrated to for a given
+    target instance space, based on the ``viewMappings.observation`` entries of the InField CDM location
+    configs already deployed for that space.
+
+    Args:
+        configs: All deployed InField CDM location configs (``client.infield.cdm_config.list()``).
+        target_space: The instance space Infield data is being migrated to.
+
+    Returns:
+        The custom observation ``ViewId`` to migrate Observations to, or ``None`` if no location targeting
+        ``target_space`` has a custom observation view configured (in which case the default
+        ``cdf_infield/FieldObservation`` view should be used).
+
+    Raises:
+        ToolkitMigrationError: If locations targeting ``target_space`` specify conflicting observation views.
+
+    """
+    view_id_by_location: dict[str, ViewId] = {}
+    for config in configs:
+        if config.data_storage is None or config.data_storage.app_instance_space != target_space:
+            continue
+        view_mappings = config.view_mappings or {}
+        observations = view_mappings.get("observation")
+        if not isinstance(observations, list) or not observations:
+            continue
+        view = observations[0].get("view") if isinstance(observations[0], dict) else None
+        if not isinstance(view, dict) or not all(key in view for key in ("space", "externalId", "version")):
+            continue
+        view_id_by_location[config.external_id] = ViewId(
+            space=str(view["space"]), external_id=str(view["externalId"]), version=str(view["version"])
+        )
+
+    distinct_view_ids = set(view_id_by_location.values())
+    if not distinct_view_ids:
+        return None
+    if len(distinct_view_ids) == 1:
+        return next(iter(distinct_view_ids))
+
+    conflicts = ", ".join(f"{location}={view_id!s}" for location, view_id in view_id_by_location.items())
+    raise ToolkitMigrationError(
+        f"You have configured multiple InField locations targeting the same appInstanceSpace {target_space!r} with different observation "
+        f"views: {conflicts}. Therefore, Toolkit cannot automatically determine which view to migrate Observations to. "
+        "You need to use the --skip-observations flag and migrate Observations manually, or ensure all locations targeting this "
+        f"appInstanceSpace share the same observation view. Distinct views found: "
+        f"{humanize_collection([str(view_id) for view_id in distinct_view_ids])}."
+    )
 
 
 def create_infield_schedule_selector(instance_space: str | None = None) -> InstanceQuerySelector:

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.py
@@ -74,7 +74,7 @@ def resolve_observation_view_id(
         if not isinstance(view, dict):
             continue
         view_id_by_location[config.external_id] = ViewId(
-            space=str(view["space"]), external_id=str(view.get("externalId")), version=str(view.get("version"))
+            space=str(view.get("space")), external_id=str(view.get("externalId")), version=str(view.get("version"))
         )
 
     distinct_view_ids = set(view_id_by_location.values())

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.py
@@ -70,7 +70,10 @@ def resolve_observation_view_id(
         observations = config.view_mappings.get("observation") if config.view_mappings else None
         if not isinstance(observations, list) or not observations:
             continue
-        view = observations[0]
+        observation_config = observations[0]
+        if not isinstance(observation_config, dict):
+            continue
+        view = observation_config.get("view")
         if not isinstance(view, dict):
             continue
         view_id_by_location[config.external_id] = ViewId(

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.py
@@ -67,15 +67,14 @@ def resolve_observation_view_id(
     for config in configs:
         if config.data_storage is None or config.data_storage.app_instance_space != target_space:
             continue
-        view_mappings = config.view_mappings or {}
-        observations = view_mappings.get("observation")
+        observations = config.view_mappings.get("observation") if config.view_mappings else None
         if not isinstance(observations, list) or not observations:
             continue
         view = observations[0]
-        if not isinstance(view, dict) or not all(key in view for key in ("space", "externalId", "version")):
+        if not isinstance(view, dict):
             continue
         view_id_by_location[config.external_id] = ViewId(
-            space=str(view["space"]), external_id=str(view["externalId"]), version=str(view["version"])
+            space=str(view["space"]), external_id=str(view.get("externalId")), version=str(view.get("version"))
         )
 
     distinct_view_ids = set(view_id_by_location.values())

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -1085,7 +1085,7 @@ class TestFDMtoCDMMapper:
             pytest.param(
                 "Sent",
                 True,
-                {"status": "completed", "sapStatus": "Sent", "notificationIdInSap": "sap-notification-123"},
+                {"status": "completed", "sapStatus": "sent", "notificationIdInSap": "sap-notification-123"},
                 False,
                 id="sent_with_writeback_view",
             ),
@@ -1093,7 +1093,7 @@ class TestFDMtoCDMMapper:
             pytest.param(
                 "Not sent",
                 True,
-                {"status": "completed", "sapStatus": "Not sent"},
+                {"status": "completed", "sapStatus": "notSent"},
                 False,
                 id="not_sent_with_writeback_view",
             ),
@@ -1103,7 +1103,7 @@ class TestFDMtoCDMMapper:
                 True,
                 {
                     "status": "completed",
-                    "sapStatus": "File not sent",
+                    "sapStatus": "fileNotSent",
                     "notificationIdInSap": "sap-notification-123",
                 },
                 False,

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -1076,27 +1076,61 @@ class TestFDMtoCDMMapper:
     OBSERVATION_SOURCE_VIEW_ID = ViewId(space="cdf_apm", external_id="Observation", version="v5")
 
     @pytest.mark.parametrize(
-        "destination_supports_writeback, expected_properties",
+        "status, destination_supports_writeback, expected_properties, expect_missing_writeback_error",
         [
+            # "Draft" and "Completed" are business-only statuses in APM: CDM's dedicated 'status' field
+            # gets them unchanged regardless of whether the view also supports SAP writeback.
+            pytest.param("Draft", True, {"status": "draft"}, False, id="draft_with_writeback_view"),
+            pytest.param("Draft", False, {"status": "draft"}, False, id="draft_without_writeback_view"),
+            pytest.param("Completed", True, {"status": "completed"}, False, id="completed_with_writeback_view"),
+            pytest.param("Completed", False, {"status": "completed"}, False, id="completed_without_writeback_view"),
+            # "Sent", "Not sent" and "File not sent" are APM's SAP send-states, which the ADR splits out
+            # into the dedicated 'sapStatus'/'notificationIdInSap' fields, collapsing business 'status'
+            # to "completed" in all cases.
             pytest.param(
+                "Sent",
                 True,
                 {"status": "completed", "sapStatus": "Sent", "notificationIdInSap": "sap-notification-123"},
-                id="custom_view_with_writeback_fields",
+                False,
+                id="sent_with_writeback_view",
+            ),
+            pytest.param("Sent", False, {"status": "completed"}, True, id="sent_without_writeback_view"),
+            pytest.param(
+                "Not sent",
+                True,
+                # No SAP notification ID has been sent yet, so there is nothing to carry over.
+                {"status": "completed", "sapStatus": "Not sent"},
+                False,
+                id="not_sent_with_writeback_view",
+            ),
+            pytest.param("Not sent", False, {"status": "completed"}, True, id="not_sent_without_writeback_view"),
+            pytest.param(
+                "File not sent",
+                True,
+                {
+                    "status": "completed",
+                    "sapStatus": "File not sent",
+                    "notificationIdInSap": "sap-notification-123",
+                },
+                False,
+                id="file_not_sent_with_writeback_view",
             ),
             pytest.param(
-                False,
-                {"status": "completed"},
-                id="custom_view_without_writeback_fields",
+                "File not sent", False, {"status": "completed"}, True, id="file_not_sent_without_writeback_view"
             ),
         ],
     )
     def test_infield_observation_sap_status_migrates_to_custom_observation_view(
-        self, destination_supports_writeback: bool, expected_properties: dict[str, str]
+        self,
+        status: str,
+        destination_supports_writeback: bool,
+        expected_properties: dict[str, str],
+        expect_missing_writeback_error: bool,
     ) -> None:
-        """Regression test for the SAP writeback ADR: migrating an Observation with a SAP writeback status
-        onto a customer's custom observation view must succeed, with the business 'status' correctly
-        collapsed to the destination enum's "completed" value, regardless of whether the destination view
-        has the two writeback fields.
+        """Regression test for the SAP writeback ADR: migrating an Observation with any APM status onto a
+        customer's custom observation view must succeed, with the business 'status' correctly set on the
+        destination enum (with correct casing) and the SAP-specific fields populated per the ADR's mapping
+        rules, regardless of whether the destination view has the two writeback fields.
         """
         source_container = ContainerId(space="cdf_apm", external_id="Observation")
         source_view = ViewResponse(
@@ -1162,7 +1196,7 @@ class TestFDMtoCDMMapper:
             created_time=0,
             version=1,
             properties={
-                self.OBSERVATION_SOURCE_VIEW_ID: {"status": "Sent", "sourceId": "sap-notification-123"},
+                self.OBSERVATION_SOURCE_VIEW_ID: {"status": status, "sourceId": "sap-notification-123"},
             },
         )
 
@@ -1193,7 +1227,7 @@ class TestFDMtoCDMMapper:
         )
         assert observation_source.properties == expected_properties
 
-        if destination_supports_writeback:
+        if not expect_missing_writeback_error:
             logger.log.assert_not_called()
         else:
             # Exactly one informative issue is logged about the missing writeback fields, not a second

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -42,6 +42,8 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     DirectNodeRelation,
     EdgeRequest,
     EdgeResponse,
+    EnumProperty,
+    EnumValue,
     FileCDFExternalIdReference,
     InstanceRequest,
     InstanceResponse,
@@ -77,6 +79,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.view_to_view_mapping import
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.commands._migrate.conversion import (
     ConnectionCreator,
+    InFieldObservationSapStatusMapping,
     SpaceMappingInstanceIdMapper,
     SuffixInstanceIdMapper,
 )
@@ -1069,6 +1072,139 @@ class TestFDMtoCDMMapper:
             assert isinstance(entry, MigrationEntryV2)
             assert entry.id == f"{self.SOURCE_SPACE}:second"
             assert "does not exist" in entry.message
+
+    OBSERVATION_SOURCE_VIEW_ID = ViewId(space="cdf_apm", external_id="Observation", version="v5")
+
+    @pytest.mark.parametrize(
+        "destination_supports_writeback, expected_properties",
+        [
+            pytest.param(
+                True,
+                {"status": "completed", "sapStatus": "Sent", "notificationIdInSap": "sap-notification-123"},
+                id="custom_view_with_writeback_fields",
+            ),
+            pytest.param(
+                False,
+                {"status": "completed"},
+                id="custom_view_without_writeback_fields",
+            ),
+        ],
+    )
+    def test_infield_observation_sap_status_migrates_to_custom_observation_view(
+        self, destination_supports_writeback: bool, expected_properties: dict[str, str]
+    ) -> None:
+        """Regression test for the SAP writeback ADR: migrating an Observation with a SAP writeback status
+        onto a customer's custom observation view must succeed, with the business 'status' correctly
+        collapsed to the destination enum's "completed" value, regardless of whether the destination view
+        has the two writeback fields.
+        """
+        source_container = ContainerId(space="cdf_apm", external_id="Observation")
+        source_view = ViewResponse(
+            space=self.OBSERVATION_SOURCE_VIEW_ID.space,
+            external_id=self.OBSERVATION_SOURCE_VIEW_ID.external_id,
+            version=self.OBSERVATION_SOURCE_VIEW_ID.version,
+            **self.DEFAULT_ARGS,
+            properties={
+                "status": ViewCorePropertyResponse(
+                    constraint_state=ConstraintOrIndexState(),
+                    type=TextProperty(),
+                    container_property_identifier="status",
+                    container=source_container,
+                ),
+                "sourceId": ViewCorePropertyResponse(
+                    constraint_state=ConstraintOrIndexState(),
+                    type=TextProperty(),
+                    container_property_identifier="sourceId",
+                    container=source_container,
+                ),
+            },
+        )
+        destination_container = ContainerId(space="sp_customer_idm", external_id="CustomObservation")
+        destination_properties: dict[str, ViewCorePropertyResponse] = {
+            "status": ViewCorePropertyResponse(
+                constraint_state=ConstraintOrIndexState(),
+                type=EnumProperty(values={"completed": EnumValue(), "draft": EnumValue()}),
+                container_property_identifier="status",
+                container=destination_container,
+            ),
+        }
+        if destination_supports_writeback:
+            destination_properties["sapStatus"] = ViewCorePropertyResponse(
+                constraint_state=ConstraintOrIndexState(),
+                type=TextProperty(),
+                container_property_identifier="sapStatus",
+                container=destination_container,
+            )
+            destination_properties["notificationIdInSap"] = ViewCorePropertyResponse(
+                constraint_state=ConstraintOrIndexState(),
+                type=TextProperty(),
+                container_property_identifier="notificationIdInSap",
+                container=destination_container,
+            )
+        destination_view = ViewResponse(
+            space="sp_custom",
+            external_id="CustomObservation",
+            version="v2",
+            **self.DEFAULT_ARGS,
+            properties=destination_properties,
+        )
+        mapping = ViewToViewMapping(
+            external_id="infield_observation_mapping",
+            source_view=self.OBSERVATION_SOURCE_VIEW_ID,
+            destination_view=destination_view.as_id(),
+            container_mapping={"status": "status"},
+            ignore_source_properties={"sourceId"},
+        )
+        node = NodeResponse(
+            space=self.SOURCE_SPACE,
+            external_id="observation1",
+            last_updated_time=1,
+            created_time=0,
+            version=1,
+            properties={
+                self.OBSERVATION_SOURCE_VIEW_ID: {"status": "Sent", "sourceId": "sap-notification-123"},
+            },
+        )
+
+        with monkeypatch_toolkit_client() as client:
+            client.tool.views.retrieve.return_value = [source_view, destination_view]
+            client.tool.instances.retrieve.return_value = []
+
+            connection_creator = ConnectionCreator(
+                client, instance_id_mapper=SpaceMappingInstanceIdMapper(self.SPACE_MAPPING)
+            )
+            mapper = FDMtoCDMMapper(
+                client,
+                [mapping],
+                connection_creator,
+                custom_properties_mappings=[InFieldObservationSapStatusMapping()],
+            )
+            logger = MagicMock(spec=DataLogger)
+            mapper.logger = logger
+            mapper.prepare(MagicMock())
+
+            actual = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:observation1", item=node)])
+
+        assert len(actual) == 1
+        request = actual[0].item
+        assert isinstance(request, NodeRequest)
+        observation_source = next(
+            source for source in request.sources or [] if source.source == destination_view.as_id()
+        )
+        assert observation_source.properties == expected_properties
+
+        if destination_supports_writeback:
+            logger.log.assert_not_called()
+        else:
+            # Exactly one informative issue is logged about the missing writeback fields, not a second
+            # error from the generic mapping separately failing to convert the raw SAP status value.
+            logger.log.assert_called_once()
+            entries = logger.log.call_args[0][0]
+            assert len(entries) == 1
+            assert entries[0].message.count(";") == 0
+            assert "does not have the required target 'sapStatus' and/or 'notificationIdInSap' properties" in (
+                entries[0].message
+            )
 
     @classmethod
     def _make_image360_views(cls, cube_map_properties: dict[str, str]) -> tuple[ViewResponse, ViewResponse]:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -1078,15 +1078,10 @@ class TestFDMtoCDMMapper:
     @pytest.mark.parametrize(
         "status, destination_supports_writeback, expected_properties, expect_missing_writeback_error",
         [
-            # "Draft" and "Completed" are business-only statuses in APM: CDM's dedicated 'status' field
-            # gets them unchanged regardless of whether the view also supports SAP writeback.
             pytest.param("Draft", True, {"status": "draft"}, False, id="draft_with_writeback_view"),
             pytest.param("Draft", False, {"status": "draft"}, False, id="draft_without_writeback_view"),
             pytest.param("Completed", True, {"status": "completed"}, False, id="completed_with_writeback_view"),
             pytest.param("Completed", False, {"status": "completed"}, False, id="completed_without_writeback_view"),
-            # "Sent", "Not sent" and "File not sent" are APM's SAP send-states, which the ADR splits out
-            # into the dedicated 'sapStatus'/'notificationIdInSap' fields, collapsing business 'status'
-            # to "completed" in all cases.
             pytest.param(
                 "Sent",
                 True,
@@ -1098,7 +1093,6 @@ class TestFDMtoCDMMapper:
             pytest.param(
                 "Not sent",
                 True,
-                # No SAP notification ID has been sent yet, so there is nothing to carry over.
                 {"status": "completed", "sapStatus": "Not sent"},
                 False,
                 id="not_sent_with_writeback_view",

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -42,8 +42,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     DirectNodeRelation,
     EdgeRequest,
     EdgeResponse,
-    EnumProperty,
-    EnumValue,
     FileCDFExternalIdReference,
     InstanceRequest,
     InstanceResponse,
@@ -79,7 +77,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.view_to_view_mapping import
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.commands._migrate.conversion import (
     ConnectionCreator,
-    InFieldObservationSapStatusMapping,
     SpaceMappingInstanceIdMapper,
     SuffixInstanceIdMapper,
 )
@@ -1072,167 +1069,6 @@ class TestFDMtoCDMMapper:
             assert isinstance(entry, MigrationEntryV2)
             assert entry.id == f"{self.SOURCE_SPACE}:second"
             assert "does not exist" in entry.message
-
-    OBSERVATION_SOURCE_VIEW_ID = ViewId(space="cdf_apm", external_id="Observation", version="v5")
-
-    @pytest.mark.parametrize(
-        "status, destination_supports_writeback, expected_properties, expect_missing_writeback_error",
-        [
-            pytest.param("Draft", True, {"status": "draft"}, False, id="draft_with_writeback_view"),
-            pytest.param("Draft", False, {"status": "draft"}, False, id="draft_without_writeback_view"),
-            pytest.param("Completed", True, {"status": "completed"}, False, id="completed_with_writeback_view"),
-            pytest.param("Completed", False, {"status": "completed"}, False, id="completed_without_writeback_view"),
-            pytest.param(
-                "Sent",
-                True,
-                {"status": "completed", "sapStatus": "sent", "notificationIdInSap": "sap-notification-123"},
-                False,
-                id="sent_with_writeback_view",
-            ),
-            pytest.param("Sent", False, {"status": "completed"}, True, id="sent_without_writeback_view"),
-            pytest.param(
-                "Not sent",
-                True,
-                {"status": "completed", "sapStatus": "notSent"},
-                False,
-                id="not_sent_with_writeback_view",
-            ),
-            pytest.param("Not sent", False, {"status": "completed"}, True, id="not_sent_without_writeback_view"),
-            pytest.param(
-                "File not sent",
-                True,
-                {
-                    "status": "completed",
-                    "sapStatus": "fileNotSent",
-                    "notificationIdInSap": "sap-notification-123",
-                },
-                False,
-                id="file_not_sent_with_writeback_view",
-            ),
-            pytest.param(
-                "File not sent", False, {"status": "completed"}, True, id="file_not_sent_without_writeback_view"
-            ),
-        ],
-    )
-    def test_infield_observation_sap_status_migrates_to_custom_observation_view(
-        self,
-        status: str,
-        destination_supports_writeback: bool,
-        expected_properties: dict[str, str],
-        expect_missing_writeback_error: bool,
-    ) -> None:
-        """Regression test for the SAP writeback ADR: migrating an Observation with any APM status onto a
-        customer's custom observation view must succeed, with the business 'status' correctly set on the
-        destination enum (with correct casing) and the SAP-specific fields populated per the ADR's mapping
-        rules, regardless of whether the destination view has the two writeback fields.
-        """
-        source_container = ContainerId(space="cdf_apm", external_id="Observation")
-        source_view = ViewResponse(
-            space=self.OBSERVATION_SOURCE_VIEW_ID.space,
-            external_id=self.OBSERVATION_SOURCE_VIEW_ID.external_id,
-            version=self.OBSERVATION_SOURCE_VIEW_ID.version,
-            **self.DEFAULT_ARGS,
-            properties={
-                "status": ViewCorePropertyResponse(
-                    constraint_state=ConstraintOrIndexState(),
-                    type=TextProperty(),
-                    container_property_identifier="status",
-                    container=source_container,
-                ),
-                "sourceId": ViewCorePropertyResponse(
-                    constraint_state=ConstraintOrIndexState(),
-                    type=TextProperty(),
-                    container_property_identifier="sourceId",
-                    container=source_container,
-                ),
-            },
-        )
-        destination_container = ContainerId(space="sp_customer_idm", external_id="CustomObservation")
-        destination_properties: dict[str, ViewCorePropertyResponse] = {
-            "status": ViewCorePropertyResponse(
-                constraint_state=ConstraintOrIndexState(),
-                type=EnumProperty(values={"completed": EnumValue(), "draft": EnumValue()}),
-                container_property_identifier="status",
-                container=destination_container,
-            ),
-        }
-        if destination_supports_writeback:
-            destination_properties["sapStatus"] = ViewCorePropertyResponse(
-                constraint_state=ConstraintOrIndexState(),
-                type=TextProperty(),
-                container_property_identifier="sapStatus",
-                container=destination_container,
-            )
-            destination_properties["notificationIdInSap"] = ViewCorePropertyResponse(
-                constraint_state=ConstraintOrIndexState(),
-                type=TextProperty(),
-                container_property_identifier="notificationIdInSap",
-                container=destination_container,
-            )
-        destination_view = ViewResponse(
-            space="sp_custom",
-            external_id="CustomObservation",
-            version="v2",
-            **self.DEFAULT_ARGS,
-            properties=destination_properties,
-        )
-        mapping = ViewToViewMapping(
-            external_id="infield_observation_mapping",
-            source_view=self.OBSERVATION_SOURCE_VIEW_ID,
-            destination_view=destination_view.as_id(),
-            container_mapping={"status": "status"},
-            ignore_source_properties={"sourceId"},
-        )
-        node = NodeResponse(
-            space=self.SOURCE_SPACE,
-            external_id="observation1",
-            last_updated_time=1,
-            created_time=0,
-            version=1,
-            properties={
-                self.OBSERVATION_SOURCE_VIEW_ID: {"status": status, "sourceId": "sap-notification-123"},
-            },
-        )
-
-        with monkeypatch_toolkit_client() as client:
-            client.tool.views.retrieve.return_value = [source_view, destination_view]
-            client.tool.instances.retrieve.return_value = []
-
-            connection_creator = ConnectionCreator(
-                client, instance_id_mapper=SpaceMappingInstanceIdMapper(self.SPACE_MAPPING)
-            )
-            mapper = FDMtoCDMMapper(
-                client,
-                [mapping],
-                connection_creator,
-                custom_properties_mappings=[InFieldObservationSapStatusMapping()],
-            )
-            logger = MagicMock(spec=DataLogger)
-            mapper.logger = logger
-            mapper.prepare(MagicMock())
-
-            actual = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:observation1", item=node)])
-
-        assert len(actual) == 1
-        request = actual[0].item
-        assert isinstance(request, NodeRequest)
-        observation_source = next(
-            source for source in request.sources or [] if source.source == destination_view.as_id()
-        )
-        assert observation_source.properties == expected_properties
-
-        if not expect_missing_writeback_error:
-            logger.log.assert_not_called()
-        else:
-            # Exactly one informative issue is logged about the missing writeback fields, not a second
-            # error from the generic mapping separately failing to convert the raw SAP status value.
-            logger.log.assert_called_once()
-            entries = logger.log.call_args[0][0]
-            assert len(entries) == 1
-            assert entries[0].message.count(";") == 0
-            assert "does not have the required target 'sapStatus' and/or 'notificationIdInSap' properties" in (
-                entries[0].message
-            )
 
     @classmethod
     def _make_image360_views(cls, cube_map_properties: dict[str, str]) -> tuple[ViewResponse, ViewResponse]:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_infield_mapping.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_infield_mapping.py
@@ -148,37 +148,54 @@ class TestInFieldObservationSapStatusMapping:
         assert source_properties["status"] == status
 
     @pytest.mark.parametrize(
-        "status, expected_container_properties",
+        "status, expected_container_properties, expected_business_status",
         [
             pytest.param(
                 "Sent",
                 {"sapStatus": "sent", "notificationIdInSap": "sap-notification-123"},
+                "Completed",
                 id="sent",
             ),
             pytest.param(
                 "Not sent",
                 {"sapStatus": "notSent"},
+                "Completed",
                 id="not_sent_has_no_notification_id",
             ),
             pytest.param(
                 "File not sent",
                 {"sapStatus": "fileNotSent", "notificationIdInSap": "sap-notification-123"},
+                "Completed",
                 id="file_not_sent",
+            ),
+            pytest.param(
+                "Pending",
+                {"sapStatus": "pending"},
+                "Draft",
+                id="pending_has_no_notification_id_and_is_draft",
+            ),
+            pytest.param(
+                "Failed",
+                {"sapStatus": "notSent"},
+                "Completed",
+                id="failed_is_folded_into_not_sent",
             ),
             pytest.param(
                 "sent",
                 {"sapStatus": "sent", "notificationIdInSap": "sap-notification-123"},
+                "Completed",
                 id="lowercase_status_matches_case_insensitively",
             ),
             pytest.param(
                 "NOT SENT",
                 {"sapStatus": "notSent"},
+                "Completed",
                 id="uppercase_status_matches_case_insensitively",
             ),
         ],
     )
     def test_sap_statuses_are_mapped_when_writeback_supported(
-        self, status: str, expected_container_properties: dict[str, str]
+        self, status: str, expected_container_properties: dict[str, str], expected_business_status: str
     ) -> None:
         mapping = InFieldObservationSapStatusMapping()
         context = MagicMock(destination_properties={"sapStatus": MagicMock(), "notificationIdInSap": MagicMock()})
@@ -193,7 +210,7 @@ class TestInFieldObservationSapStatusMapping:
         assert result.errors == []
         # 'status' itself is left to the generic mapping (which runs after us on this same dict) to
         # convert with the correct destination enum casing, so we just normalize the source value here.
-        assert source_properties["status"] == "Completed"
+        assert source_properties["status"] == expected_business_status
 
     def test_sent_without_writeback_support_falls_back_to_completed_business_status(self) -> None:
         mapping = InFieldObservationSapStatusMapping()

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_infield_mapping.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_infield_mapping.py
@@ -31,11 +31,10 @@ def _location_config(
         view_mappings = {
             "observation": [
                 {
-                    "view": {
-                        "space": observation_view.space,
-                        "externalId": observation_view.external_id,
-                        "version": observation_view.version,
-                    }
+                    "type": "view",
+                    "space": observation_view.space,
+                    "externalId": observation_view.external_id,
+                    "version": observation_view.version,
                 }
             ]
         }
@@ -139,32 +138,30 @@ class TestInFieldObservationSapStatusMapping:
     def test_business_only_statuses_are_left_to_generic_mapping(self, status: str) -> None:
         mapping = InFieldObservationSapStatusMapping()
         context = MagicMock(destination_properties={"status": MagicMock()})
+        source_properties = {"status": status}
 
-        result = mapping.convert({"status": status}, context)
+        result = mapping.convert(source_properties, context)
 
         assert result.container_properties == {}
         assert result.errors == []
+        assert source_properties["status"] == status
 
     @pytest.mark.parametrize(
         "status, expected_container_properties",
         [
             pytest.param(
                 "Sent",
-                {"status": "Completed", "sapStatus": "Sent", "notificationIdInSap": "sap-notification-123"},
+                {"sapStatus": "Sent", "notificationIdInSap": "sap-notification-123"},
                 id="sent",
             ),
             pytest.param(
                 "Not sent",
-                {"status": "Completed", "sapStatus": "Not sent"},
+                {"sapStatus": "Not sent"},
                 id="not_sent_has_no_notification_id",
             ),
             pytest.param(
                 "File not sent",
-                {
-                    "status": "Completed",
-                    "sapStatus": "File not sent",
-                    "notificationIdInSap": "sap-notification-123",
-                },
+                {"sapStatus": "File not sent", "notificationIdInSap": "sap-notification-123"},
                 id="file_not_sent",
             ),
         ],
@@ -174,13 +171,17 @@ class TestInFieldObservationSapStatusMapping:
     ) -> None:
         mapping = InFieldObservationSapStatusMapping()
         context = MagicMock(destination_properties={"sapStatus": MagicMock(), "notificationIdInSap": MagicMock()})
+        source_properties = {"status": status, "sourceId": "sap-notification-123"}
 
-        result = mapping.convert({"status": status, "sourceId": "sap-notification-123"}, context)
+        result = mapping.convert(source_properties, context)
 
         assert result.container_properties == expected_container_properties
         assert result.errors == []
+        # 'status' itself is left to the generic mapping (which runs after us on this same dict) to
+        # convert with the correct destination enum casing, so we just normalize the source value here.
+        assert source_properties["status"] == "Completed"
 
-    def test_sent_without_writeback_support_is_left_to_generic_mapping(self) -> None:
+    def test_sent_without_writeback_support_falls_back_to_completed_business_status(self) -> None:
         mapping = InFieldObservationSapStatusMapping()
         context = MagicMock(
             destination_properties={"status": MagicMock()},
@@ -188,11 +189,15 @@ class TestInFieldObservationSapStatusMapping:
                 destination_view=ViewId(space="cdf_infield", external_id="FieldObservation", version="v1")
             ),
         )
+        source_properties = {"status": "Sent", "sourceId": "sap-notification-123"}
 
-        result = mapping.convert({"status": "Sent", "sourceId": "sap-notification-123"}, context)
+        result = mapping.convert(source_properties, context)
 
         assert result.container_properties == {}
         assert len(result.errors) == 1
         assert (
             "does not have the required target 'sapStatus' and/or 'notificationIdInSap' properties" in result.errors[0]
         )
+        # The generic container mapping still runs afterwards and must not also fail to convert
+        # 'status', so we overwrite it to a valid business status here.
+        assert source_properties["status"] == "Completed"

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_infield_mapping.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_infield_mapping.py
@@ -10,7 +10,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.infield import (
 )
 from cognite_toolkit._cdf_tk.commands._migrate.conversion import (
     InFieldConditionMapping,
-    InFieldObservationSapStatusMapping,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.infield_data_mappings import (
     create_infield_data_mappings,
@@ -129,86 +128,3 @@ class TestResolveObservationViewId:
 
         with pytest.raises(ToolkitMigrationError, match="different observation views"):
             resolve_observation_view_id(configs, "sp_target")
-
-
-class TestInFieldObservationSapStatusMapping:
-    @pytest.mark.parametrize(
-        "status",
-        ["Draft", "Completed", "SomeUnrecognizedStatus"],
-    )
-    def test_business_only_statuses_are_left_to_generic_mapping(self, status: str) -> None:
-        mapping = InFieldObservationSapStatusMapping()
-        context = MagicMock(destination_properties={"status": MagicMock()})
-        source_properties = {"status": status}
-
-        result = mapping.convert(source_properties, context)
-
-        assert result.container_properties == {}
-        assert result.errors == []
-        assert source_properties["status"] == status
-
-    @pytest.mark.parametrize(
-        "status, expected_container_properties",
-        [
-            pytest.param(
-                "Sent",
-                {"sapStatus": "sent", "notificationIdInSap": "sap-notification-123"},
-                id="sent",
-            ),
-            pytest.param(
-                "Not sent",
-                {"sapStatus": "notSent"},
-                id="not_sent_has_no_notification_id",
-            ),
-            pytest.param(
-                "File not sent",
-                {"sapStatus": "fileNotSent", "notificationIdInSap": "sap-notification-123"},
-                id="file_not_sent",
-            ),
-            pytest.param(
-                "sent",
-                {"sapStatus": "sent", "notificationIdInSap": "sap-notification-123"},
-                id="lowercase_status_matches_case_insensitively",
-            ),
-            pytest.param(
-                "NOT SENT",
-                {"sapStatus": "notSent"},
-                id="uppercase_status_matches_case_insensitively",
-            ),
-        ],
-    )
-    def test_sap_statuses_are_mapped_when_writeback_supported(
-        self, status: str, expected_container_properties: dict[str, str]
-    ) -> None:
-        mapping = InFieldObservationSapStatusMapping()
-        context = MagicMock(destination_properties={"sapStatus": MagicMock(), "notificationIdInSap": MagicMock()})
-        source_properties = {"status": status, "sourceId": "sap-notification-123"}
-
-        result = mapping.convert(source_properties, context)
-
-        assert result.container_properties == expected_container_properties
-        assert result.errors == []
-        # 'status' itself is left to the generic mapping (which runs after us on this same dict) to
-        # convert with the correct destination enum casing, so we just normalize the source value here.
-        assert source_properties["status"] == "Completed"
-
-    def test_sent_without_writeback_support_falls_back_to_completed_business_status(self) -> None:
-        mapping = InFieldObservationSapStatusMapping()
-        context = MagicMock(
-            destination_properties={"status": MagicMock()},
-            mapping=MagicMock(
-                destination_view=ViewId(space="cdf_infield", external_id="FieldObservation", version="v1")
-            ),
-        )
-        source_properties = {"status": "Sent", "sourceId": "sap-notification-123"}
-
-        result = mapping.convert(source_properties, context)
-
-        assert result.container_properties == {}
-        assert len(result.errors) == 1
-        assert (
-            "does not have the required target 'sapStatus' and/or 'notificationIdInSap' properties" in result.errors[0]
-        )
-        # The generic container mapping still runs afterwards and must not also fail to convert
-        # 'status', so we overwrite it to a valid business status here.
-        assert source_properties["status"] == "Completed"

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_infield_mapping.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_infield_mapping.py
@@ -1,10 +1,54 @@
 from unittest.mock import MagicMock
 
-from cognite_toolkit._cdf_tk.commands._migrate.conversion import InFieldConditionMapping
+import pytest
+from pydantic import JsonValue
+
+from cognite_toolkit._cdf_tk.client.identifiers import ViewId
+from cognite_toolkit._cdf_tk.client.resource_classes.infield import (
+    DataStorage,
+    InFieldCDMLocationConfigResponse,
+)
+from cognite_toolkit._cdf_tk.commands._migrate.conversion import (
+    InFieldConditionMapping,
+    InFieldObservationSapStatusMapping,
+)
 from cognite_toolkit._cdf_tk.commands._migrate.infield_data_mappings import (
     create_infield_data_mappings,
     create_infield_schedule_selector,
+    resolve_observation_view_id,
 )
+from cognite_toolkit._cdf_tk.exceptions import ToolkitMigrationError
+
+CUSTOM_OBSERVATION_VIEW = ViewId(space="sp_customer_idm", external_id="ObservationView", version="v1")
+OTHER_CUSTOM_OBSERVATION_VIEW = ViewId(space="sp_customer_idm", external_id="OtherObservationView", version="v1")
+
+
+def _location_config(
+    external_id: str, app_instance_space: str | None, observation_view: ViewId | None
+) -> InFieldCDMLocationConfigResponse:
+    view_mappings: dict[str, JsonValue] | None = None
+    if observation_view is not None:
+        view_mappings = {
+            "observation": [
+                {
+                    "view": {
+                        "space": observation_view.space,
+                        "externalId": observation_view.external_id,
+                        "version": observation_view.version,
+                    }
+                }
+            ]
+        }
+    return InFieldCDMLocationConfigResponse(
+        instance_type="node",
+        space="sp_instance",
+        external_id=external_id,
+        version=1,
+        created_time=0,
+        last_updated_time=0,
+        data_storage=DataStorage(app_instance_space=app_instance_space) if app_instance_space else None,
+        view_mappings=view_mappings,
+    )
 
 
 class TestInFieldMapping:
@@ -34,3 +78,121 @@ class TestInFieldMapping:
         assert result.container_properties == {}
         assert len(result.errors) == 1
         assert "Unexpected sourceView value" in result.errors[0]
+
+
+class TestResolveObservationViewId:
+    @pytest.mark.parametrize(
+        "location_specs, expected",
+        [
+            pytest.param(
+                [("loc1", "sp_other_target", CUSTOM_OBSERVATION_VIEW)],
+                None,
+                id="no_matching_location",
+            ),
+            pytest.param(
+                [("loc1", "sp_target", None)],
+                None,
+                id="location_without_observation_config",
+            ),
+            pytest.param(
+                [
+                    ("loc1", "sp_target", CUSTOM_OBSERVATION_VIEW),
+                    ("loc2", "sp_other_target", OTHER_CUSTOM_OBSERVATION_VIEW),
+                ],
+                CUSTOM_OBSERVATION_VIEW,
+                id="single_location_with_custom_view",
+            ),
+            pytest.param(
+                [
+                    ("loc1", "sp_target", CUSTOM_OBSERVATION_VIEW),
+                    ("loc2", "sp_target", CUSTOM_OBSERVATION_VIEW),
+                ],
+                CUSTOM_OBSERVATION_VIEW,
+                id="multiple_locations_with_same_view",
+            ),
+        ],
+    )
+    def test_resolve_observation_view_id(
+        self,
+        location_specs: list[tuple[str, str | None, ViewId | None]],
+        expected: ViewId | None,
+    ) -> None:
+        configs = [_location_config(*spec) for spec in location_specs]
+
+        assert resolve_observation_view_id(configs, "sp_target") == expected
+
+    def test_conflicting_observation_views_raises(self) -> None:
+        configs = [
+            _location_config("loc1", "sp_target", CUSTOM_OBSERVATION_VIEW),
+            _location_config("loc2", "sp_target", OTHER_CUSTOM_OBSERVATION_VIEW),
+        ]
+
+        with pytest.raises(ToolkitMigrationError, match="different observation views"):
+            resolve_observation_view_id(configs, "sp_target")
+
+
+class TestInFieldObservationSapStatusMapping:
+    @pytest.mark.parametrize(
+        "status",
+        ["Draft", "Completed", "SomeUnrecognizedStatus"],
+    )
+    def test_business_only_statuses_are_left_to_generic_mapping(self, status: str) -> None:
+        mapping = InFieldObservationSapStatusMapping()
+        context = MagicMock(destination_properties={"status": MagicMock()})
+
+        result = mapping.convert({"status": status}, context)
+
+        assert result.container_properties == {}
+        assert result.errors == []
+
+    @pytest.mark.parametrize(
+        "status, expected_container_properties",
+        [
+            pytest.param(
+                "Sent",
+                {"status": "Completed", "sapStatus": "Sent", "notificationIdInSap": "sap-notification-123"},
+                id="sent",
+            ),
+            pytest.param(
+                "Not sent",
+                {"status": "Completed", "sapStatus": "Not sent"},
+                id="not_sent_has_no_notification_id",
+            ),
+            pytest.param(
+                "File not sent",
+                {
+                    "status": "Completed",
+                    "sapStatus": "File not sent",
+                    "notificationIdInSap": "sap-notification-123",
+                },
+                id="file_not_sent",
+            ),
+        ],
+    )
+    def test_sap_statuses_are_mapped_when_writeback_supported(
+        self, status: str, expected_container_properties: dict[str, str]
+    ) -> None:
+        mapping = InFieldObservationSapStatusMapping()
+        context = MagicMock(destination_properties={"sapStatus": MagicMock(), "notificationIdInSap": MagicMock()})
+
+        result = mapping.convert({"status": status, "sourceId": "sap-notification-123"}, context)
+
+        assert result.container_properties == expected_container_properties
+        assert result.errors == []
+
+    def test_sent_without_writeback_support_is_left_to_generic_mapping(self) -> None:
+        mapping = InFieldObservationSapStatusMapping()
+        context = MagicMock(
+            destination_properties={"status": MagicMock()},
+            mapping=MagicMock(
+                destination_view=ViewId(space="cdf_infield", external_id="FieldObservation", version="v1")
+            ),
+        )
+
+        result = mapping.convert({"status": "Sent", "sourceId": "sap-notification-123"}, context)
+
+        assert result.container_properties == {}
+        assert len(result.errors) == 1
+        assert (
+            "does not have the required target 'sapStatus' and/or 'notificationIdInSap' properties" in result.errors[0]
+        )

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_infield_mapping.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_infield_mapping.py
@@ -31,10 +31,11 @@ def _location_config(
         view_mappings = {
             "observation": [
                 {
-                    "type": "view",
-                    "space": observation_view.space,
-                    "externalId": observation_view.external_id,
-                    "version": observation_view.version,
+                    "view": {
+                        "space": observation_view.space,
+                        "externalId": observation_view.external_id,
+                        "version": observation_view.version,
+                    }
                 }
             ]
         }
@@ -151,18 +152,28 @@ class TestInFieldObservationSapStatusMapping:
         [
             pytest.param(
                 "Sent",
-                {"sapStatus": "Sent", "notificationIdInSap": "sap-notification-123"},
+                {"sapStatus": "sent", "notificationIdInSap": "sap-notification-123"},
                 id="sent",
             ),
             pytest.param(
                 "Not sent",
-                {"sapStatus": "Not sent"},
+                {"sapStatus": "notSent"},
                 id="not_sent_has_no_notification_id",
             ),
             pytest.param(
                 "File not sent",
-                {"sapStatus": "File not sent", "notificationIdInSap": "sap-notification-123"},
+                {"sapStatus": "fileNotSent", "notificationIdInSap": "sap-notification-123"},
                 id="file_not_sent",
+            ),
+            pytest.param(
+                "sent",
+                {"sapStatus": "sent", "notificationIdInSap": "sap-notification-123"},
+                id="lowercase_status_matches_case_insensitively",
+            ),
+            pytest.param(
+                "NOT SENT",
+                {"sapStatus": "notSent"},
+                id="uppercase_status_matches_case_insensitively",
             ),
         ],
     )

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_infield_mapping.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_infield_mapping.py
@@ -3,13 +3,14 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import JsonValue
 
-from cognite_toolkit._cdf_tk.client.identifiers import ViewId
+from cognite_toolkit._cdf_tk.client.identifiers import NodeId, ViewId
 from cognite_toolkit._cdf_tk.client.resource_classes.infield import (
     DataStorage,
     InFieldCDMLocationConfigResponse,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.conversion import (
     InFieldConditionMapping,
+    InFieldObservationSapStatusMapping,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.infield_data_mappings import (
     create_infield_data_mappings,
@@ -128,3 +129,92 @@ class TestResolveObservationViewId:
 
         with pytest.raises(ToolkitMigrationError, match="different observation views"):
             resolve_observation_view_id(configs, "sp_target")
+
+
+class TestInFieldObservationSapStatusMapping:
+    @pytest.mark.parametrize(
+        "status",
+        ["Draft", "Completed", "SomeUnrecognizedStatus"],
+    )
+    def test_business_only_statuses_are_left_to_generic_mapping(self, status: str) -> None:
+        mapping = InFieldObservationSapStatusMapping()
+        context = MagicMock(destination_properties={"status": MagicMock()})
+        source_properties: dict[str, JsonValue | NodeId | list[NodeId]] = {"status": status}
+
+        result = mapping.convert(source_properties, context)
+
+        assert result.container_properties == {}
+        assert result.errors == []
+        assert source_properties["status"] == status
+
+    @pytest.mark.parametrize(
+        "status, expected_container_properties",
+        [
+            pytest.param(
+                "Sent",
+                {"sapStatus": "sent", "notificationIdInSap": "sap-notification-123"},
+                id="sent",
+            ),
+            pytest.param(
+                "Not sent",
+                {"sapStatus": "notSent"},
+                id="not_sent_has_no_notification_id",
+            ),
+            pytest.param(
+                "File not sent",
+                {"sapStatus": "fileNotSent", "notificationIdInSap": "sap-notification-123"},
+                id="file_not_sent",
+            ),
+            pytest.param(
+                "sent",
+                {"sapStatus": "sent", "notificationIdInSap": "sap-notification-123"},
+                id="lowercase_status_matches_case_insensitively",
+            ),
+            pytest.param(
+                "NOT SENT",
+                {"sapStatus": "notSent"},
+                id="uppercase_status_matches_case_insensitively",
+            ),
+        ],
+    )
+    def test_sap_statuses_are_mapped_when_writeback_supported(
+        self, status: str, expected_container_properties: dict[str, str]
+    ) -> None:
+        mapping = InFieldObservationSapStatusMapping()
+        context = MagicMock(destination_properties={"sapStatus": MagicMock(), "notificationIdInSap": MagicMock()})
+        source_properties: dict[str, JsonValue | NodeId | list[NodeId]] = {
+            "status": status,
+            "sourceId": "sap-notification-123",
+        }
+
+        result = mapping.convert(source_properties, context)
+
+        assert result.container_properties == expected_container_properties
+        assert result.errors == []
+        # 'status' itself is left to the generic mapping (which runs after us on this same dict) to
+        # convert with the correct destination enum casing, so we just normalize the source value here.
+        assert source_properties["status"] == "Completed"
+
+    def test_sent_without_writeback_support_falls_back_to_completed_business_status(self) -> None:
+        mapping = InFieldObservationSapStatusMapping()
+        context = MagicMock(
+            destination_properties={"status": MagicMock()},
+            mapping=MagicMock(
+                destination_view=ViewId(space="cdf_infield", external_id="FieldObservation", version="v1")
+            ),
+        )
+        source_properties: dict[str, JsonValue | NodeId | list[NodeId]] = {
+            "status": "Sent",
+            "sourceId": "sap-notification-123",
+        }
+
+        result = mapping.convert(source_properties, context)
+
+        assert result.container_properties == {}
+        assert len(result.errors) == 1
+        assert (
+            "does not have the required target 'sapStatus' and/or 'notificationIdInSap' properties" in result.errors[0]
+        )
+        # The generic container mapping still runs afterwards and must not also fail to convert
+        # 'status', so we overwrite it to a valid business status here.
+        assert source_properties["status"] == "Completed"


### PR DESCRIPTION
# Description

Adds support for migrating InField observations containing SAP writeback state over to custom CDM observation views, per the accepted ADR in the fusion repo: [SAP writeback on CDM custom observation views](https://github.com/cognitedata/fusion/blob/master/docs/decisions/infield/2026-06-19-sap-writeback-on-cdm-custom-observation-views.md).

- `resolve_observation_view_id()` scans deployed InField CDM location configs for the target space to auto-detect a custom observation view, raising an error if there are multiple location configs that sharing the same `appInstanceSpace` yet for some reason have a different Observation view configured. Such a conflict is unlikely to occur, and if so the user will need to run a fully manual migration.
- `InFieldObservationSapStatusMapping` splits the APM model's conflated `status` field into the new business logic `status` field and the predetermined and Infield-enforced SAP-specific `sapStatus`/`notificationIdInSap` fields. This is only done when the destination view supports those two properties.
- Wired into `cdf migrate infield-data`: the destination view for Observations is now always swapped to the resolved custom view (unless `--skip-observations` is set, in which case the observations won't be migrated at all), and the new mapping is added to `custom_properties_mappings`. 
- A practical side-effect of these changes is that we now also do a "best effort" attempt to map legacy observations to custom observations view. This will however only work if the user in practice has made a very basic extension / modification of FieldObservation, if any property rename or more advanced mapping logic is done, the solution will still be to use `--skip-observations` and make a custom script. The method to enable best-effort custom observation migration is to have a custom view defined in the Infield location.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- [alpha] When running `cdf migrate infield-data`, toolkit now supports migrating Observations with SAP writeback state onto a custom CDM observation view