### PR TITLE
[CDF-28267] Fix 360-image migration pagination issue and dry-run/dangling-model issues

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -1832,7 +1832,7 @@ class MigrateApp(typer.Typer):
             connection_creator=connection_creator,
             custom_properties_mappings=[Station360PropertiesMapping()],
             custom_instance_mappings={
-                LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW: Image360CollectionMapper(client, dry_run=dry_run),
+                LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW: Image360CollectionMapper(client),
             },
         )
         cmd.run(

--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -1806,7 +1806,7 @@ class MigrateApp(typer.Typer):
                     "They must first be migrated from the Events service to the [italic]cdf_360_image_schema[/italic] "
                     "data model using a standalone custom script before they can be migrated to CDM. "
                     "Toolkit does not support this step. Please see the documentation for this migration "
-                    "command for more details and guidance on how to perform this separate migration.\n\n",
+                    "command for more details and guidance on how to perform this separate migration.",
                     title="Unsupported Events-based 360-image data detected",
                     expand=False,
                     border_style="yellow",

--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -1831,7 +1831,7 @@ class MigrateApp(typer.Typer):
             connection_creator=connection_creator,
             custom_properties_mappings=[Station360PropertiesMapping()],
             custom_instance_mappings={
-                LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW: Image360CollectionMapper(client),
+                LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW: Image360CollectionMapper(client, dry_run=dry_run),
             },
         )
         cmd.run(

--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -59,6 +59,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.migration_io import (
     AnnotationMigrationIO,
     AssetCentricMigrationIO,
     Image360AnnotationMigrationIO,
+    Image360CollectionInstanceIO,
     RecordsMigrationIO,
     ThreeDAssetMappingMigrationIO,
     ThreeDMigrationIO,
@@ -1837,7 +1838,7 @@ class MigrateApp(typer.Typer):
         cmd.run(
             lambda: cmd.migrate(
                 selectors=selectors,
-                data=InstanceIO(client),
+                data=Image360CollectionInstanceIO(client),
                 mapper=mapper,
                 log_dir=log_dir,
                 dry_run=dry_run,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -2155,7 +2155,8 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
             instance_space = node.space
             collection_ext_id = sanitize_instance_external_id(node.external_id, "_cdm")
             migrated_id = NodeId(space=instance_space, external_id=collection_ext_id)
-            name = ((node.properties or {}).get(LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW) or {}).get("label")
+            label_value = ((node.properties or {}).get(LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW) or {}).get("label")
+            name = label_value if isinstance(label_value, str) else None
 
             model_external_id: str | None = None
             migrated_node = existing_migrated_by_id.get(migrated_id)
@@ -2186,7 +2187,9 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
         return results
 
     @staticmethod
-    def _revision_node_request(space: str, external_id: str, name: Any, model_external_id: str | None) -> NodeRequest:
+    def _revision_node_request(
+        space: str, external_id: str, name: str | None, model_external_id: str | None
+    ) -> NodeRequest:
         revision_properties: dict[str, Any] = {
             "status": "Done",
             "published": True,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -10,6 +10,7 @@ from cognite.client.exceptions import CogniteException
 from pydantic import JsonValue
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
+from cognite_toolkit._cdf_tk.client.http_client import ToolkitAPIError
 from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, EdgeTypeId, ExternalId, InstanceId, InternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.annotation import (
     AnnotationResponse,
@@ -2130,13 +2131,22 @@ class Image360FDMtoCDMMapper(FDMtoCDMMapper):
 class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdgeRequest]):
     """Maps each legacy Image360Collection node to a Cognite360ImageCollection CDM node.
 
-    First, as a side-effect, registers an Image360 3D model in the 3D backend per collection
-    (or reuses an existing model3D reference when the collection was already migrated previously)
-    and sets model3D on the collection revision.
+    As a side-effect, registers an Image360 3D model in the 3D backend per collection (or reuses
+    an existing model3D reference when the collection was already migrated previously) and sets
+    model3D on the collection revision.
+
+    To avoid ever leaving a dangling/orphaned 3D model behind, the revision node is first
+    created/upserted *without* a model3D reference. Only once that write has been confirmed to
+    succeed do we create the 3D model; the mapped node returned from `map` (which includes the
+    model3D reference) is then written by the regular upload step, effectively patching the
+    revision node with the reference to the newly created model.
 
     Registered via FDMtoCDMMapper.custom_instance_mappings so it runs instead of the default
     ViewToViewMapping path for Image360Collection source nodes.
     """
+
+    SOURCE_LABEL: ClassVar[str] = "Image360Collection"
+    DESTINATION_LABEL: ClassVar[str] = "Cognite360ImageCollection"
 
     def map(self, source: Sequence[DataItem[NodeOrEdgeResponse]]) -> Sequence[DataItem[NodeOrEdgeRequest]]:
         raw_items = [data_item.item for data_item in source]
@@ -2161,6 +2171,7 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
             instance_space = node.space
             collection_ext_id = sanitize_instance_external_id(node.external_id, "_cdm")
             migrated_id = NodeId(space=instance_space, external_id=collection_ext_id)
+            name = ((node.properties or {}).get(LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW) or {}).get("label")
 
             model_external_id: str | None = None
             migrated_node = existing_migrated_by_id.get(migrated_id)
@@ -2173,10 +2184,25 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
                 if self.dry_run:
                     model_external_id = "cog_3d_model_<dry-run>"
                 else:
-                    label = str(
-                        ((node.properties or {}).get(LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW) or {}).get("label")
-                        or node.external_id
-                    )
+                    try:
+                        self.client.tool.instances.create(
+                            [self._revision_node_request(instance_space, collection_ext_id, name, None)]
+                        )
+                    except ToolkitAPIError as error:
+                        self.logger.log(
+                            [
+                                MigrationEntryV2(
+                                    id=str(node.as_id()),
+                                    label="Image360 collection migration failed",
+                                    message=f"Could not create the collection revision node: {error.message}",
+                                    severity=Severity.failure,
+                                    source=self.SOURCE_LABEL,
+                                    destination=self.DESTINATION_LABEL,
+                                )
+                            ]
+                        )
+                        continue
+                    label = str(name or node.external_id)
                     created_model = self.client.tool.three_d.models_classic.create(
                         [ThreeDModelDMSRequest(name=label, space=instance_space, type="Image360")]
                     )[0]
@@ -2185,32 +2211,36 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
             results.append(
                 DataItem(
                     tracking_id=data_item.tracking_id,
-                    item=NodeRequest(
-                        space=instance_space,
-                        external_id=collection_ext_id,
-                        sources=[
-                            InstanceSource(
-                                source=ContainerId(space="cdf_cdm_3d", external_id="Cognite3DRevision"),
-                                properties={
-                                    "model3D": {"space": instance_space, "externalId": model_external_id},
-                                    "status": "Done",
-                                    "published": True,
-                                    "type": "Image360",
-                                },
-                            ),
-                            InstanceSource(
-                                source=ContainerId(space="cdf_cdm", external_id="CogniteDescribable"),
-                                properties={
-                                    "name": (
-                                        (node.properties or {}).get(LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW) or {}
-                                    ).get("label")
-                                },
-                            ),
-                        ],
-                    ),
+                    item=self._revision_node_request(instance_space, collection_ext_id, name, model_external_id),
                 )
             )
         return results
+
+    @staticmethod
+    def _revision_node_request(
+        space: str, external_id: str, name: Any, model_external_id: str | None
+    ) -> NodeRequest:
+        revision_properties: dict[str, Any] = {
+            "status": "Done",
+            "published": True,
+            "type": "Image360",
+        }
+        if model_external_id is not None:
+            revision_properties["model3D"] = {"space": space, "externalId": model_external_id}
+        return NodeRequest(
+            space=space,
+            external_id=external_id,
+            sources=[
+                InstanceSource(
+                    source=ContainerId(space="cdf_cdm_3d", external_id="Cognite3DRevision"),
+                    properties=revision_properties,
+                ),
+                InstanceSource(
+                    source=ContainerId(space="cdf_cdm", external_id="CogniteDescribable"),
+                    properties={"name": name},
+                ),
+            ],
+        )
 
 
 class Station360PropertiesMapping(CustomContainerPropertiesMapping):

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1434,8 +1434,7 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
         ):
             if len(intersecting_view_ids) == 1:
                 intersection_view_id = next(iter(intersecting_view_ids))
-                custom_mapper = self._custom_instance_mappings[intersection_view_id]
-                custom_mapped = custom_mapper.map(source)
+                custom_mapped = self._custom_instance_mappings[intersection_view_id].map(source)
                 if self.dry_run:
                     for data_item in custom_mapped:
                         if isinstance(data_item.item, NodeRequest):
@@ -2145,8 +2144,6 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
             instance_space = node.space
             collection_ext_id = sanitize_instance_external_id(node.external_id, "_cdm")
             migrated_id = NodeId(space=instance_space, external_id=collection_ext_id)
-            label_value = ((node.properties or {}).get(LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW) or {}).get("label")
-            name = label_value if isinstance(label_value, str) else None
 
             model_external_id: str | None = None
             migrated_node = existing_migrated_by_id.get(migrated_id)
@@ -2178,7 +2175,11 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
                             ),
                             InstanceSource(
                                 source=ContainerId(space="cdf_cdm", external_id="CogniteDescribable"),
-                                properties={"name": name},
+                                properties={
+                                    "name": (
+                                        (node.properties or {}).get(LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW) or {}
+                                    ).get("label")
+                                },
                             ),
                         ],
                     ),

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -2055,6 +2055,18 @@ class Image360FDMtoCDMMapper(FDMtoCDMMapper):
             custom_instance_mappings=custom_instance_mappings,
         )
 
