### PR TITLE
Fix view implements order normalization on deploy

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -224,7 +224,7 @@ class DataModelFinder(ResourceFinder[DataModelNoVersionId]):
             yield list(self.container_ids), None, ContainerCRUD.create_loader(self.client), "containers"
             yield list(self.space_ids), None, SpaceCRUD.create_loader(self.client), None
         else:
-            view_loader = ViewIO(self.client, None, None, topological_sort_implements=True)
+            view_loader = ViewIO(self.client, None, None)
             views = [view for view in view_loader.retrieve(list(self.view_ids)) if not view.is_global]
             yield [], views, view_loader, "views"
             container_loader = ContainerCRUD.create_loader(self.client)

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -547,7 +547,7 @@ class InstanceIO(
             )
         if not selector.view:
             return
-        view_crud = ViewIO(self.client, None, None, topological_sort_implements=True)
+        view_crud = ViewIO(self.client, None, None)
         views = self.client.tool.views.retrieve([selector.view.as_id()], include_inherited_properties=False)
         views = [view for view in views if not view.is_global]
         if not views:

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
@@ -588,10 +588,8 @@ class ViewIO(ResourceIO[ViewId, ViewRequest, ViewResponse]):
         client: ToolkitClient,
         build_dir: Path | None,
         console: Console | None,
-        topological_sort_implements: bool = False,
     ) -> None:
         super().__init__(client, build_dir, console)
-        self._topological_sort_implements = topological_sort_implements
         self._view_by_id: dict[ViewId, ViewResponse] = {}
 
     @property
@@ -713,15 +711,11 @@ class ViewIO(ResourceIO[ViewId, ViewRequest, ViewResponse]):
                 dumped["implements"] = local["implements"]
             else:
                 dumped.pop("implements", None)
-        if resource.implements and len(resource.implements) > 1 and self._topological_sort_implements:
-            # This is a special case that we want to do when we run the cdf dump datamodel command.
-            # The issue is as follows:
-            # 1. If a data model is deployed through GraphQL, the implements for a child view are sorted
-            #   from parent, grandparent, etc.
-            # 2. If the grand parent has a direct relation that the parent overwrites to update the source.
-            #   The child will get the grandparent's source, not the parent's.
-            # We sort the implements in topological order to ensure that the child view get the order grandparent,
-            # parent, such that the parent's source is used.
+        if resource.implements and len(resource.implements) > 1:
+            # If a data model is deployed through GraphQL, the implements for a child view are sorted
+            # from parent, grandparent, etc. If the grand parent has a direct relation that the parent
+            # overwrites to update the source, the child will get the grandparent's source, not the parent's,
+            # unless implements are in topological order (grandparent before parent).
             try:
                 dumped["implements"] = [
                     view_id.dump() for view_id in self.topological_sort_implements(resource.implements)
@@ -760,8 +754,14 @@ class ViewIO(ResourceIO[ViewId, ViewRequest, ViewResponse]):
             return diff_list_identifiable(local, cdf, get_identifier=dm_identifier)
         return super().diff_list(local, cdf, json_path)
 
+    def load_resource(self, resource: dict[str, Any], is_dry_run: bool = False) -> ViewRequest:
+        view = self.resource_write_cls._load(resource)
+        return self._normalize_view_implements(view)
+
     def create(self, items: Sequence[ViewRequest]) -> list[ViewResponse]:
-        creation_order = self._compute_deploy_batches(items)
+        views_by_id = {self.get_id(item): item for item in items}
+        normalized = [self._normalize_view_implements(item, local_views=views_by_id) for item in items]
+        creation_order = self._compute_deploy_batches(normalized)
         created: list[ViewResponse] = []
         for batch in creation_order:
             created.extend(self.client.tool.views.create(batch))
@@ -920,10 +920,45 @@ class ViewIO(ResourceIO[ViewId, ViewRequest, ViewResponse]):
                 f"Failed to sort views topologically. This is likely due to a cycle in implements. {e.args[1]}"
             )
 
