### PR TITLE
feat(infield): updated requiredProperty assetNotificationsCardView id createdDate -> sourceCreatedTime

### DIFF
--- a/cognite_toolkit/_cdf_tk/rules/_infield.py
+++ b/cognite_toolkit/_cdf_tk/rules/_infield.py
@@ -20,7 +20,7 @@ _REQUIRED_PROPERTIES: dict[str, frozenset[str]] = {
         {"sourceId", "name", "status", "type", "mainAsset", "scheduledEndTime", "scheduledStartTime"}
     ),
     "assetNotificationsCardView": frozenset(
-        {"name", "sourceId", "type", "status", "description", "asset", "createdDate", "priority"}
+        {"name", "sourceId", "type", "status", "description", "asset", "sourceCreatedTime", "priority"}
     ),
 }
 


### PR DESCRIPTION
# Description

In the custom InfieldNotificationsCardView, `createdDate `is mapped with:
`"containerPropertyIdentifier": "sourceCreatedTime",`
The default CogniteNotification does not have createdDate. This causes an error when createdDate is passed to CogniteNotification as a sorting property. Updated required properties array

PR to fix it in the GUI https://github.com/cognitedata/fusion/pull/26280

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Changed

- Updated assetNotificationsCardView required field id from createdDate to sourceCreatedTime