+    def map(self, source: Sequence[DataItem[NodeOrEdgeResponse]]) -> Sequence[DataItem[NodeOrEdgeRequest]]:
+        # 'image360' nodes are included in the 'image360station' query selector purely to drive
+        # pagination (see create_360_image_selectors) and are selected without any properties.
+        # The images themselves are migrated separately by the 'Image360' InstanceViewSelector, so
+        # they must be skipped here to avoid creating empty placeholder nodes.
+        filtered = [
+            data_item
+            for data_item in source
+            if not (isinstance(data_item.item, NodeResponse) and not data_item.item.properties)
+        ]
+        return super().map(filtered)
+
     @staticmethod
     def missing_cubemap_face_file_external_ids(
         source_node: NodeResponse,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -2113,19 +2113,14 @@ class Image360FDMtoCDMMapper(FDMtoCDMMapper):
 class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdgeRequest]):
     """Maps each legacy Image360Collection node to a Cognite360ImageCollection CDM node.
 
-    Reuses the existing model3D reference when the collection was already migrated previously.
-    Otherwise, the mapped node is returned *without* a model3D reference; creating the Image360
-    3D model and patching the reference onto the revision node is handled by
-    Image360CollectionInstanceIO as part of the upload step (and is skipped entirely on dry-run),
-    so that this mapper only maps and never writes to CDF.
+    When the collection was already migrated, the existing model3D reference is included in the
+    mapped NodeRequest so that Image360CollectionInstanceIO skips model creation on re-runs.
+    Otherwise, the node is emitted without model3D; Image360CollectionInstanceIO will create the
+    Image360 3D model and patch the reference in during the upload step.
 
     Registered via FDMtoCDMMapper.custom_instance_mappings so it runs instead of the default
     ViewToViewMapping path for Image360Collection source nodes.
     """
-
-    def __init__(self, client: ToolkitClient, dry_run: bool = False) -> None:
-        super().__init__(client)
-        self.dry_run = dry_run
 
     def map(self, source: Sequence[DataItem[NodeOrEdgeResponse]]) -> Sequence[DataItem[NodeOrEdgeRequest]]:
         raw_items = [data_item.item for data_item in source]
@@ -2160,10 +2155,15 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
                 if isinstance(model_3d, dict) and (existing_external_id := model_3d.get("externalId")):
                     model_external_id = str(existing_external_id)
 
