### PR TITLE
[CDF-28394] Fix functions limits validation failing due to new py314 runtime

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/function.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/function.py
@@ -75,8 +75,8 @@ class FunctionLimits(BaseModelObject):
     timeout_minutes: int
     cpu_cores: ResourceLimit
     memory_gb: ResourceLimit
-    # Kept as a plain list of strings (rather than list[FunctionRuntime]) so that the API adding a new
+    # Kept as a list of FunctionRuntime | str so that the API adding a new
     # runtime before the toolkit knows about it does not break parsing of the limits response.
-    runtimes: list[str]
+    runtimes: list[FunctionRuntime | str]
     # As of 24.04.2026 this is marked as a required field in the API, but it's currently only returned for projects on Gcloud
     response_size_mb: int | None = None

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/function.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/function.py
@@ -7,7 +7,7 @@ from cognite_toolkit._cdf_tk.client._types import Metadata
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 
 FunctionStatus: TypeAlias = Literal["Queued", "Deploying", "Ready", "Failed", "Retired"]
-FunctionRuntime: TypeAlias = Literal["py38", "py39", "py310", "py311", "py312", "py313"]
+FunctionRuntime: TypeAlias = Literal["py38", "py39", "py310", "py311", "py312", "py313", "py314"]
 
 
 class FunctionBase(BaseModelObject):
@@ -75,6 +75,8 @@ class FunctionLimits(BaseModelObject):
     timeout_minutes: int
     cpu_cores: ResourceLimit
     memory_gb: ResourceLimit
-    runtimes: list[FunctionRuntime]
+    # Kept as a plain list of strings (rather than list[FunctionRuntime]) so that the API adding a new
+    # runtime before the toolkit knows about it does not break parsing of the limits response.
+    runtimes: list[str]
     # As of 24.04.2026 this is marked as a required field in the API, but it's currently only returned for projects on Gcloud
     response_size_mb: int | None = None

--- a/cognite_toolkit/_cdf_tk/yaml_classes/functions.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/functions.py
@@ -45,7 +45,7 @@ class FunctionsYAML(ToolkitResource):
     )
     cpu: float | None = Field(default=None, description="Number of CPU cores per function.")
     memory: float | None = Field(default=None, description="Memory per function measured in GB.")
-    runtime: Literal["py39", "py310", "py311", "py312", "py313"] | None = Field(
+    runtime: Literal["py39", "py310", "py311", "py312", "py313", "py314"] | None = Field(
         default="py311", description="Runtime of the function."
     )
     metadata: dict[str, str] | None = Field(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_functions.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_functions.py
@@ -23,7 +23,7 @@ def invalid_function_test_cases() -> Iterable:
             "secrets": {f"secret_name{i}": f"super_secret{i}" for i in range(31)},
         },
         {
-            "In field runtime input should be 'py39', 'py310', 'py311', 'py312' or 'py313'. Got 'py36'.",
+            "In field runtime input should be 'py39', 'py310', 'py311', 'py312', 'py313' or 'py314'. Got 'py36'.",
             "In field secrets dictionary should have at most 30 items after validation, not 31",
         },
         id="Invalid runtime",


### PR DESCRIPTION
# Description

The CDF functions limits API now returns `py314` as a supported runtime, which broke toolkit's build-time function validation since `FunctionLimits` failed to parse the response. This PR adds `py314` support and additonally relaxes `runtimes` on the response object to a plain string list such that future runtime additions don't hard-fail parsing.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- Fix `cdf build` failing with "Function limits validation failed" when building Cognite Functions.