### PR TITLE
Add automatic debug output for 408s and surface X-Request-ID in errors

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/api/instances.py
+++ b/cognite_toolkit/_cdf_tk/client/api/instances.py
@@ -182,7 +182,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
                 QuerySortSpec(property=[instance_type, "space"], direction="ascending"),
                 QuerySortSpec(property=[instance_type, "externalId"], direction="ascending"),
             ]
-        sync_mode: Literal["onePhase", "twoPhase", "noBackfill"] | None = "onePhase" if endpoint == "sync" else None
+        sync_mode: Literal["onePhase", "twoPhase", "noBackfill"] | None = "twoPhase" if endpoint == "sync" else None
 
         if filter is None:
             query = QueryRequest(
@@ -192,7 +192,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
                         nodes=QueryNodeTableExpression(),
                         sort=space_ext_id_sort,
                         mode=sync_mode,
-                        # backfill_sort=space_ext_id_sort,
+                        backfill_sort=space_ext_id_sort,
                     )
                 },
                 select={"root": QuerySelect()},
@@ -208,7 +208,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
                 edges=QueryEdgeTableExpression(filter=filter.dump_filter(include_has_data=True)),
                 sort=space_ext_id_sort,
                 mode=sync_mode,
-                # backfill_sort=space_ext_id_sort,
+                backfill_sort=space_ext_id_sort,
             )
         else:  # Node or none
             expression = QueryNodeExpression(
@@ -216,7 +216,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
                 nodes=QueryNodeTableExpression(filter=filter.dump_filter(include_has_data=True)),
                 sort=space_ext_id_sort,
                 mode=sync_mode,
-                # backfill_sort=space_ext_id_sort,
+                backfill_sort=space_ext_id_sort,
             )
         sources: list[QuerySelectSource] = []
         if filter.source:
@@ -574,7 +574,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         This is written with a dedicated NDJsonWriter/kind so it does not mix with the per-item
         LogEntryV2 entries written to the download issues log.
         """
-        filestem = create_logfile_stem(output_dir, f"debug_{endpoint_name}")
+        filestem = create_logfile_stem(output_dir, f"download")
         with NDJsonWriter(
             output_dir, kind="QueryDebugResponse", default_filestem=filestem, compression=Uncompressed
         ) as writer:

--- a/cognite_toolkit/_cdf_tk/client/api/instances.py
+++ b/cognite_toolkit/_cdf_tk/client/api/instances.py
@@ -574,7 +574,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         This is written with a dedicated NDJsonWriter/kind so it does not mix with the per-item
         LogEntryV2 entries written to the download issues log.
         """
-        filestem = create_logfile_stem(output_dir, f"download")
+        filestem = create_logfile_stem(output_dir, "download")
         with NDJsonWriter(
             output_dir, kind="QueryDebugResponse", default_filestem=filestem, compression=Uncompressed
         ) as writer:

--- a/cognite_toolkit/_cdf_tk/client/api/instances.py
+++ b/cognite_toolkit/_cdf_tk/client/api/instances.py
@@ -1,8 +1,8 @@
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
-from datetime import datetime, timezone
 from itertools import zip_longest
+from pathlib import Path
 from typing import Generic, Literal, TypeAlias, TypeVar, overload
 
 from pydantic import JsonValue
@@ -42,7 +42,8 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._query import
     QuerySortSpec,
 )
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
-from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter
+from cognite_toolkit._cdf_tk.utils.file import create_logfile_stem
+from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter, Uncompressed
 
 log = logging.getLogger(__name__)
 
@@ -181,7 +182,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
                 QuerySortSpec(property=[instance_type, "space"], direction="ascending"),
                 QuerySortSpec(property=[instance_type, "externalId"], direction="ascending"),
             ]
-        sync_mode: Literal["onePhase", "twoPhase", "noBackfill"] | None = "twoPhase" if endpoint == "sync" else None
+        sync_mode: Literal["onePhase", "twoPhase", "noBackfill"] | None = "onePhase" if endpoint == "sync" else None
 
         if filter is None:
             query = QueryRequest(
@@ -191,7 +192,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
                         nodes=QueryNodeTableExpression(),
                         sort=space_ext_id_sort,
                         mode=sync_mode,
-                        backfill_sort=space_ext_id_sort,
+                        # backfill_sort=space_ext_id_sort,
                     )
                 },
                 select={"root": QuerySelect()},
@@ -207,7 +208,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
                 edges=QueryEdgeTableExpression(filter=filter.dump_filter(include_has_data=True)),
                 sort=space_ext_id_sort,
                 mode=sync_mode,
