### PR TITLE
[CDF-28248] Continue with next selector after repeated upload/migration failures

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -162,6 +162,10 @@ class MigrationCommand(ToolkitCommand):
 
             executor.run(start_item=step.completed_count)
 
+            if isinstance(executor.error_exception, ToolkitRepeatedUploadFailureError):
+                logger.apply_to_all_unprocessed(label="Early termination of migration", severity=Severity.skipped)
+                logger.force_write()
+
             items_results = logger.finalize(dry_run)
             results_by_selector[str(selected)] = items_results
 
@@ -176,8 +180,8 @@ class MigrationCommand(ToolkitCommand):
                 progress.dump_to_file(log_dir, filestem=str(selected))
             if isinstance(executor.error_exception, ToolkitRepeatedUploadFailureError):
                 console.print(
-                    f"[yellow]Continuing with the next view after repeatedly failed uploads for "
-                    f"{selected.display_name}. Check the log files in {log_dir}.[/yellow]"
+                    f"[yellow]Skipping migrating further items for {selected.display_name} after "
+                    f"encountering repeated failures. Check the log files in {log_dir}.[/yellow]"
                 )
             else:
                 executor.raise_on_error()
@@ -365,10 +369,6 @@ class MigrationCommand(ToolkitCommand):
                         )
 
             if responses and all(isinstance(result, ItemsFailedResponse | ItemsFailedRequest) for result in responses):
-                target.logger.apply_to_all_unprocessed(
-                    label="Early termination of migration",
-                    severity=Severity.skipped,
-                )
                 target.logger.force_write()
                 raise ToolkitRepeatedUploadFailureError(
                     f"Migration was stopped due to repeatedly failed uploads. Check the log files in {log_dir}."

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -42,7 +42,7 @@ from cognite_toolkit._cdf_tk.dataio.logger import (
 from cognite_toolkit._cdf_tk.dataio.progress import Bookmark, CursorBookmark, ProgressYAML
 from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitMigrationError,
-    ToolkitRuntimeError,
+    ToolkitRepeatedUploadFailureError,
     ToolkitValueError,
 )
 from cognite_toolkit._cdf_tk.resource_ios import ResourceWorker
@@ -174,7 +174,13 @@ class MigrationCommand(ToolkitCommand):
             if progress is not None:
                 progress.status = executor.result
                 progress.dump_to_file(log_dir, filestem=str(selected))
-            executor.raise_on_error()
+            if isinstance(executor.error_exception, ToolkitRepeatedUploadFailureError):
+                console.print(
+                    f"[yellow]Continuing with the next view after repeatedly failed uploads for "
+                    f"{selected.display_name}. Check the log files in {log_dir}.[/yellow]"
+                )
+            else:
+                executor.raise_on_error()
 
             action = "Would migrate" if dry_run else "Migrating"
             target = "records" if isinstance(data, RecordsMigrationIO) else "instances"
@@ -364,7 +370,7 @@ class MigrationCommand(ToolkitCommand):
                     severity=Severity.skipped,
                 )
                 target.logger.force_write()
