### PR TITLE
feat(infield): update config to add sorting for infield

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
@@ -412,8 +412,6 @@ class InFieldCDMLocationConfigIO(ResourceIO[NodeId, InFieldCDMLocationConfigRequ
         if resource.view_mappings and resource.view_mappings.observation:
             for obs_config in resource.view_mappings.observation:
                 yield (ViewIO, obs_config.view.as_id())
-                if obs_config.form_view is not None:
-                    yield (ViewIO, obs_config.form_view.as_id())
 
     @classmethod
     def get_dependent_items(cls, item: dict) -> Iterable[tuple[type[ResourceIO], Hashable]]:
@@ -440,20 +438,19 @@ class InFieldCDMLocationConfigIO(ResourceIO[NodeId, InFieldCDMLocationConfigRequ
                 for obs_config in observations:
                     if not isinstance(obs_config, dict):
                         continue
-                    for view_key in ("view", "formView"):
-                        view = obs_config.get(view_key)
-                        if not isinstance(view, dict):
-                            continue
-                        if not in_dict(("space", "externalId", "version"), view):
-                            continue
-                        yield (
-                            ViewIO,
-                            ViewId(
-                                space=view["space"],
-                                external_id=view["externalId"],
-                                version=str(view["version"]),
-                            ),
-                        )
+                    view = obs_config.get("view")
+                    if not isinstance(view, dict):
+                        continue
+                    if not in_dict(("space", "externalId", "version"), view):
+                        continue
+                    yield (
+                        ViewIO,
+                        ViewId(
+                            space=view["space"],
+                            external_id=view["externalId"],
+                            version=str(view["version"]),
+                        ),
+                    )
 
     @cached_property
     def _legacy_instance_spaces(self) -> set[str]:

--- a/cognite_toolkit/_cdf_tk/rules/_infield.py
+++ b/cognite_toolkit/_cdf_tk/rules/_infield.py
@@ -26,6 +26,8 @@ _REQUIRED_PROPERTIES: dict[str, frozenset[str]] = {
 
 # (resource, card_key, view_id, required properties)
 _CardViewRef = tuple[BuiltResource, str, ViewId, frozenset[str]]
+# (resource, config_key, view_id, configured field keys)
+_FieldConfigRef = tuple[BuiltResource, str, ViewId, frozenset[str]]
 
 
 class InFieldCDMViewPropertiesRuleSet(ToolkitGlobalRuleSet):
@@ -38,12 +40,12 @@ class InFieldCDMViewPropertiesRuleSet(ToolkitGlobalRuleSet):
                 code="reduced",
                 message=(
                     "InField CDM view property validation requires a client. "
-                    "Provide client credentials to validate required properties on card views."
+                    "Provide client credentials to validate card views and field configs against CDF."
                 ),
             )
         return RuleSetStatus(
             code="ready",
-            message="Will validate required properties on InField CDM card views against CDF.",
+            message="Will validate InField CDM card views and field configs against CDF view properties.",
         )
 
     def validate(self) -> Iterable[ConsistencyError]:
@@ -54,6 +56,7 @@ class InFieldCDMViewPropertiesRuleSet(ToolkitGlobalRuleSet):
             kind=InFieldCDMLocationConfigIO.kind,
         )
         card_view_refs: list[_CardViewRef] = []
+        field_config_refs: list[_FieldConfigRef] = []
 
         for module in self.modules:
             for resource in module.resources:
@@ -61,24 +64,35 @@ class InFieldCDMViewPropertiesRuleSet(ToolkitGlobalRuleSet):
                     continue
                 if resource.type != config_type:
                     continue
-                card_view_refs.extend(self._collect_card_view_refs(resource))
+                card_refs, field_refs, errors = self._collect_refs(resource)
+                card_view_refs.extend(card_refs)
+                field_config_refs.extend(field_refs)
+                yield from errors
 
-        if not card_view_refs:
+        if not card_view_refs and not field_config_refs:
             return
 
-        unique_view_ids = list({ref[2] for ref in card_view_refs})
+        unique_view_ids = list({ref[2] for ref in card_view_refs} | {ref[2] for ref in field_config_refs})
         retrieved = self.client.tool.views.retrieve(unique_view_ids, include_inherited_properties=True)
         views_by_id: dict[ViewId, ViewResponse] = {v.as_id(): v for v in retrieved}
 
         for resource, card_key, view_id, required in card_view_refs:
-            yield from self._check_view(resource, card_key, view_id, required, views_by_id)
+            yield from self._check_required_properties(resource, card_key, view_id, required, views_by_id)
+
+        for resource, config_key, view_id, field_keys in field_config_refs:
+            yield from self._check_field_config_keys(resource, config_key, view_id, field_keys, views_by_id)
 
     @staticmethod
-    def _collect_card_view_refs(resource: BuiltResource) -> list[_CardViewRef]:
+    def _collect_refs(
+        resource: BuiltResource,
+    ) -> tuple[list[_CardViewRef], list[_FieldConfigRef], list[ConsistencyError]]:
         raw_data = read_yaml_file(resource.build_path, expected_output="dict")
         config = InFieldCDMLocationConfigYAML.model_validate(raw_data)
 
-        refs: list[_CardViewRef] = []
+        card_refs: list[_CardViewRef] = []
+        field_refs: list[_FieldConfigRef] = []
+        errors: list[ConsistencyError] = []
+
         if config.data_exploration_config:
             for attr, card_key in INFIELD_CDM_CARD_VIEW_ATTR_TO_JSON_KEY.items():
                 mapping: ViewReference | None = getattr(config.data_exploration_config, attr, None)
@@ -86,23 +100,46 @@ class InFieldCDMViewPropertiesRuleSet(ToolkitGlobalRuleSet):
                     continue
                 view_id = mapping.as_id()
                 required = _REQUIRED_PROPERTIES[card_key]
-                refs.append((resource, card_key, view_id, required))
+                card_refs.append((resource, card_key, view_id, required))
+
+            if card_config := config.data_exploration_config.asset_properties_card_config:
+                if config.view_mappings is None or config.view_mappings.asset is None:
+                    errors.append(
+                        ConsistencyError(
+                            code=f"{InFieldCDMViewPropertiesRuleSet.CODE_PREFIX}-MISSING-ASSET-VIEW",
+                            message=(
+                                f"dataExplorationConfig.assetPropertiesCardConfig in {resource.source_path.name!r} "
+                                "requires viewMappings.asset to validate field keys."
+                            ),
+                            fix="Add viewMappings.asset or remove assetPropertiesCardConfig.",
+                        )
+                    )
+                else:
+                    field_refs.append(
+                        (
+                            resource,
+                            "assetPropertiesCardConfig",
+                            config.view_mappings.asset.as_id(),
+                            frozenset(card_config.keys()),
+                        )
+                    )
 
         if config.view_mappings and config.view_mappings.observation:
             for observation_config in config.view_mappings.observation:
-                if not observation_config.required_properties:
+                if not observation_config.fields_config:
                     continue
-                refs.append(
+                field_refs.append(
                     (
                         resource,
-                        "observation",
+                        "observation.fieldsConfig",
                         observation_config.view.as_id(),
-                        frozenset(observation_config.required_properties),
+                        frozenset(observation_config.fields_config.keys()),
                     )
                 )
-        return refs
 
-    def _check_view(
+        return card_refs, field_refs, errors
+
+    def _check_required_properties(
         self,
         resource: BuiltResource,
         card_key: str,
@@ -123,4 +160,27 @@ class InFieldCDMViewPropertiesRuleSet(ToolkitGlobalRuleSet):
                     f"is missing required properties: {humanize_collection(sorted(missing))}."
                 ),
                 fix=f"Ensure the view has these properties: {humanize_collection(sorted(missing))}.",
+            )
+
+    def _check_field_config_keys(
+        self,
+        resource: BuiltResource,
+        config_key: str,
+        view_id: ViewId,
+        field_keys: frozenset[str],
+        views_by_id: dict[ViewId, ViewResponse],
+    ) -> Iterable[ConsistencyError]:
+        view = views_by_id.get(view_id)
+        if view is None:
+            return
+
+        unknown = field_keys - set(view.properties.keys())
+        if unknown:
+            yield ConsistencyError(
+                code=f"{self.CODE_PREFIX}-UNKNOWN-VIEW-PROPERTY",
+                message=(
+                    f"View {view_id!s} used for {config_key!r} in {resource.source_path.name!r} "
+                    f"does not have properties: {humanize_collection(sorted(unknown))}."
+                ),
+                fix=f"Use property names that exist on the view: {humanize_collection(sorted(unknown))}.",
             )

--- a/cognite_toolkit/_cdf_tk/rules/_infield.py
+++ b/cognite_toolkit/_cdf_tk/rules/_infield.py
@@ -28,6 +28,7 @@ _REQUIRED_PROPERTIES: dict[str, frozenset[str]] = {
 _CardViewRef = tuple[BuiltResource, str, ViewId, frozenset[str]]
 # (resource, config_key, view_id, configured field keys)
 _FieldConfigRef = tuple[BuiltResource, str, ViewId, frozenset[str]]
+_DEFAULT_ASSET_VIEW_ID = ViewId(space="cdf_cdm", external_id="CogniteAsset", version="v1")
 
 
 class InFieldCDMViewPropertiesRuleSet(ToolkitGlobalRuleSet):
@@ -64,10 +65,9 @@ class InFieldCDMViewPropertiesRuleSet(ToolkitGlobalRuleSet):
                     continue
                 if resource.type != config_type:
                     continue
-                card_refs, field_refs, errors = self._collect_refs(resource)
+                card_refs, field_refs = self._collect_refs(resource)
                 card_view_refs.extend(card_refs)
                 field_config_refs.extend(field_refs)
-                yield from errors
 
         if not card_view_refs and not field_config_refs:
             return
@@ -83,15 +83,20 @@ class InFieldCDMViewPropertiesRuleSet(ToolkitGlobalRuleSet):
             yield from self._check_field_config_keys(resource, config_key, view_id, field_keys, views_by_id)
 
     @staticmethod
+    def _asset_view_id_for_card_config(config: InFieldCDMLocationConfigYAML) -> ViewId:
+        if config.view_mappings and config.view_mappings.asset is not None:
+            return config.view_mappings.asset.as_id()
+        return _DEFAULT_ASSET_VIEW_ID
+
+    @staticmethod
     def _collect_refs(
         resource: BuiltResource,
-    ) -> tuple[list[_CardViewRef], list[_FieldConfigRef], list[ConsistencyError]]:
+    ) -> tuple[list[_CardViewRef], list[_FieldConfigRef]]:
         raw_data = read_yaml_file(resource.build_path, expected_output="dict")
         config = InFieldCDMLocationConfigYAML.model_validate(raw_data)
 
         card_refs: list[_CardViewRef] = []
         field_refs: list[_FieldConfigRef] = []
-        errors: list[ConsistencyError] = []
 
         if config.data_exploration_config:
             for attr, card_key in INFIELD_CDM_CARD_VIEW_ATTR_TO_JSON_KEY.items():
@@ -103,26 +108,14 @@ class InFieldCDMViewPropertiesRuleSet(ToolkitGlobalRuleSet):
                 card_refs.append((resource, card_key, view_id, required))
 
             if card_config := config.data_exploration_config.asset_properties_card_config:
-                if config.view_mappings is None or config.view_mappings.asset is None:
-                    errors.append(
-                        ConsistencyError(
-                            code=f"{InFieldCDMViewPropertiesRuleSet.CODE_PREFIX}-MISSING-ASSET-VIEW",
-                            message=(
-                                f"dataExplorationConfig.assetPropertiesCardConfig in {resource.source_path.name!r} "
-                                "requires viewMappings.asset to validate field keys."
-                            ),
-                            fix="Add viewMappings.asset or remove assetPropertiesCardConfig.",
-                        )
+                field_refs.append(
+                    (
+                        resource,
+                        "assetPropertiesCardConfig",
+                        InFieldCDMViewPropertiesRuleSet._asset_view_id_for_card_config(config),
+                        frozenset(card_config.keys()),
                     )
-                else:
-                    field_refs.append(
-                        (
-                            resource,
-                            "assetPropertiesCardConfig",
-                            config.view_mappings.asset.as_id(),
-                            frozenset(card_config.keys()),
-                        )
-                    )
+                )
 
         if config.view_mappings and config.view_mappings.observation:
             for observation_config in config.view_mappings.observation:
@@ -137,7 +130,7 @@ class InFieldCDMViewPropertiesRuleSet(ToolkitGlobalRuleSet):
                     )
                 )
 
-        return card_refs, field_refs, errors
+        return card_refs, field_refs
 
     def _check_required_properties(
         self,

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
@@ -1,10 +1,32 @@
-from pydantic import Field
+import re
+from collections.abc import Mapping
+
+from pydantic import Field, field_validator
 
 from cognite_toolkit._cdf_tk.client.identifiers import NodeId
-from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
+from cognite_toolkit._cdf_tk.constants import (
+    CONTAINER_AND_VIEW_PROPERTIES_IDENTIFIER_PATTERN,
+    FORBIDDEN_CONTAINER_AND_VIEW_PROPERTIES_IDENTIFIER,
+    SPACE_FORMAT_PATTERN,
+)
+from cognite_toolkit._cdf_tk.utils.collection import humanize_collection
 
 from .base import BaseModelResource, ToolkitResource
 from .view_field_definitions import ViewReference
+
+_PROPERTY_KEY_PATTERN = re.compile(CONTAINER_AND_VIEW_PROPERTIES_IDENTIFIER_PATTERN)
+
+
+def _validate_view_property_keys(val: Mapping[str, object]) -> Mapping[str, object]:
+    for key in val:
+        if not _PROPERTY_KEY_PATTERN.match(key):
+            raise ValueError(f"Property '{key}' does not match the required pattern: {_PROPERTY_KEY_PATTERN.pattern}")
+        if key in FORBIDDEN_CONTAINER_AND_VIEW_PROPERTIES_IDENTIFIER:
+            raise ValueError(
+                f"'{key}' is a reserved property identifier. Reserved identifiers are: "
+                f"{humanize_collection(FORBIDDEN_CONTAINER_AND_VIEW_PROPERTIES_IDENTIFIER)}"
+            )
+    return val
 
 
 class FeatureToggles(BaseModelResource):
@@ -69,13 +91,35 @@ class ObservationViewWriteBack(BaseModelResource):
     attachments_endpoint_external_id: str | None = Field(None, min_length=1)
 
 
+class ObservationFieldConfig(BaseModelResource):
+    """Per-field configuration for an observation view."""
+
+    is_required: bool | None = None
+    is_editable: bool | None = None
+    order_number: int | None = Field(None, ge=0)
+
+
+class AssetPropertiesCardFieldConfig(BaseModelResource):
+    """Per-field configuration for the asset properties card."""
+
+    display_name: str | None = None
+    order_number: int | None = Field(None, ge=0)
+
+
 class ObservationViewConfig(BaseModelResource):
     """Observation view configuration."""
 
     view: ViewReference
-    form_view: ViewReference | None = None
-    required_properties: list[str] | None = None
+    fields_config: dict[str, ObservationFieldConfig] | None = None
     write_back: ObservationViewWriteBack | None = None
+
+    @field_validator("fields_config")
+    @classmethod
+    def validate_fields_config_keys(cls, val: dict[str, ObservationFieldConfig] | None) -> dict[str, ObservationFieldConfig] | None:
+        if val is None:
+            return val
+        _validate_view_property_keys(val)
+        return val
 
 
 class ViewMappings(BaseModelResource):
@@ -99,9 +143,19 @@ class ViewMappings(BaseModelResource):
 class DataExplorationConfig(BaseModelResource):
     """Data exploration configuration."""
 
-    asset_properties_card_view: ViewReference | None = None
+    asset_properties_card_config: dict[str, AssetPropertiesCardFieldConfig] | None = None
     asset_activities_card_view: ViewReference | None = None
     asset_notifications_card_view: ViewReference | None = None
+
+    @field_validator("asset_properties_card_config")
+    @classmethod
+    def validate_asset_properties_card_config_keys(
+        cls, val: dict[str, AssetPropertiesCardFieldConfig] | None
+    ) -> dict[str, AssetPropertiesCardFieldConfig] | None:
+        if val is None:
+            return val
+        _validate_view_property_keys(val)
+        return val
 
 
 # Pydantic attribute name -> YAML/API key for card views used in build dependency and validation rules.

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
@@ -115,7 +115,9 @@ class ObservationViewConfig(BaseModelResource):
 
     @field_validator("fields_config")
     @classmethod
-    def validate_fields_config_keys(cls, val: dict[str, ObservationFieldConfig] | None) -> dict[str, ObservationFieldConfig] | None:
+    def validate_fields_config_keys(
+        cls, val: dict[str, ObservationFieldConfig] | None
+    ) -> dict[str, ObservationFieldConfig] | None:
         if val is None:
             return val
         _validate_view_property_keys(val)

--- a/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/infield_cdm_location_config.py
@@ -1,32 +1,10 @@
-import re
-from collections.abc import Mapping
-
-from pydantic import Field, field_validator
+from pydantic import Field
 
 from cognite_toolkit._cdf_tk.client.identifiers import NodeId
-from cognite_toolkit._cdf_tk.constants import (
-    CONTAINER_AND_VIEW_PROPERTIES_IDENTIFIER_PATTERN,
-    FORBIDDEN_CONTAINER_AND_VIEW_PROPERTIES_IDENTIFIER,
-    SPACE_FORMAT_PATTERN,
-)
-from cognite_toolkit._cdf_tk.utils.collection import humanize_collection
+from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 
 from .base import BaseModelResource, ToolkitResource
 from .view_field_definitions import ViewReference
-
-_PROPERTY_KEY_PATTERN = re.compile(CONTAINER_AND_VIEW_PROPERTIES_IDENTIFIER_PATTERN)
-
-
-def _validate_view_property_keys(val: Mapping[str, object]) -> Mapping[str, object]:
-    for key in val:
-        if not _PROPERTY_KEY_PATTERN.match(key):
-            raise ValueError(f"Property '{key}' does not match the required pattern: {_PROPERTY_KEY_PATTERN.pattern}")
-        if key in FORBIDDEN_CONTAINER_AND_VIEW_PROPERTIES_IDENTIFIER:
-            raise ValueError(
-                f"'{key}' is a reserved property identifier. Reserved identifiers are: "
-                f"{humanize_collection(FORBIDDEN_CONTAINER_AND_VIEW_PROPERTIES_IDENTIFIER)}"
-            )
-    return val
 
 
 class FeatureToggles(BaseModelResource):
@@ -113,16 +91,6 @@ class ObservationViewConfig(BaseModelResource):
     fields_config: dict[str, ObservationFieldConfig] | None = None
     write_back: ObservationViewWriteBack | None = None
 
-    @field_validator("fields_config")
-    @classmethod
-    def validate_fields_config_keys(
-        cls, val: dict[str, ObservationFieldConfig] | None
-    ) -> dict[str, ObservationFieldConfig] | None:
-        if val is None:
-            return val
-        _validate_view_property_keys(val)
-        return val
-
 
 class ViewMappings(BaseModelResource):
     """View mappings configuration."""
@@ -148,16 +116,6 @@ class DataExplorationConfig(BaseModelResource):
     asset_properties_card_config: dict[str, AssetPropertiesCardFieldConfig] | None = None
     asset_activities_card_view: ViewReference | None = None
     asset_notifications_card_view: ViewReference | None = None
-
-    @field_validator("asset_properties_card_config")
-    @classmethod
-    def validate_asset_properties_card_config_keys(
-        cls, val: dict[str, AssetPropertiesCardFieldConfig] | None
-    ) -> dict[str, AssetPropertiesCardFieldConfig] | None:
-        if val is None:
-            return val
-        _validate_view_property_keys(val)
-        return val
 
 
 # Pydantic attribute name -> YAML/API key for card views used in build dependency and validation rules.

--- a/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InFieldCDMLocationConfig.yaml
+++ b/tests/data/complete_org_alpha_flags/modules/my_example_module/cdf_applications/my_location.InFieldCDMLocationConfig.yaml
@@ -80,10 +80,12 @@ disciplines:
 - name: Civil
   externalId: discipline_civil
 dataExplorationConfig:
-  assetPropertiesCardView:
-    space: customer_idm_extention
-    version: v3
-    externalId: AssetPropertiesCard
+  assetPropertiesCardConfig:
+    name:
+      displayName: Asset name
+      orderNumber: 0
+    description:
+      orderNumber: 1
   assetActivitiesCardView:
     space: customer_idm_extention
     version: v4

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_fieldops.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_fieldops.py
@@ -244,6 +244,38 @@ class TestInFieldCDMLocationConfigCRUD:
             (ViewIO.__name__, ViewId(space="customer_idm_extention", external_id="ObservationView", version="v2")),
         }
 
+    def test_get_dependent_items_skips_malformed_observation_entries(self) -> None:
+        item = {
+            "space": "sp_instance",
+            "externalId": "my_location_config",
+            "viewMappings": {
+                "observation": [
+                    "not-a-dict",
+                    {"view": "not-a-dict"},
+                    {
+                        "view": {
+                            "space": "customer_idm_extention",
+                            "version": "v2",
+                        },
+                    },
+                    {
+                        "view": {
+                            "space": "customer_idm_extention",
+                            "version": "v2",
+                            "externalId": "ObservationView",
+                        },
+                    },
+                ],
+            },
+        }
+        actual = {
+            (loader_cls.__name__, identifier)
+            for loader_cls, identifier in InFieldCDMLocationConfigIO.get_dependent_items(item)
+        }
+        assert actual == {
+            (ViewIO.__name__, ViewId(space="customer_idm_extention", external_id="ObservationView", version="v2")),
+        }
+
     def test_skip_illegal_configuration(self) -> None:
         legacy_space = "my_infield_legacy_space"
         item = InFieldCDMLocationConfigRequest(

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_fieldops.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_fieldops.py
@@ -134,40 +134,22 @@ class TestInFieldCDMLocationConfigCRUD:
             (ViewIO.__name__, ViewId(space="customer_idm_extention", external_id="ObservationView", version="v2")),
         }
 
-    def test_get_dependencies_includes_observation_view_and_form_view(self) -> None:
+    def test_get_dependencies_without_asset_properties_card_config(self) -> None:
         config = InFieldCDMLocationConfigYAML.model_validate(
             {
                 "space": "sp_instance",
                 "externalId": "my_location_config",
-                "viewMappings": {
-                    "observation": [
-                        {
-                            "view": {
-                                "space": "customer_idm_extention",
-                                "version": "v2",
-                                "externalId": "ObservationView",
-                            },
-                            "formView": {
-                                "space": "customer_idm_extention",
-                                "version": "v2",
-                                "externalId": "ObservationFormView",
-                            },
+                "dataExplorationConfig": {
+                    "assetPropertiesCardConfig": {
+                        "name": {
+                            "displayName": "Asset name",
+                            "orderNumber": 0,
                         },
-                    ],
+                    },
                 },
             }
         )
-        actual = {
-            (loader_cls.__name__, identifier)
-            for loader_cls, identifier in InFieldCDMLocationConfigIO.get_dependencies(config)
-        }
-        assert actual == {
-            (ViewIO.__name__, ViewId(space="customer_idm_extention", external_id="ObservationView", version="v2")),
-            (
-                ViewIO.__name__,
-                ViewId(space="customer_idm_extention", external_id="ObservationFormView", version="v2"),
-            ),
-        }
+        assert list(InFieldCDMLocationConfigIO.get_dependencies(config)) == []
 
     def test_get_dependencies_includes_card_views_and_observation_view(self) -> None:
         config = InFieldCDMLocationConfigYAML.model_validate(
@@ -206,22 +188,6 @@ class TestInFieldCDMLocationConfigCRUD:
     def test_get_dependencies_without_data_exploration_config(self) -> None:
         config = InFieldCDMLocationConfigYAML.model_validate(
             {"space": "sp_instance", "externalId": "my_location_config"}
-        )
-        assert list(InFieldCDMLocationConfigIO.get_dependencies(config)) == []
-
-    def test_get_dependencies_ignores_asset_properties_card(self) -> None:
-        config = InFieldCDMLocationConfigYAML.model_validate(
-            {
-                "space": "sp_instance",
-                "externalId": "my_location_config",
-                "dataExplorationConfig": {
-                    "assetPropertiesCardView": {
-                        "space": "customer_idm_extention",
-                        "version": "v2",
-                        "externalId": "PropertiesCard",
-                    },
-                },
-            }
         )
         assert list(InFieldCDMLocationConfigIO.get_dependencies(config)) == []
 
@@ -276,39 +242,6 @@ class TestInFieldCDMLocationConfigCRUD:
         }
         assert actual == {
             (ViewIO.__name__, ViewId(space="customer_idm_extention", external_id="ObservationView", version="v2")),
-        }
-
-    def test_get_dependent_items_includes_observation_view_and_form_view(self) -> None:
-        item = {
-            "space": "sp_instance",
-            "externalId": "my_location_config",
-            "viewMappings": {
-                "observation": [
-                    {
-                        "view": {
-                            "space": "customer_idm_extention",
-                            "version": "v2",
-                            "externalId": "ObservationView",
-                        },
-                        "formView": {
-                            "space": "customer_idm_extention",
-                            "version": "v2",
-                            "externalId": "ObservationFormView",
-                        },
-                    },
-                ],
-            },
-        }
-        actual = {
-            (loader_cls.__name__, identifier)
-            for loader_cls, identifier in InFieldCDMLocationConfigIO.get_dependent_items(item)
-        }
-        assert actual == {
-            (ViewIO.__name__, ViewId(space="customer_idm_extention", external_id="ObservationView", version="v2")),
-            (
-                ViewIO.__name__,
-                ViewId(space="customer_idm_extention", external_id="ObservationFormView", version="v2"),
-            ),
         }
 
     def test_skip_illegal_configuration(self) -> None:

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
@@ -106,7 +106,9 @@ def invalid_test_cases() -> Iterable:
                 },
             },
         },
-        {"In dataExplorationConfig.assetPropertiesCardConfig.name.orderNumber input should be greater than or equal to 0"},
+        {
+            "In dataExplorationConfig.assetPropertiesCardConfig.name.orderNumber input should be greater than or equal to 0"
+        },
         id="Negative orderNumber in dataExplorationConfig.assetPropertiesCardConfig",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
@@ -99,15 +99,45 @@ def invalid_test_cases() -> Iterable:
             "externalId": "my_config",
             "space": "my_space",
             "dataExplorationConfig": {
-                "assetPropertiesCardView": {
-                    "space": "my_space",
-                    "version": "v1",
-                    # Missing externalId
+                "assetPropertiesCardConfig": {
+                    "name": {
+                        "orderNumber": -1,
+                    },
                 },
             },
         },
-        {"In dataExplorationConfig.assetPropertiesCardView missing required field: 'externalId'"},
-        id="Missing required field in dataExplorationConfig.assetPropertiesCardView",
+        {"In dataExplorationConfig.assetPropertiesCardConfig.name.orderNumber input should be greater than or equal to 0"},
+        id="Negative orderNumber in dataExplorationConfig.assetPropertiesCardConfig",
+    )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
+            "dataExplorationConfig": {
+                "assetPropertiesCardConfig": {
+                    "name": {
+                        "unknownField": "bad_value",
+                    },
+                },
+            },
+        },
+        {"In dataExplorationConfig.assetPropertiesCardConfig.name unknown field: 'unknownField'"},
+        id="Unknown field in dataExplorationConfig.assetPropertiesCardConfig entry",
+    )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
+            "dataExplorationConfig": {
+                "assetPropertiesCardConfig": {
+                    "invalid@": {},
+                },
+            },
+        },
+        {
+            "In dataExplorationConfig.assetPropertiesCardConfig property 'invalid@' does not match the required pattern: ^[a-zA-Z0-9][a-zA-Z0-9_-]{0,253}[a-zA-Z0-9]?$"
+        },
+        id="Invalid property key in dataExplorationConfig.assetPropertiesCardConfig",
     )
     yield pytest.param(
         {
@@ -272,16 +302,17 @@ def invalid_test_cases() -> Iterable:
                             "version": "v1",
                             "externalId": "ObsView",
                         },
-                        "formView": {
-                            "space": "my_space",
-                            "version": "v1",
+                        "fieldsConfig": {
+                            "assets": {
+                                "orderNumber": -1,
+                            },
                         },
                     },
                 ],
             },
         },
