### PR TITLE
[CDF-28413] Order GraphQL schemas before dependent data models

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -49,7 +49,9 @@ from cognite_toolkit._cdf_tk.exceptions import (
 from cognite_toolkit._cdf_tk.resource_ios import (
     RESOURCE_CRUD_BY_FOLDER_NAME,
     ContainerCRUD,
+    DataModelIO,
     EdgeCRUD,
+    GraphQLCRUD,
     NodeCRUD,
     RawTableCRUD,
     ResourceContainerIO,
@@ -517,7 +519,10 @@ class DeployV2Command(ToolkitCommand):
         dependencies_by_crud: dict[type[ResourceIO], Set[type[ResourceIO]]] = {}
         skipped_by_crud: dict[type[ResourceIO], Set[type[ResourceIO]]] = {}
         for crud_cls in files_by_crud.keys():
-            dependencies = crud_cls.dependencies
+            dependencies = set(crud_cls.dependencies)
+            if crud_cls is DataModelIO and GraphQLCRUD in files_by_crud.keys() | skipped_cruds:
+                # GraphQL schemas create views that can be referenced by entity-based data models.
+                dependencies.add(GraphQLCRUD)
             if missing := (skipped_cruds.intersection(dependencies)):
                 skipped_by_crud[crud_cls] = missing
             dependencies_by_crud[crud_cls] = dependencies

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Any, Generic, Literal, TypeAlias, cast
 
 import questionary
-from cognite.client import data_modeling as dm
 from pydantic import ValidationError
 from rich.console import Console, Group, RenderableType
 from rich.markup import escape
@@ -21,7 +20,7 @@ from yaml import YAMLError
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client._resource_base import T_Identifier, T_RequestResource, T_ResponseResource
 from cognite_toolkit._cdf_tk.client.http_client import ToolkitAPIError
-from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, DataModelId, RawTableId, ViewId
+from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, RawTableId, ViewId
 from cognite_toolkit._cdf_tk.commands import UploadCommand
 from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
 from cognite_toolkit._cdf_tk.commands._utils import (
@@ -50,9 +49,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
 from cognite_toolkit._cdf_tk.resource_ios import (
     RESOURCE_CRUD_BY_FOLDER_NAME,
     ContainerCRUD,
-    DataModelIO,
     EdgeCRUD,
-    GraphQLCRUD,
     NodeCRUD,
     RawTableCRUD,
     ResourceContainerIO,
@@ -74,14 +71,7 @@ from cognite_toolkit._cdf_tk.ui import (
     ToolkitTable,
     hanging_indent,
 )
-from cognite_toolkit._cdf_tk.utils import (
-    GraphQLParser,
-    humanize_collection,
-    read_yaml_content,
-    safe_read,
-    sanitize_filename,
-    to_diff,
-)
+from cognite_toolkit._cdf_tk.utils import humanize_collection, sanitize_filename, to_diff
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 from cognite_toolkit._version import __version__
 
@@ -524,13 +514,10 @@ class DeployV2Command(ToolkitCommand):
         """
         files_by_crud = read_dir.as_files_by_crud()
         skipped_cruds = read_dir.skipped_cruds()
-        cross_dependencies = cls._get_data_modeling_cross_dependencies(files_by_crud)
         dependencies_by_crud: dict[type[ResourceIO], Set[type[ResourceIO]]] = {}
         skipped_by_crud: dict[type[ResourceIO], Set[type[ResourceIO]]] = {}
         for crud_cls in files_by_crud.keys():
-            dependencies = crud_cls.dependencies
-            if additional_dependencies := cross_dependencies.get(crud_cls):
-                dependencies = dependencies | additional_dependencies
+            dependencies = crud_cls.get_deployment_dependencies(files_by_crud)
             if missing := (skipped_cruds.intersection(dependencies)):
                 skipped_by_crud[crud_cls] = missing
             dependencies_by_crud[crud_cls] = dependencies
@@ -548,66 +535,6 @@ class DeployV2Command(ToolkitCommand):
                 DeploymentStep(crud_cls=step, files=files_by_crud[step], skipped_cruds=skipped_by_crud.get(step, set()))
             )
         return plan
-
-    @classmethod
-    def _get_data_modeling_cross_dependencies(
-        cls, files_by_crud: Mapping[type[ResourceIO], list[Path]]
-    ) -> dict[type[ResourceIO], set[type[ResourceIO]]]:
-        graphql_files = files_by_crud.get(GraphQLCRUD)
-        data_model_files = files_by_crud.get(DataModelIO)
-        if not graphql_files or not data_model_files:
-            return {}
-
-        generated_views: set[tuple[str, str]] = set()
-        imported_data_models: set[DataModelId] = set()
-        for filepath in graphql_files:
-            raw = read_yaml_content(GraphQLCRUD.safe_read(filepath))
-            for item in raw if isinstance(raw, list) else [raw]:
-                model_id = GraphQLCRUD.get_id(item)
-                graphql_file = GraphQLCRUD._get_graphql_file(filepath, dml=item.get("dml"))
-                parser = GraphQLParser(
-                    safe_read(graphql_file),
-                    dm.DataModelId(
-                        space=model_id.space,
-                        external_id=model_id.external_id,
-                        version=model_id.version,
-                    ),
-                )
-                generated_views.update((view.space, view.external_id) for view in parser.get_views())
-                imported_data_models.update(
-                    DataModelId(
-                        space=dependency.space,
-                        external_id=dependency.external_id,
-                        version=str(dependency.version or ""),
-                    )
-                    for dependency in parser.get_dependencies()
-                    if isinstance(dependency, dm.DataModelId)
-                )
-
-        local_data_models: set[DataModelId] = set()
-        referenced_views: set[tuple[str, str]] = set()
-        for filepath in data_model_files:
-            raw = read_yaml_content(DataModelIO.safe_read(filepath))
-            for item in raw if isinstance(raw, list) else [raw]:
-                local_data_models.add(DataModelIO.get_id(item))
-                referenced_views.update(
-                    (view["space"], view["externalId"])
-                    for view in item.get("views") or []
-                    if "space" in view and "externalId" in view
-                )
-
-        data_model_depends_on_graphql = bool(referenced_views & generated_views)
-        graphql_depends_on_data_model = bool(imported_data_models & local_data_models)
-        if data_model_depends_on_graphql and graphql_depends_on_data_model:
-            raise ToolkitValidationError(
-                "Cannot deploy mixed GraphQL and entity-based data models with dependencies in both directions "
-                "in a single deployment. Split the deployment to avoid a cyclic resource-type dependency."
-            )
-        if data_model_depends_on_graphql:
-            return {DataModelIO: {GraphQLCRUD}}
-        if graphql_depends_on_data_model:
-            return {GraphQLCRUD: {DataModelIO}}
-        return {}
 
     @classmethod
     def _display_plan(cls, plan: list[DeploymentStep], operation: str, operation_noun: str, console: Console) -> None:

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -519,10 +519,10 @@ class DeployV2Command(ToolkitCommand):
         dependencies_by_crud: dict[type[ResourceIO], Set[type[ResourceIO]]] = {}
         skipped_by_crud: dict[type[ResourceIO], Set[type[ResourceIO]]] = {}
         for crud_cls in files_by_crud.keys():
-            dependencies = set(crud_cls.dependencies)
-            if crud_cls is DataModelIO and GraphQLCRUD in files_by_crud.keys() | skipped_cruds:
+            dependencies = crud_cls.dependencies
+            if crud_cls is DataModelIO and (GraphQLCRUD in files_by_crud or GraphQLCRUD in skipped_cruds):
                 # GraphQL schemas create views that can be referenced by entity-based data models.
-                dependencies.add(GraphQLCRUD)
+                dependencies = dependencies | {GraphQLCRUD}
             if missing := (skipped_cruds.intersection(dependencies)):
                 skipped_by_crud[crud_cls] = missing
             dependencies_by_crud[crud_cls] = dependencies

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Generic, Literal, TypeAlias, cast
 
 import questionary
+from cognite.client import data_modeling as dm
 from pydantic import ValidationError
 from rich.console import Console, Group, RenderableType
 from rich.markup import escape
@@ -20,7 +21,7 @@ from yaml import YAMLError
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client._resource_base import T_Identifier, T_RequestResource, T_ResponseResource
 from cognite_toolkit._cdf_tk.client.http_client import ToolkitAPIError
-from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, RawTableId, ViewId
+from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, DataModelId, RawTableId, ViewId
 from cognite_toolkit._cdf_tk.commands import UploadCommand
 from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
 from cognite_toolkit._cdf_tk.commands._utils import (
@@ -73,7 +74,14 @@ from cognite_toolkit._cdf_tk.ui import (
     ToolkitTable,
     hanging_indent,
 )
-from cognite_toolkit._cdf_tk.utils import humanize_collection, sanitize_filename, to_diff
+from cognite_toolkit._cdf_tk.utils import (
+    GraphQLParser,
+    humanize_collection,
+    read_yaml_content,
+    safe_read,
+    sanitize_filename,
+    to_diff,
+)
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 from cognite_toolkit._version import __version__
 
@@ -516,13 +524,13 @@ class DeployV2Command(ToolkitCommand):
         """
         files_by_crud = read_dir.as_files_by_crud()
         skipped_cruds = read_dir.skipped_cruds()
+        cross_dependencies = cls._get_data_modeling_cross_dependencies(files_by_crud)
         dependencies_by_crud: dict[type[ResourceIO], Set[type[ResourceIO]]] = {}
         skipped_by_crud: dict[type[ResourceIO], Set[type[ResourceIO]]] = {}
         for crud_cls in files_by_crud.keys():
             dependencies = crud_cls.dependencies
-            if crud_cls is DataModelIO and (GraphQLCRUD in files_by_crud or GraphQLCRUD in skipped_cruds):
-                # GraphQL schemas create views that can be referenced by entity-based data models.
-                dependencies = dependencies | {GraphQLCRUD}
+            if additional_dependencies := cross_dependencies.get(crud_cls):
+                dependencies = dependencies | additional_dependencies
             if missing := (skipped_cruds.intersection(dependencies)):
                 skipped_by_crud[crud_cls] = missing
             dependencies_by_crud[crud_cls] = dependencies
@@ -540,6 +548,66 @@ class DeployV2Command(ToolkitCommand):
                 DeploymentStep(crud_cls=step, files=files_by_crud[step], skipped_cruds=skipped_by_crud.get(step, set()))
             )
         return plan
+
+    @classmethod
+    def _get_data_modeling_cross_dependencies(
+        cls, files_by_crud: Mapping[type[ResourceIO], list[Path]]
+    ) -> dict[type[ResourceIO], set[type[ResourceIO]]]:
+        graphql_files = files_by_crud.get(GraphQLCRUD)
+        data_model_files = files_by_crud.get(DataModelIO)
+        if not graphql_files or not data_model_files:
+            return {}
+
+        generated_views: set[tuple[str, str]] = set()
+        imported_data_models: set[DataModelId] = set()
+        for filepath in graphql_files:
+            raw = read_yaml_content(GraphQLCRUD.safe_read(filepath))
+            for item in raw if isinstance(raw, list) else [raw]:
+                model_id = GraphQLCRUD.get_id(item)
+                graphql_file = GraphQLCRUD._get_graphql_file(filepath, dml=item.get("dml"))
+                parser = GraphQLParser(
+                    safe_read(graphql_file),
+                    dm.DataModelId(
+                        space=model_id.space,
+                        external_id=model_id.external_id,
+                        version=model_id.version,
+                    ),
+                )
+                generated_views.update((view.space, view.external_id) for view in parser.get_views())
+                imported_data_models.update(
+                    DataModelId(
+                        space=dependency.space,
+                        external_id=dependency.external_id,
+                        version=str(dependency.version or ""),
+                    )
+                    for dependency in parser.get_dependencies()
+                    if isinstance(dependency, dm.DataModelId)
+                )
+
+        local_data_models: set[DataModelId] = set()
+        referenced_views: set[tuple[str, str]] = set()
+        for filepath in data_model_files:
+            raw = read_yaml_content(DataModelIO.safe_read(filepath))
+            for item in raw if isinstance(raw, list) else [raw]:
+                local_data_models.add(DataModelIO.get_id(item))
+                referenced_views.update(
+                    (view["space"], view["externalId"])
+                    for view in item.get("views") or []
+                    if "space" in view and "externalId" in view
+                )
+
+        data_model_depends_on_graphql = bool(referenced_views & generated_views)
+        graphql_depends_on_data_model = bool(imported_data_models & local_data_models)
+        if data_model_depends_on_graphql and graphql_depends_on_data_model:
+            raise ToolkitValidationError(
+                "Cannot deploy mixed GraphQL and entity-based data models with dependencies in both directions "
+                "in a single deployment. Split the deployment to avoid a cyclic resource-type dependency."
+            )
+        if data_model_depends_on_graphql:
+            return {DataModelIO: {GraphQLCRUD}}
+        if graphql_depends_on_data_model:
+            return {GraphQLCRUD: {DataModelIO}}
+        return {}
 
     @classmethod
     def _display_plan(cls, plan: list[DeploymentStep], operation: str, operation_noun: str, console: Console) -> None:

--- a/cognite_toolkit/_cdf_tk/resource_ios/_base_ios.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_base_ios.py
@@ -1,6 +1,6 @@
 import sys
 from abc import ABC, abstractmethod
-from collections.abc import Hashable, Iterable, Sequence, Sized
+from collections.abc import Hashable, Iterable, Mapping, Sequence, Sized
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Literal, TypeVar
 
@@ -82,6 +82,12 @@ class Loader(ABC):
     @classmethod
     def doc_url(cls) -> str:
         return cls._doc_base_url + cls._doc_url
+
+    @classmethod
+    def get_deployment_dependencies(
+        cls, files_by_crud: Mapping[type["ResourceIO"], list[Path]]
+    ) -> "frozenset[type[ResourceIO]]":
+        return cls.dependencies
 
     def find_files(self, dir_or_file: Path | None = None) -> list[Path]:
         """Find all files that are supported by this loader in the given directory or file.

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
@@ -95,7 +95,12 @@ from cognite_toolkit._cdf_tk.constants import (
     URL,
     VIEW_UPSERT_BATCH_LIMIT,
 )
-from cognite_toolkit._cdf_tk.exceptions import GraphQLParseError, ToolkitCycleError, ToolkitFileNotFoundError
+from cognite_toolkit._cdf_tk.exceptions import (
+    GraphQLParseError,
+    ToolkitCycleError,
+    ToolkitFileNotFoundError,
+    ToolkitValidationError,
+)
 from cognite_toolkit._cdf_tk.resource_ios._base_ios import (
     FailedReadExtra,
     ReadExtra,
@@ -111,6 +116,7 @@ from cognite_toolkit._cdf_tk.utils import (
     in_dict,
     load_yaml_inject_variables,
     quote_int_value_by_key_in_yaml,
+    read_yaml_content,
     safe_read,
     sanitize_filename,
     to_diff,
@@ -1053,6 +1059,12 @@ class DataModelIO(ResourceIO[DataModelId, DataModelRequest, DataModelResponse]):
     yaml_cls = DataModelYAML
     _doc_url = "Data-models/operation/createDataModels"
 
+    @classmethod
+    def get_deployment_dependencies(
+        cls, files_by_crud: Mapping[type[ResourceIO], list[Path]]
+    ) -> frozenset[type[ResourceIO]]:
+        return cls.dependencies | _get_data_modeling_cross_dependencies(files_by_crud).get(cls, frozenset())
+
     @property
     def display_name(self) -> str:
         return "data models"
@@ -1376,6 +1388,12 @@ class GraphQLCRUD(ResourceContainerIO[DataModelId, GraphQLDataModelRequest, Grap
     _doc_url = "Data-models/operation/createDataModels"
     _hash_name = "CDFToolkitHash:"
 
+    @classmethod
+    def get_deployment_dependencies(
+        cls, files_by_crud: Mapping[type[ResourceIO], list[Path]]
+    ) -> frozenset[type[ResourceIO]]:
+        return cls.dependencies | _get_data_modeling_cross_dependencies(files_by_crud).get(cls, frozenset())
+
     def __init__(self, client: ToolkitClient, build_dir: Path, console: Console | None) -> None:
         super().__init__(client, build_dir, console)
         self._graphql_filepath_cache: dict[DataModelId, Path] = {}
@@ -1614,6 +1632,66 @@ class GraphQLCRUD(ResourceContainerIO[DataModelId, GraphQLDataModelRequest, Grap
                 f"Cannot create GraphQL schemas. Cycle detected between models {e.args} using the @import directive.",
                 *e.args[1:],
             )
+
+
+def _get_data_modeling_cross_dependencies(
+    files_by_crud: Mapping[type[ResourceIO], list[Path]],
+) -> dict[type[ResourceIO], frozenset[type[ResourceIO]]]:
+    graphql_files = files_by_crud.get(GraphQLCRUD)
+    data_model_files = files_by_crud.get(DataModelIO)
+    if not graphql_files or not data_model_files:
+        return {}
+
+    generated_views: set[tuple[str, str]] = set()
+    imported_data_models: set[DataModelId] = set()
+    for filepath in graphql_files:
+        raw = read_yaml_content(GraphQLCRUD.safe_read(filepath))
+        for item in raw if isinstance(raw, list) else [raw]:
+            model_id = GraphQLCRUD.get_id(item)
+            graphql_file = GraphQLCRUD._get_graphql_file(filepath, dml=item.get("dml"))
+            parser = GraphQLParser(
+                safe_read(graphql_file),
+                dm.DataModelId(
+                    space=model_id.space,
+                    external_id=model_id.external_id,
+                    version=model_id.version,
+                ),
+            )
+            generated_views.update((view.space, view.external_id) for view in parser.get_views())
+            imported_data_models.update(
+                DataModelId(
+                    space=dependency.space,
+                    external_id=dependency.external_id,
+                    version=str(dependency.version or ""),
+                )
+                for dependency in parser.get_dependencies()
+                if isinstance(dependency, dm.DataModelId)
+            )
+
+    local_data_models: set[DataModelId] = set()
+    referenced_views: set[tuple[str, str]] = set()
+    for filepath in data_model_files:
+        raw = read_yaml_content(DataModelIO.safe_read(filepath))
+        for item in raw if isinstance(raw, list) else [raw]:
+            local_data_models.add(DataModelIO.get_id(item))
+            referenced_views.update(
+                (view["space"], view["externalId"])
+                for view in item.get("views") or []
+                if "space" in view and "externalId" in view
+            )
+
+    data_model_depends_on_graphql = bool(referenced_views & generated_views)
+    graphql_depends_on_data_model = bool(imported_data_models & local_data_models)
+    if data_model_depends_on_graphql and graphql_depends_on_data_model:
+        raise ToolkitValidationError(
+            "Cannot deploy mixed GraphQL and entity-based data models with dependencies in both directions "
+            "in a single deployment. Split the deployment to avoid a cyclic resource-type dependency."
+        )
+    if data_model_depends_on_graphql:
+        return {DataModelIO: frozenset({GraphQLCRUD})}
+    if graphql_depends_on_data_model:
+        return {GraphQLCRUD: frozenset({DataModelIO})}
+    return {}
 
 
 @final

--- a/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
@@ -281,10 +281,10 @@ class TestCreateDeploymentPlan:
             tmp_path,
             graphql_content='type Generated @view(space: "my_space", version: "v1") { name: String }',
         )
+        files_by_crud = read_dir.as_files_by_crud()
 
-        actual = DeployV2Command._get_data_modeling_cross_dependencies(read_dir.as_files_by_crud())
-
-        assert actual == {}
+        assert DataModelIO.get_deployment_dependencies(files_by_crud) == DataModelIO.dependencies
+        assert GraphQLCRUD.get_deployment_dependencies(files_by_crud) == GraphQLCRUD.dependencies
 
     @staticmethod
     def _create_mixed_data_model_build(

--- a/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
@@ -38,8 +38,10 @@ from cognite_toolkit._cdf_tk.exceptions import (
 from cognite_toolkit._cdf_tk.resource_ios import (
     CogniteFileCRUD,
     ContainerCRUD,
+    DataModelIO,
     DataSetsIO,
     FunctionScheduleIO,
+    GraphQLCRUD,
     LabelIO,
     RawDatabaseCRUD,
     RawTableCRUD,
@@ -196,6 +198,25 @@ class TestCreateDeploymentPlan:
                     DeploymentStep(ContainerCRUD, [Path("build/data_modeling/my.Container.yaml")]),
                 ],
                 id="Topological sorting of dependencies",
+            ),
+            pytest.param(
+                ReadBuildDirectory(
+                    path=Path("build"),
+                    resource_directories=[
+                        ResourceDirectory(
+                            directory=Path("build/data_modeling"),
+                            files_by_crud={
+                                DataModelIO: [Path("build/data_modeling/my.DataModel.yaml")],
+                                GraphQLCRUD: [Path("build/data_modeling/schema.GraphQLSchema.yaml")],
+                            },
+                        )
+                    ],
+                ),
+                [
+                    DeploymentStep(GraphQLCRUD, [Path("build/data_modeling/schema.GraphQLSchema.yaml")]),
+                    DeploymentStep(DataModelIO, [Path("build/data_modeling/my.DataModel.yaml")]),
+                ],
+                id="GraphQL schemas deploy before entity-based data models",
             ),
             pytest.param(
                 ReadBuildDirectory(

--- a/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
@@ -261,16 +261,30 @@ class TestCreateDeploymentPlan:
     def test_bidirectional_mixed_data_model_dependencies_raise(self, tmp_path: Path) -> None:
         read_dir = self._create_mixed_data_model_build(
             tmp_path,
-            graphql_content=(
-                'type Generated @view(space: "my_space", version: "v1") { name: String }\n'
-                'type Imported @import(dataModel: {space: "my_space", externalId: "entity_model", version: "v1"}) '
-                "{ name: String }\n"
-            ),
+            graphql_content='type Generated @view(space: "my_space", version: "v1") { name: String }',
             data_model_views=[{"type": "view", "space": "my_space", "externalId": "Generated", "version": "v1"}],
         )
+        resource_dir = read_dir.resource_directories[0]
+        consumer_yaml = resource_dir.directory / "consumer.GraphQLSchema.yaml"
+        consumer_yaml.write_text("space: my_space\nexternalId: consumer_model\nversion: v1\n")
+        consumer_yaml.with_name("consumer.graphql").write_text(
+            'type Imported @import(dataModel: {space: "my_space", externalId: "entity_model", version: "v1"}) '
+            "{ name: String }"
+        )
+        resource_dir.files_by_crud[GraphQLCRUD].append(consumer_yaml)
 
         with pytest.raises(ToolkitValidationError, match="dependencies in both directions"):
             DeployV2Command.create_deployment_plan(read_dir)
+
+    def test_unrelated_mixed_data_models_add_no_cross_dependency(self, tmp_path: Path) -> None:
+        read_dir = self._create_mixed_data_model_build(
+            tmp_path,
+            graphql_content='type Generated @view(space: "my_space", version: "v1") { name: String }',
+        )
+
+        actual = DeployV2Command._get_data_modeling_cross_dependencies(read_dir.as_files_by_crud())
+
+        assert actual == {}
 
     @staticmethod
     def _create_mixed_data_model_build(

--- a/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 import respx
+import yaml
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
 from cognite_toolkit._cdf_tk.client.identifiers import RawDatabaseId, RawTableId, SpaceId
@@ -204,25 +205,6 @@ class TestCreateDeploymentPlan:
                     path=Path("build"),
                     resource_directories=[
                         ResourceDirectory(
-                            directory=Path("build/data_modeling"),
-                            files_by_crud={
-                                DataModelIO: [Path("build/data_modeling/my.DataModel.yaml")],
-                                GraphQLCRUD: [Path("build/data_modeling/schema.GraphQLSchema.yaml")],
-                            },
-                        )
-                    ],
-                ),
-                [
-                    DeploymentStep(GraphQLCRUD, [Path("build/data_modeling/schema.GraphQLSchema.yaml")]),
-                    DeploymentStep(DataModelIO, [Path("build/data_modeling/my.DataModel.yaml")]),
-                ],
-                id="GraphQL schemas deploy before entity-based data models",
-            ),
-            pytest.param(
-                ReadBuildDirectory(
-                    path=Path("build"),
-                    resource_directories=[
-                        ResourceDirectory(
                             directory=Path("build/files"),
                             files_by_crud={
                                 CogniteFileCRUD: [Path("build/files/my.CogniteFile.yaml")],
@@ -251,6 +233,76 @@ class TestCreateDeploymentPlan:
         actual_plan = DeployV2Command.create_deployment_plan(read_dir)
 
         assert actual_plan == expected_plan
+
+    def test_graphql_deploys_before_data_model_referencing_generated_view(self, tmp_path: Path) -> None:
+        read_dir = self._create_mixed_data_model_build(
+            tmp_path,
+            graphql_content='type Generated @view(space: "my_space", version: "v1") { name: String }',
+            data_model_views=[{"type": "view", "space": "my_space", "externalId": "Generated", "version": "v1"}],
+        )
+
+        actual_plan = DeployV2Command.create_deployment_plan(read_dir)
+
+        assert [step.crud_cls for step in actual_plan] == [GraphQLCRUD, DataModelIO]
+
+    def test_data_model_deploys_before_graphql_importing_it(self, tmp_path: Path) -> None:
+        read_dir = self._create_mixed_data_model_build(
+            tmp_path,
+            graphql_content=(
+                'type Imported @import(dataModel: {space: "my_space", externalId: "entity_model", version: "v1"}) '
+                "{ name: String }"
+            ),
+        )
+
+        actual_plan = DeployV2Command.create_deployment_plan(read_dir)
+
+        assert [step.crud_cls for step in actual_plan] == [DataModelIO, GraphQLCRUD]
+
+    def test_bidirectional_mixed_data_model_dependencies_raise(self, tmp_path: Path) -> None:
+        read_dir = self._create_mixed_data_model_build(
+            tmp_path,
+            graphql_content=(
+                'type Generated @view(space: "my_space", version: "v1") { name: String }\n'
+                'type Imported @import(dataModel: {space: "my_space", externalId: "entity_model", version: "v1"}) '
+                "{ name: String }\n"
+            ),
+            data_model_views=[{"type": "view", "space": "my_space", "externalId": "Generated", "version": "v1"}],
+        )
+
+        with pytest.raises(ToolkitValidationError, match="dependencies in both directions"):
+            DeployV2Command.create_deployment_plan(read_dir)
+
+    @staticmethod
+    def _create_mixed_data_model_build(
+        tmp_path: Path,
+        graphql_content: str,
+        data_model_views: list[dict[str, str]] | None = None,
+    ) -> ReadBuildDirectory:
+        resource_dir = tmp_path / "build" / "data_modeling"
+        resource_dir.mkdir(parents=True)
+        graphql_yaml = resource_dir / "schema.GraphQLSchema.yaml"
+        graphql_yaml.write_text("space: my_space\nexternalId: graphql_model\nversion: v1\n")
+        graphql_yaml.with_name("schema.graphql").write_text(graphql_content)
+        data_model_yaml = resource_dir / "entity.DataModel.yaml"
+        data_model = {
+            "space": "my_space",
+            "externalId": "entity_model",
+            "version": "v1",
+            "views": data_model_views,
+        }
+        data_model_yaml.write_text(yaml.safe_dump(data_model))
+        return ReadBuildDirectory(
+            path=resource_dir.parent,
+            resource_directories=[
+                ResourceDirectory(
+                    directory=resource_dir,
+                    files_by_crud={
+                        DataModelIO: [data_model_yaml],
+                        GraphQLCRUD: [graphql_yaml],
+                    },
+                )
+            ],
+        )
 
 
 @dataclass


### PR DESCRIPTION
# Description

Infer the deploy-v2 ordering between local GraphQL schemas and entity-based data models from their actual references. Dependency detection lives with the data-modeling CRUD classes; the deployment command remains a generic topological planner.

- Deploy a GraphQL schema first when an entity-based data model references one of its generated views.
- Deploy an entity-based data model first when GraphQL DML imports it with `@import(dataModel: ...)`.
- Reject dependencies in both directions with an actionable error. The current planner has one node per resource type, so it cannot interleave a resource-level chain such as GraphQL producer → entity DataModel → GraphQL consumer; those resources must currently be deployed in stages.

This avoids imposing a global ordering that would break the valid reverse dependency.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Determine deployment order between GraphQL schemas and entity-based data models from their local references.