-                raise ToolkitRuntimeError(
+                raise ToolkitRepeatedUploadFailureError(
                     f"Migration was stopped due to repeatedly failed uploads. Check the log files in {log_dir}."
                 )
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -582,7 +582,8 @@ class SpaceMappingInstanceIdMapper(InstanceIdMapper):
                 f"configured to map instances from the following source space(s): "
                 f"{humanize_collection(self._space_mapping)}. Instances (or direct-relation/edge targets) outside these "
                 f"spaces cannot be migrated. To fix this, re-run the migration with {instance_id.space!r} included as "
-                f"a source space."
+                f"a source space.",
+                severity=Severity.skipped,
             )
         return NodeId(
             space=self._space_mapping[instance_id.space],

--- a/cognite_toolkit/_cdf_tk/commands/_upload.py
+++ b/cognite_toolkit/_cdf_tk/commands/_upload.py
@@ -37,7 +37,7 @@ from cognite_toolkit._cdf_tk.dataio.logger import (
 )
 from cognite_toolkit._cdf_tk.dataio.selectors import Selector, load_selector
 from cognite_toolkit._cdf_tk.dataio.selectors._instances import InstanceSpaceSelector, InstanceViewSelector
-from cognite_toolkit._cdf_tk.exceptions import ToolkitRuntimeError, ToolkitValueError
+from cognite_toolkit._cdf_tk.exceptions import ToolkitRepeatedUploadFailureError, ToolkitValueError
 from cognite_toolkit._cdf_tk.protocols import T_ResourceRequest, T_ResourceResponse
 from cognite_toolkit._cdf_tk.resource_ios import ViewIO
 from cognite_toolkit._cdf_tk.tk_warnings import HighSeverityWarning, MediumSeverityWarning, ToolkitWarning
@@ -307,7 +307,13 @@ class UploadCommand(ToolkitCommand):
                 items_results = logger.finalize(dry_run)
                 display_item_results(items_results, title=f"Finished upload {selector.display_name}", console=console)
                 tracker.track(DataTracking.from_item_results("UploadResult", selector.kind, items_results), client)
-                executor.raise_on_error()
+                if isinstance(executor.error_exception, ToolkitRepeatedUploadFailureError):
+                    console.print(
+                        f"[yellow]Continuing with the next file after repeatedly failed uploads for "
+                        f"{selector.display_name}. Check the log files in {input_dir}.[/yellow]"
+                    )
+                else:
+                    executor.raise_on_error()
 
     @staticmethod
     def _create_upload_logfile_stem(log_dir: Path) -> str:
@@ -392,4 +398,4 @@ class UploadCommand(ToolkitCommand):
             suffix = " Failed to get log file"
             if log_file:
                 suffix = f"\nCheck the log file {cls._path_as_display_name(log_file).as_posix()}."
-            raise ToolkitRuntimeError(f"Upload process was stopped due to repeatedly failed uploads.{suffix}")
+            raise ToolkitRepeatedUploadFailureError(f"Upload process was stopped due to repeatedly failed uploads.{suffix}")

--- a/cognite_toolkit/_cdf_tk/commands/_upload.py
+++ b/cognite_toolkit/_cdf_tk/commands/_upload.py
@@ -304,13 +304,20 @@ class UploadCommand(ToolkitCommand):
                     console=console,
                 )
                 executor.run()
+
+                if isinstance(executor.error_exception, ToolkitRepeatedUploadFailureError):
+                    logger.apply_to_all_unprocessed(
+                        label="Early termination of upload process", severity=Severity.skipped
+                    )
+                    logger.force_write()
+
                 items_results = logger.finalize(dry_run)
                 display_item_results(items_results, title=f"Finished upload {selector.display_name}", console=console)
                 tracker.track(DataTracking.from_item_results("UploadResult", selector.kind, items_results), client)
                 if isinstance(executor.error_exception, ToolkitRepeatedUploadFailureError):
                     console.print(
-                        f"[yellow]Continuing with the next file after repeatedly failed uploads for "
-                        f"{selector.display_name}. Check the log files in {input_dir}.[/yellow]"
+                        f"[yellow]Skipping uploading further items for {selector.display_name} after "
+                        f"encountering repeated failures. Check the log files in {input_dir}.[/yellow]"
                     )
                 else:
                     executor.raise_on_error()
@@ -389,13 +396,11 @@ class UploadCommand(ToolkitCommand):
                     logger.log(LogEntryV2(id=id_, label=label, severity=Severity.failure, message=error_description))
 
         if all_failed and results:
-            logger.apply_to_all_unprocessed(
-                label="Early termination of upload process",
-                severity=Severity.skipped,
-            )
             logger.force_write()
             log_file = get_log_file()
             suffix = " Failed to get log file"
             if log_file:
                 suffix = f"\nCheck the log file {cls._path_as_display_name(log_file).as_posix()}."
-            raise ToolkitRepeatedUploadFailureError(f"Upload process was stopped due to repeatedly failed uploads.{suffix}")
+            raise ToolkitRepeatedUploadFailureError(
+                f"Upload process was stopped due to repeatedly failed uploads.{suffix}"
+            )

--- a/cognite_toolkit/_cdf_tk/exceptions.py
+++ b/cognite_toolkit/_cdf_tk/exceptions.py
@@ -255,3 +255,10 @@ class ToolkitRuntimeError(RuntimeError, ToolkitError):
     """General runtime error for toolkit operations."""
 
     ...
+
+
+class ToolkitRepeatedUploadFailureError(ToolkitRuntimeError):
+    """Raised when uploads for a page of data repeatedly fail in full, causing early termination of that data's
+    processing."""
+
+    ...

