### PR TITLE
[CDF-28173] Show conversion target view and instance space in migration progress bar

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -154,7 +154,7 @@ class MigrationCommand(ToolkitCommand):
                 total_item_count=step.total_count,
                 max_queue_size=10,
                 download_description=f"Downloading {selected.display_name}",
-                process_description="Converting",
+                process_description=mapper.process_description(selected),
                 write_description="Uploading",
                 console=console,
                 verbose=verbose,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -570,6 +570,13 @@ class InstanceIdMapper(ABC):
     def map_instance_id(self, instance_id: NodeId | EdgeId) -> NodeId:
         raise NotImplementedError
 
+    def get_destination_spaces(self, source_spaces: Iterable[str]) -> list[str]:
+        """Return the destination instance spaces corresponding to the given source spaces, for display purposes.
+
+        Override in subclasses if the mapper can determine this without a full instance ID.
+        """
+        return []
+
 
 class SpaceMappingInstanceIdMapper(InstanceIdMapper):
     def __init__(self, space_mapping: Mapping[str, str]) -> None:
@@ -589,6 +596,9 @@ class SpaceMappingInstanceIdMapper(InstanceIdMapper):
             external_id=instance_id.external_id,
         )
 
+    def get_destination_spaces(self, source_spaces: Iterable[str]) -> list[str]:
+        return [self._space_mapping[space] for space in source_spaces if space in self._space_mapping]
+
 
 class SuffixInstanceIdMapper(InstanceIdMapper):
     def __init__(self, suffix: str = "_cdm") -> None:
@@ -599,6 +609,10 @@ class SuffixInstanceIdMapper(InstanceIdMapper):
             space=instance_id.space,
             external_id=sanitize_instance_external_id(instance_id.external_id, self._suffix),
         )
+
+    def get_destination_spaces(self, source_spaces: Iterable[str]) -> list[str]:
+        # The suffix mapper does not change the instance space.
+        return list(source_spaces)
 
 
 class ConnectionCreator:
@@ -633,6 +647,10 @@ class ConnectionCreator:
         self._timeseries_reference_cache: dict[str, NodeId] = {}
         self._file_reference_cache: dict[str, NodeId] = {}
         self._direct_relation_edge_tiebreakers = direct_relation_edge_tiebreakers or {}
+
+    def get_destination_spaces(self, source_spaces: Iterable[str]) -> list[str]:
+        """Return the destination instance spaces corresponding to the given source spaces, for display purposes."""
+        return self._instance_id_mapper.get_destination_spaces(source_spaces)
 
     def _create_custom_case_caches(
         self, custom_mappings: Sequence[CustomConnectionMapping]

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -597,7 +597,7 @@ class SpaceMappingInstanceIdMapper(InstanceIdMapper):
         )
 
     def get_destination_spaces(self, source_spaces: Iterable[str]) -> list[str]:
-        return [self._space_mapping[space] for space in source_spaces if space in self._space_mapping]
+        return list({self._space_mapping[space] for space in source_spaces if space in self._space_mapping})
 
 
 class SuffixInstanceIdMapper(InstanceIdMapper):
@@ -612,7 +612,7 @@ class SuffixInstanceIdMapper(InstanceIdMapper):
 
     def get_destination_spaces(self, source_spaces: Iterable[str]) -> list[str]:
         # The suffix mapper does not change the instance space.
-        return list(source_spaces)
+        return list(set(source_spaces))
 
 
 class ConnectionCreator:

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -124,6 +124,7 @@ from cognite_toolkit._cdf_tk.dataio.selectors import (
     CanvasSelector,
     ChartSelector,
     InstanceSelector,
+    InstanceViewSelector,
     ThreeDSelector,
 )
 from cognite_toolkit._cdf_tk.exceptions import ToolkitMigrationError, ToolkitValueError
