### PR TITLE
Update InField CDM location config space defaults during migration and emit required spaces

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -1527,8 +1527,9 @@ class MigrateApp(typer.Typer):
             )
         )
         cmd.console(
-            "[bold]IMPORTANT:[/] The next steps needs to be performed manually. Place the generated [bold]cdf_applications/[/] "
-            "(and optionally, the [bold]locations/[/] folder) inside a Toolkit module, "
+            f"[bold]IMPORTANT:[/] The next steps needs to be performed manually. Place the generated folders "
+            f"[bold]{output_dir / 'data_modeling'}[/], [bold]{output_dir / 'cdf_applications'}[/] "
+            f"(and optionally [bold]{output_dir / 'locations'}[/]) inside a Toolkit module, "
             "then deploy to CDF with [bold]cdf deploy[/] before running [bold]cdf migrate infield-data[/].",
             prefix=HINT_LEAD_TEXT,
         )

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -48,7 +48,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
 from cognite_toolkit._cdf_tk.resource_ios import ResourceWorker
 from cognite_toolkit._cdf_tk.utils import humanize_collection, safe_write, sanitize_filename
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
-from cognite_toolkit._cdf_tk.utils.file import yaml_safe_dump
+from cognite_toolkit._cdf_tk.utils.file import add_top_level_comment_in_yaml, yaml_safe_dump
 from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter, Uncompressed
 from cognite_toolkit._cdf_tk.utils.producer_worker import ProducerWorkerExecutor
 
@@ -522,7 +522,10 @@ class MigrationCommand(ToolkitCommand):
                         output_dir / crud_cls.folder_name / f"{sanitize_filename(item.filestem)}.{crud_cls.kind}.yaml"
                     )
                     filepath.parent.mkdir(parents=True, exist_ok=True)
-                    safe_write(filepath, yaml_safe_dump(item.config_data))
+                    content = yaml_safe_dump(item.config_data)
+                    for key, comment in (item.field_comments or {}).items():
+                        content = add_top_level_comment_in_yaml(content, key, comment)
+                    safe_write(filepath, content)
             self.console(
                 f"{len(to_create.resources)} {crud_cls.kind} resource configurations written to {(output_dir / crud_cls.folder_name).as_posix()!r}"
             )

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -62,6 +62,7 @@ class CreatedResource(Generic[T_RequestResource]):
     resource: T_RequestResource
     config_data: dict[str, Any] | None = None
     filestem: str | None = None
+    field_comments: dict[str, str] | None = None
 
 
 @dataclass
@@ -284,6 +285,13 @@ class SourceSystemCreator(MigrationCreator):
             raise ValueError("This should not happen.")
 
 
+LOCATION_CONFIG_SPACE_COMMENT = (
+    "This space controls who can see this location in InField (dataModelInstancesAcl READ). "
+    "Defaulted to the appInstanceSpace; set a dedicated space here if you need different access "
+    "control for location visibility than for write access."
+)
+
+
 class InfieldV2ConfigCreator(MigrationCreator):
     TARGET_SPACE = "APM_Config"
 
@@ -322,6 +330,7 @@ class InfieldV2ConfigCreator(MigrationCreator):
                     resource=loc_config,
                     config_data=loc_config.dump(context="toolkit", exclude={"instance_type"}),
                     filestem=f"{apm_config.external_id}_location_{loc_config.name}",
+                    field_comments={"space": LOCATION_CONFIG_SPACE_COMMENT},
                 )
                 for loc_config in location_configs
             )
@@ -463,15 +472,25 @@ class InfieldV2ConfigCreator(MigrationCreator):
         if config.checklist_admins:
             access_management["checklistAdmins"] = config.checklist_admins  # type: ignore[assignment]
 
