### PR TITLE
[CDF-28401] Include source filename in upload tracking IDs and propagate split error messages

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/http_client/_client.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_client.py
@@ -386,7 +386,7 @@ class HTTPClient:
             return [
                 ItemsFailedRequest(
                     ids=[str(item) for item in message.items],
-                    error_message=f"Aborting further splitting of requests after {message.tracker.failed_split_count} failed attempts.",
+                    error_message=message.parent_error_message or "Unknown error",
                 )
             ]
         try:
@@ -444,17 +444,18 @@ class HTTPClient:
         elif len(request.items) > 1 and response.status_code in self._split_items_status_codes:
             # 4XX: Status there is at least one item that is invalid, split the batch to get all valid items processed
             # 5xx: Server error, split to reduce the number of items in each request, and count as a status attempt
+            error_details = ErrorDetails.from_response(response)
             status_attempts = request.status_attempt
             if 500 <= response.status_code < 600:
                 status_attempts += 1
-            splits = request.split(status_attempts=status_attempts)
+            splits = request.split(status_attempts=status_attempts, error_message=error_details.message)
             if splits[0].tracker and splits[0].tracker.limit_reached():
                 return [
                     ItemsFailedResponse(
                         ids=[str(item) for item in request.items],
                         status_code=response.status_code,
                         body=response.text,
-                        error=ErrorDetails.from_response(response),
+                        error=error_details,
                     )
                 ]
             return splits

--- a/cognite_toolkit/_cdf_tk/client/http_client/_client.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_client.py
@@ -386,7 +386,8 @@ class HTTPClient:
             return [
                 ItemsFailedRequest(
                     ids=[str(item) for item in message.items],
-                    error_message=message.parent_error_message or "Unknown error",
+                    error_message=message.parent_error_message
+                    or f"Aborting further splitting of requests after {message.tracker.failed_split_count} failed attempts.",
                 )
             ]
         try:

--- a/cognite_toolkit/_cdf_tk/client/http_client/_item_classes.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_item_classes.py
@@ -55,7 +55,7 @@ class ItemsRequest(BaseRequestMessage):
     max_failures_before_abort: int = 50
     tracker: ItemsRequestTracker = Field(init=False, default_factory=_set_default_tracker, exclude=True)
     # The error message from the parent batch this request was split out from, if any. Used to propagate
-    # the error causing this batch to potentially be skipped without being attempted, if that should that happen.
+    # the error causing this batch to potentially be skipped without being attempted, if that should happen.
     parent_error_message: str | None = Field(init=False, default=None, exclude=True)
 
     @property

--- a/cognite_toolkit/_cdf_tk/client/http_client/_item_classes.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_item_classes.py
@@ -54,6 +54,9 @@ class ItemsRequest(BaseRequestMessage):
     extra_body_fields: dict[str, JsonValue] | None = None
     max_failures_before_abort: int = 50
     tracker: ItemsRequestTracker = Field(init=False, default_factory=_set_default_tracker, exclude=True)
+    # The error message from the parent batch this request was split out from, if any. Used to propagate
+    # the error causing this batch to potentially be skipped without being attempted, if that should that happen.
+    parent_error_message: str | None = Field(init=False, default=None, exclude=True)
 
     @property
     def content(self) -> str | bytes | None:
@@ -65,7 +68,7 @@ class ItemsRequest(BaseRequestMessage):
             return gzip.compress(res)
         return res
 
-    def split(self, status_attempts: int) -> list["ItemsRequest"]:
+    def split(self, status_attempts: int, error_message: str | None = None) -> list["ItemsRequest"]:
         """Split the request into multiple requests with a single item each."""
         mid = len(self.items) // 2
         if mid == 0:
@@ -75,6 +78,7 @@ class ItemsRequest(BaseRequestMessage):
         for part in (self.items[:mid], self.items[mid:]):
             new_request = self.model_copy(update={"items": part, "status_attempt": status_attempts})
             new_request.tracker = self.tracker
+            new_request.parent_error_message = error_message
             messages.append(new_request)
         return messages
 

--- a/cognite_toolkit/_cdf_tk/client/http_client/_tracker.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_tracker.py
@@ -22,7 +22,7 @@ class ItemsRequestTracker:
     failed_split_count: int = field(default=0, init=False)
 
     def register_failure(self) -> None:
-        """Register a failed split request and return whether to continue splitting."""
+        """Register a failed split request."""
         with self.lock:
             self.failed_split_count += 1
 

--- a/cognite_toolkit/_cdf_tk/client/http_client/_tracker.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_tracker.py
@@ -22,7 +22,7 @@ class ItemsRequestTracker:
     failed_split_count: int = field(default=0, init=False)
 
     def register_failure(self) -> None:
-        """Register a failed split request."""
+        """Register a failed split request and return whether to continue splitting."""
         with self.lock:
             self.failed_split_count += 1
 

--- a/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
@@ -30,6 +30,7 @@ from cognite_toolkit._cdf_tk.utils.aggregators import (
     TimeSeriesAggregator,
 )
 from cognite_toolkit._cdf_tk.utils.fileio import FileReader, SchemaColumn
+from cognite_toolkit._cdf_tk.utils.fileio._readers import TableReader
 from cognite_toolkit._cdf_tk.utils.useful_types import (
     AssetCentricType,
     JsonVal,
@@ -393,6 +394,7 @@ class AssetDataIO(UploadableAssetCentricIO[AssetResponse, AssetRequest]):
     def read_chunks(cls, reader: FileReader, selector: AssetCentricSelector) -> Iterable[Page[dict[str, JsonVal]]]:
         """Assets require special handling when reading data to ensure parent assets are created first."""
         current_depth = max_depth = 0
+        label: Literal["line", "row"] = "row" if isinstance(reader, TableReader) else "line"
         # We read the file multiple times, once for each depth level, to ensure parents are created before children.
         batch: list[DataItem[dict[str, JsonVal]]] = []
         while current_depth <= max_depth:
@@ -403,12 +405,16 @@ class AssetDataIO(UploadableAssetCentricIO[AssetResponse, AssetRequest]):
                     if current_depth == 0:
                         # If depth is not set, we yield it at depth 0
                         batch.append(
-                            DataItem(tracking_id=file_line_tracking_id(reader.current_file, line_number), item=item)
+                            DataItem(
+                                tracking_id=file_line_tracking_id(reader.current_file, line_number, label), item=item
+                            )
                         )
                 else:
                     if depth == current_depth:
                         batch.append(
-                            DataItem(tracking_id=file_line_tracking_id(reader.current_file, line_number), item=item)
+                            DataItem(
+                                tracking_id=file_line_tracking_id(reader.current_file, line_number, label), item=item
+                            )
                         )
                     elif current_depth == 0:
                         max_depth = max(max_depth, depth)

--- a/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_asset_centric.py
@@ -30,7 +30,6 @@ from cognite_toolkit._cdf_tk.utils.aggregators import (
     TimeSeriesAggregator,
 )
 from cognite_toolkit._cdf_tk.utils.fileio import FileReader, SchemaColumn
-from cognite_toolkit._cdf_tk.utils.fileio._readers import TableReader
 from cognite_toolkit._cdf_tk.utils.useful_types import (
     AssetCentricType,
     JsonVal,
@@ -45,6 +44,7 @@ from ._base import (
     StorageIOConfig,
     TableDataIO,
     TableUploadableDataIO,
+    file_line_tracking_id,
 )
 from .logger import DataLogger
 from .progress import CursorBookmark, NoBookmark
@@ -393,7 +393,6 @@ class AssetDataIO(UploadableAssetCentricIO[AssetResponse, AssetRequest]):
     def read_chunks(cls, reader: FileReader, selector: AssetCentricSelector) -> Iterable[Page[dict[str, JsonVal]]]:
         """Assets require special handling when reading data to ensure parent assets are created first."""
         current_depth = max_depth = 0
-        data_name = "row" if isinstance(reader, TableReader) else "line"
         # We read the file multiple times, once for each depth level, to ensure parents are created before children.
         batch: list[DataItem[dict[str, JsonVal]]] = []
         while current_depth <= max_depth:
@@ -403,10 +402,14 @@ class AssetDataIO(UploadableAssetCentricIO[AssetResponse, AssetRequest]):
                 except (TypeError, ValueError, KeyError):
                     if current_depth == 0:
                         # If depth is not set, we yield it at depth 0
-                        batch.append(DataItem(tracking_id=f"{data_name} {line_number}", item=item))
+                        batch.append(
+                            DataItem(tracking_id=file_line_tracking_id(reader.current_file, line_number), item=item)
+                        )
                 else:
                     if depth == current_depth:
-                        batch.append(DataItem(tracking_id=f"{data_name} {line_number}", item=item))
+                        batch.append(
+                            DataItem(tracking_id=file_line_tracking_id(reader.current_file, line_number), item=item)
+                        )
                     elif current_depth == 0:
                         max_depth = max(max_depth, depth)
                 if len(batch) >= cls.CHUNK_SIZE:

--- a/cognite_toolkit/_cdf_tk/dataio/_base.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_base.py
@@ -19,13 +19,13 @@ from .logger import DataLogger, NoOpLogger
 from .selectors import DataSelector
 
 
-def file_line_tracking_id(filepath: Path, line_no: int) -> str:
-    """Build a tracking ID that identifies the file and line number an item came from.
+def file_line_tracking_id(filepath: Path, line_no: int, label: Literal["line", "row"] = "line") -> str:
+    """Build a tracking ID that identifies the file and line/row number an item came from.
 
     Only the filename is used (not the full path), since the log file that these tracking IDs
     end up in is always written alongside the data file it refers to.
     """
-    return f"{filepath.name}:line-{line_no}"
+    return f"{filepath.name}:{label}-{line_no}"
 
 
 @runtime_checkable
@@ -278,10 +278,13 @@ class UploadableDataIO(Generic[T_Selector, T_DataResponse, T_DataRequest], DataI
             reader: An instance of MultiFileReader to read data from.
             selector: The selection criteria to identify the data.
         """
+        label: Literal["line", "row"] = "row" if reader.is_table else "line"
         batch: list[DataItem[dict[str, JsonVal]]] = []
         line_no: int = -1
         for line_no, item in reader.read_chunks_with_line_numbers():
-            batch.append(DataItem(tracking_id=file_line_tracking_id(reader.current_file, line_no), item=item))
+            batch.append(
+                DataItem(tracking_id=file_line_tracking_id(reader.current_file, line_no, label), item=item)
+            )
             if len(batch) >= cls.CHUNK_SIZE:
                 yield Page(
                     worker_id="main",

--- a/cognite_toolkit/_cdf_tk/dataio/_base.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_base.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Mapping, Sequence, Sized
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, ClassVar, Generic, Literal, Protocol, TypeVar, runtime_checkable
 
 from pydantic import ConfigDict, Field
@@ -16,6 +17,15 @@ from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 
 from .logger import DataLogger, NoOpLogger
 from .selectors import DataSelector
+
+
+def file_line_tracking_id(filepath: Path, line_no: int) -> str:
+    """Build a tracking ID that identifies the file and line number an item came from.
+
+    Only the filename is used (not the full path), since the log file that these tracking IDs
+    end up in is always written alongside the data file it refers to.
+    """
+    return f"{filepath.name}:line-{line_no}"
 
 
 @runtime_checkable
@@ -268,11 +278,10 @@ class UploadableDataIO(Generic[T_Selector, T_DataResponse, T_DataRequest], DataI
             reader: An instance of MultiFileReader to read data from.
             selector: The selection criteria to identify the data.
         """
-        data_name = "row" if reader.is_table else "line"
         batch: list[DataItem[dict[str, JsonVal]]] = []
         line_no: int = -1
         for line_no, item in reader.read_chunks_with_line_numbers():
-            batch.append(DataItem(tracking_id=f"{data_name} {line_no}", item=item))
+            batch.append(DataItem(tracking_id=file_line_tracking_id(reader.current_file, line_no), item=item))
             if len(batch) >= cls.CHUNK_SIZE:
                 yield Page(
                     worker_id="main",

--- a/cognite_toolkit/_cdf_tk/dataio/_base.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_base.py
@@ -282,9 +282,7 @@ class UploadableDataIO(Generic[T_Selector, T_DataResponse, T_DataRequest], DataI
         batch: list[DataItem[dict[str, JsonVal]]] = []
         line_no: int = -1
         for line_no, item in reader.read_chunks_with_line_numbers():
-            batch.append(
-                DataItem(tracking_id=file_line_tracking_id(reader.current_file, line_no, label), item=item)
-            )
+            batch.append(DataItem(tracking_id=file_line_tracking_id(reader.current_file, line_no, label), item=item))
             if len(batch) >= cls.CHUNK_SIZE:
                 yield Page(
                     worker_id="main",

--- a/cognite_toolkit/_cdf_tk/utils/fileio/_readers.py
+++ b/cognite_toolkit/_cdf_tk/utils/fileio/_readers.py
@@ -25,6 +25,8 @@ from ._compression import COMPRESSION_BY_SUFFIX, Compression
 class FileReader(FileIO, ABC):
     def __init__(self, input_file: Path) -> None:
         self.input_file = input_file
+        # Tracks the file currently being read. Overridden by MultiFileReader when it moves between files.
+        self.current_file = input_file
 
     def read_chunks(self) -> Iterator[dict[str, JsonVal]]:
         compression = Compression.from_filepath(self.input_file)

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_asset_centric.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_asset_centric.py
@@ -374,14 +374,18 @@ class TestAssetIO:
         other_reader = MagicMock(spec=FileReader)
         other_reader.read_chunks_with_line_numbers.return_value = assets_with_line_numbers
         other_reader.input_file = Path("mocked_file.csv")
+        other_reader.current_file = Path("mocked_file.csv")
         output = list(
             AssetDataIO.read_chunks(other_reader, AssetSubtreeSelector(hierarchy="does not matter", kind="Assets"))
         )
 
         result = [[(di.tracking_id, di.item) for di in page.items] for page in output]
         assert result == [
-            [("line 4", {"id": 4}), ("line 5", {"id": 5, "depth": "not_an_int"})],
-            [("line 3", {"id": 3, "depth": 1})],
-            [("line 2", {"id": 2, "depth": 2})],
-            [("line 1", {"id": 1, "depth": 3})],
+            [
+                ("mocked_file.csv:line-4", {"id": 4}),
+                ("mocked_file.csv:line-5", {"id": 5, "depth": "not_an_int"}),
+            ],
+            [("mocked_file.csv:line-3", {"id": 3, "depth": 1})],
+            [("mocked_file.csv:line-2", {"id": 2, "depth": 2})],
+            [("mocked_file.csv:line-1", {"id": 1, "depth": 3})],
         ]

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_base.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_base.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from cognite_toolkit._cdf_tk.dataio._base import UploadableDataIO
+from cognite_toolkit._cdf_tk.utils.fileio import MultiFileReader
+
+
+class TestUploadableDataIOReadChunks:
+    def test_read_chunks_tracking_id_includes_source_file(self, tmp_path: Path) -> None:
+        """The tracking ID must identify which physical file an item came from, even when a
+        single batch spans a file boundary (i.e. the file is smaller than CHUNK_SIZE)."""
+        file1 = tmp_path / "part-0000.ndjson"
+        file1.write_text('{"id": 1}\n{"id": 2}\n')
+        file2 = tmp_path / "part-0001.ndjson"
+        file2.write_text('{"id": 3}\n{"id": 4}\n')
+        reader = MultiFileReader([file1, file2])
+
+        pages = list(UploadableDataIO.read_chunks(reader, selector=None))
+
+        assert len(pages) == 1
+        tracking_ids = [di.tracking_id for di in pages[0].items]
+        assert tracking_ids == [
+            "part-0000.ndjson:line-1",
+            "part-0000.ndjson:line-2",
+            "part-0001.ndjson:line-3",
+            "part-0001.ndjson:line-4",
+        ]

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
@@ -125,8 +125,8 @@ my_text_file,my_text_file.txt,{text_file.relative_to(tmp_path)}\n
         results = self._upload_files(selector, tmp_path)
 
         assert results == [
-            ItemsSuccessResponse(ids=[f"{csv_path.name}:line-1"], status_code=200, body="", content=b""),
-            ItemsSuccessResponse(ids=[f"{csv_path.name}:line-2"], status_code=200, body="", content=b""),
+            ItemsSuccessResponse(ids=[f"{csv_path.name}:row-1"], status_code=200, body="", content=b""),
+            ItemsSuccessResponse(ids=[f"{csv_path.name}:row-2"], status_code=200, body="", content=b""),
         ]
 
     def _upload_files(self, selector: FileMetadataContentSelectorV2, tmp_path: Path) -> list[ItemsResultMessage]:
@@ -254,5 +254,5 @@ class TestCogniteFileContentIO:
             result_pages = [io.upload_items(page, MagicMock(spec=HTTPClient), selector) for page in requests]
 
         assert result_pages[0] == [
-            ItemsSuccessResponse(ids=[f"{csv_path.name}:line-1"], status_code=200, body="", content=b""),
+            ItemsSuccessResponse(ids=[f"{csv_path.name}:row-1"], status_code=200, body="", content=b""),
         ]

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent_v2.py
@@ -119,13 +119,14 @@ class TestFileMetadataContentIO:
 my_json_file,my_json_file.json,{json_file.relative_to(tmp_path)}\n
 my_text_file,my_text_file.txt,{text_file.relative_to(tmp_path)}\n
 """
-        (tmp_path / f"{selector.as_filestem()}.csv").write_text(csv_file)
+        csv_path = tmp_path / f"{selector.as_filestem()}.csv"
+        csv_path.write_text(csv_file)
 
         results = self._upload_files(selector, tmp_path)
 
         assert results == [
-            ItemsSuccessResponse(ids=["row 1"], status_code=200, body="", content=b""),
-            ItemsSuccessResponse(ids=["row 2"], status_code=200, body="", content=b""),
+            ItemsSuccessResponse(ids=[f"{csv_path.name}:line-1"], status_code=200, body="", content=b""),
+            ItemsSuccessResponse(ids=[f"{csv_path.name}:line-2"], status_code=200, body="", content=b""),
         ]
 
     def _upload_files(self, selector: FileMetadataContentSelectorV2, tmp_path: Path) -> list[ItemsResultMessage]:
@@ -219,7 +220,8 @@ class TestCogniteFileContentIO:
         selector = CogniteFileFilesSelectorV2()
         selector.dump_to_file(tmp_path)
         csv_file = f"""space,externalId,name,{FILEPATH}\nmy-space,r1,row-1,{text_file.relative_to(tmp_path)}\n"""
-        (tmp_path / f"{selector.as_filestem()}.csv").write_text(csv_file)
+        csv_path = tmp_path / f"{selector.as_filestem()}.csv"
+        csv_path.write_text(csv_file)
 
         with monkeypatch_toolkit_client() as client:
             client.tool.cognite_files.create.return_value = [
@@ -252,5 +254,5 @@ class TestCogniteFileContentIO:
             result_pages = [io.upload_items(page, MagicMock(spec=HTTPClient), selector) for page in requests]
 
         assert result_pages[0] == [
-            ItemsSuccessResponse(ids=["row 1"], status_code=200, body="", content=b""),
+            ItemsSuccessResponse(ids=[f"{csv_path.name}:line-1"], status_code=200, body="", content=b""),
         ]


### PR DESCRIPTION
# Description

Tracking IDs for uploaded items now include the source filename (e.g. `part-0000.ndjson:line-1`) instead of a generic `row N`/`line N`, so failures can be traced back to the exact file when reading spans multiple files. As an additional benefit, since one single upload log is used for multiple ndjson files (e.g. "part-0000", "part-0001" and so on), this mitigates potential `Toolkit bug - multiple registrations` warnings that could occur if e.g. the item on "line 1" had an error in both files (since both individual errors would previously get the same tracking ID). 

Additionally, when a batch is aborted after exceeding the failed-split limit, the error message now propagates the actual error from the parent request instead of a generic `Aborting further splitting of requests after 50 failed attempts` message. This makes the originating error / the reason for the item being skipped more obvious. 

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Improved

- Upload failure logs now reference the source filename and line number (e.g. `part-0000.ndjson:line-1`), making it easier to locate the offending item when uploading data from multiple files.
- Error messages for aborted upload batches now reflect the underlying cause instead of the generic `Aborting further splitting of requests after 50 failed attempts` message.