-                backfill_sort=space_ext_id_sort,
+                # backfill_sort=space_ext_id_sort,
             )
         else:  # Node or none
             expression = QueryNodeExpression(
@@ -215,7 +216,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
                 nodes=QueryNodeTableExpression(filter=filter.dump_filter(include_has_data=True)),
                 sort=space_ext_id_sort,
                 mode=sync_mode,
-                backfill_sort=space_ext_id_sort,
+                # backfill_sort=space_ext_id_sort,
             )
         sources: list[QuerySelectSource] = []
         if filter.source:
@@ -404,17 +405,19 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
                 batch = self._query(query, response_cls, endpoint_prop, exhaust_sub_selections, endpoint_name=endpoint)
             except ReduceLoadException as e:
                 if current_chunk_size <= 1:
-                    debug_written = False
+                    debug_file: Path | None = None
                     if endpoint == "sync":
-                        debug_written = self._run_and_log_debug_query(query, endpoint_prop, endpoint, debug_writer)
+                        debug_file = self._run_and_log_debug_query(query, endpoint_prop, endpoint, debug_writer)
                     source = e.source_exception
-                    if debug_written and isinstance(source, ToolkitAPIError):
+                    if isinstance(source, ToolkitAPIError) and debug_file is not None:
                         source = ToolkitAPIError(
-                            f"{source.message} Debug info written to {debug_writer.output_dir}",  # type: ignore[union-attr]
-                            missing=source.missing,  # type: ignore[arg-type]
-                            duplicated=source.duplicated,  # type: ignore[arg-type]
+                            f"{source.message} | Debug info (query plan and notices) was written to {debug_file}.",
+                            missing=source.missing,
+                            duplicated=source.duplicated,
                             code=source.code,
                             request=source.request,
+                            debug_file=debug_file,
+                            x_request_id=source.x_request_id,
                         )
                     raise source
                 min_failed_chunk_size = min(current_chunk_size, min_failed_chunk_size)
@@ -509,6 +512,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
                     duplicated=response.error.duplicated,  # type: ignore[arg-type]
                     code=response.error.code,
                     request=request,
+                    x_request_id=response.error.x_request_id,
                 )
             )
 
@@ -522,17 +526,22 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
 
     def _run_and_log_debug_query(
         self, query: QueryRequest, endpoint: Endpoint, endpoint_name: QueryEndpoint, debug_writer: NDJsonWriter | None
-    ) -> bool:
-        """Issue a diagnostic query with plan/profile debug parameters and write the result to disk."""
+    ) -> Path | None:
+        """Issue a diagnostic query with plan/profile debug parameters and write the result to disk.
+
+        Returns:
+            The path to the file the debug info was written to, or None if no debug info was written.
+        """
         if debug_writer is None:
-            return False
+            return None
         debug_query = query.model_copy(
             update={
                 "debug": QueryDebugParameters(
                     include_plan=True,
+                    include_translated_query=True,
                     emit_results=False,
                     profile=True,
-                    timeout=60000,
+                    timeout=55000,
                 )
             }
         )
@@ -546,35 +555,29 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         )
         try:
             response = self._http_client.request_single_retries(request)
-            if isinstance(response, FailedResponse):
-                log.warning(
-                    "Debug query (plan/profile) for %s also failed with status %s: %s",
-                    endpoint_name,
-                    response.status_code,
-                    response.body,
-                )
-                return False
             success_response = response.get_success_or_raise(request)
             debug_response = QueryResponseUntyped.model_validate_json(success_response.body)
             if debug_response.debug:
-                self._write_debug_info(endpoint_name, debug_response.debug, debug_writer)
-                return True
-            return False
-        except Exception as exc:
-            log.warning("Debug query (plan/profile) for %s failed: %s", endpoint_name, exc)
-            return False
+                return self._write_debug_info(endpoint_name, debug_response.debug, debug_writer.output_dir)
+            return None
+        except Exception:
+            # The debug query itself may fail with e.g. a 408 error, but if that happens we do not want to
+            # potentially distract from the original error by printing diagnostic info for a separate query.
+            return None
 
-    def _write_debug_info(
-        self, endpoint_name: QueryEndpoint, debug_data: dict[str, JsonValue], debug_writer: NDJsonWriter
-    ) -> None:
-        """Write debug notices and query plan via the provided NDJsonWriter."""
-        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-        filestem = f"query_408_debug_{endpoint_name}_{timestamp}"
-        debug_writer.write_chunks([debug_data], filestem=filestem)  # type: ignore[arg-type]
-        log.warning(
-            "Query 408 debug info written to %s",
-            debug_writer.output_dir,
-        )
+    @staticmethod
+    def _write_debug_info(endpoint_name: QueryEndpoint, debug_data: dict[str, JsonValue], output_dir: Path) -> Path | None:
+        """Write the (potentially large) query plan/profile to its own file, once, and return its path.
+
+        This is written with a dedicated NDJsonWriter/kind so it does not mix with the per-item
+        LogEntryV2 entries written to the download issues log.
+        """
+        filestem = create_logfile_stem(output_dir, f"debug_{endpoint_name}")
+        with NDJsonWriter(
+            output_dir, kind="QueryDebugResponse", default_filestem=filestem, compression=Uncompressed
+        ) as writer:
+            writer.write_chunks([debug_data])  # type: ignore[list-item]
+            return writer.latest_file
 
     def _get_endpoint(self, endpoint: QueryEndpoint) -> Endpoint:
         if endpoint == "query":