-        data_filters: dict[str, JsonValue] = {}
-        for key in ["assets", "files", "timeseries", "maintenanceOrders", "operations", "notifications"]:
-            # Todo Assets does not support multiple instanceSpaces.
-            #    add to Validation in cdf build.
-            data_filters[key] = {"instanceSpaces": [config.source_data_instance_space]}
+        app_instance_space = f"{config.app_data_instance_space}_cdm"
+        # The source data migration (not yet implemented) will also suffix its destination space with
+        # "_cdm", so we anticipate that space here rather than the raw (classic) source_data_instance_space.
+        source_instance_space = f"{config.source_data_instance_space}_cdm"
+        # dataFilters.assets.instanceSpaces[0] must match dataStorage.rootLocation.space, otherwise the
+        # asset hierarchy query (which filters on both) silently returns nothing.
+        data_filters: dict[str, JsonValue] = {
+            "assets": {"instanceSpaces": [root_node.space]},
+        }
+        for key in ["timeseries", "files"]:
+            # appInstanceSpace must come first so that by-externalId lookups (which use the first
+            # instance space as the view's default space) resolve to app-written data correctly.
+            data_filters[key] = {"instanceSpaces": [app_instance_space]}
+        for key in ["maintenanceOrders", "operations", "notifications"]:
+            data_filters[key] = {"instanceSpaces": [source_instance_space]}
 
         data_storage = DataStorage(
             root_location=root_node.dump(include_instance_type=False),
-            app_instance_space=f"{config.app_data_instance_space}_cdm",
+            app_instance_space=app_instance_space,
         )
         view_mappings: dict[str, JsonValue] = {}
         for key, default_view in [
@@ -484,8 +503,11 @@ class InfieldV2ConfigCreator(MigrationCreator):
             view_mappings[key] = default_view.dump()
 
         name = config.display_name or config.asset_external_id or external_id
+        # The node's own space determines who can see this location in InField (dataModelInstancesAcl READ),
+        # independent of appInstanceSpace, which only governs write access. We default it to the
+        # appInstanceSpace, see LOCATION_CONFIG_SPACE_COMMENT for the caveat surfaced to the user.
         return InFieldCDMLocationConfigRequest(
-            space=config.source_data_instance_space or "<Please fill in the source data instance space>",
+            space=app_instance_space,
             external_id=external_id,
             name=name,
             description="Migrated InField Location Configuration",

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -288,8 +288,8 @@ class SourceSystemCreator(MigrationCreator):
 
 LOCATION_CONFIG_SPACE_COMMENT = (
     "This space controls who can see this location in InField (dataModelInstancesAcl READ). "
-    "Defaulted to the appInstanceSpace; set a dedicated space here if you need different access "
-    "control for location visibility than for write access."
+    "Defaulted to a dedicated config space (<appInstanceSpaceBase>_cfg). This space controls "
+    "read access to this Infield location within the Infield app, as well as write access to the Location config itself."
 )
 
 
@@ -423,10 +423,19 @@ class InfieldV2ConfigCreator(MigrationCreator):
                     spaces.append(
                         SpaceRequest(
                             space=f"{space_name}_cdm",
-                            name=f"{origin.name}_cdm" if origin and origin.name else None,
+                            name=f"{origin.name} (CDM)" if origin and origin.name else None,
                             description=f"{origin.description} (migrated)" if origin and origin.description else None,
                         )
                     )
+            if root_location_config.app_data_instance_space is not None:
+                origin = origin_spaces.get(root_location_config.app_data_instance_space)
+                spaces.append(
+                    SpaceRequest(
+                        space=f"{root_location_config.app_data_instance_space}_cfg",
+                        name=f"{origin.name} (config)" if origin and origin.name else None,
+                        description=f"{origin.description} (config)" if origin and origin.description else None,
+                    )
+                )
             location_filters.append(self._create_location_filter(root_location_config))
             location_configs.append(location_config)
 
@@ -504,6 +513,20 @@ class InfieldV2ConfigCreator(MigrationCreator):
             feature_toggles = config.feature_toggles.dump()
             if config.feature_toggles.observations:
                 feature_toggles["observations"] = config.feature_toggles.observations.is_enabled
+        else:
+            # featureToggles was not set in the old location; default all toggles to True
+            feature_toggles = {
+                "threeD": True,
+                "trends": True,
+                "documents": True,
+                "workorders": True,
+                "notifications": True,
+                "media": True,
+                "templateChecklistFlow": True,
+                "workorderChecklistFlow": True,
+                "observations": True,
+                "copilot": True,
+            }
 
         access_management: dict[str, JsonValue] = {}
         if config.template_admins:
@@ -515,6 +538,7 @@ class InfieldV2ConfigCreator(MigrationCreator):
 
         app_instance_space = f"{config.app_data_instance_space}_cdm"
         source_instance_space = f"{config.source_data_instance_space}_cdm"
+        cfg_space = f"{config.app_data_instance_space}_cfg"
         # dataFilters.assets.instanceSpaces[0] must match dataStorage.rootLocation.space, otherwise the
         # asset hierarchy query (which filters on both) can silently return nothing.
         data_filters: dict[str, JsonValue] = {
@@ -543,10 +567,11 @@ class InfieldV2ConfigCreator(MigrationCreator):
 
         name = config.display_name or config.asset_external_id or external_id
         # The node's own space determines who can see this location in InField (dataModelInstancesAcl READ),
-        # independent of appInstanceSpace, which only governs write access. We default it to the
-        # appInstanceSpace, see LOCATION_CONFIG_SPACE_COMMENT for the caveat surfaced to the user.
+        # independent of appInstanceSpace, which only governs write access. We use a dedicated _cfg space
+        # (same base as appInstanceSpace but with _cfg suffix) so location visibility is independently
+        # access-controlled from app data writes. See LOCATION_CONFIG_SPACE_COMMENT.
         return InFieldCDMLocationConfigRequest(
-            space=app_instance_space,
+            space=cfg_space,
             external_id=external_id,
             name=name,
             description="Migrated InField Location Configuration",

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -293,8 +293,8 @@ DATA_FILTERS_COMMENT = (
 
 LOCATION_CONFIG_SPACE_COMMENT = (
     "This space controls who can see this location in InField (dataModelInstancesAcl READ). "
-    "Defaulted to a dedicated config space (<appInstanceSpaceBase>_cfg). This space controls "
-    "read access to this Infield location within the Infield app, as well as write access to the Location config itself."
+    "Defaulted to a dedicated config space (<appInstanceSpaceBase>_cfg). This space also controls "
+    "write access to the Location config itself (dataModelInstancesAcl WRITE)."
 )
 
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -385,15 +385,13 @@ class InfieldV2ConfigCreator(MigrationCreator):
         if not config.feature_configuration:
             return location_configs, location_filters, spaces
 
-        origin_space_ids = list(
-            {
-                space_id
-                for root in (config.feature_configuration.root_location_configurations or [])
-                for space_id in [root.app_data_instance_space, root.source_data_instance_space]
-                if space_id is not None
-            }
-        )
-        origin_space_ids = [SpaceId(space=space_id) for space_id in origin_space_ids]
+        origin_space_names = {
+            space_id
+            for root in (config.feature_configuration.root_location_configurations or [])
+            for space_id in [root.app_data_instance_space, root.source_data_instance_space]
+            if space_id is not None
+        }
+        origin_space_ids = [SpaceId(space=space_name) for space_name in origin_space_names]
         origin_spaces = {s.space: s for s in self.client.tool.spaces.retrieve(origin_space_ids)}
 
         for index, root_location_config in enumerate(config.feature_configuration.root_location_configurations or []):

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -414,24 +414,19 @@ class InfieldV2ConfigCreator(MigrationCreator):
                     console=self.client.console
                 )
                 continue
-            if root_location_config.app_data_instance_space is not None:
-                origin = origin_spaces.get(root_location_config.app_data_instance_space)
-                spaces.append(
-                    SpaceRequest(
-                        space=f"{root_location_config.app_data_instance_space}_cdm",
-                        name=f"{origin.name}_cdm" if origin and origin.name else None,
-                        description=f"{origin.description} (migrated)" if origin and origin.description else None,
+            for space_name in [
+                root_location_config.app_data_instance_space,
+                root_location_config.source_data_instance_space,
+            ]:
+                if space_name is not None:
+                    origin = origin_spaces.get(space_name)
+                    spaces.append(
+                        SpaceRequest(
+                            space=f"{space_name}_cdm",
+                            name=f"{origin.name}_cdm" if origin and origin.name else None,
+                            description=f"{origin.description} (migrated)" if origin and origin.description else None,
+                        )
                     )
-                )
-            if root_location_config.source_data_instance_space is not None:
-                origin = origin_spaces.get(root_location_config.source_data_instance_space)
-                spaces.append(
-                    SpaceRequest(
-                        space=f"{root_location_config.source_data_instance_space}_cdm",
-                        name=f"{origin.name}_cdm" if origin and origin.name else None,
-                        description=f"{origin.description} (migrated)" if origin and origin.description else None,
-                    )
-                )
             location_filters.append(self._create_location_filter(root_location_config))
             location_configs.append(location_config)
 
@@ -519,11 +514,9 @@ class InfieldV2ConfigCreator(MigrationCreator):
             access_management["checklistAdmins"] = config.checklist_admins  # type: ignore[assignment]
 
         app_instance_space = f"{config.app_data_instance_space}_cdm"
-        # The source data migration (not yet implemented) will also suffix its destination space with
-        # "_cdm", so we anticipate that space here rather than the raw (classic) source_data_instance_space.
         source_instance_space = f"{config.source_data_instance_space}_cdm"
         # dataFilters.assets.instanceSpaces[0] must match dataStorage.rootLocation.space, otherwise the
-        # asset hierarchy query (which filters on both) silently returns nothing.
+        # asset hierarchy query (which filters on both) can silently return nothing.
         data_filters: dict[str, JsonValue] = {
             "assets": {"instanceSpaces": [root_node.space]},
         }

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -27,6 +27,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     InstanceSource,
     NodeId,
     NodeRequest,
+    SpaceId,
     SpaceRequest,
     ViewId,
 )
@@ -316,12 +317,14 @@ class InfieldV2ConfigCreator(MigrationCreator):
             # We know this is not None from the check in __init__
             apm_configs = list(cast(Sequence[APMConfigResponse], self.apm_configs))
 
+        all_spaces: list[CreatedResource[SpaceRequest]] = []
         all_location_configs: list[CreatedResource[InFieldCDMLocationConfigRequest]] = []
         all_location_filters: list[CreatedResource[LocationFilterRequest]] = []
+        seen_spaces: set[str] = set()
         success_count = 0
         skipped_external_ids_by_label: dict[str, list[str]] = {}
         for apm_config in apm_configs:
-            location_configs, location_filters = self._create_infield_v2_config(
+            location_configs, location_filters, spaces = self._create_infield_v2_config(
                 apm_config, skipped_external_ids_by_label
             )
             success_count += len(location_configs)
@@ -342,9 +345,24 @@ class InfieldV2ConfigCreator(MigrationCreator):
                 )
                 for loc_filter in location_filters
             )
+            for space in spaces:
+                if space.space not in seen_spaces:
+                    seen_spaces.add(space.space)
+                    all_spaces.append(
+                        CreatedResource(
+                            resource=space,
+                            config_data=space.dump(),
+                            filestem=space.space,
+                        )
+                    )
 
         self._display_summary(success_count, skipped_external_ids_by_label)
 
+        yield ToCreateResources(
+            resources=all_spaces,
+            crud_cls=SpaceCRUD,
+            display_name="Instance Spaces",
+        )
         yield ToCreateResources(
             resources=all_location_filters,
             crud_cls=LocationFilterIO,
@@ -360,11 +378,23 @@ class InfieldV2ConfigCreator(MigrationCreator):
         self,
         config: APMConfigResponse,
         skipped_external_ids_by_label: dict[str, list[str]],
-    ) -> tuple[list[InFieldCDMLocationConfigRequest], list[LocationFilterRequest]]:
+    ) -> tuple[list[InFieldCDMLocationConfigRequest], list[LocationFilterRequest], list[SpaceRequest]]:
         location_configs: list[InFieldCDMLocationConfigRequest] = []
         location_filters: list[LocationFilterRequest] = []
+        spaces: list[SpaceRequest] = []
         if not config.feature_configuration:
-            return location_configs, location_filters
+            return location_configs, location_filters, spaces
+
+        origin_space_ids = [
+            SpaceId(space=root.app_data_instance_space)
+            for root in (config.feature_configuration.root_location_configurations or [])
+            if root.app_data_instance_space is not None
+        ] + [
+            SpaceId(space=root.source_data_instance_space)
+            for root in (config.feature_configuration.root_location_configurations or [])
+            if root.source_data_instance_space is not None
+        ]
+        origin_spaces = {s.space: s for s in self.client.tool.spaces.retrieve(origin_space_ids)}
 
         for index, root_location_config in enumerate(config.feature_configuration.root_location_configurations or []):
             identifier = root_location_config.external_id or root_location_config.asset_external_id or f"index {index}"
@@ -386,10 +416,28 @@ class InfieldV2ConfigCreator(MigrationCreator):
                     console=self.client.console
                 )
                 continue
+            if root_location_config.app_data_instance_space is not None:
+                origin = origin_spaces.get(root_location_config.app_data_instance_space)
+                spaces.append(
+                    SpaceRequest(
+                        space=f"{root_location_config.app_data_instance_space}_cdm",
+                        name=f"{origin.name}_cdm" if origin and origin.name else None,
+                        description=f"{origin.description} (migrated)" if origin and origin.description else None,
+                    )
+                )
+            if root_location_config.source_data_instance_space is not None:
+                origin = origin_spaces.get(root_location_config.source_data_instance_space)
+                spaces.append(
+                    SpaceRequest(
+                        space=f"{root_location_config.source_data_instance_space}_cdm",
+                        name=f"{origin.name}_cdm" if origin and origin.name else None,
+                        description=f"{origin.description} (migrated)" if origin and origin.description else None,
+                    )
+                )
             location_filters.append(self._create_location_filter(root_location_config))
             location_configs.append(location_config)
 
-        return location_configs, location_filters
+        return location_configs, location_filters, spaces
 
     def _display_summary(self, success_count: int, skipped_external_ids_by_label: dict[str, list[str]]) -> None:
         items: list[ItemsResult] = []

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -286,6 +286,11 @@ class SourceSystemCreator(MigrationCreator):
             raise ValueError("This should not happen.")
 
 
+DATA_FILTERS_COMMENT = (
+    "Defaulted time series and files to the asset instance space. If your timeseries or files live in a different space, "
+    "update instanceSpaces under 'timeseries' and 'files' accordingly."
+)
+
 LOCATION_CONFIG_SPACE_COMMENT = (
     "This space controls who can see this location in InField (dataModelInstancesAcl READ). "
     "Defaulted to a dedicated config space (<appInstanceSpaceBase>_cfg). This space controls "
@@ -333,7 +338,7 @@ class InfieldV2ConfigCreator(MigrationCreator):
                     resource=loc_config,
                     config_data=loc_config.dump(context="toolkit", exclude={"instance_type"}),
                     filestem=f"{apm_config.external_id}_location_{loc_config.name}",
-                    field_comments={"space": LOCATION_CONFIG_SPACE_COMMENT},
+                    field_comments={"space": LOCATION_CONFIG_SPACE_COMMENT, "dataFilters": DATA_FILTERS_COMMENT},
                 )
                 for loc_config in location_configs
             )