--- a/cognite_toolkit/_cdf_tk/utils/producer_worker.py
+++ b/cognite_toolkit/_cdf_tk/utils/producer_worker.py
@@ -23,7 +23,7 @@ from rich.progress import (
     TimeRemainingColumn,
 )
 
-from cognite_toolkit._cdf_tk.exceptions import ToolkitRuntimeError
+from cognite_toolkit._cdf_tk.exceptions import ToolkitRepeatedUploadFailureError, ToolkitRuntimeError
 
 T_Download = TypeVar("T_Download", bound=Sized)
 T_Processed = TypeVar("T_Processed", bound=Sized)
@@ -220,6 +220,20 @@ class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
         else:
             return "completed"
 
+    def _report_error(self, description: str, error: Exception) -> None:
+        """Record the error and print it, unless the caller reports this error type itself.
+
+        `ToolkitRepeatedUploadFailureError` is deliberately handled and reported by the caller
+        (which decides whether to abort or continue with the next selector), so printing it here
+        too would just duplicate that message.
+        """
+        self._error_event.set()
+        self.error_message = f"{type(error).__name__} {error!s}"
+        self.error_traceback = traceback.format_exc()
+        self.error_exception = error
+        if not isinstance(error, ToolkitRepeatedUploadFailureError):
+            self.console.print(f"[red]Error[/red] occurred while {description}: {self.error_message}")
+
     def print_traceback(self) -> None:
         """Prints the traceback if an error occurred during execution."""
         if self.error_traceback:
@@ -257,11 +271,7 @@ class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
             except StopIteration:
                 break
             except Exception as e:
-                self._error_event.set()
-                self.error_message = f"{type(e).__name__} {e!s}"
-                self.error_traceback = traceback.format_exc()
-                self.error_exception = e
-                self.console.print(f"[red]Error[/red] occurred while {self.download_description}: {self.error_message}")
+                self._report_error(self.download_description, e)
                 break
         self._put_with_error_check(PROCESS_FINISH_SENTINEL, self.process_queue)  # type: ignore[misc]
 
@@ -300,11 +310,7 @@ class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
             except queue.Empty:
                 continue
             except Exception as e:
-                self._error_event.set()
-                self.error_message = f"{type(e).__name__} {e!s}"
-                self.error_traceback = traceback.format_exc()
-                self.error_exception = e
-                self.console.print(f"[red]Error[/red] occurred while {self.process_description}: {self.error_message}")
+                self._report_error(self.process_description, e)
                 break
 
     def _write_worker(self, progress: Progress, write_task: TaskID, start_item: int = 0) -> None:
@@ -325,11 +331,7 @@ class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
             except queue.Empty:
                 continue
             except Exception as e:
-                self._error_event.set()
-                self.error_message = f"{type(e).__name__} {e!s}"
-                self.error_traceback = traceback.format_exc()
-                self.error_exception = e
-                self.console.print(f"[red]Error[/red] occurred while {self.write_description}: {self.error_message}")
+                self._report_error(self.write_description, e)
                 break
 
 

--- a/cognite_toolkit/_cdf_tk/utils/producer_worker.py
+++ b/cognite_toolkit/_cdf_tk/utils/producer_worker.py
@@ -111,6 +111,7 @@ class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
         self.downloaded_items = 0
         self.error_message = ""
         self.error_traceback = ""
+        self.error_exception: Exception | None = None
         self.verbose = verbose
 
     @property
@@ -259,6 +260,7 @@ class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
                 self._error_event.set()
                 self.error_message = f"{type(e).__name__} {e!s}"
                 self.error_traceback = traceback.format_exc()
+                self.error_exception = e
                 self.console.print(f"[red]Error[/red] occurred while {self.download_description}: {self.error_message}")
                 break
         self._put_with_error_check(PROCESS_FINISH_SENTINEL, self.process_queue)  # type: ignore[misc]
@@ -301,6 +303,7 @@ class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
                 self._error_event.set()
                 self.error_message = f"{type(e).__name__} {e!s}"
                 self.error_traceback = traceback.format_exc()
+                self.error_exception = e
                 self.console.print(f"[red]Error[/red] occurred while {self.process_description}: {self.error_message}")
                 break
 
@@ -325,6 +328,7 @@ class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
                 self._error_event.set()
                 self.error_message = f"{type(e).__name__} {e!s}"
                 self.error_traceback = traceback.format_exc()