--- a/cognite_toolkit/_cdf_tk/client/api/instances.py
+++ b/cognite_toolkit/_cdf_tk/client/api/instances.py
@@ -1,5 +1,7 @@
+import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
+from datetime import datetime, timezone
 from itertools import zip_longest
 from typing import Generic, Literal, TypeAlias, TypeVar, overload
 
@@ -28,6 +30,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._instance import InstanceSlimDefinition
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._query import (
+    QueryDebugParameters,
     QueryEdgeExpression,
     QueryEdgeTableExpression,
     QueryNodeExpression,
@@ -39,6 +42,9 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._query import
     QuerySortSpec,
 )
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
+from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter
+
+log = logging.getLogger(__name__)
 
 METHOD_MAP: dict[APIMethod, Endpoint] = {
     "upsert": Endpoint(method="POST", path="/models/instances", item_limit=1000),
@@ -131,6 +137,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         limit: int = 100,
         cursor: str | None = None,
         endpoint: QueryEndpoint = "query",
+        debug_writer: NDJsonWriter | None = None,
     ) -> PagedResponse[InstanceResponse]:
         """Iterate over all instances in CDF.
 
@@ -144,7 +151,9 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
             PagedResponse of InstanceResponse objects.
         """
         request = self._create_query(filter, limit, cursor, endpoint=endpoint)
-        response = self.query(request, type_results=True, endpoint=endpoint, exhaust_sub_selections=False)
+        response = self.query(
+            request, type_results=True, endpoint=endpoint, exhaust_sub_selections=False, debug_writer=debug_writer
+        )
         return PagedResponse(items=response.items["root"], nextCursor=response.root_cursor)
 
     def _create_query(
@@ -259,6 +268,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         type_results: Literal[True] = True,
         endpoint: QueryEndpoint = "query",
         exhaust_sub_selections: bool = False,
+        debug_writer: NDJsonWriter | None = None,
     ) -> QueryResponseTyped: ...
 
     @overload
@@ -268,6 +278,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         type_results: Literal[False],
         endpoint: QueryEndpoint = "query",
         exhaust_sub_selections: bool = False,