@@ -547,7 +552,7 @@ class InfieldV2ConfigCreator(MigrationCreator):
         for key in ["timeseries", "files"]:
             # appInstanceSpace must come first so that by-externalId lookups (which use the first
             # instance space as the view's default space) resolve to app-written data correctly.
-            data_filters[key] = {"instanceSpaces": [app_instance_space]}
+            data_filters[key] = {"instanceSpaces": [root_node.space]}
         for key in ["maintenanceOrders", "operations", "notifications"]:
             data_filters[key] = {"instanceSpaces": [source_instance_space]}
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -385,15 +385,15 @@ class InfieldV2ConfigCreator(MigrationCreator):
         if not config.feature_configuration:
             return location_configs, location_filters, spaces
 
-        origin_space_ids = [
-            SpaceId(space=root.app_data_instance_space)
-            for root in (config.feature_configuration.root_location_configurations or [])
-            if root.app_data_instance_space is not None
-        ] + [
-            SpaceId(space=root.source_data_instance_space)
-            for root in (config.feature_configuration.root_location_configurations or [])
-            if root.source_data_instance_space is not None
-        ]
+        origin_space_ids = list(
+            {
+                space_id
+                for root in (config.feature_configuration.root_location_configurations or [])
+                for space_id in [root.app_data_instance_space, root.source_data_instance_space]
+                if space_id is not None
+            }
+        )
+        origin_space_ids = [SpaceId(space=space_id) for space_id in origin_space_ids]
         origin_spaces = {s.space: s for s in self.client.tool.spaces.retrieve(origin_space_ids)}
 
         for index, root_location_config in enumerate(config.feature_configuration.root_location_configurations or []):