+                self.error_exception = e
                 self.console.print(f"[red]Error[/red] occurred while {self.write_description}: {self.error_message}")
                 break
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -96,7 +96,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.migration_io import (
 )
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import MigrationCSVFileSelector
 from cognite_toolkit._cdf_tk.dataio import CanvasIO, ChartIO, DataItem, Page
-from cognite_toolkit._cdf_tk.dataio.logger import FileWithAggregationLogger, ItemsResult, Severity
+from cognite_toolkit._cdf_tk.dataio.logger import FileWithAggregationLogger, ItemsResult
 from cognite_toolkit._cdf_tk.dataio.progress import CursorBookmark, ProgressYAML
 from cognite_toolkit._cdf_tk.dataio.selectors import (
     CanvasExternalIdSelector,
@@ -1200,7 +1200,9 @@ class TestMigrationCommand:
             total_item_count=2,
             start_item=0,
         )
-        with pytest.raises(ToolkitRepeatedUploadFailureError, match="Migration was stopped due to repeatedly failed uploads"):
+        with pytest.raises(
+            ToolkitRepeatedUploadFailureError, match="Migration was stopped due to repeatedly failed uploads"
+        ):
             upload(page)
 
         target.logger.force_write.assert_called_once()

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -102,7 +102,11 @@ from cognite_toolkit._cdf_tk.dataio.selectors import (
     CanvasExternalIdSelector,
     ChartExternalIdSelector,
 )
-from cognite_toolkit._cdf_tk.exceptions import ToolkitMigrationError, ToolkitRuntimeError, ToolkitValueError
+from cognite_toolkit._cdf_tk.exceptions import (
+    ToolkitMigrationError,
+    ToolkitRepeatedUploadFailureError,
+    ToolkitValueError,
+)
 
 
 def _migration_status_totals(results: Sequence[ItemsResult]) -> dict[str, int]:
@@ -1195,7 +1199,7 @@ class TestMigrationCommand:
             total_item_count=2,
             start_item=0,
         )
