### PR TITLE
[CDF-28252] Improve source/destination specificity in FDMtoCDMMapper conversion logs

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -124,6 +124,7 @@ from cognite_toolkit._cdf_tk.dataio.selectors import (
     CanvasSelector,
     ChartSelector,
     InstanceSelector,
+    InstanceViewSelector,
     ThreeDSelector,
 )
 from cognite_toolkit._cdf_tk.exceptions import ToolkitMigrationError, ToolkitValueError
@@ -1368,6 +1369,10 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
         # given container.
         self._constrained_properties_by_view_id: dict[ViewId, dict[str, ContainerId]] = {}
         self._is_existing_by_node_id: dict[NodeId, bool] = {}
+        # Set in prepare() so that reported issues can point to the specific source/destination
+        # view of the current migration step, instead of a generic "FDM/CDM instances" label.
+        self._current_issue_source: str = "FDM instances"
+        self._current_issue_destination: str = "CDM instances"
 
     def prepare(self, source_selector: InstanceSelector) -> None:
         view_ids = set(mapping.source_view for mapping in self._mappings_by_source_view.values()) | set(
@@ -1375,6 +1380,16 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
         )
         views = self.client.tool.views.retrieve(list(view_ids))
         self._connection_creator.update_view_cache(views)
+        self._current_issue_source = str(source_selector)
+        mapping = None
+        if isinstance(source_selector, InstanceViewSelector) and source_selector.view.version is not None:
+            selected_view = ViewId(
+                space=source_selector.view.space,
+                external_id=source_selector.view.external_id,
+                version=source_selector.view.version,
+            )
+            mapping = self._mappings_by_source_view.get(selected_view)
+        self._current_issue_destination = str(mapping.destination_view) if mapping is not None else "CDM instances"
 
     def map(self, source: Sequence[DataItem[NodeOrEdgeResponse]]) -> Sequence[DataItem[NodeOrEdgeRequest]]:
         raw_items = [data_item.item for data_item in source]
@@ -1441,7 +1456,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
             self.logger.log(
                 [
                     instance_conversion_issue_as_migration_entry(
-                        issue, source="FDM instances", destination="CDM instances"
+                        issue, source=self._current_issue_source, destination=self._current_issue_destination
                     )
                     for issue in issue_by_source_node_id.values()
                 ]


### PR DESCRIPTION
# Description

`FDMtoCDMMapper` reported all instance conversion issues in the MigrationIssue logging file with generic sources and destinations: `{"source": "FDM instances", "destination": "CDM instances"}`, making it hard for users to identify which step failed / which view was affected. This PR ensures that when running FDMtoCDMMapper, the current migration step's selector and resolved destination view is used instead, with default fallbacks to the current generic source names.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Improved

- [alpha] When running `cdf migrate infield-data` and `cdf migrate 360-images`, conversion error logs now reports more specific source and destination views instead of the generic labels.