--- a/cognite_toolkit/_cdf_tk/utils/file.py
+++ b/cognite_toolkit/_cdf_tk/utils/file.py
@@ -258,6 +258,14 @@ def quote_int_value_by_key_in_yaml(content: str, key: str) -> str:
     return re.sub(pattern, replacement, content, flags=re.MULTILINE)
 
 
+def add_top_level_comment_in_yaml(content: str, key: str, comment: str) -> str:
+    """Append an inline comment to a top-level (non-indented) key's line in a yaml string"""
+    pattern = rf"^{key}:.*$"
+    replacement = rf"\g<0>  # {comment}"
+
+    return re.sub(pattern, replacement, content, count=1, flags=re.MULTILINE)
+
+
 def stringify_value_by_key_in_yaml(content: str, key: str) -> str:
     """Quote a value in a yaml string"""
     pattern = rf"^{key}:\s*$"

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator/test_create_infield_config.yml
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator/test_create_infield_config.yml
@@ -7,22 +7,22 @@ InField CDM Location Configs:
   dataFilters:
     assets:
       instanceSpaces:
-      - sp_asset_oid_source
+      - migrated
     files:
       instanceSpaces:
-      - sp_asset_oid_source
+      - sp_infield_oid_app_data_cdm
     maintenanceOrders:
       instanceSpaces:
-      - sp_asset_oid_source
+      - sp_asset_oid_source_cdm
     notifications:
       instanceSpaces:
-      - sp_asset_oid_source
+      - sp_asset_oid_source_cdm
     operations:
       instanceSpaces:
-      - sp_asset_oid_source
+      - sp_asset_oid_source_cdm
     timeseries:
       instanceSpaces:
-      - sp_asset_oid_source
+      - sp_infield_oid_app_data_cdm
   dataStorage:
     appInstanceSpace: sp_infield_oid_app_data_cdm
     rootLocation:
@@ -33,7 +33,7 @@ InField CDM Location Configs:
   externalId: WMT:VAL_0
   featureToggles: null
   name: WMT:VAL
-  space: sp_asset_oid_source
+  space: sp_infield_oid_app_data_cdm
   viewMappings:
     asset:
       externalId: CogniteAsset

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator/test_create_infield_config.yml
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator/test_create_infield_config.yml
@@ -10,7 +10,7 @@ InField CDM Location Configs:
       - migrated
     files:
       instanceSpaces:
-      - sp_infield_oid_app_data_cdm
+      - migrated
     maintenanceOrders:
       instanceSpaces:
       - sp_asset_oid_source_cdm
@@ -22,7 +22,7 @@ InField CDM Location Configs:
       - sp_asset_oid_source_cdm
     timeseries:
       instanceSpaces:
-      - sp_infield_oid_app_data_cdm
+      - migrated
   dataStorage:
     appInstanceSpace: sp_infield_oid_app_data_cdm
     rootLocation:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator/test_create_infield_config.yml
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator/test_create_infield_config.yml
@@ -55,6 +55,13 @@ InField CDM Location Configs:
       externalId: CogniteOperation
       space: cdf_idm
       version: v1
+Instance Spaces:
+- description: null
+  name: null
+  space: sp_infield_oid_app_data_cdm
+- description: null
+  name: null
+  space: sp_asset_oid_source_cdm
 Location Filters:
 - dataModelingType: DATA_MODELING_ONLY
   dataModels:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator/test_create_infield_config.yml
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator/test_create_infield_config.yml
@@ -31,9 +31,19 @@ InField CDM Location Configs:
   description: Migrated InField Location Configuration
   disciplines: null
   externalId: WMT:VAL_0
-  featureToggles: null
+  featureToggles:
+    copilot: true
+    documents: true
+    media: true
+    notifications: true
+    observations: true
+    templateChecklistFlow: true
+    threeD: true
+    trends: true
+    workorderChecklistFlow: true
+    workorders: true
   name: WMT:VAL
-  space: sp_infield_oid_app_data_cdm
+  space: sp_infield_oid_app_data_cfg
   viewMappings:
     asset:
       externalId: CogniteAsset