+        debug_writer: NDJsonWriter | None = None,
     ) -> QueryResponseUntyped: ...
 
     def query(
@@ -276,6 +287,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         type_results: bool = True,
         endpoint: QueryEndpoint = "query",
         exhaust_sub_selections: bool = False,
+        debug_writer: NDJsonWriter | None = None,
     ) -> QueryResponseTyped | QueryResponseUntyped:
         """Execute a query against the instances query endpoint.
 
@@ -302,6 +314,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
             endpoint,
             exhaust_sub_selections,
             limit,
+            debug_writer,
         ):
             results.append(batch)
         if not results:
@@ -335,6 +348,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         endpoint: QueryEndpoint = "query",
         exhaust_sub_selections: bool = False,
         limit: int | None = None,
+        debug_writer: NDJsonWriter | None = None,
     ) -> Iterable[QueryResponseTyped]: ...
 
     @overload
@@ -345,6 +359,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         endpoint: QueryEndpoint = "query",
         exhaust_sub_selections: bool = False,
         limit: int | None = None,
+        debug_writer: NDJsonWriter | None = None,
     ) -> Iterable[QueryResponseUntyped]: ...
 
     def query_iterate(
@@ -354,6 +369,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         endpoint: QueryEndpoint = "query",
         exhaust_sub_selections: bool = False,
         limit: int | None = None,
+        debug_writer: NDJsonWriter | None = None,
     ) -> Iterable[QueryResponseTyped | QueryResponseUntyped]:
         """Iterate over the results of a query against the instances query/sync endpoint."""
         yield from self._query_iterate(
@@ -363,6 +379,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
             endpoint,
             exhaust_sub_selections,
             limit,
+            debug_writer,
         )
 
     def _query_iterate(
@@ -372,6 +389,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         endpoint: QueryEndpoint = "query",
         exhaust_sub_selections: bool = False,
         limit: int | None = None,
+        debug_writer: NDJsonWriter | None = None,
     ) -> Iterable[QueryResponseTyped | QueryResponseUntyped]:
         endpoint_prop = self._get_endpoint(endpoint)
         response_cls = QueryResponseTyped if type_results else QueryResponseUntyped
@@ -386,7 +404,19 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
                 batch = self._query(query, response_cls, endpoint_prop, exhaust_sub_selections, endpoint_name=endpoint)
             except ReduceLoadException as e:
                 if current_chunk_size <= 1:
-                    raise e.source_exception
+                    debug_written = False
+                    if endpoint == "sync":
+                        debug_written = self._run_and_log_debug_query(query, endpoint_prop, endpoint, debug_writer)
+                    source = e.source_exception
+                    if debug_written and isinstance(source, ToolkitAPIError):
+                        source = ToolkitAPIError(
+                            f"{source.message} Debug info written to {debug_writer.output_dir}",  # type: ignore[union-attr]
+                            missing=source.missing,  # type: ignore[arg-type]
+                            duplicated=source.duplicated,  # type: ignore[arg-type]
+                            code=source.code,
+                            request=source.request,
+                        )
+                    raise source
                 min_failed_chunk_size = min(current_chunk_size, min_failed_chunk_size)
                 success_request_count = 0
                 current_chunk_size = current_chunk_size // 2
@@ -489,6 +519,62 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         # We persist the root from the query. This is for convenience.
         query_response.root = query.root
         return query_response
+
+    def _run_and_log_debug_query(
+        self, query: QueryRequest, endpoint: Endpoint, endpoint_name: QueryEndpoint, debug_writer: NDJsonWriter | None
+    ) -> bool:
+        """Issue a diagnostic query with plan/profile debug parameters and write the result to disk."""
+        if debug_writer is None:
+            return False
+        debug_query = query.model_copy(
+            update={
+                "debug": QueryDebugParameters(
+                    include_plan=True,
+                    emit_results=False,
+                    profile=True,
+                    timeout=60000,
+                )
+            }
+        )
+        request = RequestMessage(
+            endpoint_url=self._http_client.config.create_api_url(endpoint.path),
+            method=endpoint.method,
+            body_content=debug_query.dump(endpoint=endpoint_name),
+            retry_status_codes=set(),
+            api_version="alpha",
+            client_timeout=65,
+        )
+        try:
+            response = self._http_client.request_single_retries(request)
+            if isinstance(response, FailedResponse):
+                log.warning(
+                    "Debug query (plan/profile) for %s also failed with status %s: %s",
+                    endpoint_name,
+                    response.status_code,
+                    response.body,
+                )
+                return False
+            success_response = response.get_success_or_raise(request)
+            debug_response = QueryResponseUntyped.model_validate_json(success_response.body)
+            if debug_response.debug:
+                self._write_debug_info(endpoint_name, debug_response.debug, debug_writer)
+                return True
+            return False
+        except Exception as exc:
+            log.warning("Debug query (plan/profile) for %s failed: %s", endpoint_name, exc)
+            return False
+
+    def _write_debug_info(
+        self, endpoint_name: QueryEndpoint, debug_data: dict[str, JsonValue], debug_writer: NDJsonWriter
+    ) -> None:
+        """Write debug notices and query plan via the provided NDJsonWriter."""
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        filestem = f"query_408_debug_{endpoint_name}_{timestamp}"
+        debug_writer.write_chunks([debug_data], filestem=filestem)  # type: ignore[arg-type]
+        log.warning(
+            "Query 408 debug info written to %s",
+            debug_writer.output_dir,
+        )
 
     def _get_endpoint(self, endpoint: QueryEndpoint) -> Endpoint:
         if endpoint == "query":

--- a/cognite_toolkit/_cdf_tk/client/api/instances.py
+++ b/cognite_toolkit/_cdf_tk/client/api/instances.py
@@ -566,7 +566,9 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
             return None
 
     @staticmethod
-    def _write_debug_info(endpoint_name: QueryEndpoint, debug_data: dict[str, JsonValue], output_dir: Path) -> Path | None:
+    def _write_debug_info(
+        endpoint_name: QueryEndpoint, debug_data: dict[str, JsonValue], output_dir: Path
+    ) -> Path | None:
         """Write the (potentially large) query plan/profile to its own file, once, and return its path.
 
         This is written with a dedicated NDJsonWriter/kind so it does not mix with the per-item

--- a/cognite_toolkit/_cdf_tk/client/http_client/_client.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_client.py
@@ -1,3 +1,4 @@
+import logging
 import random
 import sys
 import time
@@ -35,6 +36,8 @@ else:
     from typing_extensions import Self
 
 from cognite_toolkit._cdf_tk.client.config import ToolkitClientConfig
+
+log = logging.getLogger(__name__)
 
 _T_Request_Message = TypeVar("_T_Request_Message", bound=BaseRequestMessage)
 
@@ -206,7 +209,17 @@ class HTTPClient:
         if retry_request := self._retry_request(response, request, error_details):
             return retry_request
         else:
-            # Permanent failure
+            if error_details.x_request_id is None:
+                # No X-Request-ID to surface in the raised error (e.g. a gateway-level failure that
+                # never reached CDF's application layer). Log the full headers at debug level in case
+                # there is another lead worth handing to support; this is deliberately not a warning,
+                # since 408s are routinely handled as expected control flow (e.g. query chunk-size backoff).
+                log.debug(
+                    "Request to %s failed with status %s and no X-Request-ID. Response headers: %s",
+                    request.endpoint_url,
+                    response.status_code,
+                    dict(response.headers),
+                )
             return FailedResponse(
                 status_code=response.status_code,
                 body=response.text,

--- a/cognite_toolkit/_cdf_tk/client/http_client/_client.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_client.py
@@ -209,7 +209,7 @@ class HTTPClient:
         if retry_request := self._retry_request(response, request, error_details):
             return retry_request
         else:
-            # Permenant failure
+            # Permanent failure
             return FailedResponse(
                 status_code=response.status_code,
                 body=response.text,

--- a/cognite_toolkit/_cdf_tk/client/http_client/_client.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_client.py
@@ -209,17 +209,7 @@ class HTTPClient:
         if retry_request := self._retry_request(response, request, error_details):
             return retry_request
         else:
-            if error_details.x_request_id is None:
-                # No X-Request-ID to surface in the raised error (e.g. a gateway-level failure that
-                # never reached CDF's application layer). Log the full headers at debug level in case
-                # there is another lead worth handing to support; this is deliberately not a warning,
-                # since 408s are routinely handled as expected control flow (e.g. query chunk-size backoff).
-                log.debug(
-                    "Request to %s failed with status %s and no X-Request-ID. Response headers: %s",
-                    request.endpoint_url,
-                    response.status_code,
-                    dict(response.headers),
-                )
+            # Permenant failure
             return FailedResponse(
                 status_code=response.status_code,
                 body=response.text,

--- a/cognite_toolkit/_cdf_tk/client/http_client/_data_classes.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_data_classes.py
@@ -32,6 +32,7 @@ class HTTPResult(HTTPBaseModel):
                 code=self.error.code,
                 request=request,
                 response=self,
+                x_request_id=self.error.x_request_id,
             )
         elif isinstance(self, FailedRequest):
             raise ToolkitAPIError(f"Request failed with error: {self.error}", request=request)
@@ -92,15 +93,19 @@ class ErrorDetails(HTTPBaseModel):
     missing: list[JsonValue] | None = None
     duplicated: list[JsonValue] | None = None
     is_auto_retryable: bool | None = None
+    x_request_id: str | None = None
 
     @classmethod
     def from_response(cls, response: httpx.Response) -> "ErrorDetails":
         """Populate the error details from a httpx response."""
+        x_request_id = response.headers.get("x-request-id")
         try:
             res = TypeAdapter(dict[Literal["error"], ErrorDetails]).validate_json(response.text)
+            error_details = res["error"]
         except ValueError:
-            return cls(code=response.status_code, message=response.text)
-        return res["error"]
+            error_details = cls(code=response.status_code, message=response.text)
+        error_details.x_request_id = x_request_id
+        return error_details
 
 
 class FailedResponse(HTTPResult):

--- a/cognite_toolkit/_cdf_tk/client/http_client/_exception.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_exception.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -16,7 +17,11 @@ class ToolkitAPIError(Exception):
         is_auto_retryable: bool | None = None,
         request: "RequestMessage | None " = None,
         response: "FailedResponse | None " = None,
+        debug_file: Path | None = None,
+        x_request_id: str | None = None,
     ) -> None:
+        if x_request_id is not None and x_request_id not in message:
+            message = f"{message} | X-Request-ID: {x_request_id}"
         super().__init__(message)
         self.message = message
         self.missing = missing
@@ -25,6 +30,10 @@ class ToolkitAPIError(Exception):
         self.is_auto_retryable = is_auto_retryable
         self.request = request
         self.response = response
+        # Path to a file with additional debug information (e.g. a query plan/profile) written to disk,
+        # for errors too large to include in a log message directly.
+        self.debug_file = debug_file
+        self.x_request_id = x_request_id
 
     def as_debug_dict(self) -> dict[str, Any]:
         debug_info: dict[str, Any] = {}

--- a/cognite_toolkit/_cdf_tk/client/http_client/_item_classes.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_item_classes.py
@@ -93,7 +93,11 @@ class ItemsResultList(UserList[ItemsResultMessage]):
         failed_requests = [resp for resp in self.data if isinstance(resp, ItemsFailedRequest)]
         if not failed_responses and not failed_requests:
             return
-        error_messages = "; ".join(f"Status {err.status_code}: {err.error.message}" for err in failed_responses)
+        error_messages = "; ".join(
+            f"Status {err.status_code}: {err.error.message}"
+            + (f" | X-Request-ID: {err.error.x_request_id}" if err.error.x_request_id else "")
+            for err in failed_responses
+        )
         if failed_requests:
             if error_messages:
                 error_messages += "; "

--- a/cognite_toolkit/_cdf_tk/commands/_download.py
+++ b/cognite_toolkit/_cdf_tk/commands/_download.py
@@ -1,6 +1,5 @@
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from datetime import date
 from functools import partial
 from pathlib import Path
 from typing import Generic, Literal, TypeAlias
@@ -23,7 +22,7 @@ from cognite_toolkit._cdf_tk.dataio import (
 from cognite_toolkit._cdf_tk.dataio.logger import FileWithAggregationLogger, ItemsResult, display_item_results
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 from cognite_toolkit._cdf_tk.protocols import T_ResourceResponse
-from cognite_toolkit._cdf_tk.utils.file import safe_write, sanitize_filename, yaml_safe_dump
+from cognite_toolkit._cdf_tk.utils.file import create_logfile_stem, safe_write, sanitize_filename, yaml_safe_dump
 from cognite_toolkit._cdf_tk.utils.fileio import (
     TABLE_WRITE_CLS_BY_FORMAT,
     Compression,
@@ -215,8 +214,8 @@ class DownloadCommand(ToolkitCommand):
 
     @classmethod
     def _create_log_file_writer(cls, target_dir: Path) -> NDJsonWriter:
-        log_filestem = f"download_{date.today().strftime('%Y%m%d')}"
-        return NDJsonWriter(target_dir, kind="DownloadLogs", default_filestem=log_filestem, compression=Uncompressed)
+        log_filestem = create_logfile_stem(target_dir, "download")
+        return NDJsonWriter(target_dir, kind="DownloadIssues", default_filestem=log_filestem, compression=Uncompressed)
 
     def _download_data(
         self,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -1,4 +1,3 @@
-import re
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -48,7 +47,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
 from cognite_toolkit._cdf_tk.resource_ios import ResourceWorker
 from cognite_toolkit._cdf_tk.utils import humanize_collection, safe_write, sanitize_filename
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
-from cognite_toolkit._cdf_tk.utils.file import add_top_level_comment_in_yaml, yaml_safe_dump
+from cognite_toolkit._cdf_tk.utils.file import add_top_level_comment_in_yaml, create_logfile_stem, yaml_safe_dump
 from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter, Uncompressed
 from cognite_toolkit._cdf_tk.utils.producer_worker import ProducerWorkerExecutor
 
@@ -79,7 +78,7 @@ class MigrationCommand(ToolkitCommand):
     ) -> dict[str, list[ItemsResult]]:
         self.validate_migration_model_available(data.client)
         log_dir.mkdir(parents=True, exist_ok=True)
-        log_filestem = self._create_logfile_stem(log_dir, user_log_filestem, data.KIND)
+        log_filestem = create_logfile_stem(log_dir, user_log_filestem or data.KIND)
 
         console = data.client.console
 
@@ -270,29 +269,6 @@ class MigrationCommand(ToolkitCommand):
         table.add_row("Total", f"{total_completed:,}", f"{total_count:,}")
         console.print(table)
         return None
-
-    @staticmethod
-    def _create_logfile_stem(log_dir: Path, user_log_filestem: str | None, data_kind: str) -> str:
-        """Create a filestem for the log file that does not conflict with existing files in the log directory."""
-        base_logstem = user_log_filestem or data_kind
-        if not base_logstem.endswith("-"):
-            base_logstem += "-"
-
-        existing_files = list(log_dir.glob(f"{base_logstem}*"))
-        if not existing_files:
-            return base_logstem
-
-        run_pattern = re.compile(re.escape(base_logstem) + r"run(\d+)-")
-        max_run = 0
-        for f in existing_files:
-            match = run_pattern.match(f.name)
-            if match:
-                max_run = max(max_run, int(match.group(1)))
-
-        # If max_run is 0, it means files with base_logstem exist, but none have 'runX'.
-        next_run = max(2, max_run + 1)
-
-        return f"{base_logstem}run{next_run}-"
 
     def _print_txt(self, results: list[ItemsResult], log_dir: Path, filestem: str, console: Console) -> None:
         summary_file = log_dir / f"{filestem}_migration_summary.txt"

--- a/cognite_toolkit/_cdf_tk/commands/_upload.py
+++ b/cognite_toolkit/_cdf_tk/commands/_upload.py
@@ -1,4 +1,3 @@
-import re
 from collections import Counter
 from collections.abc import Callable, Iterator, Mapping
 from functools import partial
@@ -43,6 +42,7 @@ from cognite_toolkit._cdf_tk.resource_ios import ViewIO
 from cognite_toolkit._cdf_tk.tk_warnings import HighSeverityWarning, MediumSeverityWarning, ToolkitWarning
 from cognite_toolkit._cdf_tk.tracker import Tracker
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
+from cognite_toolkit._cdf_tk.utils.file import create_logfile_stem
 from cognite_toolkit._cdf_tk.utils.fileio import MultiFileReader, NDJsonWriter, Uncompressed
 from cognite_toolkit._cdf_tk.utils.producer_worker import ProducerWorkerExecutor
 from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
@@ -248,7 +248,7 @@ class UploadCommand(ToolkitCommand):
         action = "Would upload" if dry_run else "Uploading"
 
         input_dir.mkdir(parents=True, exist_ok=True)
-        log_filestem = cls._create_upload_logfile_stem(input_dir)
+        log_filestem = create_logfile_stem(input_dir, "upload")
         with (
             NDJsonWriter(
                 input_dir, kind="UploadIssues", default_filestem=log_filestem, compression=Uncompressed
@@ -321,24 +321,6 @@ class UploadCommand(ToolkitCommand):
                     )
                 else:
                     executor.raise_on_error()
-
-    @staticmethod
-    def _create_upload_logfile_stem(log_dir: Path) -> str:
-        """Create a filestem for the upload log file that does not conflict with existing files in the directory."""
-        base_logstem = "upload-"
-        existing_files = list(log_dir.glob(f"{base_logstem}*"))
-        if not existing_files:
-            return base_logstem
-
-        run_pattern = re.compile(re.escape(base_logstem) + r"run(\d+)-")
-        max_run = 0
-        for f in existing_files:
-            match = run_pattern.match(f.name)
-            if match:
-                max_run = max(max_run, int(match.group(1)))
-
-        next_run = max(2, max_run + 1)
-        return f"{base_logstem}run{next_run}-"
 
     @staticmethod
     def _path_as_display_name(input_path: Path, cwd: Path = Path.cwd()) -> Path:

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -409,12 +409,14 @@ class InstanceIO(
             query.cursors = {query.root: init_cursor}
 
         included_groups = [group for group in query.with_ if include_root or group != query.root]
+        debug_writer = self._logger.writer if isinstance(self._logger, FileWithAggregationLogger) else None
         for batch in self.client.tool.instances.query_iterate(
             query,
             type_results=True,
             exhaust_sub_selections=True,
             limit=limit,
             endpoint=endpoint,
+            debug_writer=debug_writer,
         ):
             wrapped_items = [
                 DataItem(tracking_id=f"{item.space}:{item.external_id}", item=item)
@@ -443,7 +445,11 @@ class InstanceIO(
         while cursor is not None or total == 0:
             page_limit = min(self.CHUNK_SIZE, limit - total) if limit is not None else self.CHUNK_SIZE
             page = self.client.tool.instances.paginate(
-                instance_filter, limit=page_limit, cursor=cursor, endpoint=selector.endpoint, debug_writer=debug_writer
+                instance_filter,
+                limit=page_limit,
+                cursor=cursor,
+                endpoint=selector.endpoint,
+                debug_writer=debug_writer,
             )
             total += len(page.items)
             if page:

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -42,7 +42,7 @@ from cognite_toolkit._cdf_tk.utils.useful_types import DataType, JsonVal
 
 from . import StorageIOConfig
 from ._base import Bookmark, ConfigurableDataIO, DataItem, Page, TableDataIO, TableUploadableDataIO
-from .logger import LogEntryV2, Severity
+from .logger import FileWithAggregationLogger, LogEntryV2, Severity
 from .progress import CursorBookmark, NoBookmark
 from .selectors import InstanceFileSelector, InstanceSelector, InstanceSpaceSelector, InstanceViewSelector, SelectedView
 from .selectors._instances import InstanceQuerySelector
@@ -439,10 +439,11 @@ class InstanceIO(
         instance_filter = self._build_list_filter(selector)
         total = 0
         cursor: str | None = init_cursor
+        debug_writer = self._logger.writer if isinstance(self._logger, FileWithAggregationLogger) else None
         while cursor is not None or total == 0:
             page_limit = min(self.CHUNK_SIZE, limit - total) if limit is not None else self.CHUNK_SIZE
             page = self.client.tool.instances.paginate(
-                instance_filter, limit=page_limit, cursor=cursor, endpoint=selector.endpoint
+                instance_filter, limit=page_limit, cursor=cursor, endpoint=selector.endpoint, debug_writer=debug_writer
             )
             total += len(page.items)
             if page:

--- a/cognite_toolkit/_cdf_tk/dataio/logger.py
+++ b/cognite_toolkit/_cdf_tk/dataio/logger.py
@@ -120,6 +120,10 @@ class FileWithAggregationLogger(DataLogger):
         self._batch: list[LogEntryV2] = []
         self.aggregations_by_ids: dict[str, list[LogAggregation]] = {}
 
+    @property
+    def writer(self) -> NDJsonWriter:
+        return self._writer
+
     def __enter__(self) -> "FileWithAggregationLogger":
         return self
 

--- a/cognite_toolkit/_cdf_tk/utils/file.py
+++ b/cognite_toolkit/_cdf_tk/utils/file.py
@@ -195,6 +195,30 @@ def read_yaml_content(content: str) -> dict[str, Any] | list[dict[str, Any]]:
 _ILLEGAL_CHARACTERS = re.compile(r"[<>:\"/\\|?*\s]")
 
 
+def create_logfile_stem(log_dir: Path, base_logstem: str) -> str:
+    """Create a filestem for a log file that does not conflict with existing files in the directory.
+
+    Returns base_logstem unchanged if no files with that prefix exist yet, otherwise appends a
+    "run{n}-" suffix with the next unused run number.
+    """
+    if not base_logstem.endswith("-"):
+        base_logstem += "-"
+
+    existing_files = list(log_dir.glob(f"{base_logstem}*"))
+    if not existing_files:
+        return base_logstem
+
+    run_pattern = re.compile(re.escape(base_logstem) + r"run(\d+)-")
+    max_run = 0
+    for f in existing_files:
+        match = run_pattern.match(f.name)
+        if match:
+            max_run = max(max_run, int(match.group(1)))
+
+    next_run = max(2, max_run + 1)
+    return f"{base_logstem}run{next_run}-"
+
+
 def sanitize_filename(text: str) -> str:
     """Convert a string to be a valid filename by replacing illegal characters with underscores."""
     cleaned = _ILLEGAL_CHARACTERS.sub("_", text)

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -1343,21 +1343,6 @@ class TestMigrationCommand:
             client.data_modeling.statistics.project.return_value = stats
             cmd.validate_available_capacity(client, 10_000)
 
-    @pytest.mark.parametrize(
-        "existing_files, stem, expected",
-        [
-            ([], "migration_log", "migration_log-"),
-            (["migration_log-part001.log"], "migration_log", "migration_log-run2-"),
-            (["migration_log-part001.log", "migration_log-run3-part001.log"], "migration_log", "migration_log-run4-"),
-        ],
-    )
-    def test_create_logfile_stem(self, existing_files: list[str], stem: str, expected: str, tmp_path: Path) -> None:
-        for filename in existing_files:
-            (tmp_path / filename).touch()
-        actual = MigrationCommand._create_logfile_stem(tmp_path, stem, "not_important")
-
-        assert actual == expected
-
     def test_validate_stream_capacity_insufficient_records(self) -> None:
         stream = _make_stream_response(provisioned_records=1_000, consumed_records=900)
         with pytest.raises(ToolkitValueError, match="enough record capacity"):

--- a/tests/test_unit/test_cdf_tk/test_utils/test_file.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_file.py
@@ -4,7 +4,12 @@ from zipfile import ZipFile
 
 import pytest
 
-from cognite_toolkit._cdf_tk.utils.file import create_temporary_zip, read_yaml_content, sanitize_filename
+from cognite_toolkit._cdf_tk.utils.file import (
+    create_logfile_stem,
+    create_temporary_zip,
+    read_yaml_content,
+    sanitize_filename,
+)
 
 
 class TestCreateTemporaryZip:
@@ -56,6 +61,23 @@ class TestSanitizeFilename:
     )
     def test_sanitize_filename(self, filename: str, expected: str) -> None:
         assert sanitize_filename(filename) == expected
+
+
+class TestCreateLogfileStem:
+    @pytest.mark.parametrize(
+        "existing_files, stem, expected",
+        [
+            ([], "migration_log", "migration_log-"),
+            (["migration_log-part001.log"], "migration_log", "migration_log-run2-"),
+            (["migration_log-part001.log", "migration_log-run3-part001.log"], "migration_log", "migration_log-run4-"),
+        ],
+    )
+    def test_create_logfile_stem(self, existing_files: list[str], stem: str, expected: str, tmp_path: Path) -> None:
+        for filename in existing_files:
+            (tmp_path / filename).touch()
+        actual = create_logfile_stem(tmp_path, stem)
+
+        assert actual == expected
 
 
 class TestReadYamlContent:


### PR DESCRIPTION
# Description

When a sync query fails without any way to recover (which is, after we have attempted to reduce the chunk size all the way down to 1 and it still fails), automatically issue a diagnostic query with plan/profile debug parameters and write the result to disk, then reference that file path in the raised error as to aid the debugging process.

Additionally, we now surface the `X-Request-ID` header on API errors so it's available for support investigations, and deduplicate the log-filestem-generation logic (`_download.py`, `_upload.py`, `_migrate/command.py`) into a shared `create_logfile_stem` util.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Added

- When downloading instances, toolkit will now automatically capture a query plan/profile debug file and reference it in the error message when a sync query request repeatedly times out (408).

### Fixed

- Include the `X-Request-ID` in API error messages so it can be shared with support when troubleshooting failed requests.