-        {"In viewMappings.observation[1].formView missing required field: 'externalId'"},
-        id="Missing required field in viewMappings.observation formView",
+        {"In viewMappings.observation[1].fieldsConfig.assets.orderNumber input should be greater than or equal to 0"},
+        id="Negative orderNumber in viewMappings.observation.fieldsConfig",
     )
     yield pytest.param(
         {
@@ -295,18 +326,41 @@ def invalid_test_cases() -> Iterable:
                             "version": "v1",
                             "externalId": "ObsView",
                         },
-                        "formView": {
-                            "space": "my_space",
-                            "version": "v1",
-                            "externalId": "ObsFormView",
-                            "unknownField": "bad_value",
+                        "fieldsConfig": {
+                            "assets": {
+                                "unknownField": "bad_value",
+                            },
                         },
                     },
                 ],
             },
         },
-        {"In viewMappings.observation[1].formView unknown field: 'unknownField'"},
-        id="Unknown field in viewMappings.observation.formView",
+        {"In viewMappings.observation[1].fieldsConfig.assets unknown field: 'unknownField'"},
+        id="Unknown field in viewMappings.observation.fieldsConfig entry",
+    )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
+            "viewMappings": {
+                "observation": [
+                    {
+                        "view": {
+                            "space": "my_space",
+                            "version": "v1",
+                            "externalId": "ObsView",
+                        },
+                        "fieldsConfig": {
+                            "invalid@": {},
+                        },
+                    },
+                ],
+            },
+        },
+        {
+            "In viewMappings.observation[1].fieldsConfig property 'invalid@' does not match the required pattern: ^[a-zA-Z0-9][a-zA-Z0-9_-]{0,253}[a-zA-Z0-9]?$"
+        },
+        id="Invalid property key in viewMappings.observation.fieldsConfig",
     )
     yield pytest.param(
         {
@@ -415,7 +469,7 @@ class TestInfieldCDMLocationConfigYAML:
         dumped = loaded.model_dump(exclude_unset=True, by_alias=True)
         assert dumped == data
 
-    def test_load_valid_observation_view_config_with_required_properties(self) -> None:
+    def test_load_valid_observation_view_config_with_fields_config(self) -> None:
         data = {
             "externalId": "my_config",
             "space": "my_space",
@@ -427,7 +481,16 @@ class TestInfieldCDMLocationConfigYAML:
                             "version": "v1",
                             "externalId": "ObsView",
                         },
-                        "requiredProperties": ["assets", "files"],
+                        "fieldsConfig": {
+                            "assets": {
+                                "isRequired": True,
+                                "isEditable": False,
+                                "orderNumber": 1,
+                            },
+                            "files": {
+                                "orderNumber": 2,
+                            },
+                        },
                         "writeBack": {
                             "notificationsEndpointExternalId": "notif-endpoint",
                         },
@@ -439,29 +502,20 @@ class TestInfieldCDMLocationConfigYAML:
         dumped = loaded.model_dump(exclude_unset=True, by_alias=True)
         assert dumped == data
 
-    def test_load_valid_observation_view_config_with_form_view(self) -> None:
+    def test_load_valid_asset_properties_card_config(self) -> None:
         data = {
             "externalId": "my_config",
             "space": "my_space",
-            "viewMappings": {
-                "observation": [
-                    {
-                        "view": {
-                            "space": "my_space",
-                            "version": "v1",
-                            "externalId": "ObsView",
-                        },
-                        "formView": {
-                            "space": "my_space",
-                            "version": "v1",
-                            "externalId": "ObsFormView",
-                        },
-                        "requiredProperties": ["assets", "files"],
-                        "writeBack": {
-                            "notificationsEndpointExternalId": "notif-endpoint",
-                        },
+            "dataExplorationConfig": {
+                "assetPropertiesCardConfig": {
+                    "name": {
+                        "displayName": "Asset name",
+                        "orderNumber": 0,
                     },
-                ],
+                    "description": {
+                        "orderNumber": 1,
+                    },
+                },
             },
         }
         loaded = InFieldCDMLocationConfigYAML.model_validate(data)

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
@@ -368,6 +368,45 @@ def invalid_test_cases() -> Iterable:
         {
             "externalId": "my_config",
             "space": "my_space",
+            "viewMappings": {
+                "observation": [
+                    {
+                        "view": {
+                            "space": "my_space",
+                            "version": "v1",
+                            "externalId": "ObsView",
+                        },
+                        "fieldsConfig": {
+                            "externalId": {},
+                        },
+                    },
+                ],
+            },
+        },
+        {
+            "In viewMappings.observation[1].fieldsConfig 'externalId' is a reserved property identifier. Reserved identifiers are: createdTime, deletedTime, edge_id, extensions, externalId, lastUpdatedTime, node_id, project_id, property_group, seq, space and tg_table_name"
+        },
+        id="Reserved property key in viewMappings.observation.fieldsConfig",
+    )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
+            "dataExplorationConfig": {
+                "assetPropertiesCardConfig": {
+                    "externalId": {},
+                },
+            },
+        },
+        {
+            "In dataExplorationConfig.assetPropertiesCardConfig 'externalId' is a reserved property identifier. Reserved identifiers are: createdTime, deletedTime, edge_id, extensions, externalId, lastUpdatedTime, node_id, project_id, property_group, seq, space and tg_table_name"
+        },
+        id="Reserved property key in dataExplorationConfig.assetPropertiesCardConfig",
+    )
+    yield pytest.param(
+        {
+            "externalId": "my_config",
+            "space": "my_space",
             "dataExplorationConfig": {
                 "assetActivitiesCardView": {
                     "space": "my_space",

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
@@ -130,21 +130,6 @@ def invalid_test_cases() -> Iterable:
         {
             "externalId": "my_config",
             "space": "my_space",
-            "dataExplorationConfig": {
-                "assetPropertiesCardConfig": {
-                    "invalid@": {},
-                },
-            },
-        },
-        {
-            "In dataExplorationConfig.assetPropertiesCardConfig property 'invalid@' does not match the required pattern: ^[a-zA-Z0-9][a-zA-Z0-9_-]{0,253}[a-zA-Z0-9]?$"
-        },
-        id="Invalid property key in dataExplorationConfig.assetPropertiesCardConfig",
-    )
-    yield pytest.param(
-        {
-            "externalId": "my_config",
-            "space": "my_space",
             "viewMappings": {
                 "observation": [],
             },
@@ -339,69 +324,6 @@ def invalid_test_cases() -> Iterable:
         },
         {"In viewMappings.observation[1].fieldsConfig.assets unknown field: 'unknownField'"},
         id="Unknown field in viewMappings.observation.fieldsConfig entry",
-    )
-    yield pytest.param(
-        {
-            "externalId": "my_config",
-            "space": "my_space",
-            "viewMappings": {
-                "observation": [
-                    {
-                        "view": {
-                            "space": "my_space",
-                            "version": "v1",
-                            "externalId": "ObsView",
-                        },
-                        "fieldsConfig": {
-                            "invalid@": {},
-                        },
-                    },
-                ],
-            },
-        },
-        {
-            "In viewMappings.observation[1].fieldsConfig property 'invalid@' does not match the required pattern: ^[a-zA-Z0-9][a-zA-Z0-9_-]{0,253}[a-zA-Z0-9]?$"
-        },
-        id="Invalid property key in viewMappings.observation.fieldsConfig",
-    )
-    yield pytest.param(
-        {
-            "externalId": "my_config",
-            "space": "my_space",
-            "viewMappings": {
-                "observation": [
-                    {
-                        "view": {
-                            "space": "my_space",
-                            "version": "v1",
-                            "externalId": "ObsView",
-                        },
-                        "fieldsConfig": {
-                            "externalId": {},
-                        },
-                    },
-                ],
-            },
-        },
-        {
-            "In viewMappings.observation[1].fieldsConfig 'externalId' is a reserved property identifier. Reserved identifiers are: createdTime, deletedTime, edge_id, extensions, externalId, lastUpdatedTime, node_id, project_id, property_group, seq, space and tg_table_name"
-        },
-        id="Reserved property key in viewMappings.observation.fieldsConfig",
-    )
-    yield pytest.param(
-        {
-            "externalId": "my_config",
-            "space": "my_space",
-            "dataExplorationConfig": {
-                "assetPropertiesCardConfig": {
-                    "externalId": {},
-                },
-            },
-        },
-        {
-            "In dataExplorationConfig.assetPropertiesCardConfig 'externalId' is a reserved property identifier. Reserved identifiers are: createdTime, deletedTime, edge_id, extensions, externalId, lastUpdatedTime, node_id, project_id, property_group, seq, space and tg_table_name"
-        },
-        id="Reserved property key in dataExplorationConfig.assetPropertiesCardConfig",
     )
     yield pytest.param(
         {

--- a/tests/test_unit/test_cdf_tk/test_rules/test_infield.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_infield.py
@@ -232,7 +232,7 @@ class TestInFieldCDMViewPropertiesRuleSet:
         call_view_ids = mock_client.tool.views.retrieve.call_args[0][0]
         assert set(call_view_ids) == {activities_id, notifications_id}
 
-    def test_observation_view_with_required_properties_present(
+    def test_observation_fields_config_keys_present(
         self,
         tmp_path: Path,
         mock_view: Callable[[ViewId, frozenset[str]], MagicMock],
@@ -254,7 +254,10 @@ class TestInFieldCDMViewPropertiesRuleSet:
                                 "version": "v2",
                                 "externalId": "ObservationView",
                             },
-                            "requiredProperties": ["assets", "files"],
+                            "fieldsConfig": {
+                                "assets": {"orderNumber": 1},
+                                "files": {"orderNumber": 2},
+                            },
                         },
                     ],
                 },
@@ -268,7 +271,7 @@ class TestInFieldCDMViewPropertiesRuleSet:
         rule = InFieldCDMViewPropertiesRuleSet(modules=[module], client=mock_client)
         assert list(rule.validate()) == []
 
-    def test_observation_view_missing_required_properties(
+    def test_observation_fields_config_unknown_property(
         self,
         tmp_path: Path,
         mock_view: Callable[[ViewId, frozenset[str]], MagicMock],
@@ -290,7 +293,10 @@ class TestInFieldCDMViewPropertiesRuleSet:
                                 "version": "v2",
                                 "externalId": "ObservationView",
                             },
-                            "requiredProperties": ["assets", "files"],
+                            "fieldsConfig": {
+                                "assets": {"orderNumber": 1},
+                                "files": {"orderNumber": 2},
+                            },
                         },
                     ],
                 },
@@ -304,10 +310,10 @@ class TestInFieldCDMViewPropertiesRuleSet:
         rule = InFieldCDMViewPropertiesRuleSet(modules=[module], client=mock_client)
         errors = list(rule.validate())
         assert len(errors) == 1
-        assert errors[0].code == f"{InFieldCDMViewPropertiesRuleSet.CODE_PREFIX}-VIEW-MISSING-PROPERTIES"
+        assert errors[0].code == f"{InFieldCDMViewPropertiesRuleSet.CODE_PREFIX}-UNKNOWN-VIEW-PROPERTY"
         assert "files" in errors[0].message
 
-    def test_observation_view_without_required_properties_is_not_checked(
+    def test_observation_without_fields_config_is_not_checked(
         self,
         tmp_path: Path,
         write_config_yaml: Callable[[Path, dict], None],
@@ -338,6 +344,112 @@ class TestInFieldCDMViewPropertiesRuleSet:
         mock_client = MagicMock()
         rule = InFieldCDMViewPropertiesRuleSet(modules=[module], client=mock_client)
         assert list(rule.validate()) == []
+        mock_client.tool.views.retrieve.assert_not_called()
+
+    def test_asset_properties_card_config_keys_present(
+        self,
+        tmp_path: Path,
+        mock_view: Callable[[ViewId, frozenset[str]], MagicMock],
+        write_config_yaml: Callable[[Path, dict], None],
+        create_built_resource: Callable[[Path, Path], BuiltResource],
+        create_module: Callable[[Path, list[BuiltResource]], BuiltModule],
+    ) -> None:
+        yaml_file = tmp_path / "cdf_applications" / "my_location.InFieldCDMLocationConfig.yaml"
+        write_config_yaml(
+            yaml_file,
+            {
+                "space": "sp_instance",
+                "externalId": "my_location_config",
+                "viewMappings": {
+                    "asset": {
+                        "space": "cdf_core",
+                        "version": "v1",
+                        "externalId": "CogniteAsset",
+                    },
+                },
+                "dataExplorationConfig": {
+                    "assetPropertiesCardConfig": {
+                        "name": {"orderNumber": 0},
+                        "description": {"orderNumber": 1},
+                    },
+                },
+            },
+        )
+        resource = create_built_resource(yaml_file, yaml_file)
+        module = create_module(tmp_path, [resource])
+        asset_id = ViewId(space="cdf_core", external_id="CogniteAsset", version="v1")
+        mock_client = MagicMock()
+        mock_client.tool.views.retrieve.return_value = [mock_view(asset_id, frozenset({"name", "description"}))]
+        rule = InFieldCDMViewPropertiesRuleSet(modules=[module], client=mock_client)
+        assert list(rule.validate()) == []
+
+    def test_asset_properties_card_config_unknown_property(
+        self,
+        tmp_path: Path,
+        mock_view: Callable[[ViewId, frozenset[str]], MagicMock],
+        write_config_yaml: Callable[[Path, dict], None],
+        create_built_resource: Callable[[Path, Path], BuiltResource],
+        create_module: Callable[[Path, list[BuiltResource]], BuiltModule],
+    ) -> None:
+        yaml_file = tmp_path / "cdf_applications" / "my_location.InFieldCDMLocationConfig.yaml"
+        write_config_yaml(
+            yaml_file,
+            {
+                "space": "sp_instance",
+                "externalId": "my_location_config",
+                "viewMappings": {
+                    "asset": {
+                        "space": "cdf_core",
+                        "version": "v1",
+                        "externalId": "CogniteAsset",
+                    },
+                },
+                "dataExplorationConfig": {
+                    "assetPropertiesCardConfig": {
+                        "name": {"orderNumber": 0},
+                        "unknownField": {"orderNumber": 1},
+                    },
+                },
+            },
+        )
+        resource = create_built_resource(yaml_file, yaml_file)
+        module = create_module(tmp_path, [resource])
+        asset_id = ViewId(space="cdf_core", external_id="CogniteAsset", version="v1")
+        mock_client = MagicMock()
+        mock_client.tool.views.retrieve.return_value = [mock_view(asset_id, frozenset({"name"}))]
+        rule = InFieldCDMViewPropertiesRuleSet(modules=[module], client=mock_client)
+        errors = list(rule.validate())
+        assert len(errors) == 1
+        assert errors[0].code == f"{InFieldCDMViewPropertiesRuleSet.CODE_PREFIX}-UNKNOWN-VIEW-PROPERTY"
+        assert "unknownField" in errors[0].message
+
+    def test_asset_properties_card_config_without_asset_view_errors(
+        self,
+        tmp_path: Path,
+        write_config_yaml: Callable[[Path, dict], None],
+        create_built_resource: Callable[[Path, Path], BuiltResource],
+        create_module: Callable[[Path, list[BuiltResource]], BuiltModule],
+    ) -> None:
+        yaml_file = tmp_path / "cdf_applications" / "my_location.InFieldCDMLocationConfig.yaml"
+        write_config_yaml(
+            yaml_file,
+            {
+                "space": "sp_instance",
+                "externalId": "my_location_config",
+                "dataExplorationConfig": {
+                    "assetPropertiesCardConfig": {
+                        "name": {"orderNumber": 0},
+                    },
+                },
+            },
+        )
+        resource = create_built_resource(yaml_file, yaml_file)
+        module = create_module(tmp_path, [resource])
+        mock_client = MagicMock()
+        rule = InFieldCDMViewPropertiesRuleSet(modules=[module], client=mock_client)
+        errors = list(rule.validate())
+        assert len(errors) == 1
+        assert errors[0].code == f"{InFieldCDMViewPropertiesRuleSet.CODE_PREFIX}-MISSING-ASSET-VIEW"
         mock_client.tool.views.retrieve.assert_not_called()
 
     def test_retrieve_batch_failure_propagates(

--- a/tests/test_unit/test_cdf_tk/test_rules/test_infield.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_infield.py
@@ -423,9 +423,10 @@ class TestInFieldCDMViewPropertiesRuleSet:
         assert errors[0].code == f"{InFieldCDMViewPropertiesRuleSet.CODE_PREFIX}-UNKNOWN-VIEW-PROPERTY"
         assert "unknownField" in errors[0].message
 
-    def test_asset_properties_card_config_without_asset_view_errors(
+    def test_asset_properties_card_config_defaults_to_cognite_asset_view(
         self,
         tmp_path: Path,
+        mock_view: Callable[[ViewId, frozenset[str]], MagicMock],
         write_config_yaml: Callable[[Path, dict], None],
         create_built_resource: Callable[[Path, Path], BuiltResource],
         create_module: Callable[[Path, list[BuiltResource]], BuiltModule],
@@ -445,12 +446,12 @@ class TestInFieldCDMViewPropertiesRuleSet:
         )
         resource = create_built_resource(yaml_file, yaml_file)
         module = create_module(tmp_path, [resource])
+        default_asset_id = ViewId(space="cdf_cdm", external_id="CogniteAsset", version="v1")
         mock_client = MagicMock()
+        mock_client.tool.views.retrieve.return_value = [mock_view(default_asset_id, frozenset({"name"}))]
         rule = InFieldCDMViewPropertiesRuleSet(modules=[module], client=mock_client)
-        errors = list(rule.validate())
-        assert len(errors) == 1
-        assert errors[0].code == f"{InFieldCDMViewPropertiesRuleSet.CODE_PREFIX}-MISSING-ASSET-VIEW"
-        mock_client.tool.views.retrieve.assert_not_called()
+        assert list(rule.validate()) == []
+        mock_client.tool.views.retrieve.assert_called_once_with([default_asset_id], include_inherited_properties=True)
 
     def test_retrieve_batch_failure_propagates(
         self,

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags.yaml
@@ -168,10 +168,12 @@ InFieldCDMLocationConfigResponse:
           externalId: NotificationsCard
           space: customer_idm_extention
           version: v2
-        assetPropertiesCard:
-          externalId: AssetPropertiesCard
-          space: customer_idm_extention
-          version: v2
+        assetPropertiesCardConfig:
+          description:
+            orderNumber: 1
+          name:
+            displayName: Asset name
+            orderNumber: 0
       dataFilters:
         assets:
           instanceSpaces:

--- a/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags_v2.yaml
+++ b/tests/test_unit/test_cli/test_build_deploy_snapshots/complete_org_alpha_flags_v2.yaml
@@ -158,10 +158,12 @@ InFieldCDMLocationConfigResponse:
           externalId: InfieldNotificationsCardView
           space: customer_idm_extention
           version: v2
-        assetPropertiesCardView:
-          externalId: AssetPropertiesCard
-          space: customer_idm_extention
-          version: v3
+        assetPropertiesCardConfig:
+          description:
+            orderNumber: 1
+          name:
+            displayName: Asset name
+            orderNumber: 0
       dataFilters:
         assets:
           instanceSpaces:


### PR DESCRIPTION
# Description

Replaces legacy InField CDM location config fields with structured field mappings and validates them at schema and build time.

**Observation config (`viewMappings.observation[]`):**
- Removes `formView` and `requiredProperties`
- Adds `fieldsConfig` — a map of view property names to per-field settings (`isRequired`, `isEditable`, `orderNumber`)

Asset properties card (`dataExplorationConfig`):
- Removes `assetPropertiesCardView`
- Adds `assetPropertiesCardConfig` — a map of asset view property names to display settings (`displayName`, `orderNumber`)

**Validation:**
- Schema: property key format, forbidden identifiers, `orderNumber >= 0`, unknown nested fields rejected
- Build: `fieldsConfig` keys checked against the observation view; `assetPropertiesCardConfig` keys checked against `viewMappings.asset` (defaults to `CogniteAsset` if asset view is missing)

**Breaking change:** configs using `formView`, `requiredProperties`, or `assetPropertiesCardView` must migrate to the new fields.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Removed

- `formView` and `requiredProperties` from `viewMappings.observation`
- `assetPropertiesCardView` from `dataExplorationConfig`

### Added
- `fieldsConfig` on observation view config for per-field `isRequired`, `isEditable`, and `orderNumber`
- `assetPropertiesCardConfig` on `dataExplorationConfig` for per-field `displayName` and `orderNumber`
- Schema validation for field-config property key format and reserved identifiers
- Build-time validation (`INFIELD-CDM-UNKNOWN-VIEW-PROPERTY`, `INFIELD-CDM-MISSING-ASSET-VIEW`) that field-config keys exist on the referenced CDF views