@@ -62,6 +72,9 @@ Instance Spaces:
 - description: null
   name: null
   space: sp_asset_oid_source_cdm
+- description: null
+  name: null
+  space: sp_infield_oid_app_data_cfg
 Location Filters:
 - dataModelingType: DATA_MODELING_ONLY
   dataModels:


### PR DESCRIPTION
# Description

The understanding of what should be defaults when running `cdf migrate infield-configs` has changed based on recent trial runs:

- Previously the `InFieldCDMLocationConfig` node's own `space` defaulted to the legacy `SourceDataInstanceSpace`, which is wrong per InField's access-control model: this space should be used for source data only. The `space` of the `InFieldCDMLocationConfig` itself is what governs access to Infield locations for users. The node's `space` now uses a dedicated `<appInstanceSpaceBase>_cfg` space so that write access to InField location configs are independently access-controlled.
- When `featureToggles` was not configured in the old location, all toggles now default to `true` instead of being left null, ensuring features are available out of the box after migration.
- `dataFilters` for `timeseries` and `files` default to the asset instance space (same as `assets`/`rootLocation`), with an inline YAML comment instructing users to update `instanceSpaces` if their time series or files live elsewhere. This is the closest we can get to an automatically derived space for these.
- The `assets` data filter now defaults to the same space as the `rootLocation` asset, since divergence between the two can lead to the asset hierarchy not being visible in InField.
- The space derived from `SourceDataInstanceSpace` is now also suffixed with `_cdm`, and a soon-to-follow-up PR will introduce separate tooling to migrate those instances to new spaces as well since the data in the APM_SourceData model(s) currently have not straightforward migration path.
- The command now emits the `_cdm` and `_cdf`-suffixed spaces it depends on, so the generated config is deployable out of the box.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Improved

- [alpha] Improved `cdf migrate infield-configs` to generate location configs with better defaults that reflect the access control and data setup required for InField on CDM to work.