### PR TITLE
fix: drop sourceId when members present in auth verify group update

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/auth.py
+++ b/cognite_toolkit/_cdf_tk/commands/auth.py
@@ -373,6 +373,10 @@ class AuthCommand(ToolkitCommand):
     ) -> bool:
         """Updates the missing capabilities. This assumes interactive mode."""
         updated_group = existing_group.as_request_resource()
+        # CDF API rejects requests with both members and sourceId set.
+        # When the group uses members (CDF-managed), drop the IDP-populated sourceId.
+        if updated_group.members and updated_group.source_id is not None:
+            updated_group.source_id = None
         missing_group_caps = [GroupCapability(acl=acl) for acl in missing_capabilities]
         if updated_group.capabilities is None:
             updated_group.capabilities = list(missing_group_caps)

--- a/tests/test_unit/test_cdf_tk/test_commands/test_auth.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_auth.py
@@ -272,3 +272,49 @@ def test_update_missing_capabilities_dm_only_project() -> None:
     created_group_request = client.tool.groups.create.call_args[0][0][0]
     assert len(created_group_request.capabilities) == 1
     assert isinstance(created_group_request.capabilities[0].acl, StreamsAcl)
+
+
+def test_update_missing_capabilities_drops_source_id_when_members_present() -> None:
+    """On Entra ID clusters, the API returns groups with both members and sourceId.
+    The create call must not send both simultaneously."""
+    missing_acls = [
+        StreamsAcl(actions=["READ"], scope=AllScope()),
+    ]
+    existing = GroupResponse(
+        id=42,
+        is_deleted=False,
+        name=TOOLKIT_SERVICE_PRINCIPAL_GROUP_NAME,
+        source_id="entra-id-group-id",
+        members=["service-account@example.com"],
+        capabilities=[
+            GroupCapability(acl=AssetsAcl(actions=["READ"], scope=AllScope())),
+        ],
+    )
+    created_response = GroupResponse(
+        id=43,
+        is_deleted=False,
+        name=TOOLKIT_SERVICE_PRINCIPAL_GROUP_NAME,
+        members=["service-account@example.com"],
+        capabilities=[
+            GroupCapability(acl=AssetsAcl(actions=["READ"], scope=AllScope())),
+            GroupCapability(acl=StreamsAcl(actions=["READ"], scope=AllScope())),
+        ],
+    )
+    with monkeypatch_toolkit_client() as client:
+        client.tool.groups.create.return_value = [created_response]
+        client.tool.groups.delete.return_value = None
+
+        result = AuthCommand()._update_missing_capabilities(
+            client,
+            existing,
+            missing_acls,
+            dry_run=False,
+            project=CDF_PROJECT,
+            data_modeling_status="HYBRID",
+        )
+
+    assert result is True
+    client.tool.groups.create.assert_called_once()
+    created_group_request = client.tool.groups.create.call_args[0][0][0]
+    assert created_group_request.members == ["service-account@example.com"]
+    assert created_group_request.source_id is None


### PR DESCRIPTION
# Description

Fix `cdf auth verify` failing on Entra ID (Azure AD) clusters when updating the `cognite_toolkit_service_principal` group.

The CDF API returns groups with both `members` and `sourceId` in responses, but rejects create requests that set both simultaneously (`"Fields members, sourceId cannot be set at the same time"`). In `_update_missing_capabilities`, `existing_group.as_request_resource()` copies both fields from the response into the new `GroupRequest`, which then fails on `groups.create()`.

- Clear `source_id` from the group request when `members` is present, matching the mutual exclusion already enforced by the YAML deploy path (`GroupYAML.select_group_type()`)
- Add a unit test covering the Entra ID scenario (group with both fields populated)
- Manually verified against an Entra ID cluster project that previously triggered the error

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- `cdf auth verify` no longer fails with `"Fields members, sourceId cannot be set at the same time"` when updating groups on Entra ID clusters.