### PR TITLE
[CDF-28400] Add --include-edges CLI flag for downloading instances

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -7,7 +7,7 @@ import typer
 from questionary import Choice
 from rich import print
 
-from cognite_toolkit._cdf_tk.client.identifiers import EdgeTypeId, RawTableId, ViewId
+from cognite_toolkit._cdf_tk.client.identifiers import EdgeTypeId, RawTableId, ViewNoVersionId
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import EdgeProperty
 from cognite_toolkit._cdf_tk.commands import DownloadCommand
 from cognite_toolkit._cdf_tk.constants import DATA_DEFAULT_DIR
@@ -911,6 +911,14 @@ class DownloadApp(typer.Typer):
                 hidden=not Flags.EXTEND_DOWNLOAD.is_enabled(),
             ),
         ] = ApiFormat.request,
+        include_edges: Annotated[
+            bool,
+            typer.Option(
+                "--include-edges",
+                help="Include edges connected to downloaded node instances.",
+                hidden=not Flags.EXTEND_DOWNLOAD.is_enabled(),
+            ),
+        ] = False,
         compression: Annotated[
             CompressionFormat,
             typer.Option(
@@ -982,11 +990,11 @@ class DownloadApp(typer.Typer):
             selected_instance_spaces: tuple[str, ...] | None = None
             if select_instance_space:
                 selected_instance_spaces = tuple(selector.select_instance_space(multiselect=True))
-            edge_type_ids_by_view_id: dict[ViewId, set[EdgeTypeId]] = {}
-            if Flags.EXTEND_DOWNLOAD.EXTEND_DOWNLOAD.is_enabled():
+            edge_type_ids_by_view_id: dict[ViewNoVersionId, set[EdgeTypeId]] = {}
+            if Flags.EXTEND_DOWNLOAD.is_enabled():
                 include_edges = questionary.confirm(
                     "Do you want to include edges when downloading node instances? If yes, all edges connected to the downloaded nodes will be downloaded as well.",
-                    default=False,
+                    default=include_edges,
                 ).unsafe_ask()
                 if include_edges:
                     for view in data_model.views or []:
@@ -1024,19 +1032,30 @@ class DownloadApp(typer.Typer):
         elif schema_space is not None and view_external_ids is not None:
             selected_instance_spaces = tuple(instance_spaces) if instance_spaces else None
             download_dir_name = sanitize_filename(schema_space)
+            selected_views = [
+                SelectedView(
+                    space=schema_space,
+                    external_id=view_id_str.split("/", maxsplit=1)[0],
+                    version=view_id_str.split("/", maxsplit=1)[1] if "/" in view_id_str else None,
+                )
+                for view_id_str in view_external_ids
+            ]
+            edge_types_by_view_id: dict[ViewNoVersionId, tuple[EdgeTypeId, ...]] = {}
+            if include_edges:
+                for view in client.tool.views.retrieve([view.as_id() for view in selected_views]):
+                    edge_types_by_view_id[view.as_id()] = tuple(
+                        prop.as_edge_type_id() for prop in view.properties.values() if isinstance(prop, EdgeProperty)
+                    )
             selectors = [
                 InstanceViewSelector(
-                    view=SelectedView(
-                        space=schema_space,
-                        external_id=view_id_str.split("/", maxsplit=1)[0],
-                        version=view_id_str.split("/", maxsplit=1)[1] if "/" in view_id_str else None,
-                    ),
+                    view=view,
                     instance_spaces=selected_instance_spaces,
                     instance_type=instance_type.value,
                     download_dir_name=download_dir_name,
+                    edge_types=edge_types_by_view_id.get(view.as_id()) or None,
                     endpoint="sync",
                 )
-                for view_id_str in view_external_ids
+                for view in selected_views
             ]
         else:
             raise typer.BadParameter(

--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -1042,9 +1042,7 @@ class DownloadApp(typer.Typer):
             ]
             edge_types_by_view_id: dict[ViewNoVersionId, tuple[EdgeTypeId, ...]] = {}
             if include_edges:
-                for retrieved_view in client.tool.views.retrieve(
-                    [view.as_id() for view in selected_schema_views]
-                ):
+                for retrieved_view in client.tool.views.retrieve([view.as_id() for view in selected_schema_views]):
                     edge_types_by_view_id[retrieved_view.as_id()] = tuple(
                         prop.as_edge_type_id()
                         for prop in retrieved_view.properties.values()

--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -1032,7 +1032,7 @@ class DownloadApp(typer.Typer):
         elif schema_space is not None and view_external_ids is not None:
             selected_instance_spaces = tuple(instance_spaces) if instance_spaces else None
             download_dir_name = sanitize_filename(schema_space)
-            selected_views = [
+            selected_schema_views = [
                 SelectedView(
                     space=schema_space,
                     external_id=view_id_str.split("/", maxsplit=1)[0],
@@ -1042,9 +1042,13 @@ class DownloadApp(typer.Typer):
             ]
             edge_types_by_view_id: dict[ViewNoVersionId, tuple[EdgeTypeId, ...]] = {}
             if include_edges:
-                for view in client.tool.views.retrieve([view.as_id() for view in selected_views]):
-                    edge_types_by_view_id[view.as_id()] = tuple(
-                        prop.as_edge_type_id() for prop in view.properties.values() if isinstance(prop, EdgeProperty)
+                for retrieved_view in client.tool.views.retrieve(
+                    [view.as_id() for view in selected_schema_views]
+                ):
+                    edge_types_by_view_id[retrieved_view.as_id()] = tuple(
+                        prop.as_edge_type_id()
+                        for prop in retrieved_view.properties.values()
+                        if isinstance(prop, EdgeProperty)
                     )
             selectors = [
                 InstanceViewSelector(
@@ -1055,7 +1059,7 @@ class DownloadApp(typer.Typer):
                     edge_types=edge_types_by_view_id.get(view.as_id()) or None,
                     endpoint="sync",
                 )
-                for view in selected_views
+                for view in selected_schema_views
             ]
         else:
             raise typer.BadParameter(


### PR DESCRIPTION
# Description

Expose the existing "include edges when downloading node instances" capability, previously only reachable through the interactive prompt, as a `--include-edges` CLI flag on `cdf data download instances` (gated behind the `EXTEND_DOWNLOAD` feature flag). The flag also seeds the default answer for the interactive prompt when running in interactive mode.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- [alpha] Add `--include-edges` flag to `cdf data download instances` to download edges connected to node instances directly from the CLI, without needing interactive mode. Requires alpha flag `extend-download=true`.