-        with pytest.raises(ToolkitRuntimeError, match="Migration was stopped due to repeatedly failed uploads"):
+        with pytest.raises(ToolkitRepeatedUploadFailureError, match="Migration was stopped due to repeatedly failed uploads"):
             upload(page)
 
         target.logger.apply_to_all_unprocessed.assert_called_once_with(

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -69,7 +69,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.streams import (
     StreamSettings,
 )
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
-from cognite_toolkit._cdf_tk.commands._migrate.command import MigrationCommand
+from cognite_toolkit._cdf_tk.commands._migrate.command import MigrationCommand, MigrationStep
 from cognite_toolkit._cdf_tk.commands._migrate.data_mapper import (
     AssetCentricToInstanceMapper,
     AssetCentricToRecordMapper,
@@ -96,7 +96,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.migration_io import (
 )
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import MigrationCSVFileSelector
 from cognite_toolkit._cdf_tk.dataio import CanvasIO, ChartIO, DataItem, Page
-from cognite_toolkit._cdf_tk.dataio.logger import ItemsResult, Severity
+from cognite_toolkit._cdf_tk.dataio.logger import FileWithAggregationLogger, ItemsResult, Severity
 from cognite_toolkit._cdf_tk.dataio.progress import CursorBookmark, ProgressYAML
 from cognite_toolkit._cdf_tk.dataio.selectors import (
     CanvasExternalIdSelector,
@@ -107,6 +107,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitRepeatedUploadFailureError,
     ToolkitValueError,
 )
+from cognite_toolkit._cdf_tk.utils.producer_worker import ProducerWorkerExecutor
 
 
 def _migration_status_totals(results: Sequence[ItemsResult]) -> dict[str, int]:
@@ -1202,11 +1203,49 @@ class TestMigrationCommand:
         with pytest.raises(ToolkitRepeatedUploadFailureError, match="Migration was stopped due to repeatedly failed uploads"):
             upload(page)
 
-        target.logger.apply_to_all_unprocessed.assert_called_once_with(
-            label="Early termination of migration",
-            severity=Severity.skipped,
-        )
         target.logger.force_write.assert_called_once()
+
+    def test_late_registrations_after_abort_are_marked_skipped_not_success(self, tmp_path: Path) -> None:
+        """Regression test for the race between the download thread registering items and the
+        "unprocessed" sweep on early termination, see `_run_migration_steps`."""
+        logger = FileWithAggregationLogger(MagicMock())
+
+        def _fake_run(self: ProducerWorkerExecutor, start_item: int = 0) -> None:
+            logger.register(["item-1"])
+            try:
+                self._write(Page(worker_id="main", items=[DataItem(tracking_id="item-1", item=1)]))
+            except Exception as error:
+                self.error_exception = error
+            # Simulate the download thread registering more items concurrently, after the write
+            # failure is detected but before the executor's threads have actually joined.
+            logger.register(["item-2", "item-3"])
+
+        data = MagicMock(CHUNK_SIZE=1000, KIND="Instances")
+        data.upload_items.return_value = [ItemsFailedRequest(ids=["item-1"], error_message="boom")]
+        data.stream_data.return_value = iter([])
+        selected = MagicMock(display_name="TestView", kind="TestKind", __str__=lambda self: "TestView")
+        step = MigrationStep(
+            total_count=1, completed_count=0, bookmark=None, message="", is_completed=False, selector=selected
+        )
+
+        command = MigrationCommand(silent=True)
+        with patch.object(ProducerWorkerExecutor, "run", autospec=True, side_effect=_fake_run):
+            results_by_selector = command._run_migration_steps(
+                plan=[step],
+                data=data,
+                mapper=MagicMock(),
+                logger=logger,
+                write_client=MagicMock(),
+                log_dir=tmp_path,
+                dry_run=False,
+                verbose=False,
+                console=MagicMock(),
+            )
+
+        totals = _migration_status_totals(results_by_selector["TestView"])
+        assert totals["failure"] == 1
+        assert totals["skipped"] == 2
+        assert totals["success"] == 0
 
     def test_validate_migration_model_available(self) -> None:
         with monkeypatch_toolkit_client() as client:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_upload.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_upload.py
@@ -33,7 +33,7 @@ from cognite_toolkit._cdf_tk.dataio.selectors import (
     Selector,
 )
 from cognite_toolkit._cdf_tk.dataio.selectors._asset_centric import DataSetSelector
-from cognite_toolkit._cdf_tk.exceptions import ToolkitRuntimeError
+from cognite_toolkit._cdf_tk.exceptions import ToolkitRepeatedUploadFailureError
 from cognite_toolkit._cdf_tk.resource_ios import RawTableCRUD
 from cognite_toolkit._cdf_tk.utils._auxiliary import get_concrete_subclasses
 from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter, Uncompressed
@@ -228,7 +228,7 @@ class TestUploadCommand:
         ]
         with HTTPClient(config=toolkit_config) as http_client:
             with pytest.raises(
-                ToolkitRuntimeError, match="Upload process was stopped due to repeatedly failed uploads"
+                ToolkitRepeatedUploadFailureError, match="Upload process was stopped due to repeatedly failed uploads"
             ):
                 UploadCommand._upload_items(
                     data_chunk=Page(worker_id="main", items=items),


### PR DESCRIPTION
# Description

After #3095, if uploads for a page of data repeatedly failed in full (e.g. all items in a chunk rejected), `cdf migrate` and `cdf data upload` would abort the entire run, requiring a restart even though other selectors/files hadn't been affected. This introduces a dedicated `ToolkitRepeatedUploadFailureError` so both commands can distinguish this case, mark the remaining unprocessed items for that selector as skipped, and continue with the next selector/file instead of raising. This makes debugging issues, in particular for infield migrations where you can't currently opt-in to migrating specific views, easier for users as they can easier understand if their issues are constrained to the current selectors or if subsequent ones would also fail.

This PR also addresses **CDF-28253** which was discovered while implementing this change. This fixes a race condition where the "mark unprocessed items as skipped" step was done from within the write callback, concurrently with the download thread still registering further items. Items registered in that window were never set to "skipped" and instead silently defaulted to "success" once the run stopped, even though they were never actually uploaded, leading to failed requests to be potentially _also_ counted as succeeded ones erroneously. The sweep is now deferred until after the executor's threads have fully joined, closing the race.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Changed

- Whenever `cdf migrate` and `cdf data upload` skips the remaining items for a view/file after repeated upload failures, toolkit will now proceed with the next one in queue, instead of failing the whole command immediately.

### Fixed

- Fixes a but where items that were never actually uploaded sometimes being incorrectly reported as successful after a batch of repeated upload failures during `cdf migrate` or `cdf data upload`.