### PR TITLE
Fix smoke test miscounting CDF_User as a missing InField migration mapping

### DIFF
--- a/tests_smoke/test_commands/test_migrate_infield.py
+++ b/tests_smoke/test_commands/test_migrate_infield.py
@@ -375,13 +375,19 @@ class TestMigrateInfield:
         for instance in infield_legacy:
             if not isinstance(instance, NodeRequest):
                 continue
-            if instance.sources and instance.sources[0].source.space in {"cdf_apm", "cdf_apps_shared"}:
-                expected_node_count += 1
+            if instance.sources:
+                source = instance.sources[0].source
+                if source.space == "cdf_apm" or (
+                    source.space == "cdf_apps_shared" and source.external_id == "CogniteSolutionTag"
+                ):
+                    expected_node_count += 1
             for source in instance.sources or []:
                 if not isinstance(source.source, ViewId):
                     continue
                 if source.source not in mapping_by_source:
-                    if source.source.space in {"cdf_apm", "cdf_apps_shared"}:
+                    if source.source.space == "cdf_apm" or (
+                        source.source.space == "cdf_apps_shared" and source.source.external_id == "CogniteSolutionTag"
+                    ):
                         missing_mappings.append(source.source)
                     continue
                 mapping = mapping_by_source[source.source]

--- a/tests_smoke/test_commands/test_migrate_infield.py
+++ b/tests_smoke/test_commands/test_migrate_infield.py
@@ -376,9 +376,9 @@ class TestMigrateInfield:
             if not isinstance(instance, NodeRequest):
                 continue
             if instance.sources:
-                source = instance.sources[0].source
-                if source.space == "cdf_apm" or (
-                    source.space == "cdf_apps_shared" and source.external_id == "CogniteSolutionTag"
+                first_source = instance.sources[0].source
+                if first_source.space == "cdf_apm" or (
+                    first_source.space == "cdf_apps_shared" and first_source.external_id == "CogniteSolutionTag"
                 ):
                     expected_node_count += 1
             for source in instance.sources or []:


### PR DESCRIPTION
# Description

The InField migration smoke test's expected-node-count check was recently widened to include the `cdf_apps_shared` space when the `CogniteSolutionTag` mapping was added, but this also swept in the `CDF_User` view, which is never migrated (it represents an actual CDF user account, not project data). This caused the smoke test to fail with a spurious "missing mapping" error. Narrow the check to only require a mapping for `cdf_apm` views and the specific `cdf_apps_shared:CogniteSolutionTag` view.

## Bump

- [ ] Patch
- [x] Skip