### PR TITLE
feat(infield): support requiredProperties on observation view mapping

### DIFF
--- a/cognite_toolkit/_cdf_tk/rules/_infield.py
+++ b/cognite_toolkit/_cdf_tk/rules/_infield.py
@@ -77,17 +77,29 @@ class InFieldCDMViewPropertiesRuleSet(ToolkitGlobalRuleSet):
     def _collect_card_view_refs(resource: BuiltResource) -> list[_CardViewRef]:
         raw_data = read_yaml_file(resource.build_path, expected_output="dict")
         config = InFieldCDMLocationConfigYAML.model_validate(raw_data)
-        if not config.data_exploration_config:
-            return []
 
         refs: list[_CardViewRef] = []
-        for attr, card_key in INFIELD_CDM_CARD_VIEW_ATTR_TO_JSON_KEY.items():
-            mapping: ViewReference | None = getattr(config.data_exploration_config, attr, None)
-            if mapping is None:
-                continue
-            view_id = mapping.as_id()
-            required = _REQUIRED_PROPERTIES[card_key]
-            refs.append((resource, card_key, view_id, required))
+        if config.data_exploration_config:
+            for attr, card_key in INFIELD_CDM_CARD_VIEW_ATTR_TO_JSON_KEY.items():
+                mapping: ViewReference | None = getattr(config.data_exploration_config, attr, None)
+                if mapping is None:
+                    continue
+                view_id = mapping.as_id()
+                required = _REQUIRED_PROPERTIES[card_key]
+                refs.append((resource, card_key, view_id, required))
+
+        if config.view_mappings and config.view_mappings.observation:
+            for observation_config in config.view_mappings.observation:
+                if not observation_config.required_properties:
+                    continue
+                refs.append(
+                    (
+                        resource,
+                        "observation",
+                        observation_config.view.as_id(),
+                        frozenset(observation_config.required_properties),
+                    )
+                )
         return refs
 
     def _check_view(

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
@@ -73,6 +73,7 @@ class ObservationViewConfig(BaseModelResource):
     """Observation view configuration."""
 
     view: ViewReference
+    required_properties: list[str] | None = None
     write_back: ObservationViewWriteBack | None = None
 
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
@@ -366,3 +366,27 @@ class TestInfieldCDMLocationConfigYAML:
         loaded = InFieldCDMLocationConfigYAML.model_validate(data)
         dumped = loaded.model_dump(exclude_unset=True, by_alias=True)
         assert dumped == data
+
+    def test_load_valid_observation_view_config_with_required_properties(self) -> None:
+        data = {
+            "externalId": "my_config",
+            "space": "my_space",
+            "viewMappings": {
+                "observation": [
+                    {
+                        "view": {
+                            "space": "my_space",
+                            "version": "v1",
+                            "externalId": "ObsView",
+                        },
+                        "requiredProperties": ["assets", "files"],
+                        "writeBack": {
+                            "notificationsEndpointExternalId": "notif-endpoint",
+                        },
+                    },
+                ],
+            },
+        }
+        loaded = InFieldCDMLocationConfigYAML.model_validate(data)
+        dumped = loaded.model_dump(exclude_unset=True, by_alias=True)
+        assert dumped == data

--- a/tests/test_unit/test_cdf_tk/test_rules/test_infield.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_infield.py
@@ -232,6 +232,116 @@ class TestInFieldCDMViewPropertiesRuleSet:
         call_view_ids = mock_client.tool.views.retrieve.call_args[0][0]
         assert set(call_view_ids) == {activities_id, notifications_id}
 
+    def test_observation_view_with_required_properties_present(
+        self,
+        tmp_path: Path,
+        mock_view: Callable[[ViewId, frozenset[str]], MagicMock],
+        write_config_yaml: Callable[[Path, dict], None],
+        create_built_resource: Callable[[Path, Path], BuiltResource],
+        create_module: Callable[[Path, list[BuiltResource]], BuiltModule],
+    ) -> None:
+        yaml_file = tmp_path / "cdf_applications" / "my_location.InFieldCDMLocationConfig.yaml"
+        write_config_yaml(
+            yaml_file,
+            {
+                "space": "sp_instance",
+                "externalId": "my_location_config",
+                "viewMappings": {
+                    "observation": [
+                        {
+                            "view": {
+                                "space": "customer_idm",
+                                "version": "v2",
+                                "externalId": "ObservationView",
+                            },
+                            "requiredProperties": ["assets", "files"],
+                        },
+                    ],
+                },
+            },
+        )
+        resource = create_built_resource(yaml_file, yaml_file)
+        module = create_module(tmp_path, [resource])
+        observation_id = ViewId(space="customer_idm", external_id="ObservationView", version="v2")
+        mock_client = MagicMock()
+        mock_client.tool.views.retrieve.return_value = [
+            mock_view(observation_id, frozenset({"assets", "files"}))
+        ]
+        rule = InFieldCDMViewPropertiesRuleSet(modules=[module], client=mock_client)
+        assert list(rule.validate()) == []
+
+    def test_observation_view_missing_required_properties(
+        self,
+        tmp_path: Path,
+        mock_view: Callable[[ViewId, frozenset[str]], MagicMock],
+        write_config_yaml: Callable[[Path, dict], None],
+        create_built_resource: Callable[[Path, Path], BuiltResource],
+        create_module: Callable[[Path, list[BuiltResource]], BuiltModule],
+    ) -> None:
+        yaml_file = tmp_path / "cdf_applications" / "my_location.InFieldCDMLocationConfig.yaml"
+        write_config_yaml(
+            yaml_file,
+            {
+                "space": "sp_instance",
+                "externalId": "my_location_config",
+                "viewMappings": {
+                    "observation": [
+                        {
+                            "view": {
+                                "space": "customer_idm",
+                                "version": "v2",
+                                "externalId": "ObservationView",
+                            },
+                            "requiredProperties": ["assets", "files"],
+                        },
+                    ],
+                },
+            },
+        )
+        resource = create_built_resource(yaml_file, yaml_file)
+        module = create_module(tmp_path, [resource])
+        observation_id = ViewId(space="customer_idm", external_id="ObservationView", version="v2")
+        mock_client = MagicMock()
+        mock_client.tool.views.retrieve.return_value = [mock_view(observation_id, frozenset({"assets"}))]
+        rule = InFieldCDMViewPropertiesRuleSet(modules=[module], client=mock_client)
+        errors = list(rule.validate())
+        assert len(errors) == 1
+        assert errors[0].code == f"{InFieldCDMViewPropertiesRuleSet.CODE_PREFIX}-VIEW-MISSING-PROPERTIES"
+        assert "files" in errors[0].message
+
+    def test_observation_view_without_required_properties_is_not_checked(
+        self,
+        tmp_path: Path,
+        write_config_yaml: Callable[[Path, dict], None],
+        create_built_resource: Callable[[Path, Path], BuiltResource],
+        create_module: Callable[[Path, list[BuiltResource]], BuiltModule],
+    ) -> None:
+        yaml_file = tmp_path / "cdf_applications" / "my_location.InFieldCDMLocationConfig.yaml"
+        write_config_yaml(
+            yaml_file,
+            {
+                "space": "sp_instance",
+                "externalId": "my_location_config",
+                "viewMappings": {
+                    "observation": [
+                        {
+                            "view": {
+                                "space": "customer_idm",
+                                "version": "v2",
+                                "externalId": "ObservationView",
+                            },
+                        },
+                    ],
+                },
+            },
+        )
+        resource = create_built_resource(yaml_file, yaml_file)
+        module = create_module(tmp_path, [resource])
+        mock_client = MagicMock()
+        rule = InFieldCDMViewPropertiesRuleSet(modules=[module], client=mock_client)
+        assert list(rule.validate()) == []
+        mock_client.tool.views.retrieve.assert_not_called()
+
     def test_retrieve_batch_failure_propagates(
         self,
         tmp_path: Path,

--- a/tests/test_unit/test_cdf_tk/test_rules/test_infield.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_infield.py
@@ -264,9 +264,7 @@ class TestInFieldCDMViewPropertiesRuleSet:
         module = create_module(tmp_path, [resource])
         observation_id = ViewId(space="customer_idm", external_id="ObservationView", version="v2")
         mock_client = MagicMock()
-        mock_client.tool.views.retrieve.return_value = [
-            mock_view(observation_id, frozenset({"assets", "files"}))
-        ]
+        mock_client.tool.views.retrieve.return_value = [mock_view(observation_id, frozenset({"assets", "files"}))]
         rule = InFieldCDMViewPropertiesRuleSet(modules=[module], client=mock_client)
         assert list(rule.validate()) == []
 


### PR DESCRIPTION
# Description

InField now lets customers mark arbitrary properties (e.g. direct-relation fields like `assets`/`files`) as required on a custom observation view, via `viewMappings.observation[].requiredProperties`. This adds `requiredProperties` (a plain list of property names, not restricted to any fixed set) as a sibling of `view`/`writeBack` on the observation view mapping, and extends the existing `InFieldCDMViewPropertiesRuleSet` (already used for card views) to validate at build time that the referenced observation view actually has each listed property.

Follows on from #3090, which introduced the `view`/`writeBack` structure for `viewMappings.observation`.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- When deploying `InFieldCDMLocationConfig` resources: `viewMappings.observation` entries now support an optional `requiredProperties` list. Toolkit will now validate at build time that the referenced observation view has each listed property, surfacing a `INFIELD-CDM-VIEW-MISSING-PROPERTIES` error if not.