### PR TITLE
[CDF-28272] Fall back to textRegion bounding box when migrating 360-image annotations without objectRegion polygon

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -12,6 +12,7 @@ from pydantic import JsonValue
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, EdgeTypeId, ExternalId, InstanceId, InternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.annotation import (
+    AnnotationPoint,
     AnnotationResponse,
     ImageAssetLinkData,
 )
@@ -2326,20 +2327,16 @@ class Image360AnnotationMapper(DataMapper[Image360AnnotationSelector, Annotation
             return None
 
         object_region = annotation_data.object_region
-        if object_region is None or object_region.polygon is None:
-            self.logger.log(
-                MigrationEntryV2(
-                    id=str(annotation.id),
-                    severity=Severity.skipped,
-                    label="Skipped",
-                    message="Annotation has no objectRegion polygon.",
-                    source="Image360 annotations",
-                    destination="360-image-annotations",
-                )
-            )
-            return None
-
-        vertices = object_region.polygon.vertices
+        if object_region is not None and object_region.polygon is not None:
+            vertices = object_region.polygon.vertices
+        else:
+            bb = annotation_data.text_region
+            vertices = [
+                AnnotationPoint(x=bb.x_min, y=bb.y_min),
+                AnnotationPoint(x=bb.x_max, y=bb.y_min),
+                AnnotationPoint(x=bb.x_max, y=bb.y_max),
+                AnnotationPoint(x=bb.x_min, y=bb.y_max),
+            ]
         if len(vertices) < 3:
             self.logger.log(
                 MigrationEntryV2(

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -2330,7 +2330,10 @@ class Image360AnnotationMapper(DataMapper[Image360AnnotationSelector, Annotation
         if object_region is not None and object_region.polygon is not None:
             vertices = object_region.polygon.vertices
         else:
-            bb = annotation_data.text_region
+            if object_region is not None and object_region.bounding_box is not None:
+                bb = object_region.bounding_box
+            else:
+                bb = annotation_data.text_region
             vertices = [
                 AnnotationPoint(x=bb.x_min, y=bb.y_min),
                 AnnotationPoint(x=bb.x_max, y=bb.y_min),

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_data_mapper.py
@@ -1783,3 +1783,42 @@ class TestImage360AnnotationMapper:
         # First vertex (front face, 0.1, 0.2) matches the fusion reference values.
         assert item.polygon.data[1] == pytest.approx(2.3562, abs=1e-4)
         assert item.polygon.data[2] == pytest.approx(0.9273, abs=1e-4)
+
+    def test_map_falls_back_to_text_region_when_no_object_region(self) -> None:
+        """When objectRegion polygon is absent, text_region bounding box is used to synthesise a 4-vertex polygon."""
+        annotation = AnnotationResponse(
+            id=43,
+            annotation_type="images.AssetLink",
+            annotated_resource_type="file",
+            annotated_resource_id=111,
+            data=ImageAssetLinkData(
+                asset_ref=InternalId(id=222),
+                text="pump",
+                text_region=BoundingBox(x_min=0.1, x_max=0.5, y_min=0.2, y_max=0.6),
+                object_region=None,
+            ),
+            status="approved",
+            creating_app="unit_test",
+            creating_app_version="1.0.0",
+            creating_user="tester",
+            created_time=0,
+            last_updated_time=1,
+        )
+        new_image360_node_id = NodeId(space=self.SOURCE_SPACE, external_id="image_in_cdm")
+        asset_node_id = NodeId(space="asset_space", external_id="pump_1")
+
+        with monkeypatch_toolkit_client() as client:
+            client.lookup.files.external_id.return_value = "file_in"
+            client.migration.lookup.assets.return_value = asset_node_id
+            mapper = Image360AnnotationMapper(client)
+            mapper._face_by_file_ext_id = {"file_in": ("front", new_image360_node_id)}
+
+            result = mapper.map([DataItem(tracking_id="43", item=annotation)])
+
+        assert len(result) == 1
+        item = result[0].item
+        assert item.asset.instance_id == asset_node_id
+        assert item.image360.instance_id == new_image360_node_id
+        # polygon.data: [N, phi1, theta1, ..., phiN, thetaN] for N=4 vertices → 9 floats
+        assert item.polygon.data[0] == 4.0
+        assert len(item.polygon.data) == 9


### PR DESCRIPTION
# Description

When migrating `images.AssetLink` 360-image annotations, the migration tool previously
skipped any annotation whose `data.objectRegion.polygon` was absent. Some asset-centric
annotations store their region in `data.textRegion` (a bounding box) instead. The mapper
now converts `{xMin, xMax, yMin, yMax}` into a 4-vertex rectangle polygon and proceeds
with the spherical coordinate conversion.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- [alpha] Fix `cdf migrate 360-image-annotations` skipping annotations whose region is stored in `textRegion` instead of `objectRegion.polygon`.