### PR TITLE
feat(infield): add formView property in the viewMappings observation config

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
@@ -412,6 +412,8 @@ class InFieldCDMLocationConfigIO(ResourceIO[NodeId, InFieldCDMLocationConfigRequ
         if resource.view_mappings and resource.view_mappings.observation:
             for obs_config in resource.view_mappings.observation:
                 yield (ViewIO, obs_config.view.as_id())
+                if obs_config.form_view is not None:
+                    yield (ViewIO, obs_config.form_view.as_id())
 
     @classmethod
     def get_dependent_items(cls, item: dict) -> Iterable[tuple[type[ResourceIO], Hashable]]:
@@ -438,19 +440,20 @@ class InFieldCDMLocationConfigIO(ResourceIO[NodeId, InFieldCDMLocationConfigRequ
                 for obs_config in observations:
                     if not isinstance(obs_config, dict):
                         continue
-                    view = obs_config.get("view")
-                    if not isinstance(view, dict):
-                        continue
-                    if not in_dict(("space", "externalId", "version"), view):
-                        continue
-                    yield (
-                        ViewIO,
-                        ViewId(
-                            space=view["space"],
-                            external_id=view["externalId"],
-                            version=str(view["version"]),
-                        ),
-                    )
+                    for view_key in ("view", "formView"):
+                        view = obs_config.get(view_key)
+                        if not isinstance(view, dict):
+                            continue
+                        if not in_dict(("space", "externalId", "version"), view):
+                            continue
+                        yield (
+                            ViewIO,
+                            ViewId(
+                                space=view["space"],
+                                external_id=view["externalId"],
+                                version=str(view["version"]),
+                            ),
+                        )
 
     @cached_property
     def _legacy_instance_spaces(self) -> set[str]:

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
@@ -73,6 +73,7 @@ class ObservationViewConfig(BaseModelResource):
     """Observation view configuration."""
 
     view: ViewReference
+    form_view: ViewReference | None = None
     required_properties: list[str] | None = None
     write_back: ObservationViewWriteBack | None = None
 

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_fieldops.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_fieldops.py
@@ -134,6 +134,41 @@ class TestInFieldCDMLocationConfigCRUD:
             (ViewIO.__name__, ViewId(space="customer_idm_extention", external_id="ObservationView", version="v2")),
         }
 
+    def test_get_dependencies_includes_observation_view_and_form_view(self) -> None:
+        config = InFieldCDMLocationConfigYAML.model_validate(
+            {
+                "space": "sp_instance",
+                "externalId": "my_location_config",
+                "viewMappings": {
+                    "observation": [
+                        {
+                            "view": {
+                                "space": "customer_idm_extention",
+                                "version": "v2",
+                                "externalId": "ObservationView",
+                            },
+                            "formView": {
+                                "space": "customer_idm_extention",
+                                "version": "v2",
+                                "externalId": "ObservationFormView",
+                            },
+                        },
+                    ],
+                },
+            }
+        )
+        actual = {
+            (loader_cls.__name__, identifier)
+            for loader_cls, identifier in InFieldCDMLocationConfigIO.get_dependencies(config)
+        }
+        assert actual == {
+            (ViewIO.__name__, ViewId(space="customer_idm_extention", external_id="ObservationView", version="v2")),
+            (
+                ViewIO.__name__,
+                ViewId(space="customer_idm_extention", external_id="ObservationFormView", version="v2"),
+            ),
+        }
+
     def test_get_dependencies_includes_card_views_and_observation_view(self) -> None:
         config = InFieldCDMLocationConfigYAML.model_validate(
             {
@@ -241,6 +276,39 @@ class TestInFieldCDMLocationConfigCRUD:
         }
         assert actual == {
             (ViewIO.__name__, ViewId(space="customer_idm_extention", external_id="ObservationView", version="v2")),
+        }
+
+    def test_get_dependent_items_includes_observation_view_and_form_view(self) -> None:
+        item = {
+            "space": "sp_instance",
+            "externalId": "my_location_config",
+            "viewMappings": {
+                "observation": [
+                    {
+                        "view": {
+                            "space": "customer_idm_extention",
+                            "version": "v2",
+                            "externalId": "ObservationView",
+                        },
+                        "formView": {
+                            "space": "customer_idm_extention",
+                            "version": "v2",
+                            "externalId": "ObservationFormView",
+                        },
+                    },
+                ],
+            },
+        }
+        actual = {
+            (loader_cls.__name__, identifier)
+            for loader_cls, identifier in InFieldCDMLocationConfigIO.get_dependent_items(item)
+        }
+        assert actual == {
+            (ViewIO.__name__, ViewId(space="customer_idm_extention", external_id="ObservationView", version="v2")),
+            (
+                ViewIO.__name__,
+                ViewId(space="customer_idm_extention", external_id="ObservationFormView", version="v2"),
+            ),
         }
 
     def test_skip_illegal_configuration(self) -> None:

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
@@ -264,6 +264,54 @@ def invalid_test_cases() -> Iterable:
         {
             "externalId": "my_config",
             "space": "my_space",
+            "viewMappings": {
+                "observation": [
+                    {
+                        "view": {
+                            "space": "my_space",
+                            "version": "v1",
+                            "externalId": "ObsView",
+                        },
+                        "formView": {
+                            "space": "my_space",
+                            "version": "v1",
+                        },
+                    },
+                ],
+            },
+        },
+        {"In viewMappings.observation[1].formView missing required field: 'externalId'"},
+        id="Missing required field in viewMappings.observation formView",
+    )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
+            "viewMappings": {
+                "observation": [
+                    {
+                        "view": {
+                            "space": "my_space",
+                            "version": "v1",
+                            "externalId": "ObsView",
+                        },
+                        "formView": {
+                            "space": "my_space",
+                            "version": "v1",
+                            "externalId": "ObsFormView",
+                            "unknownField": "bad_value",
+                        },
+                    },
+                ],
+            },
+        },
+        {"In viewMappings.observation[1].formView unknown field: 'unknownField'"},
+        id="Unknown field in viewMappings.observation.formView",
+    )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
             "dataExplorationConfig": {
                 "assetActivitiesCardView": {
                     "space": "my_space",
@@ -378,6 +426,35 @@ class TestInfieldCDMLocationConfigYAML:
                             "space": "my_space",
                             "version": "v1",
                             "externalId": "ObsView",
+                        },
+                        "requiredProperties": ["assets", "files"],
+                        "writeBack": {
+                            "notificationsEndpointExternalId": "notif-endpoint",
+                        },
+                    },
+                ],
+            },
+        }
+        loaded = InFieldCDMLocationConfigYAML.model_validate(data)
+        dumped = loaded.model_dump(exclude_unset=True, by_alias=True)
+        assert dumped == data
+
+    def test_load_valid_observation_view_config_with_form_view(self) -> None:
+        data = {
+            "externalId": "my_config",
+            "space": "my_space",
+            "viewMappings": {
+                "observation": [
+                    {
+                        "view": {
+                            "space": "my_space",
+                            "version": "v1",
+                            "externalId": "ObsView",
+                        },
+                        "formView": {
+                            "space": "my_space",
+                            "version": "v1",
+                            "externalId": "ObsFormView",
                         },
                         "requiredProperties": ["assets", "files"],
                         "writeBack": {


### PR DESCRIPTION
# Description

`viewMappings.observaions` now allow the addition of `formView` which can be different from `view`. It would be used for the infield UI to customize the form page experience. Relevant docs: https://cognitedata.atlassian.net/wiki/spaces/PD/pages/6115886032/Creating+a+Custom+Observation+Form+View

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- viewMappings.observations now has the option to include an optional formView defined that can be used to customize the form page in infield