@@ -154,6 +155,16 @@ class DataMapper(Generic[T_Selector, T_DataResponse, T_DataRequest], ABC):
         """
         # Override in subclass if needed.
         pass
+
+    def process_description(self, source_selector: T_Selector) -> str:
+        """A short description of the conversion step, used for progress tracking.
+
+        Args:
+            source_selector: The selector for the source data being converted.
+
+        """
+        # Override in subclass to provide more context, e.g., the conversion target.
+        return "Converting"
 
     @abstractmethod
     def map(self, source: Sequence[DataItem[T_DataResponse]]) -> Sequence[DataItem[T_DataRequest]]:
@@ -1368,6 +1379,29 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
         # given container.
         self._constrained_properties_by_view_id: dict[ViewId, dict[str, ContainerId]] = {}
         self._is_existing_by_node_id: dict[NodeId, bool] = {}
+
+    def process_description(self, source_selector: InstanceSelector) -> str:
+        destination_view = self._get_destination_view(source_selector)
+        if destination_view is None:
+            return "Converting"
+        message = f"Converting into view {destination_view!s}"
+        source_spaces = source_selector.get_instance_spaces()
+        if source_spaces:
+            destination_spaces = self._connection_creator.get_destination_spaces(source_spaces)
+            if destination_spaces:
+                message += f" with {humanize_collection(destination_spaces)} instance spaces"
+        return message
+
+    def _get_destination_view(self, source_selector: InstanceSelector) -> ViewId | None:
+        if not isinstance(source_selector, InstanceViewSelector) or source_selector.view.version is None:
+            return None
+        source_view = ViewId(
+            space=source_selector.view.space,
+            external_id=source_selector.view.external_id,
+            version=source_selector.view.version,
+        )
+        mapping = self._mappings_by_source_view.get(source_view)
+        return mapping.destination_view if mapping is not None else None
 
     def prepare(self, source_selector: InstanceSelector) -> None:
         view_ids = set(mapping.source_view for mapping in self._mappings_by_source_view.values()) | set(

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -112,7 +112,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.issues import MigrationEntryV2
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import Image360AnnotationSelector, MigrationCSVFileSelector
 from cognite_toolkit._cdf_tk.dataio import DataItem
 from cognite_toolkit._cdf_tk.dataio.logger import DataLogger, FileWithAggregationLogger, Severity
-from cognite_toolkit._cdf_tk.dataio.selectors import InstanceQuerySelector, InstanceViewSelector
+from cognite_toolkit._cdf_tk.dataio.selectors import InstanceQuerySelector, InstanceViewSelector, SelectedView
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 from cognite_toolkit._cdf_tk.utils.text import sanitize_instance_external_id
 from tests.data import MIGRATION_DIR
@@ -928,6 +928,38 @@ class TestFDMtoCDMMapper:
 
             actual = mapper.map([DataItem(tracking_id=str(i), item=inst) for i, inst in enumerate(instances)])
             assert [data_item.item.dump() for data_item in actual] == [item.dump() for item in expected]
+
+    def test_process_description(self) -> None:
+        with monkeypatch_toolkit_client() as client:
+            connection_creator = ConnectionCreator(
+                client, instance_id_mapper=SpaceMappingInstanceIdMapper(self.SPACE_MAPPING)
+            )
+            mapper = FDMtoCDMMapper(client, [self.VIEW_MAPPING], connection_creator)
+
+            selector = InstanceViewSelector(
+                view=SelectedView(
+                    space=self.SOURCE_VIEW_ID.space,
+                    external_id=self.SOURCE_VIEW_ID.external_id,
+                    version=self.SOURCE_VIEW_ID.version,
+                ),
+                instance_spaces=(self.SOURCE_SPACE,),
+            )
+            assert mapper.process_description(selector) == (
+                f"Converting into view {self.DESTINATION_VIEW_ID!s} with {self.TARGET_SPACE} instance spaces"
+            )
+
+    def test_process_description_unknown_view_falls_back_to_default(self) -> None:
+        with monkeypatch_toolkit_client() as client:
+            connection_creator = ConnectionCreator(
+                client, instance_id_mapper=SpaceMappingInstanceIdMapper(self.SPACE_MAPPING)
+            )
+            mapper = FDMtoCDMMapper(client, [self.VIEW_MAPPING], connection_creator)
+
+            selector = InstanceViewSelector(
+                view=SelectedView(space="other_space", external_id="OtherView", version="v1"),
+                instance_spaces=(self.SOURCE_SPACE,),
+            )
+            assert mapper.process_description(selector) == "Converting"
 
     def test_map_emits_all_mapped_items_with_tracking_ids(self) -> None:
         node = NodeResponse(

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -112,7 +112,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.issues import MigrationEntryV2
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import Image360AnnotationSelector, MigrationCSVFileSelector
 from cognite_toolkit._cdf_tk.dataio import DataItem
 from cognite_toolkit._cdf_tk.dataio.logger import DataLogger, FileWithAggregationLogger, Severity
-from cognite_toolkit._cdf_tk.dataio.selectors import InstanceQuerySelector, InstanceViewSelector, SelectedView
+from cognite_toolkit._cdf_tk.dataio.selectors import InstanceQuerySelector, InstanceViewSelector
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 from cognite_toolkit._cdf_tk.utils.text import sanitize_instance_external_id
 from tests.data import MIGRATION_DIR
@@ -928,38 +928,6 @@ class TestFDMtoCDMMapper:
 
             actual = mapper.map([DataItem(tracking_id=str(i), item=inst) for i, inst in enumerate(instances)])
             assert [data_item.item.dump() for data_item in actual] == [item.dump() for item in expected]
-
-    def test_process_description(self) -> None:
-        with monkeypatch_toolkit_client() as client:
-            connection_creator = ConnectionCreator(
-                client, instance_id_mapper=SpaceMappingInstanceIdMapper(self.SPACE_MAPPING)
-            )
-            mapper = FDMtoCDMMapper(client, [self.VIEW_MAPPING], connection_creator)
-
-            selector = InstanceViewSelector(
-                view=SelectedView(
-                    space=self.SOURCE_VIEW_ID.space,
-                    external_id=self.SOURCE_VIEW_ID.external_id,
-                    version=self.SOURCE_VIEW_ID.version,
-                ),
-                instance_spaces=(self.SOURCE_SPACE,),
-            )
-            assert mapper.process_description(selector) == (
-                f"Converting into view {self.DESTINATION_VIEW_ID!s} with {self.TARGET_SPACE} instance spaces"
-            )
-
-    def test_process_description_unknown_view_falls_back_to_default(self) -> None:
-        with monkeypatch_toolkit_client() as client:
-            connection_creator = ConnectionCreator(
-                client, instance_id_mapper=SpaceMappingInstanceIdMapper(self.SPACE_MAPPING)
-            )
-            mapper = FDMtoCDMMapper(client, [self.VIEW_MAPPING], connection_creator)
-
-            selector = InstanceViewSelector(
-                view=SelectedView(space="other_space", external_id="OtherView", version="v1"),
-                instance_spaces=(self.SOURCE_SPACE,),
-            )
-            assert mapper.process_description(selector) == "Converting"
 
     def test_map_emits_all_mapped_items_with_tracking_ids(self) -> None:
         node = NodeResponse(


### PR DESCRIPTION
# Description

The migration terminal output gave little to no context about the conversion target, unlike the download step which usually shows what view or target resource is being downloaded. Added `DataMapper.process_description()` so mappers can report the destination view and instance space(s) being converted into.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Improved

- [alpha] When running `cdf migrate infield-data`, the progress bar now shows the destination view and instance space(s) in the "Converting" step