### PR TITLE
[CDF-28250] Fix --build-dir handling relative paths

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -106,7 +106,7 @@ class BuildV2Command(ToolkitCommand):
         )
 
         self._prepare_build_directory(parameters.build_dir)
-        built_modules = self._build_modules(build_source.modules, parameters.build_dir, console)
+        built_modules = self._build_modules(build_source.modules, parameters.build_dir.resolve(), console)
 
         plan = self._create_validation_plan(built_modules, client)
         self._display_validation_plan(plan, console)
@@ -114,7 +114,7 @@ class BuildV2Command(ToolkitCommand):
 
         build_folder = BuildFolder(
             organization_dir=parameters.organization_dir.resolve(),
-            build_dir=parameters.build_dir,
+            build_dir=parameters.build_dir.resolve(),
             built_modules=built_modules,
             validation_results=validation_results,
             all_variables=build_source.all_variables,


### PR DESCRIPTION
# Description

When users pass a relative path to `--build-dir` (e.g. `build-moh_dev`), the `BuiltResource.build_path`
field fails Pydantic validation because it requires an absolute path. Fix by calling `.resolve()` on
`build_dir` at the two call sites in `BuildV2Command.build()`, this keeps it consistent with how `organization_dir`
is already handled.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fixes an issue causing `ValidationError` to be raised during `cdf build` when `--build-dir` is given as a relative path.