### PR TITLE
[CDF-28183] Default purge, migration, and deploy logs to a nested logs/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -314,11 +314,9 @@ tests/**/cdf.toml
 
 *.xlsx
 data/
-migration_logs*/
-deploy_logs*/
+logs/
 !tests/data/
 !tests/data/**
 tests/data/**/__pycache__/
 build_info.dev.yaml
 tests/data/run_data/function_local_venvs*/**
-purge_logs*/

--- a/cognite_toolkit/_cdf_tk/apps/_core_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_core_app.py
@@ -502,7 +502,7 @@ class CoreApp(typer.Typer):
                 "-l",
                 help="Path to the directory where logs will be stored. If the directory does not exist, it will be created.",
             ),
-        ] = Path(f"deploy_logs_{TODAY!s}"),
+        ] = Path(f"logs/deploy_{TODAY!s}"),
         cdf_project: Annotated[
             str | None,
             typer.Option(

--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -400,7 +400,7 @@ class MigrateApp(typer.Typer):
                 "-l",
                 help="Path to the directory where logs will be stored. If the directory does not exist, it will be created.",
             ),
-        ] = Path(f"migration_logs_{TODAY!s}"),
+        ] = Path(f"logs/migration_{TODAY!s}"),
         dry_run: Annotated[
             bool,
             typer.Option(
@@ -591,7 +591,7 @@ class MigrateApp(typer.Typer):
                 "-l",
                 help="Path to the directory where logs will be stored. If the directory does not exist, it will be created.",
             ),
-        ] = Path(f"migration_logs_{TODAY!s}"),
+        ] = Path(f"logs/migration_logs_{TODAY!s}"),
         dry_run: Annotated[
             bool,
             typer.Option(
@@ -699,7 +699,7 @@ class MigrateApp(typer.Typer):
                 "-l",
                 help="Path to the directory where logs will be stored. If the directory does not exist, it will be created.",
             ),
-        ] = Path(f"migration_logs_{TODAY!s}"),
+        ] = Path(f"logs/migration_logs_{TODAY!s}"),
         dry_run: Annotated[
             bool,
             typer.Option(
@@ -846,7 +846,7 @@ class MigrateApp(typer.Typer):
                 "-l",
                 help="Path to the directory where logs will be stored. If the directory does not exist, it will be created.",
             ),
-        ] = Path(f"migration_logs_{TODAY!s}"),
+        ] = Path(f"logs/migration_logs_{TODAY!s}"),
         skip_linking: Annotated[
             bool,
             typer.Option(
@@ -972,7 +972,7 @@ class MigrateApp(typer.Typer):
                 "-l",
                 help="Path to the directory where logs will be stored. If the directory does not exist, it will be created.",
             ),
-        ] = Path(f"migration_logs_{TODAY!s}"),
+        ] = Path(f"logs/migration_logs_{TODAY!s}"),
         skip_linking: Annotated[
             bool,
             typer.Option(
@@ -1097,7 +1097,7 @@ class MigrateApp(typer.Typer):
                 "-l",
                 help="Path to the directory where logs will be stored. If the directory does not exist, it will be created.",
             ),
-        ] = Path(f"migration_logs_{TODAY!s}"),
+        ] = Path(f"logs/migration_logs_{TODAY!s}"),
         dry_run: Annotated[
             bool,
             typer.Option(
@@ -1210,7 +1210,7 @@ class MigrateApp(typer.Typer):
                 "-l",
                 help="Path to the directory where migration logs will be stored.",
             ),
-        ] = Path(f"migration_logs_{TODAY}"),
+        ] = Path(f"logs/migration_logs_{TODAY}"),
         dry_run: Annotated[
             bool,
             typer.Option(
@@ -1278,7 +1278,7 @@ class MigrateApp(typer.Typer):
                 "-l",
                 help="Path to the directory where migration logs will be stored.",
             ),
-        ] = Path(f"migration_logs_{TODAY}"),
+        ] = Path(f"logs/migration_logs_{TODAY}"),
         dry_run: Annotated[
             bool,
             typer.Option(
@@ -1341,7 +1341,7 @@ class MigrateApp(typer.Typer):
                 "-l",
                 help="Path to the directory where migration logs will be stored.",
             ),
-        ] = Path(f"migration_logs_{TODAY}"),
+        ] = Path(f"logs/migration_logs_{TODAY}"),
         dry_run: Annotated[
             bool,
             typer.Option(
@@ -1421,7 +1421,7 @@ class MigrateApp(typer.Typer):
                 "-l",
                 help="Path to the directory where migration logs will be stored.",
             ),
-        ] = Path(f"migration_logs_{TODAY}"),
+        ] = Path(f"logs/migration_logs_{TODAY}"),
         dry_run: Annotated[
             bool,
             typer.Option(
@@ -1573,7 +1573,7 @@ class MigrateApp(typer.Typer):
                 "-l",
                 help="Path to the directory where migration logs will be stored.",
             ),
-        ] = Path(f"migration_logs_{TODAY}"),
+        ] = Path(f"logs/migration_logs_{TODAY}"),
         dry_run: Annotated[
             bool,
             typer.Option(
@@ -1783,7 +1783,7 @@ class MigrateApp(typer.Typer):
                 "-l",
                 help="Path to the directory where migration logs will be stored.",
             ),
-        ] = Path(f"migration_logs_{TODAY}"),
+        ] = Path(f"logs/migration_logs_{TODAY}"),
         dry_run: Annotated[
             bool,
             typer.Option(
@@ -1981,7 +1981,7 @@ class MigrateApp(typer.Typer):
                 "-l",
                 help="Path to the directory where migration logs will be stored.",
             ),
-        ] = Path(f"migration_logs_{TODAY}"),
+        ] = Path(f"logs/migration_logs_{TODAY}"),
         dry_run: Annotated[
             bool,
             typer.Option(
@@ -2103,7 +2103,7 @@ class MigrateApp(typer.Typer):
                 "-l",
                 help="Path to the directory where migration logs will be stored.",
             ),
-        ] = Path(f"migration_logs_{TODAY}"),
+        ] = Path(f"logs/migration_logs_{TODAY}"),
         dry_run: Annotated[
             bool,
             typer.Option(

--- a/cognite_toolkit/_cdf_tk/apps/_purge.py
+++ b/cognite_toolkit/_cdf_tk/apps/_purge.py
@@ -103,7 +103,7 @@ class PurgeApp(typer.Typer):
                 "--log-dir",
                 help="Path to the directory where logs will be stored. If the directory does not exist, it will be created.",
             ),
-        ] = Path(f"purge_logs_{TODAY!s}"),
+        ] = Path(f"logs/purge_{TODAY!s}"),
         auto_yes: Annotated[
             bool,
             typer.Option(
@@ -208,7 +208,7 @@ class PurgeApp(typer.Typer):
                 "--log-dir",
                 help="Path to the directory where logs will be stored. If the directory does not exist, it will be created.",
             ),
-        ] = Path(f"purge_logs_{TODAY!s}"),
+        ] = Path(f"logs/purge_logs_{TODAY!s}"),
         auto_yes: Annotated[
             bool,
             typer.Option(
@@ -337,7 +337,7 @@ class PurgeApp(typer.Typer):
                 "--log-dir",
                 help="Path to the directory where logs will be stored. If the directory does not exist, it will be created.",
             ),
-        ] = Path(f"purge_logs_{TODAY!s}"),
+        ] = Path(f"logs/purge_logs_{TODAY!s}"),
         auto_yes: Annotated[
             bool,
             typer.Option(

--- a/cognite_toolkit/_cdf_tk/commands/_changes.py
+++ b/cognite_toolkit/_cdf_tk/commands/_changes.py
@@ -14,7 +14,10 @@ from rich import print
 from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 from cognite_toolkit._cdf_tk.constants import DOCKER_IMAGE_NAME
 from cognite_toolkit._cdf_tk.utils import iterate_modules, read_yaml_file, safe_read, safe_write
+from cognite_toolkit._cdf_tk.utils.gitignore import append_missing_gitignore_entries
 from cognite_toolkit._version import __version__
+
+from . import _cli_commands
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -598,6 +601,47 @@ After:
             if parent.name == "functions":
                 return parent / resource_yaml.name
         return resource_yaml
+
+
+class AddCommonDirectoriesToGitignore(AutomaticChange):
+    """Toolkit commands write working data, such as downloaded/uploaded files, and debug logs to the
+'data/', 'tmp/', and 'logs/' directories by default. These may contain user/customer data and should not
+be committed to version control.
+
+This change adds any of the 'data/', 'tmp/', and 'logs/' entries that are missing to your .gitignore file.
+
+In .gitignore, before:
+```
+build/
+```
+After:
+```
+build/
+data/
+tmp/
+logs/
+```
+    """
+
+    deprecated_from = Version("0.8.154")
+    required_from = Version("0.8.154")
+    has_file_changes = True
+
+    _ENTRIES = ["data/", "tmp/", "logs/"]
+
+    def do(self) -> set[Path]:
+        gitignore_dir = Path.cwd()
+        if _cli_commands.use_git() and _cli_commands.has_initiated_repo():
+            # The .gitignore created by 'cdf repo init' lives at the git root, which may differ from the
+            # current working directory, for example if the organization directory is nested inside a
+            # larger monorepo.
+            gitignore_dir = _cli_commands.git_root() or gitignore_dir
+        gitignore = gitignore_dir / ".gitignore"
+        if not gitignore.exists():
+            return set()
+        if append_missing_gitignore_entries(self._ENTRIES, gitignore):
+            return {gitignore}
+        return set()
 
 
 class UpdateModuleVersion(AutomaticChange):

--- a/cognite_toolkit/_cdf_tk/commands/repo.py
+++ b/cognite_toolkit/_cdf_tk/commands/repo.py
@@ -9,6 +9,7 @@ from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.constants import REPO_FILES_DIR
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
 from cognite_toolkit._cdf_tk.tk_warnings import LowSeverityWarning, MediumSeverityWarning
+from cognite_toolkit._cdf_tk.utils.gitignore import append_missing_gitignore_entries, load_gitignore_entries_from_text
 
 from . import _cli_commands
 from ._base import ToolkitCommand
@@ -101,39 +102,5 @@ class RepoCommand(ToolkitCommand):
         self.console("Repo initialization complete.")
 
     def _append_missing_gitignore_entries(self, template_file: Path, destination: Path) -> bool:
-        template_entries = self._load_gitignore_entries(template_file)
-        existing_text = destination.read_text(encoding="utf-8")
-        existing_entries = self._load_gitignore_entries_from_text(existing_text)
-
-        missing_entries = [entry for entry in template_entries if entry not in existing_entries]
-        if not missing_entries:
-            return False
-
-        merged_text = existing_text
-        if merged_text and not merged_text.endswith("\n"):
-            merged_text += "\n"
-        if merged_text:
-            merged_text += "\n"
-        merged_text += f"{self._GITIGNORE_MERGE_HEADER}\n"
-        merged_text += "\n".join(missing_entries)
-        merged_text += "\n"
-        destination.write_text(merged_text, encoding="utf-8")
-        return True
-
-    @staticmethod
-    def _load_gitignore_entries(template_file: Path) -> list[str]:
-        return RepoCommand._load_gitignore_entries_from_text(template_file.read_text(encoding="utf-8"))
-
-    @staticmethod
-    def _load_gitignore_entries_from_text(content: str) -> list[str]:
-        entries: list[str] = []
-        seen_entries: set[str] = set()
-        for line in content.splitlines():
-            normalized = line.strip()
-            if not normalized or normalized.startswith("#"):
-                continue
-            if normalized in seen_entries:
-                continue
-            entries.append(normalized)
-            seen_entries.add(normalized)
-        return entries
+        template_entries = load_gitignore_entries_from_text(template_file.read_text(encoding="utf-8"))
+        return append_missing_gitignore_entries(template_entries, destination, header=self._GITIGNORE_MERGE_HEADER)

--- a/cognite_toolkit/_cdf_tk/utils/gitignore.py
+++ b/cognite_toolkit/_cdf_tk/utils/gitignore.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+DEFAULT_GITIGNORE_MERGE_HEADER = "# Added by cdf repo init (missing entries)"
+
+
+def load_gitignore_entries_from_text(content: str) -> list[str]:
+    entries: list[str] = []
+    seen_entries: set[str] = set()
+    for line in content.splitlines():
+        normalized = line.strip()
+        if not normalized or normalized.startswith("#"):
+            continue
+        if normalized in seen_entries:
+            continue
+        entries.append(normalized)
+        seen_entries.add(normalized)
+    return entries
+
+
+def append_missing_gitignore_entries(
+    entries: list[str], destination: Path, header: str = DEFAULT_GITIGNORE_MERGE_HEADER
+) -> bool:
+    existing_text = destination.read_text(encoding="utf-8") if destination.exists() else ""
+    existing_entries = load_gitignore_entries_from_text(existing_text)
+
+    missing_entries = [entry for entry in entries if entry not in existing_entries]
+    if not missing_entries:
+        return False
+
+    merged_text = existing_text
+    if merged_text and not merged_text.endswith("\n"):
+        merged_text += "\n"
+    if merged_text:
+        merged_text += "\n"
+    merged_text += f"{header}\n"
+    merged_text += "\n".join(missing_entries)
+    merged_text += "\n"
+    destination.write_text(merged_text, encoding="utf-8")
+    return True

--- a/cognite_toolkit/_repo_files/.gitignore
+++ b/cognite_toolkit/_repo_files/.gitignore
@@ -278,5 +278,4 @@ build.*
 build/
 function_local_venvs/
 data/
-migration_logs*/
-deploy_logs*/
+logs/

--- a/cognite_toolkit/_repo_files/.gitignore
+++ b/cognite_toolkit/_repo_files/.gitignore
@@ -278,4 +278,5 @@ build.*
 build/
 function_local_venvs/
 data/
+tmp/
 logs/

--- a/tests/test_unit/test_cdf_tk/test_commands/test_changes.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_changes.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from cognite_toolkit._cdf_tk.commands import _changes
+from cognite_toolkit._cdf_tk.commands._changes import AddCommonDirectoriesToGitignore
+
+
+class TestAddCommonDirectoriesToGitignore:
+    @staticmethod
+    def _run(tmp_path: Path) -> set[Path]:
+        return AddCommonDirectoriesToGitignore(tmp_path, None).do()
+
+    def test_adds_missing_entries_to_existing_gitignore(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        gitignore_path = tmp_path / ".gitignore"
+        gitignore_path.write_text("data/\n", encoding="utf-8")
+
+        changed = self._run(tmp_path)
+
+        assert changed == {gitignore_path}
+        content = gitignore_path.read_text(encoding="utf-8")
+        assert "tmp/" in content
+        assert "logs/" in content
+
+    def test_does_nothing_when_entries_already_present(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        gitignore_path = tmp_path / ".gitignore"
+        gitignore_path.write_text("data/\ntmp/\nlogs/\n", encoding="utf-8")
+
+        assert self._run(tmp_path) == set()
+
+    def test_does_nothing_when_no_gitignore_exists(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        assert self._run(tmp_path) == set()
+
+    def test_updates_gitignore_at_git_root_when_organization_dir_is_nested(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        repo_root = tmp_path
+        organization_dir = repo_root / "my_organization"
+        organization_dir.mkdir()
+        gitignore_path = repo_root / ".gitignore"
+        gitignore_path.write_text("data/\n", encoding="utf-8")
+        monkeypatch.chdir(organization_dir)
+        monkeypatch.setattr(_changes._cli_commands, "use_git", lambda: True)
+        monkeypatch.setattr(_changes._cli_commands, "has_initiated_repo", lambda: True)
+        monkeypatch.setattr(_changes._cli_commands, "git_root", lambda: repo_root)
+
+        changed = self._run(organization_dir)
+
+        assert changed == {gitignore_path}
+        content = gitignore_path.read_text(encoding="utf-8")
+        assert "tmp/" in content
+        assert "logs/" in content


### PR DESCRIPTION
# Description

The logging directories for `cdf purge`, `cdf migrate`, and `cdf deploy` defaulted to the repo root, cluttering the working directory. They now instead default to a nested `logs/` folder, and `.gitignore` templates were consolidated to ignore `logs/` instead of three separate patterns. While this change does not directly solve the linked issue, it makes it easier to avoid customer data being accidentally committed or available by AI agents by ensuring all logs by default can be ignored by ignoring `logs/`.

Also added `cdf modules upgrade` support and repo-init templates to ensure `data/`, `tmp/`, and `logs/` are gitignored, resolving the actual git root so it works correctly even when the organization directory is nested inside a larger repo.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Changed

- Purge, migration, and deploy commands now default their `--log-dir` output to a `logs/` subfolder instead of the current working directory.
- When running `cdf modules upgrade` after updating toolkit this version it will automatically add `logs/`, `data` and `tmp` as ignored folders to your repos' `.gitignore`