### PR TITLE
[CDF-28252] Report the specific target view during upload in infield-data migration failure logs

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -149,7 +149,14 @@ class MigrationCommand(ToolkitCommand):
                 download_iterable=data.stream_data(selected, bookmark=step.bookmark),
                 process=self._convert(mapper),
                 write=self._upload(
-                    selected, write_client, data, dry_run, log_dir, step.total_count, step.completed_count
+                    selected,
+                    write_client,
+                    data,
+                    mapper.destination_label or data.KIND,
+                    dry_run,
+                    log_dir,
+                    step.total_count,
+                    step.completed_count,
                 ),
                 total_item_count=step.total_count,
                 max_queue_size=10,
@@ -318,6 +325,7 @@ class MigrationCommand(ToolkitCommand):
         selected: T_Selector,
         write_client: HTTPClient,
         target: UploadableDataIO[T_Selector, T_DataResponse, T_DataRequest],
+        destination: str,
         dry_run: bool,
         log_dir: Path,
         total_item_count: int | None,
@@ -352,7 +360,7 @@ class MigrationCommand(ToolkitCommand):
                                 label=f"Failed to write to CDF: {error.code}",
                                 message=error.message,
                                 source=str(selected),
-                                destination=target.KIND,
+                                destination=destination,
                             )
                         )
                 elif isinstance(item, ItemsFailedRequest):
@@ -364,7 +372,7 @@ class MigrationCommand(ToolkitCommand):
                                 label="Failed to write to CDF: Request failed",
                                 message=item.error_message,
                                 source=str(selected),
-                                destination=target.KIND,
+                                destination=destination,
                             )
                         )
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -145,6 +145,10 @@ class DataMapper(Generic[T_Selector, T_DataResponse, T_DataRequest], ABC):
         # just-mapped target instances as if they had been uploaded, so that downstream
         # steps' constraint checks do not falsely report them as missing in CDF.
         self.dry_run: bool = False
+        # Subclasses that know the specific destination (e.g., a target view) for the data
+        # being migrated in the current step can set this in prepare() so that upload failure
+        # logs can report it instead of a generic destination label (e.g., the DataIO KIND).
+        self.destination_label: str | None = None
 
     def prepare(self, source_selector: T_Selector) -> None:
         """Prepare the data mapper with the given source selector.
@@ -1382,7 +1386,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
         # Set in prepare() so that reported issues can point to the specific source/destination
         # view of the current migration step, instead of a generic "FDM/CDM instances" label.
         self._current_issue_source: str = "FDM instances"
-        self._current_issue_destination: str = "CDM instances"
+        self.destination_label: str | None = "CDM instances"
 
     def process_description(self, source_selector: InstanceSelector) -> str:
         destination_view = self._get_destination_view(source_selector)
@@ -1422,7 +1426,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
                 version=source_selector.view.version,
             )
             mapping = self._mappings_by_source_view.get(selected_view)
-        self._current_issue_destination = str(mapping.destination_view) if mapping is not None else "CDM instances"
+        self.destination_label = str(mapping.destination_view) if mapping is not None else "CDM instances"
 
     def map(self, source: Sequence[DataItem[NodeOrEdgeResponse]]) -> Sequence[DataItem[NodeOrEdgeRequest]]:
         raw_items = [data_item.item for data_item in source]
@@ -1489,7 +1493,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
             self.logger.log(
                 [
                     instance_conversion_issue_as_migration_entry(
-                        issue, source=self._current_issue_source, destination=self._current_issue_destination
+                        issue, source=self._current_issue_source, destination=self.destination_label or "CDM instances"
                     )
                     for issue in issue_by_source_node_id.values()
                 ]

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -1175,6 +1175,7 @@ class TestMigrationCommand:
             selected=MagicMock(),
             write_client=MagicMock(),
             target=target,  # type: ignore[arg-type]
+            destination="Instances",
             dry_run=False,
             log_dir=tmp_path,
             total_item_count=1001,
@@ -1195,6 +1196,7 @@ class TestMigrationCommand:
             selected=MagicMock(__str__=lambda self: "ChecklistItem_v7_node"),
             write_client=MagicMock(),
             target=target,  # type: ignore[arg-type]
+            destination="Instances",
             dry_run=False,
             log_dir=tmp_path,
             total_item_count=2,
@@ -1235,7 +1237,7 @@ class TestMigrationCommand:
             results_by_selector = command._run_migration_steps(
                 plan=[step],
                 data=data,
-                mapper=MagicMock(),
+                mapper=MagicMock(destination_label=None),
                 logger=logger,
                 write_client=MagicMock(),
                 log_dir=tmp_path,


### PR DESCRIPTION
# Description

Migration write-failure log entries for `cdf migrate infield-data` still reported a generic `destination: "Instances"`, since the command uploads via the generic `InstanceIO` class. After #3103, `FDMtoCDMMapper` resolves the specific target view per migration step for its conversion-issue logs, and with this PR, that same label is now reused for upload-failure logs, making it clear which view a failed write was targeting.

## Bump

- [ ] Patch
- [x] Skip