-            if model_external_id is None and self.dry_run:
-                # The real model_external_id is only known once the 3D model has been created,
-                # which happens as part of the upload step (see Image360CollectionInstanceIO).
-                model_external_id = "cog_3d_model_<dry-run>"
+            revision_properties: dict[str, Any] = {
+                "status": "Done",
+                "published": True,
+                "type": "Image360",
+            }
+            if model_external_id is not None:
+                # Include the existing model3D reference so Image360CollectionInstanceIO
+                # knows not to create a new 3D model on re-runs.
+                revision_properties["model3D"] = {"space": instance_space, "externalId": model_external_id}
 
             results.append(
                 DataItem(
@@ -2174,11 +2174,7 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
                         sources=[
                             InstanceSource(
                                 source=ContainerId(space="cdf_cdm_3d", external_id="Cognite3DRevision"),
-                                properties={
-                                    "status": "Done",
-                                    "published": True,
-                                    "type": "Image360",
-                                },
+                                properties=revision_properties,
                             ),
                             InstanceSource(
                                 source=ContainerId(space="cdf_cdm", external_id="CogniteDescribable"),

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -2061,18 +2061,6 @@ class Image360FDMtoCDMMapper(FDMtoCDMMapper):
             custom_instance_mappings=custom_instance_mappings,
         )
 
-    def map(self, source: Sequence[DataItem[NodeOrEdgeResponse]]) -> Sequence[DataItem[NodeOrEdgeRequest]]:
-        # 'image360' nodes are included in the 'image360station' query selector purely to drive
-        # pagination (see create_360_image_selectors) and are selected without any properties.
-        # The images themselves are migrated separately by the 'Image360' InstanceViewSelector, so
-        # they must be skipped here to avoid creating empty placeholder nodes.
-        filtered = [
-            data_item
-            for data_item in source
-            if not (isinstance(data_item.item, NodeResponse) and not data_item.item.properties)
-        ]
-        return super().map(filtered)
-
     @staticmethod
     def missing_cubemap_face_file_external_ids(
         source_node: NodeResponse,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1435,7 +1435,12 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
         ):
             if len(intersecting_view_ids) == 1:
                 intersection_view_id = next(iter(intersecting_view_ids))
-                custom_mapped = self._custom_instance_mappings[intersection_view_id].map(source)
+                custom_mapper = self._custom_instance_mappings[intersection_view_id]
+                # dry_run is only set on this (outer) mapper by the migration command, so it
+                # must be propagated explicitly to avoid the custom mapper performing real
+                # side effects (e.g., creating 3D models) during a dry run.
+                custom_mapper.dry_run = self.dry_run
+                custom_mapped = custom_mapper.map(source)
                 if self.dry_run:
                     for data_item in custom_mapped:
                         if isinstance(data_item.item, NodeRequest):

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1436,10 +1436,6 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
             if len(intersecting_view_ids) == 1:
                 intersection_view_id = next(iter(intersecting_view_ids))
                 custom_mapper = self._custom_instance_mappings[intersection_view_id]
-                # dry_run is only set on this (outer) mapper by the migration command, so it
-                # must be propagated explicitly to avoid the custom mapper performing real
-                # side effects (e.g., creating 3D models) during a dry run.
-                custom_mapper.dry_run = self.dry_run
                 custom_mapped = custom_mapper.map(source)
                 if self.dry_run:
                     for data_item in custom_mapped:
@@ -2131,6 +2127,10 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
     Registered via FDMtoCDMMapper.custom_instance_mappings so it runs instead of the default
     ViewToViewMapping path for Image360Collection source nodes.
     """
+
+    def __init__(self, client: ToolkitClient, dry_run: bool = False) -> None:
+        super().__init__(client)
+        self.dry_run = dry_run
 
     def map(self, source: Sequence[DataItem[NodeOrEdgeResponse]]) -> Sequence[DataItem[NodeOrEdgeRequest]]:
         raw_items = [data_item.item for data_item in source]

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -74,7 +74,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.three_d import (
     AssetMappingDMRequestId,
     RevisionStatus,
     ThreeDModelClassicResponse,
-    ThreeDModelDMSRequest,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.view_to_view_mapping import ViewToViewMapping
 from cognite_toolkit._cdf_tk.commands._migrate.conversion import (
@@ -2114,15 +2113,11 @@ class Image360FDMtoCDMMapper(FDMtoCDMMapper):
 class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdgeRequest]):
     """Maps each legacy Image360Collection node to a Cognite360ImageCollection CDM node.
 
-    As a side-effect, registers an Image360 3D model in the 3D backend per collection (or reuses
-    an existing model3D reference when the collection was already migrated previously) and sets
-    model3D on the collection revision.
-
-    To avoid ever leaving a dangling/orphaned 3D model behind, the revision node is first
-    created/upserted *without* a model3D reference. Only once that write has been confirmed to
-    succeed do we create the 3D model; the mapped node returned from `map` (which includes the
-    model3D reference) is then written by the regular upload step, effectively patching the
-    revision node with the reference to the newly created model.
+    Reuses the existing model3D reference when the collection was already migrated previously.
+    Otherwise, the mapped node is returned *without* a model3D reference; creating the Image360
+    3D model and patching the reference onto the revision node is handled by
+    Image360CollectionInstanceIO as part of the upload step (and is skipped entirely on dry-run),
+    so that this mapper only maps and never writes to CDF.
 
     Registered via FDMtoCDMMapper.custom_instance_mappings so it runs instead of the default
     ViewToViewMapping path for Image360Collection source nodes.
@@ -2165,52 +2160,35 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
                 if isinstance(model_3d, dict) and (existing_external_id := model_3d.get("externalId")):
                     model_external_id = str(existing_external_id)
 
-            if model_external_id is None:
-                if self.dry_run:
-                    model_external_id = "cog_3d_model_<dry-run>"
-                else:
-                    self.client.tool.instances.create(
-                        [self._revision_node_request(instance_space, collection_ext_id, name, None)]
-                    )
-                    label = str(name or node.external_id)
-                    created_model = self.client.tool.three_d.models_classic.create(
-                        [ThreeDModelDMSRequest(name=label, space=instance_space, type="Image360")]
-                    )[0]
-                    model_external_id = f"cog_3d_model_{created_model.id}"
+            if model_external_id is None and self.dry_run:
+                # The real model_external_id is only known once the 3D model has been created,
+                # which happens as part of the upload step (see Image360CollectionInstanceIO).
+                model_external_id = "cog_3d_model_<dry-run>"
 
             results.append(
                 DataItem(
                     tracking_id=data_item.tracking_id,
-                    item=self._revision_node_request(instance_space, collection_ext_id, name, model_external_id),
+                    item=NodeRequest(
+                        space=instance_space,
+                        external_id=collection_ext_id,
+                        sources=[
+                            InstanceSource(
+                                source=ContainerId(space="cdf_cdm_3d", external_id="Cognite3DRevision"),
+                                properties={
+                                    "status": "Done",
+                                    "published": True,
+                                    "type": "Image360",
+                                },
+                            ),
+                            InstanceSource(
+                                source=ContainerId(space="cdf_cdm", external_id="CogniteDescribable"),
+                                properties={"name": name},
+                            ),
+                        ],
+                    ),
                 )
             )
         return results
-
-    @staticmethod
-    def _revision_node_request(
-        space: str, external_id: str, name: str | None, model_external_id: str | None
-    ) -> NodeRequest:
-        revision_properties: dict[str, Any] = {
-            "status": "Done",
-            "published": True,
-            "type": "Image360",
-        }
-        if model_external_id is not None:
-            revision_properties["model3D"] = {"space": space, "externalId": model_external_id}
-        return NodeRequest(
-            space=space,
-            external_id=external_id,
-            sources=[
-                InstanceSource(
-                    source=ContainerId(space="cdf_cdm_3d", external_id="Cognite3DRevision"),
-                    properties=revision_properties,
-                ),
-                InstanceSource(
-                    source=ContainerId(space="cdf_cdm", external_id="CogniteDescribable"),
-                    properties={"name": name},
-                ),
-            ],
-        )
 
 
 class Station360PropertiesMapping(CustomContainerPropertiesMapping):

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -2186,9 +2186,7 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
         return results
 
     @staticmethod
-    def _revision_node_request(
-        space: str, external_id: str, name: Any, model_external_id: str | None
-    ) -> NodeRequest:
+    def _revision_node_request(space: str, external_id: str, name: Any, model_external_id: str | None) -> NodeRequest:
         revision_properties: dict[str, Any] = {
             "status": "Done",
             "published": True,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -10,7 +10,6 @@ from cognite.client.exceptions import CogniteException
 from pydantic import JsonValue
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
-from cognite_toolkit._cdf_tk.client.http_client import ToolkitAPIError
 from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, EdgeTypeId, ExternalId, InstanceId, InternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.annotation import (
     AnnotationResponse,
@@ -2133,9 +2132,6 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
     ViewToViewMapping path for Image360Collection source nodes.
     """
 
-    SOURCE_LABEL: ClassVar[str] = "Image360Collection"
-    DESTINATION_LABEL: ClassVar[str] = "Cognite360ImageCollection"
-
     def map(self, source: Sequence[DataItem[NodeOrEdgeResponse]]) -> Sequence[DataItem[NodeOrEdgeRequest]]:
         raw_items = [data_item.item for data_item in source]
         collection_nodes = [node for node in raw_items if isinstance(node, NodeResponse)]
@@ -2172,24 +2168,9 @@ class Image360CollectionMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, 
                 if self.dry_run:
                     model_external_id = "cog_3d_model_<dry-run>"
                 else:
-                    try:
-                        self.client.tool.instances.create(
-                            [self._revision_node_request(instance_space, collection_ext_id, name, None)]
-                        )
-                    except ToolkitAPIError as error:
-                        self.logger.log(
-                            [
-                                MigrationEntryV2(
-                                    id=str(node.as_id()),
-                                    label="Image360 collection migration failed",
-                                    message=f"Could not create the collection revision node: {error.message}",
-                                    severity=Severity.failure,
-                                    source=self.SOURCE_LABEL,
-                                    destination=self.DESTINATION_LABEL,
-                                )
-                            ]
-                        )
-                        continue
+                    self.client.tool.instances.create(
+                        [self._revision_node_request(instance_space, collection_ext_id, name, None)]
+                    )
                     label = str(name or node.external_id)
                     created_model = self.client.tool.three_d.models_classic.create(
                         [ThreeDModelDMSRequest(name=label, space=instance_space, type="Image360")]

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -2054,6 +2054,23 @@ class Image360FDMtoCDMMapper(FDMtoCDMMapper):
             custom_instance_mappings=custom_instance_mappings,
         )
 
+    def map(self, source: Sequence[DataItem[NodeOrEdgeResponse]]) -> Sequence[DataItem[NodeOrEdgeRequest]]:
+        self._populate_cache([data_item.item for data_item in source])
+        return super().map(source)
+
+    def _populate_cache(self, source: Sequence[NodeOrEdgeResponse]) -> None:
+        file_external_ids: list[str] = []
+        for item in source:
+            if not isinstance(item, NodeResponse):
+                continue
+            image_props = (item.properties or {}).get(LEGACY_IMAGE360_SOURCE_VIEW) or {}
+            for source_property in CUBEMAP_SOURCE_TO_DESTINATION_PROPERTY:
+                value = image_props.get(source_property)
+                if isinstance(value, str):
+                    file_external_ids.append(value)
+        if file_external_ids:
+            self.client.migration.lookup.files(external_id=file_external_ids)
+
     @staticmethod
     def missing_cubemap_face_file_external_ids(
         source_node: NodeResponse,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/image_360_mappings.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/image_360_mappings.py
@@ -182,11 +182,11 @@ def create_360_image_selectors(
                     ),
                 },
                 select={
-                    # 'image360' has no source and is only selected so that the query endpoint emits a
-                    # cursor for it. Without this, the endpoint does not return a cursor for 'image360'
-                    # and pagination silently stops after the first page. The 'image360' items themselves
-                    # are excluded from the downloaded data by 'subselections' below, since they are
-                    # migrated separately by the 'Image360' InstanceViewSelector.
+                    # 'image360' is only selected so that the query endpoint emits a cursor for it.
+                    # Without this, the endpoint does not return a cursor for 'image360' and pagination
+                    # silently stops after the first page. Its items are excluded from the downloaded
+                    # data via 'include_root=False' below, since they are migrated separately by the
+                    # 'Image360' InstanceViewSelector.
                     "image360": QuerySelect(),
                     "image360station": QuerySelect(
                         sources=[QuerySelectSource(source=LEGACY_IMAGE360_STATION_SOURCE_VIEW, properties=["*"])]
@@ -196,6 +196,7 @@ def create_360_image_selectors(
             ).model_dump_json(),
             root="image360",
             subselections=("image360station",),
+            include_root=False,
         ),
         InstanceViewSelector(
             view=SelectedView(

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/image_360_mappings.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/image_360_mappings.py
@@ -182,6 +182,12 @@ def create_360_image_selectors(
                     ),
                 },
                 select={
+                    # 'image360' has no source and is only selected so that the query endpoint emits a
+                    # cursor for it. Without this, the endpoint does not return a cursor for 'image360'
+                    # and pagination silently stops after the first page. The 'image360' items themselves
+                    # are excluded from the downloaded data by 'subselections' below, since they are
+                    # migrated separately by the 'Image360' InstanceViewSelector.
+                    "image360": QuerySelect(),
                     "image360station": QuerySelect(
                         sources=[QuerySelectSource(source=LEGACY_IMAGE360_STATION_SOURCE_VIEW, properties=["*"])]
                     ),

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Iterator, Mapping, Sequence
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.http_client import (
@@ -21,6 +21,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     EdgeId,
     NodeId,
     NodeOrEdgeRequest,
+    NodeOrEdgeResponse,
     NodeRequest,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.migration import SpaceSource
@@ -575,6 +576,25 @@ class Image360CollectionInstanceIO(InstanceIO):
     write has succeeded do we create the 3D model; the revision node is then re-uploaded with the
     model3D reference patched in.
     """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._seen_download_ids: set[str] = set()
+
+    def emit_registered_page(self, page: "Page[NodeOrEdgeResponse]") -> "Page[NodeOrEdgeResponse]":
+        """
+        The station selector uses a graph traversal query (image360 → station) so the same station node
+        can appear on multiple root pages when it is referenced by several Image360 nodes. This class
+        deduplicates such cross-page repeats during download so the logger does not produce spurious
+        "multiple registrations" warnings.
+        """
+
+        unique_items = []
+        for data_item in page.items:
+            if data_item.tracking_id not in self._seen_download_ids:
+                self._seen_download_ids.add(data_item.tracking_id)
+                unique_items.append(data_item)
+        return super().emit_registered_page(page.create_from(unique_items))
 
     def upload_items(
         self,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
@@ -617,6 +617,11 @@ class Image360CollectionInstanceIO(InstanceIO):
 
     @staticmethod
     def _has_model_3d(node: NodeRequest) -> bool:
+        """Return True if the node already has a model3D reference, or if it is not a collection node at all.
+
+        Nodes without a Cognite3DRevision source (e.g. Image360 station/image nodes) should be skipped —
+        they are not collection revision nodes and must not trigger 3D model creation.
+        """
         for source in node.sources or []:
             if (
                 isinstance(source.source, ContainerId)
@@ -624,7 +629,8 @@ class Image360CollectionInstanceIO(InstanceIO):
                 and source.properties
             ):
                 return "model3D" in source.properties
-        return False
+        # No Cognite3DRevision source — not a collection node, treat as already handled.
+        return True
 
     @staticmethod
     def _extract_name(node: NodeRequest) -> str | None:

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/migration_io.py
@@ -14,13 +14,14 @@ from cognite_toolkit._cdf_tk.client.http_client._item_classes import (
     ItemsResultList,
     ItemsSuccessResponse,
 )
-from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, InstanceId, InternalId, SpaceId
+from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, ExternalId, InstanceId, InternalId, SpaceId
 from cognite_toolkit._cdf_tk.client.request_classes.filters import AnnotationFilter
 from cognite_toolkit._cdf_tk.client.resource_classes.annotation import AnnotationResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     EdgeId,
     NodeId,
     NodeOrEdgeRequest,
+    NodeRequest,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.migration import SpaceSource
 from cognite_toolkit._cdf_tk.client.resource_classes.pending_instance_id import PendingInstanceId
@@ -30,6 +31,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.three_d import (
     AssetMappingClassicResponse,
     AssetMappingDMRequestId,
     ThreeDModelClassicResponse,
+    ThreeDModelDMSRequest,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.data_classes import ThreeDMigrationRequest
 from cognite_toolkit._cdf_tk.constants import MISSING_EXTERNAL_ID
@@ -44,6 +46,7 @@ from cognite_toolkit._cdf_tk.dataio._base import Bookmark, DataItem, Page
 from cognite_toolkit._cdf_tk.dataio.logger import Severity
 from cognite_toolkit._cdf_tk.dataio.progress import CursorBookmark, FileBookmark, NoBookmark
 from cognite_toolkit._cdf_tk.dataio.selectors import (
+    InstanceSelector,
     ThreeDModelFilteredSelector,
     ThreeDModelIdSelector,
     ThreeDSelector,
@@ -558,6 +561,94 @@ class AnnotationMigrationIO(
         selector: AssetCentricMigrationSelector | None = None,
     ) -> Page[dict[str, JsonVal]]:
         raise NotImplementedError("Serializing Annotation Migrations to JSON is not supported.")
+
+
+class Image360CollectionInstanceIO(InstanceIO):
+    """InstanceIO for uploading Cognite360ImageCollection revision nodes mapped by Image360CollectionMapper.
+
+    In addition to the regular instance upload, this creates the underlying Image360 3D model for
+    collections that do not already have one, and patches the model3D reference onto the revision
+    node once the model has been created.
+
+    To avoid ever leaving a dangling/orphaned 3D model behind, the revision node is first
+    uploaded *without* a model3D reference (as mapped by Image360CollectionMapper). Only once that
+    write has succeeded do we create the 3D model; the revision node is then re-uploaded with the
+    model3D reference patched in.
+    """
+
+    def upload_items(
+        self,
+        data_chunk: Page[NodeOrEdgeRequest],
+        http_client: HTTPClient,
+        selector: InstanceSelector | None = None,
+    ) -> ItemsResultList:
+        results = super().upload_items(data_chunk, http_client, selector)
+        success_ids = {id_ for res in results if isinstance(res, ItemsSuccessResponse) for id_ in res.ids}
+        pending_model_items = [
+            data_item
+            for data_item in data_chunk.items
+            if data_item.tracking_id in success_ids
+            and isinstance(data_item.item, NodeRequest)
+            and not self._has_model_3d(data_item.item)
+        ]
+        if not pending_model_items:
+            return results
+        patched_chunk = data_chunk.create_from(self._create_models(pending_model_items))
+        results.extend(super().upload_items(patched_chunk, http_client, selector))
+        return results
+
+    def _create_models(
+        self, pending_model_items: Sequence[DataItem[NodeOrEdgeRequest]]
+    ) -> list[DataItem[NodeOrEdgeRequest]]:
+        patched: list[DataItem[NodeOrEdgeRequest]] = []
+        for data_item in pending_model_items:
+            node = data_item.item
+            if not isinstance(node, NodeRequest):
+                continue
+            label = self._extract_name(node) or node.external_id
+            created_model = self.client.tool.three_d.models_classic.create(
+                [ThreeDModelDMSRequest(name=label, space=node.space, type="Image360")]
+            )[0]
+            model_external_id = f"cog_3d_model_{created_model.id}"
+            patched.append(
+                DataItem(tracking_id=data_item.tracking_id, item=self._with_model_3d(node, model_external_id))
+            )
+        return patched
+
+    @staticmethod
+    def _has_model_3d(node: NodeRequest) -> bool:
+        for source in node.sources or []:
+            if (
+                isinstance(source.source, ContainerId)
+                and source.source.external_id == "Cognite3DRevision"
+                and source.properties
+            ):
+                return "model3D" in source.properties
+        return False
+
+    @staticmethod
+    def _extract_name(node: NodeRequest) -> str | None:
+        for source in node.sources or []:
+            if (
+                isinstance(source.source, ContainerId)
+                and source.source.external_id == "CogniteDescribable"
+                and source.properties
+            ):
+                name = source.properties.get("name")
+                return name if isinstance(name, str) else None
+        return None
+
+    @staticmethod
+    def _with_model_3d(node: NodeRequest, model_external_id: str) -> NodeRequest:
+        updated_sources = []
+        for source in node.sources or []:
+            if isinstance(source.source, ContainerId) and source.source.external_id == "Cognite3DRevision":
+                properties = dict(source.properties or {})
+                properties["model3D"] = {"space": node.space, "externalId": model_external_id}
+                updated_sources.append(source.model_copy(update={"properties": properties}))
+            else:
+                updated_sources.append(source)
+        return node.model_copy(update={"sources": updated_sources})
 
 
 def verify_threed_dm_migration_enabled(client: ToolkitClient) -> None:

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -327,7 +327,13 @@ class InstanceIO(
                 yield Page(worker_id="main", items=items, bookmark=NoBookmark())
             return
         elif isinstance(selector, InstanceQuerySelector):
-            pages = self._instance_by_query(selector.create_query(), limit, init_cursor, endpoint=selector.endpoint)
+            pages = self._instance_by_query(
+                selector.create_query(),
+                limit,
+                init_cursor,
+                endpoint=selector.endpoint,
+                include_root=selector.include_root,
+            )
         else:
             raise NotImplementedError()
         yield from (self.emit_registered_page(page) for page in pages)
@@ -397,10 +403,12 @@ class InstanceIO(
         limit: int | None,
         init_cursor: str | None = None,
         endpoint: Literal["query", "sync"] = "query",
+        include_root: bool = True,
     ) -> Iterable[Page]:
         if init_cursor is not None:
             query.cursors = {query.root: init_cursor}
 
+        included_groups = [group for group in query.with_ if include_root or group != query.root]
         for batch in self.client.tool.instances.query_iterate(
             query,
             type_results=True,
@@ -410,8 +418,8 @@ class InstanceIO(
         ):
             wrapped_items = [
                 DataItem(tracking_id=f"{item.space}:{item.external_id}", item=item)
-                for items in batch.items.values()
-                for item in items
+                for group in included_groups
+                for item in batch.items.get(group, [])
             ]
             next_cursor = batch.root_cursor
             yield Page(

--- a/cognite_toolkit/_cdf_tk/dataio/selectors/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/selectors/_instances.py
@@ -184,6 +184,10 @@ class InstanceQuerySelector(InstanceSelector):
         root: The root node in the query. This is used for identifying the relevant spaces for
             the migration and for identifying the relevant instances in the response.
         subselections: A list of subselection names in the query. This is used for identifying
+        include_root: Whether the root group's items should be included in the downloaded data. Set this to
+            False when the root is only selected to make the query endpoint emit a cursor for it (needed for
+            pagination), and its items are not actual migration targets, e.g. because they are downloaded
+            separately by another selector.
     """
 
     type: Literal["instanceQuery"] = "instanceQuery"
@@ -191,6 +195,7 @@ class InstanceQuerySelector(InstanceSelector):
     query: str
     root: str
     subselections: tuple[str, ...]
+    include_root: bool = True
 
     def get_schema_spaces(self) -> list[str] | None:
         return None

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -10,6 +10,7 @@ from cognite.client import data_modeling as dm
 from cognite.client.data_classes.data_modeling import InstanceApply
 from pytest_regressions.data_regression import DataRegressionFixture
 
+from cognite_toolkit._cdf_tk.client.http_client import ToolkitAPIError
 from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, EdgeTypeId, InternalId, NodeId, ViewDirectId, ViewId
 from cognite_toolkit._cdf_tk.client.resource_classes.annotation import (
     AnnotationGeometry,
@@ -1224,6 +1225,17 @@ class TestFDMtoCDMMapper:
             mapper = Image360CollectionMapper(client)
             actual = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:collection1", item=collection_node)])
 
+        # The revision node must be created (without model3D) and confirmed to succeed
+        # before the 3D model is created, so a failed node upsert never leaves a dangling model.
+        client.tool.instances.create.assert_called_once()
+        precreated_node = client.tool.instances.create.call_args[0][0][0]
+        assert isinstance(precreated_node, NodeRequest)
+        precreated_model_source = next(
+            source for source in precreated_node.sources or [] if source.source.external_id == "Cognite3DRevision"
+        )
+        assert precreated_model_source.properties is not None
+        assert "model3D" not in precreated_model_source.properties
+
         client.tool.three_d.models_classic.create.assert_called_once_with(
             [ThreeDModelDMSRequest(name="My collection", space=self.SOURCE_SPACE, type="Image360")]
         )
@@ -1240,6 +1252,32 @@ class TestFDMtoCDMMapper:
             "space": self.SOURCE_SPACE,
             "externalId": model_external_id,
         }
+
+    def test_image360_collection_mapper_skips_model_creation_when_node_upsert_fails(self) -> None:
+        """If the revision node upsert fails, the 3D model must never be created, avoiding a dangling model."""
+        collection_node = NodeResponse(
+            space=self.SOURCE_SPACE,
+            external_id="collection1",
+            last_updated_time=1,
+            created_time=0,
+            version=1,
+            properties={LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW: {"label": "My collection"}},
+        )
+
+        with monkeypatch_toolkit_client() as client:
+            client.tool.instances.retrieve.return_value = []
+            client.tool.instances.create.side_effect = ToolkitAPIError("boom")
+            mapper = Image360CollectionMapper(client)
+            logger = MagicMock(spec=DataLogger)
+            mapper.logger = logger
+            actual = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:collection1", item=collection_node)])
+
+        client.tool.three_d.models_classic.create.assert_not_called()
+        assert actual == []
+        logger.log.assert_called_once()
+        entry = logger.log.call_args[0][0][0]
+        assert isinstance(entry, MigrationEntryV2)
+        assert entry.severity == Severity.failure
 
     def test_image360_collection_mapper_reuses_existing_model3d_without_creating(self) -> None:
         collection_node = NodeResponse(

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -1177,32 +1177,6 @@ class TestFDMtoCDMMapper:
             assert actual[0].item.external_id == sanitize_instance_external_id("image1", "_cdm")
             logger.log.assert_not_called()
 
-    def test_image360_mapper_skips_bare_pagination_only_nodes(self) -> None:
-        """The 'image360station' query selector includes 'image360' nodes with no properties purely
-        to drive pagination (see create_360_image_selectors). These must be silently skipped rather
-        than turned into empty placeholder nodes, since the images are migrated separately."""
-        bare_node = NodeResponse(
-            space=self.SOURCE_SPACE,
-            external_id="image1",
-            last_updated_time=1,
-            created_time=0,
-            version=1,
-            properties=None,
-        )
-
-        with monkeypatch_toolkit_client() as client:
-            client.tool.views.retrieve.return_value = []
-            connection_creator = ConnectionCreator(client, instance_id_mapper=SuffixInstanceIdMapper())
-            mapper = Image360FDMtoCDMMapper(client, connection_creator=connection_creator)
-            logger = MagicMock(spec=DataLogger)
-            mapper.logger = logger
-            mapper.prepare(MagicMock())
-
-            actual = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:image1", item=bare_node)])
-
-        assert actual == []
-        logger.log.assert_not_called()
-
     def test_image360_collection_mapper_uses_same_space_and_model3d_from_map(self) -> None:
         collection_node = NodeResponse(
             space=self.SOURCE_SPACE,

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -1176,8 +1176,6 @@ class TestFDMtoCDMMapper:
             logger.log.assert_not_called()
 
     def test_image360_collection_mapper_leaves_model3d_unset_when_no_existing_model(self) -> None:
-        """The mapper must never write to CDF; creating the 3D model and patching the model3D
-        reference is handled by Image360CollectionInstanceIO as part of the upload step."""
         collection_node = NodeResponse(
             space=self.SOURCE_SPACE,
             external_id="collection1",

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -1240,18 +1240,13 @@ class TestFDMtoCDMMapper:
 
         with monkeypatch_toolkit_client() as client:
             client.tool.instances.retrieve.return_value = []
-            client.tool.instances.create.side_effect = ToolkitAPIError("boom")
+            client.tool.instances.create.side_effect = ToolkitAPIError("Error")
             mapper = Image360CollectionMapper(client)
-            logger = MagicMock(spec=DataLogger)
-            mapper.logger = logger
-            actual = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:collection1", item=collection_node)])
+
+            with pytest.raises(ToolkitAPIError):
+                mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:collection1", item=collection_node)])
 
         client.tool.three_d.models_classic.create.assert_not_called()
-        assert actual == []
-        logger.log.assert_called_once()
-        entry = logger.log.call_args[0][0][0]
-        assert isinstance(entry, MigrationEntryV2)
-        assert entry.severity == Severity.failure
 
     def test_image360_collection_mapper_reuses_existing_model3d_without_creating(self) -> None:
         collection_node = NodeResponse(

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -10,7 +10,6 @@ from cognite.client import data_modeling as dm
 from cognite.client.data_classes.data_modeling import InstanceApply
 from pytest_regressions.data_regression import DataRegressionFixture
 
-from cognite_toolkit._cdf_tk.client.http_client import ToolkitAPIError
 from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, EdgeTypeId, InternalId, NodeId, ViewDirectId, ViewId
 from cognite_toolkit._cdf_tk.client.resource_classes.annotation import (
     AnnotationGeometry,
@@ -71,7 +70,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.three_d import (
     AssetMappingClassicResponse,
     AssetMappingDMRequestId,
     ThreeDModelClassicResponse,
-    ThreeDModelDMSRequest,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.timeseries import TimeSeriesResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.view_to_view_mapping import ViewToViewMapping
@@ -1177,7 +1175,9 @@ class TestFDMtoCDMMapper:
             assert actual[0].item.external_id == sanitize_instance_external_id("image1", "_cdm")
             logger.log.assert_not_called()
 
-    def test_image360_collection_mapper_uses_same_space_and_model3d_from_map(self) -> None:
+    def test_image360_collection_mapper_leaves_model3d_unset_when_no_existing_model(self) -> None:
+        """The mapper must never write to CDF; creating the 3D model and patching the model3D
+        reference is handled by Image360CollectionInstanceIO as part of the upload step."""
         collection_node = NodeResponse(
             space=self.SOURCE_SPACE,
             external_id="collection1",
@@ -1186,33 +1186,15 @@ class TestFDMtoCDMMapper:
             version=1,
             properties={LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW: {"label": "My collection"}},
         )
-        created_model = ThreeDModelClassicResponse(
-            id=42,
-            name="My collection",
-            created_time=0,
-        )
-        model_external_id = f"cog_3d_model_{created_model.id}"
 
         with monkeypatch_toolkit_client() as client:
             client.tool.instances.retrieve.return_value = []
-            client.tool.three_d.models_classic.create.return_value = [created_model]
             mapper = Image360CollectionMapper(client)
             actual = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:collection1", item=collection_node)])
 
-        # The revision node must be created (without model3D) and confirmed to succeed
-        # before the 3D model is created, so a failed node upsert never leaves a dangling model.
-        client.tool.instances.create.assert_called_once()
-        precreated_node = client.tool.instances.create.call_args[0][0][0]
-        assert isinstance(precreated_node, NodeRequest)
-        precreated_model_source = next(
-            source for source in precreated_node.sources or [] if source.source.external_id == "Cognite3DRevision"
-        )
-        assert precreated_model_source.properties is not None
-        assert "model3D" not in precreated_model_source.properties
+        client.tool.instances.create.assert_not_called()
+        client.tool.three_d.models_classic.create.assert_not_called()
 
-        client.tool.three_d.models_classic.create.assert_called_once_with(
-            [ThreeDModelDMSRequest(name="My collection", space=self.SOURCE_SPACE, type="Image360")]
-        )
         assert len(actual) == 1
         collection_request = actual[0].item
         assert isinstance(collection_request, NodeRequest)
@@ -1222,13 +1204,9 @@ class TestFDMtoCDMMapper:
             source for source in collection_request.sources or [] if source.source.external_id == "Cognite3DRevision"
         )
         assert model_source.properties is not None
-        assert model_source.properties["model3D"] == {
-            "space": self.SOURCE_SPACE,
-            "externalId": model_external_id,
-        }
+        assert "model3D" not in model_source.properties
 
-    def test_image360_collection_mapper_skips_model_creation_when_node_upsert_fails(self) -> None:
-        """If the revision node upsert fails, the 3D model must never be created, avoiding a dangling model."""
+    def test_image360_collection_mapper_uses_placeholder_model3d_on_dry_run(self) -> None:
         collection_node = NodeResponse(
             space=self.SOURCE_SPACE,
             external_id="collection1",
@@ -1240,13 +1218,22 @@ class TestFDMtoCDMMapper:
 
         with monkeypatch_toolkit_client() as client:
             client.tool.instances.retrieve.return_value = []
-            client.tool.instances.create.side_effect = ToolkitAPIError("Error")
-            mapper = Image360CollectionMapper(client)
+            mapper = Image360CollectionMapper(client, dry_run=True)
+            actual = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:collection1", item=collection_node)])
 
-            with pytest.raises(ToolkitAPIError):
-                mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:collection1", item=collection_node)])
-
+        client.tool.instances.create.assert_not_called()
         client.tool.three_d.models_classic.create.assert_not_called()
+
+        collection_request = actual[0].item
+        assert isinstance(collection_request, NodeRequest)
+        model_source = next(
+            source for source in collection_request.sources or [] if source.source.external_id == "Cognite3DRevision"
+        )
+        assert model_source.properties is not None
+        assert model_source.properties["model3D"] == {
+            "space": self.SOURCE_SPACE,
+            "externalId": "cog_3d_model_<dry-run>",
+        }
 
     def test_image360_collection_mapper_reuses_existing_model3d_without_creating(self) -> None:
         collection_node = NodeResponse(

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -1206,35 +1206,6 @@ class TestFDMtoCDMMapper:
         assert model_source.properties is not None
         assert "model3D" not in model_source.properties
 
-    def test_image360_collection_mapper_uses_placeholder_model3d_on_dry_run(self) -> None:
-        collection_node = NodeResponse(
-            space=self.SOURCE_SPACE,
-            external_id="collection1",
-            last_updated_time=1,
-            created_time=0,
-            version=1,
-            properties={LEGACY_IMAGE360_COLLECTION_SOURCE_VIEW: {"label": "My collection"}},
-        )
-
-        with monkeypatch_toolkit_client() as client:
-            client.tool.instances.retrieve.return_value = []
-            mapper = Image360CollectionMapper(client, dry_run=True)
-            actual = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:collection1", item=collection_node)])
-
-        client.tool.instances.create.assert_not_called()
-        client.tool.three_d.models_classic.create.assert_not_called()
-
-        collection_request = actual[0].item
-        assert isinstance(collection_request, NodeRequest)
-        model_source = next(
-            source for source in collection_request.sources or [] if source.source.external_id == "Cognite3DRevision"
-        )
-        assert model_source.properties is not None
-        assert model_source.properties["model3D"] == {
-            "space": self.SOURCE_SPACE,
-            "externalId": "cog_3d_model_<dry-run>",
-        }
-
     def test_image360_collection_mapper_reuses_existing_model3d_without_creating(self) -> None:
         collection_node = NodeResponse(
             space=self.SOURCE_SPACE,

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -1176,6 +1176,32 @@ class TestFDMtoCDMMapper:
             assert actual[0].item.external_id == sanitize_instance_external_id("image1", "_cdm")
             logger.log.assert_not_called()
 
+    def test_image360_mapper_skips_bare_pagination_only_nodes(self) -> None:
+        """The 'image360station' query selector includes 'image360' nodes with no properties purely
+        to drive pagination (see create_360_image_selectors). These must be silently skipped rather
+        than turned into empty placeholder nodes, since the images are migrated separately."""
+        bare_node = NodeResponse(
+            space=self.SOURCE_SPACE,
+            external_id="image1",
+            last_updated_time=1,
+            created_time=0,
+            version=1,
+            properties=None,
+        )
+
+        with monkeypatch_toolkit_client() as client:
+            client.tool.views.retrieve.return_value = []
+            connection_creator = ConnectionCreator(client, instance_id_mapper=SuffixInstanceIdMapper())
+            mapper = Image360FDMtoCDMMapper(client, connection_creator=connection_creator)
+            logger = MagicMock(spec=DataLogger)
+            mapper.logger = logger
+            mapper.prepare(MagicMock())
+
+            actual = mapper.map([DataItem(tracking_id=f"{self.SOURCE_SPACE}:image1", item=bare_node)])
+
+        assert actual == []
+        logger.log.assert_not_called()
+
     def test_image360_collection_mapper_uses_same_space_and_model3d_from_map(self) -> None:
         collection_node = NodeResponse(
             space=self.SOURCE_SPACE,
@@ -1409,6 +1435,9 @@ def test_create_360_image_selectors_returns_collection_station_and_image_steps()
     assert isinstance(station_selector, InstanceQuerySelector)
     assert station_selector.root == "image360"
     assert station_selector.subselections == ("image360station",)
+    # 'image360' (root) must be in select, otherwise the query endpoint never emits a cursor for it
+    # and pagination silently stops after the first page.
+    assert set(station_selector.create_query().select) == {"image360", "image360station"}
     assert isinstance(image_selector, InstanceViewSelector)
     assert image_selector.view.external_id == "Image360"
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_migration_io.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_migration_io.py
@@ -8,15 +8,30 @@ from httpx import Response
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
 from cognite_toolkit._cdf_tk.client.http_client import HTTPClient
+from cognite_toolkit._cdf_tk.client.http_client._data_classes import ErrorDetails
+from cognite_toolkit._cdf_tk.client.http_client._item_classes import (
+    ItemsFailedResponse,
+    ItemsResultList,
+    ItemsSuccessResponse,
+)
+from cognite_toolkit._cdf_tk.client.identifiers import ContainerId
 from cognite_toolkit._cdf_tk.client.resource_classes.annotation import AnnotationResponse
-from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import SpaceResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
+    InstanceSource,
+    NodeOrEdgeRequest,
+    NodeRequest,
+    SpaceResponse,
+)
+from cognite_toolkit._cdf_tk.client.resource_classes.three_d import ThreeDModelClassicResponse, ThreeDModelDMSRequest
+from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.commands._migrate.migration_io import (
     AnnotationMigrationIO,
     AssetCentricMigrationIO,
+    Image360CollectionInstanceIO,
     ThreeDAssetMappingMigrationIO,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.selectors import MigrationCSVFileSelector
-from cognite_toolkit._cdf_tk.dataio import AssetDataIO, Page
+from cognite_toolkit._cdf_tk.dataio import AssetDataIO, DataItem, Page
 from cognite_toolkit._cdf_tk.dataio.selectors import ThreeDModelIdSelector
 
 
@@ -263,3 +278,103 @@ class TestThreeDAssetMappingMigrationIO:
 
         with pytest.raises(NotImplementedError):
             io.data_to_json_chunk(MagicMock())
+
+
+class TestImage360CollectionInstanceIO:
+    @staticmethod
+    def _revision_node(model3d: dict | None = None) -> NodeRequest:
+        revision_properties: dict = {"status": "Done", "published": True, "type": "Image360"}
+        if model3d is not None:
+            revision_properties["model3D"] = model3d
+        return NodeRequest(
+            space="mySpace",
+            external_id="collection1_cdm",
+            sources=[
+                InstanceSource(
+                    source=ContainerId(space="cdf_cdm_3d", external_id="Cognite3DRevision"),
+                    properties=revision_properties,
+                ),
+                InstanceSource(
+                    source=ContainerId(space="cdf_cdm", external_id="CogniteDescribable"),
+                    properties={"name": "My collection"},
+                ),
+            ],
+        )
+
+    def test_creates_model_and_patches_reference_after_successful_upload(self) -> None:
+        page = Page[NodeOrEdgeRequest](
+            worker_id="main", items=[DataItem(tracking_id="mySpace:collection1", item=self._revision_node())]
+        )
+        created_model = ThreeDModelClassicResponse(id=42, name="My collection", created_time=0)
+
+        with monkeypatch_toolkit_client() as client:
+            client.tool.three_d.models_classic.create.return_value = [created_model]
+            io = Image360CollectionInstanceIO(client)
+            http_client = MagicMock()
+            http_client.config.create_api_url.return_value = "https://example.com/models/instances"
+            http_client.request_items_retries.side_effect = [
+                ItemsResultList(
+                    [ItemsSuccessResponse(ids=["mySpace:collection1"], status_code=200, body="{}", content=b"{}")]
+                ),
+                ItemsResultList(
+                    [ItemsSuccessResponse(ids=["mySpace:collection1"], status_code=200, body="{}", content=b"{}")]
+                ),
+            ]
+            results = io.upload_items(page, http_client)
+
+        assert len(results) == 2
+        assert http_client.request_items_retries.call_count == 2
+        client.tool.three_d.models_classic.create.assert_called_once_with(
+            [ThreeDModelDMSRequest(name="My collection", space="mySpace", type="Image360")]
+        )
+        patched_node = http_client.request_items_retries.call_args_list[1].kwargs["message"].items[0].item
+        model_source = next(s for s in patched_node.sources if s.source.external_id == "Cognite3DRevision")
+        assert model_source.properties["model3D"] == {"space": "mySpace", "externalId": "cog_3d_model_42"}
+
+    def test_skips_model_creation_when_initial_upload_fails(self) -> None:
+        """If the revision node upsert fails, the 3D model must never be created, avoiding a dangling model."""
+        page = Page[NodeOrEdgeRequest](
+            worker_id="main", items=[DataItem(tracking_id="mySpace:collection1", item=self._revision_node())]
+        )
+
+        with monkeypatch_toolkit_client() as client:
+            io = Image360CollectionInstanceIO(client)
+            http_client = MagicMock()
+            http_client.config.create_api_url.return_value = "https://example.com/models/instances"
+            http_client.request_items_retries.return_value = ItemsResultList(
+                [
+                    ItemsFailedResponse(
+                        ids=["mySpace:collection1"],
+                        status_code=400,
+                        body="{}",
+                        error=ErrorDetails(code=400, message="Error"),
+                    )
+                ]
+            )
+            results = io.upload_items(page, http_client)
+
+        assert http_client.request_items_retries.call_count == 1
+        client.tool.three_d.models_classic.create.assert_not_called()
+        assert len(results) == 1
+
+    def test_reuses_existing_model3d_without_creating(self) -> None:
+        """When the revision node already has a model3D reference (reused from a previous migration),
+        no new model should be created and the node is only uploaded once."""
+        existing_model3d = {"space": "mySpace", "externalId": "cog_3d_model_99"}
+        page = Page[NodeOrEdgeRequest](
+            worker_id="main",
+            items=[DataItem(tracking_id="mySpace:collection1", item=self._revision_node(existing_model3d))],
+        )
+
+        with monkeypatch_toolkit_client() as client:
+            io = Image360CollectionInstanceIO(client)
+            http_client = MagicMock()
+            http_client.config.create_api_url.return_value = "https://example.com/models/instances"
+            http_client.request_items_retries.return_value = ItemsResultList(
+                [ItemsSuccessResponse(ids=["mySpace:collection1"], status_code=200, body="{}", content=b"{}")]
+            )
+            results = io.upload_items(page, http_client)
+
+        assert http_client.request_items_retries.call_count == 1
+        client.tool.three_d.models_classic.create.assert_not_called()
+        assert len(results) == 1

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_instance_io.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_instance_io.py
@@ -552,8 +552,8 @@ class TestInstanceIO:
         pages = list(InstanceIO(client).stream_data(station_selector))
 
         assert len(pages) == 2
-        assert {di.tracking_id for di in pages[0].items} == {"img_space:image1", "img_space:station1"}
-        assert {di.tracking_id for di in pages[1].items} == {"img_space:image2", "img_space:station2"}
+        assert {di.tracking_id for di in pages[0].items} == {"img_space:station1"}
+        assert {di.tracking_id for di in pages[1].items} == {"img_space:station2"}
 
     @pytest.mark.parametrize(
         "item_json,expected_properties",

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_instance_io.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_instance_io.py
@@ -498,9 +498,8 @@ class TestInstanceIO:
         self, respx_mock: respx.MockRouter, toolkit_config: ToolkitClientConfig
     ) -> None:
         """Root ('image360') must be selected so the query endpoint emits a cursor for it, allowing
-        pagination to continue past the first page. Its own (property-less) items still flow through
-        the download; it is the mapper's responsibility to discard them, since they are migrated
-        separately by the 'Image360' InstanceViewSelector."""
+        pagination to continue past the first page. They are migrated separately by the 'Image360'
+        InstanceViewSelector however so we don't want any output for them."""
         client = ToolkitClient(config=toolkit_config)
         station_selector = create_360_image_selectors([NodeId(space="img_space", external_id="col1")])[1]
         assert isinstance(station_selector, InstanceQuerySelector)

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_instance_io.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_instance_io.py
@@ -494,41 +494,66 @@ class TestInstanceIO:
         assert second_edge_ids == set()
 
     @pytest.mark.usefixtures("disable_gzip")
-    def test_stream_data_query_root_not_in_select(
+    def test_stream_data_query_root_selected_enables_pagination(
         self, respx_mock: respx.MockRouter, toolkit_config: ToolkitClientConfig
     ) -> None:
-        """Root drives pagination but may be omitted from items when not selected."""
+        """Root ('image360') must be selected so the query endpoint emits a cursor for it, allowing
+        pagination to continue past the first page. Its own (property-less) items still flow through
+        the download; it is the mapper's responsibility to discard them, since they are migrated
+        separately by the 'Image360' InstanceViewSelector."""
         client = ToolkitClient(config=toolkit_config)
         station_selector = create_360_image_selectors([NodeId(space="img_space", external_id="col1")])[1]
         assert isinstance(station_selector, InstanceQuerySelector)
 
+        def _bare_node(ext_id: str) -> dict:
+            return {
+                "instanceType": "node",
+                "space": "img_space",
+                "externalId": ext_id,
+                "version": 1,
+                "createdTime": 0,
+                "lastUpdatedTime": 0,
+            }
+
+        def _station(ext_id: str, label: str) -> dict:
+            return {
+                **_bare_node(ext_id),
+                "properties": {"cdf_360_image_schema": {"Station360/v1": {"label": label}}},
+            }
+
         query_url = toolkit_config.create_api_url("/models/instances/query")
-        respx_mock.post(query_url).respond(
-            status_code=200,
-            json={
-                "items": {
-                    "image360station": [
-                        {
-                            "instanceType": "node",
-                            "space": "img_space",
-                            "externalId": "station1",
-                            "version": 1,
-                            "createdTime": 0,
-                            "lastUpdatedTime": 0,
-                            "properties": {"cdf_360_image_schema": {"Station360/v1": {"label": "Station A"}}},
-                        }
-                    ]
-                },
-                "nextCursor": {"image360": None},
-            },
+        respx_mock.post(query_url).mock(
+            side_effect=[
+                # Call 1: image360 has a cursor, so pagination continues even though image360station doesn't.
+                httpx.Response(
+                    status_code=200,
+                    json={
+                        "items": {
+                            "image360": [_bare_node("image1")],
+                            "image360station": [_station("station1", "Station A")],
+                        },
+                        "nextCursor": {"image360": "image360_cursor_1"},
+                    },
+                ),
+                # Call 2: no more cursors → done.
+                httpx.Response(
+                    status_code=200,
+                    json={
+                        "items": {
+                            "image360": [_bare_node("image2")],
+                            "image360station": [_station("station2", "Station B")],
+                        },
+                        "nextCursor": {},
+                    },
+                ),
+            ]
         )
 
         pages = list(InstanceIO(client).stream_data(station_selector))
 
-        assert len(pages) == 1
-        assert len(pages[0].items) == 1
-        assert pages[0].items[0].tracking_id == "img_space:station1"
-        assert pages[0].items[0].item.external_id == "station1"
+        assert len(pages) == 2
+        assert {di.tracking_id for di in pages[0].items} == {"img_space:image1", "img_space:station1"}
+        assert {di.tracking_id for di in pages[1].items} == {"img_space:image2", "img_space:station2"}
 
     @pytest.mark.parametrize(
         "item_json,expected_properties",


### PR DESCRIPTION
# Description

In `cdf migrate 360-images`, the root ("image360") group of the `InstanceQuerySelector` used for 360ImageStations was only ever meant to drive query-endpoint pagination but lacked a cursor, causing downloads to silently stop after the first page. Once fixed, the root group's property-less stub items were also being flattened into the downloaded dataset alongside the real `image360station` subselection items, causing "Toolkit bug - multiple registrations" warnings when a station identity collided with a root stub. Added an explicit `include_root` flag on `InstanceQuerySelector` so callers can opt the root group out of the downloaded data when it is only there for pagination.

Also extracted 3D model creation out of `Image360CollectionMapper` into a new `Image360CollectionInstanceIO` class (replacing the plain `InstanceIO` for the 360-image-nodes migration step). The mapper now emits revision nodes without a `model3D` reference; `Image360CollectionInstanceIO.upload_items` first uploads the node, and only if that succeeds does it create the underlying 3D model and re-upload the node with the `model3D` reference patched in. This ordering ensures a failed node upsert can no longer leave behind a dangling, orphaned 3D model.

This by effect fixed a latent bug in `Image360CollectionMapper` not honoring `--dry-run`: it never received the `dry_run` flag from the outer mapper because these typically do not perform writes, however with this mapper specifically it has a side-effect of creating a 3D model, meaning a dry run could still perform real 3D model/revision-node writes. 

Finally, `Image360FDMtoCDMMapper` now overrides `map()` to collect all cubemap face file external IDs from the page and batch-warm the `migration.lookup.files` cache before per-node mapping begins, following the same `_populate_cache` pattern used by `ThreeDMapper`, `ThreeDAssetMapper`, and `ChartMapper`. The old approach was way to slow to run at scale.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- [alpha] Fix `cdf migrate 360-images` failing to migrate more than 1000 360ImageStations
- [alpha] Fixes an issue with `cdf migrate 360-images --dry-run` performing actual 3D model writes instead of simulating them.

### Improved

- [alpha] Improve download speed for `cdf migrate 360-images`