-    def topological_sort_implements(self, view_ids: list[ViewId]) -> list[ViewId]:
-        """Sorts the views in topological order based on their implements and through properties."""
-        view_by_ids = self._lookup_views(view_ids)
-        return self._sort_implements_or_raise_cycle(view_by_ids)
+    def topological_sort_implements(
+        self,
+        view_ids: list[ViewId],
+        local_views: Mapping[ViewId, ViewRequest] | None = None,
+    ) -> list[ViewId]:
+        """Sorts view references in topological order based on their implements relationships.
+
+        Views from ``local_views`` (e.g. the current deploy batch) are preferred over CDF lookups.
+        References that cannot be resolved keep their original relative order at the end.
+        """
+        if len(view_ids) <= 1:
+            return view_ids
+
+        view_by_ids: dict[ViewId, View] = {}
+        if local_views:
+            view_by_ids.update({view_id: local_views[view_id] for view_id in view_ids if view_id in local_views})
+        missing_ids = [view_id for view_id in view_ids if view_id not in view_by_ids]
+        if missing_ids:
+            view_by_ids.update(self._lookup_views(missing_ids))
+
+        relevant = {view_id: view_by_ids[view_id] for view_id in view_ids if view_id in view_by_ids}
+        if len(relevant) < 2:
+            return view_ids
+
+        sorted_portion = self._sort_implements_or_raise_cycle(relevant)
+        sorted_set = set(sorted_portion)
+        return sorted_portion + [view_id for view_id in view_ids if view_id not in sorted_set]
+
+    def _normalize_view_implements(
+        self,
+        view: ViewRequest,
+        local_views: Mapping[ViewId, ViewRequest] | None = None,
+    ) -> ViewRequest:
+        if not view.implements or len(view.implements) <= 1:
+            return view
+        sorted_implements = self.topological_sort_implements(view.implements, local_views=local_views)
+        if sorted_implements == view.implements:
+            return view
+        return view.model_copy(update={"implements": sorted_implements})
 
     def topological_sort_container_constraints(self, view_ids: list[ViewId]) -> tuple[list[ViewId], list[ViewId]]:
         """Sorts the views in topological order based on their container constraints.

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_data_model.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_data_model.py
@@ -257,7 +257,7 @@ class TestViewLoader:
             client.tool.views.retrieve.return_value = parent_grandparent_view
             parent = ViewId(space="space", external_id="Parent", version="v1")
             grandparent = ViewId(space="space", external_id="GrandParent", version="v1")
-            loader = ViewIO(client, Path("build_dir"), None, topological_sort_implements=True)
+            loader = ViewIO(client, Path("build_dir"), None)
             actual = loader.topological_sort_implements(
                 [
                     parent,
@@ -266,6 +266,77 @@ class TestViewLoader:
             )
 
         assert actual == [grandparent, parent]
+
+    def test_topological_sorting_preserves_unresolved_views(self) -> None:
+        parent = ViewId(space="space", external_id="Parent", version="v1")
+        unresolved = ViewId(space="space", external_id="Missing", version="v1")
+
+        with monkeypatch_toolkit_client() as client:
+            client.tool.views.retrieve.return_value = []
+            loader = ViewIO(client, Path("build_dir"), None)
+            actual = loader.topological_sort_implements([parent, unresolved])
+
+        assert actual == [parent, unresolved]
+
+    def test_topological_sorting_uses_local_views(self, parent_grandparent_view: list[ViewResponse]) -> None:
+        parent = ViewId(space="space", external_id="Parent", version="v1")
+        grandparent = ViewId(space="space", external_id="GrandParent", version="v1")
+        local_views = {
+            parent: ViewRequest(
+                space=parent.space,
+                external_id=parent.external_id,
+                version=parent.version,
+                implements=[grandparent],
+            ),
+            grandparent: ViewRequest(
+                space=grandparent.space,
+                external_id=grandparent.external_id,
+                version=grandparent.version,
+            ),
+        }
+
+        with monkeypatch_toolkit_client() as client:
+            client.tool.views.retrieve.return_value = []
+            loader = ViewIO(client, Path("build_dir"), None)
+            actual = loader.topological_sort_implements([parent, grandparent], local_views=local_views)
+
+        assert actual == [grandparent, parent]
+
+    def test_load_resource_normalizes_implements_order(self, parent_grandparent_view: list[ViewResponse]) -> None:
+        parent = ViewId(space="space", external_id="Parent", version="v1")
+        grandparent = ViewId(space="space", external_id="GrandParent", version="v1")
+
+        with monkeypatch_toolkit_client() as client:
+            client.tool.views.retrieve.return_value = parent_grandparent_view
+            loader = ViewIO(client, Path("build_dir"), None)
+            loaded = loader.load_resource(
+                {
+                    "space": "space",
+                    "externalId": "Child",
+                    "version": "v1",
+                    "implements": [parent.dump(), grandparent.dump()],
+                }
+            )
+
+        assert loaded.implements == [grandparent, parent]
+
+    def test_create_normalizes_implements_order(self, parent_grandparent_view: list[ViewResponse]) -> None:
+        parent = ViewId(space="space", external_id="Parent", version="v1")
+        grandparent = ViewId(space="space", external_id="GrandParent", version="v1")
+        child = ViewRequest(
+            space="space",
+            external_id="Child",
+            version="v1",
+            implements=[parent, grandparent],
+        )
+
+        with monkeypatch_toolkit_client() as client:
+            client.tool.views.retrieve.return_value = parent_grandparent_view
+            loader = ViewIO(client, Path("build_dir"), None)
+            loader.create([child])
+
+        sent_view = client.tool.views.create.call_args[0][0][0]
+        assert sent_view.implements == [grandparent, parent]
 
     def test_topological_sorting_cycle(self, parent_grandparent_view: list[ViewResponse]) -> None:
         parent_grandparent_view[1] = parent_grandparent_view[1].model_copy(
@@ -276,7 +347,7 @@ class TestViewLoader:
 
         with monkeypatch_toolkit_client() as client, pytest.raises(ToolkitCycleError) as exc_info:
             client.tool.views.retrieve.return_value = parent_grandparent_view
-            loader = ViewIO(client, Path("build_dir"), None, topological_sort_implements=True)
+            loader = ViewIO(client, Path("build_dir"), None)
             loader.topological_sort_implements(
                 [
                     parent,


### PR DESCRIPTION
## Description

Extended views (`implements`) can resolve property overrides differently depending on parent order in the `implements` list. CDF expects ancestors before descendants (e.g. grandparent, then parent), but deploy was sending YAML order as-is. Dump already sorted topologically, so push/pull cycles could mix up semantics for views with multiple parents.

This change normalizes `implements` to topological order on **load**, **create**, and **dump**, using views from the current deploy batch when parent views are not yet in CDF.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Normalize view `implements` order on deploy so extended views keep correct property override semantics.

## Test plan

- [x] `uv run pytest tests/test_unit/test_cdf_tk/test_cruds/test_data_model.py::TestViewLoader -q`
- [x] `uv run pytest tests/test_unit/test_cdf_tk/test_cruds/test_data_model.py -q`
- [ ] Deploy a data model with a multi-parent extended view and verify `implements` order in CDF matches topological order after push

Made with [Cursor](https://cursor.com)