### PR TITLE
[CDF-28431] Emit distinct CDM instance spaces when Infield locations share a space.

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -1492,7 +1492,7 @@ class MigrateApp(typer.Typer):
         external_id: Annotated[
             list[str] | None,
             typer.Argument(
-                help="The external IDs of the APM Configurations to create Infield V2 configurations for. "
+                help="The external IDs of the APM Configurations to create CDM configurations for Infield for. "
                 "If not provided, an interactive selection will be performed to select the APM Configurations."
             ),
         ] = None,
@@ -1501,7 +1501,7 @@ class MigrateApp(typer.Typer):
             typer.Option(
                 "--output-dir",
                 "-o",
-                help="Path to the directory where the Infield V2 configuration definitions will be dumped. It is recommended "
+                help="Path to the directory where the Infield CDM configuration definitions will be dumped. It is recommended "
                 "to govern these configurations in a git repository.",
             ),
         ] = Path("tmp"),
@@ -1514,7 +1514,7 @@ class MigrateApp(typer.Typer):
             ),
         ] = False,
     ) -> None:
-        """Creates Infield V2 configurations from existing APM Configurations in CDF."""
+        """Creates Infield CDM configurations from existing APM Configurations in CDF."""
         client = EnvironmentVariables.create_from_environment().get_client()
 
         cmd = MigrationCommand(client=client)
@@ -1522,7 +1522,7 @@ class MigrateApp(typer.Typer):
             apm_configs = APMConfigInteractiveSelect(client, "migrate").select_apm_configs()
             output_dir = Path(
                 questionary.path(
-                    "Specify output directory for Infield V2 configuration definitions:", default=str(output_dir)
+                    "Specify output directory for Infield CDM configuration definitions:", default=str(output_dir)
                 ).unsafe_ask()
             )
             verbose = questionary.confirm("Do you want verbose output?", default=verbose).unsafe_ask()

--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -38,7 +38,7 @@ from cognite_toolkit._cdf_tk.commands._migrate.conversion import (
     SuffixInstanceIdMapper,
 )
 from cognite_toolkit._cdf_tk.commands._migrate.creators import (
-    InfieldV2ConfigCreator,
+    InfieldCDMConfigCreator,
     InstanceSpaceCreator,
     SourceSystemCreator,
 )
@@ -1532,7 +1532,7 @@ class MigrateApp(typer.Typer):
         cmd.run(
             lambda: cmd.create(
                 client,
-                creator=InfieldV2ConfigCreator(client, external_id, apm_configs),
+                creator=InfieldCDMConfigCreator(client, external_id, apm_configs),
                 output_dir=output_dir,
                 dry_run=False,
                 deploy=False,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -56,6 +56,12 @@ from cognite_toolkit._cdf_tk.utils import humanize_collection
 from cognite_toolkit._cdf_tk.utils.text import fix_invalid_space_name, warn_invalid_space_name
 
 from .data_model import CREATED_SOURCE_SYSTEM_VIEW_ID, SPACE, SPACE_SOURCE_VIEW_ID
+from .location_split import (
+    CDM_SPACE_SUFFIX,
+    CFG_SPACE_SUFFIX,
+    build_infield_instance_space_name,
+    find_shared_legacy_instance_spaces,
+)
 
 
 @dataclass
@@ -328,9 +334,10 @@ class InfieldV2ConfigCreator(MigrationCreator):
         seen_spaces: set[str] = set()
         success_count = 0
         skipped_external_ids_by_label: dict[str, list[str]] = {}
+        shared_legacy_spaces = find_shared_legacy_instance_spaces(apm_configs)
         for apm_config in apm_configs:
             location_configs, location_filters, spaces = self._create_infield_v2_config(
-                apm_config, skipped_external_ids_by_label
+                apm_config, skipped_external_ids_by_label, shared_legacy_spaces
             )
             success_count += len(location_configs)
             all_location_configs.extend(
@@ -383,6 +390,7 @@ class InfieldV2ConfigCreator(MigrationCreator):
         self,
         config: APMConfigResponse,
         skipped_external_ids_by_label: dict[str, list[str]],
+        shared_legacy_spaces: set[str],
     ) -> tuple[list[InFieldCDMLocationConfigRequest], list[LocationFilterRequest], list[SpaceRequest]]:
         location_configs: list[InFieldCDMLocationConfigRequest] = []
         location_filters: list[LocationFilterRequest] = []
@@ -406,6 +414,7 @@ class InfieldV2ConfigCreator(MigrationCreator):
                     root_location_config,
                     config.feature_configuration.disciplines,
                     index,
+                    shared_legacy_spaces,
                 )
             except ToolkitMigrationError as error:
                 skipped_external_ids_by_label.setdefault("Missing required fields", []).append(identifier)
@@ -419,24 +428,37 @@ class InfieldV2ConfigCreator(MigrationCreator):
                     console=self.client.console
                 )
                 continue
+            asset_external_id = root_location_config.asset_external_id
             for space_name in [
                 root_location_config.app_data_instance_space,
                 root_location_config.source_data_instance_space,
             ]:
                 if space_name is not None:
                     origin = origin_spaces.get(space_name)
+                    cdm_space = build_infield_instance_space_name(
+                        space_name,
+                        CDM_SPACE_SUFFIX,
+                        asset_external_id=asset_external_id,
+                        shared=space_name in shared_legacy_spaces,
+                    )
                     spaces.append(
                         SpaceRequest(
-                            space=f"{space_name}_cdm",
+                            space=cdm_space,
                             name=f"{origin.name} (CDM)" if origin and origin.name else None,
                             description=f"{origin.description} (migrated)" if origin and origin.description else None,
                         )
                     )
             if root_location_config.app_data_instance_space is not None:
                 origin = origin_spaces.get(root_location_config.app_data_instance_space)
+                cfg_space = build_infield_instance_space_name(
+                    root_location_config.app_data_instance_space,
+                    CFG_SPACE_SUFFIX,
+                    asset_external_id=asset_external_id,
+                    shared=root_location_config.app_data_instance_space in shared_legacy_spaces,
+                )
                 spaces.append(
                     SpaceRequest(
-                        space=f"{root_location_config.app_data_instance_space}_cfg",
+                        space=cfg_space,
                         name=f"{origin.name} (config)" if origin and origin.name else None,
                         description=f"{origin.description} (config)" if origin and origin.description else None,
                     )
@@ -493,6 +515,7 @@ class InfieldV2ConfigCreator(MigrationCreator):
         config: RootLocationConfiguration,
         disciplines: list[Discipline] | None,
         index: int,
+        shared_legacy_spaces: set[str],
     ) -> InFieldCDMLocationConfigRequest:
         if (
             config.asset_external_id is None
@@ -541,9 +564,24 @@ class InfieldV2ConfigCreator(MigrationCreator):
         if config.checklist_admins:
             access_management["checklistAdmins"] = config.checklist_admins  # type: ignore[assignment]
 
-        app_instance_space = f"{config.app_data_instance_space}_cdm"
-        source_instance_space = f"{config.source_data_instance_space}_cdm"
-        cfg_space = f"{config.app_data_instance_space}_cfg"
+        app_instance_space = build_infield_instance_space_name(
+            config.app_data_instance_space,
+            CDM_SPACE_SUFFIX,
+            asset_external_id=config.asset_external_id,
+            shared=config.app_data_instance_space in shared_legacy_spaces,
+        )
+        source_instance_space = build_infield_instance_space_name(
+            config.source_data_instance_space,
+            CDM_SPACE_SUFFIX,
+            asset_external_id=config.asset_external_id,
+            shared=config.source_data_instance_space in shared_legacy_spaces,
+        )
+        cfg_space = build_infield_instance_space_name(
+            config.app_data_instance_space,
+            CFG_SPACE_SUFFIX,
+            asset_external_id=config.asset_external_id,
+            shared=config.app_data_instance_space in shared_legacy_spaces,
+        )
         # dataFilters.assets.instanceSpaces[0] must match dataStorage.rootLocation.space, otherwise the
         # asset hierarchy query (which filters on both) can silently return nothing.
         data_filters: dict[str, JsonValue] = {

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -304,7 +304,7 @@ LOCATION_CONFIG_SPACE_COMMENT = (
 )
 
 
-class InfieldV2ConfigCreator(MigrationCreator):
+class InfieldCDMConfigCreator(MigrationCreator):
     TARGET_SPACE = "APM_Config"
 
     def __init__(

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -336,7 +336,7 @@ class InfieldV2ConfigCreator(MigrationCreator):
         skipped_external_ids_by_label: dict[str, list[str]] = {}
         shared_legacy_spaces = find_shared_legacy_instance_spaces(apm_configs)
         for apm_config in apm_configs:
-            location_configs, location_filters, spaces = self._create_infield_v2_config(
+            location_configs, location_filters, spaces = self._create_infield_cdm_config(
                 apm_config, skipped_external_ids_by_label, shared_legacy_spaces
             )
             success_count += len(location_configs)
@@ -386,7 +386,7 @@ class InfieldV2ConfigCreator(MigrationCreator):
             display_name="InField CDM Location Configs",
         )
 
-    def _create_infield_v2_config(
+    def _create_infield_cdm_config(
         self,
         config: APMConfigResponse,
         skipped_external_ids_by_label: dict[str, list[str]],

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -484,7 +484,7 @@ class InfieldV2ConfigCreator(MigrationCreator):
                 for label, identifiers in skipped_external_ids_by_label.items()
             ]
             items.append(
-                ItemsResult(status="failure", count=skipped_total, severity=Severity.failure.value, labels=labels)
+                ItemsResult(status="skipped", count=skipped_total, severity=Severity.skipped.value, labels=labels)
             )
         if items:
             display_item_results(items, title="InField Location Configs", console=self.client.console)

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/creators.py
@@ -428,7 +428,6 @@ class InfieldV2ConfigCreator(MigrationCreator):
                     console=self.client.console
                 )
                 continue
-            asset_external_id = root_location_config.asset_external_id
             for space_name in [
                 root_location_config.app_data_instance_space,
                 root_location_config.source_data_instance_space,
@@ -438,7 +437,7 @@ class InfieldV2ConfigCreator(MigrationCreator):
                     cdm_space = build_infield_instance_space_name(
                         space_name,
                         CDM_SPACE_SUFFIX,
-                        asset_external_id=asset_external_id,
+                        asset_external_id=root_location_config.asset_external_id,
                         shared=space_name in shared_legacy_spaces,
                     )
                     spaces.append(
@@ -453,7 +452,7 @@ class InfieldV2ConfigCreator(MigrationCreator):
                 cfg_space = build_infield_instance_space_name(
                     root_location_config.app_data_instance_space,
                     CFG_SPACE_SUFFIX,
-                    asset_external_id=asset_external_id,
+                    asset_external_id=root_location_config.asset_external_id,
                     shared=root_location_config.app_data_instance_space in shared_legacy_spaces,
                 )
                 spaces.append(

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/location_split.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/location_split.py
@@ -16,18 +16,23 @@ def find_shared_legacy_instance_spaces(apm_configs: Sequence[APMConfigResponse])
     A space is shared if it appears as ``appDataInstanceSpace`` for more than one root location,
     or as ``sourceDataInstanceSpace`` for more than one root location. The same space used as both
     app and source data for a single location does not count as shared.
+
+    Only root locations with an ``assetExternalId`` are counted. That field is required both to
+    create a CDM location config and to disambiguate shared-space names, so roots without it cannot
+    participate in a split.
     """
     locations_by_app_space: dict[str, set[str]] = defaultdict(set)
     locations_by_source_space: dict[str, set[str]] = defaultdict(set)
     for config in apm_configs:
         if not config.feature_configuration:
             continue
-        for index, root in enumerate(config.feature_configuration.root_location_configurations or []):
-            location_key = root.external_id or root.asset_external_id or f"{config.external_id}:{index}"
+        for root in config.feature_configuration.root_location_configurations or []:
+            if not root.asset_external_id:
+                continue
             if root.app_data_instance_space:
-                locations_by_app_space[root.app_data_instance_space].add(location_key)
+                locations_by_app_space[root.app_data_instance_space].add(root.asset_external_id)
             if root.source_data_instance_space:
-                locations_by_source_space[root.source_data_instance_space].add(location_key)
+                locations_by_source_space[root.source_data_instance_space].add(root.asset_external_id)
 
     shared: set[str] = set()
     for space, locations in locations_by_app_space.items():

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/location_split.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/location_split.py
@@ -1,0 +1,62 @@
+"""Helpers for splitting shared legacy Infield instance spaces into per-location CDM spaces."""
+
+from collections import defaultdict
+from collections.abc import Sequence
+
+from cognite_toolkit._cdf_tk.client.resource_classes.apm_config_v1 import APMConfigResponse
+from cognite_toolkit._cdf_tk.utils.text import fix_invalid_space_name
+
+CDM_SPACE_SUFFIX = "_cdm"
+CFG_SPACE_SUFFIX = "_cfg"
+
+
+def find_shared_legacy_instance_spaces(apm_configs: Sequence[APMConfigResponse]) -> set[str]:
+    """Return legacy instance spaces used by more than one root location.
+
+    A space is shared if it appears as ``appDataInstanceSpace`` for more than one root location,
+    or as ``sourceDataInstanceSpace`` for more than one root location. The same space used as both
+    app and source data for a single location does not count as shared.
+    """
+    locations_by_app_space: dict[str, set[str]] = defaultdict(set)
+    locations_by_source_space: dict[str, set[str]] = defaultdict(set)
+    for config in apm_configs:
+        if not config.feature_configuration:
+            continue
+        for index, root in enumerate(config.feature_configuration.root_location_configurations or []):
+            location_key = root.external_id or root.asset_external_id or f"{config.external_id}:{index}"
+            if root.app_data_instance_space:
+                locations_by_app_space[root.app_data_instance_space].add(location_key)
+            if root.source_data_instance_space:
+                locations_by_source_space[root.source_data_instance_space].add(location_key)
+
+    shared: set[str] = set()
+    for space, locations in locations_by_app_space.items():
+        if len(locations) > 1:
+            shared.add(space)
+    for space, locations in locations_by_source_space.items():
+        if len(locations) > 1:
+            shared.add(space)
+    return shared
+
+
+def build_infield_instance_space_name(
+    legacy_space: str,
+    suffix: str,
+    *,
+    asset_external_id: str | None = None,
+    shared: bool = False,
+) -> str:
+    """Build a CDM / config instance space name from a legacy Infield instance space.
+
+    When ``shared`` is False, returns ``{legacy_space}{suffix}`` (subject to DMS space-name
+    sanitization). When ``shared`` is True, inserts the root asset external ID:
+    ``{legacy_space}_{asset_external_id}{suffix}``, truncated and hashed if needed to stay within
+    the 43-character DMS space ID limit.
+    """
+    if shared:
+        if not asset_external_id:
+            raise ValueError("asset_external_id is required when building a shared-location instance space name")
+        candidate = f"{legacy_space}_{asset_external_id}{suffix}"
+    else:
+        candidate = f"{legacy_space}{suffix}"
+    return fix_invalid_space_name(candidate)

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator.py
@@ -23,7 +23,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.migration import CreatedSou
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.commands._migrate.command import MigrationCommand
 from cognite_toolkit._cdf_tk.commands._migrate.creators import (
-    InfieldV2ConfigCreator,
+    InfieldCDMConfigCreator,
     InstanceSpaceCreator,
     SourceSystemCreator,
 )
@@ -207,7 +207,7 @@ class TestCreator:
         with monkeypatch_toolkit_client() as client:
             asset_external_id = apm_config.feature_configuration.root_location_configurations[0].asset_external_id
             client.migration.lookup.assets.return_value = NodeId(space="migrated", external_id=asset_external_id)
-            creator = InfieldV2ConfigCreator(client, apm_configs=[apm_config])
+            creator = InfieldCDMConfigCreator(client, apm_configs=[apm_config])
             for to_create in creator.create_resources():
                 for resource in to_create.resources:
                     output.setdefault(to_create.display_name, []).append(resource.config_data)
@@ -233,7 +233,7 @@ class TestCreator:
             client.migration.lookup.assets.return_value = NodeId(
                 space="migrated", external_id=valid_root_location.asset_external_id
             )
-            creator = InfieldV2ConfigCreator(client, apm_configs=[apm_config])
+            creator = InfieldCDMConfigCreator(client, apm_configs=[apm_config])
             resources_by_kind = {
                 to_create.display_name: to_create.resources for to_create in creator.create_resources()
             }
@@ -274,7 +274,7 @@ class TestCreator:
             client.migration.lookup.assets.side_effect = lambda external_id: NodeId(
                 space="migrated", external_id=external_id
             )
-            creator = InfieldV2ConfigCreator(client, apm_configs=[apm_config])
+            creator = InfieldCDMConfigCreator(client, apm_configs=[apm_config])
             resources_by_kind = {
                 to_create.display_name: [resource.resource for resource in to_create.resources]
                 for to_create in creator.create_resources()

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_creator.py
@@ -6,7 +6,11 @@ import yaml
 from cognite.client.data_classes.aggregations import UniqueResult, UniqueResultList
 from pytest_regressions.data_regression import DataRegressionFixture
 
-from cognite_toolkit._cdf_tk.client.resource_classes.apm_config_v1 import APMConfigResponse, RootLocationConfiguration
+from cognite_toolkit._cdf_tk.client.resource_classes.apm_config_v1 import (
+    APMConfigResponse,
+    FeatureConfiguration,
+    RootLocationConfiguration,
+)
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     DataModelResponse,
     NodeId,
@@ -236,3 +240,54 @@ class TestCreator:
 
         assert len(resources_by_kind["InField CDM Location Configs"]) == 1
         assert len(resources_by_kind["Location Filters"]) == 1
+
+    def test_create_infield_config_splits_shared_instance_spaces(self) -> None:
+        shared_app = "shared_app_data"
+        shared_source = "shared_source_data"
+        apm_config = APMConfigResponse(
+            space="APM_Config",
+            external_id="shared_locations_config",
+            version=1,
+            created_time=0,
+            last_updated_time=0,
+            feature_configuration=FeatureConfiguration(
+                root_location_configurations=[
+                    RootLocationConfiguration(
+                        external_id="loc_alpha",
+                        asset_external_id="ROOT_ALPHA",
+                        display_name="Alpha",
+                        app_data_instance_space=shared_app,
+                        source_data_instance_space=shared_source,
+                    ),
+                    RootLocationConfiguration(
+                        external_id="loc_beta",
+                        asset_external_id="ROOT_BETA",
+                        display_name="Beta",
+                        app_data_instance_space=shared_app,
+                        source_data_instance_space=shared_source,
+                    ),
+                ]
+            ),
+        )
+
+        with monkeypatch_toolkit_client() as client:
+            client.migration.lookup.assets.side_effect = lambda external_id: NodeId(
+                space="migrated", external_id=external_id
+            )
+            creator = InfieldV2ConfigCreator(client, apm_configs=[apm_config])
+            resources_by_kind = {
+                to_create.display_name: [resource.resource for resource in to_create.resources]
+                for to_create in creator.create_resources()
+            }
+
+        location_configs = resources_by_kind["InField CDM Location Configs"]
+        assert len(location_configs) == 2
+        app_spaces = {config.data_storage.app_instance_space for config in location_configs}
+        cfg_spaces = {config.space for config in location_configs}
+        source_spaces = {config.data_filters["maintenanceOrders"]["instanceSpaces"][0] for config in location_configs}
+        assert app_spaces == {"shared_app_data_ROOT_ALPHA_cdm", "shared_app_data_ROOT_BETA_cdm"}
+        assert cfg_spaces == {"shared_app_data_ROOT_ALPHA_cfg", "shared_app_data_ROOT_BETA_cfg"}
+        assert source_spaces == {"shared_source_data_ROOT_ALPHA_cdm", "shared_source_data_ROOT_BETA_cdm"}
+
+        created_spaces = {space.space for space in resources_by_kind["Instance Spaces"]}
+        assert app_spaces | cfg_spaces | source_spaces <= created_spaces

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_location_split.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_location_split.py
@@ -1,0 +1,107 @@
+from cognite_toolkit._cdf_tk.client.resource_classes.apm_config_v1 import (
+    APMConfigResponse,
+    FeatureConfiguration,
+    RootLocationConfiguration,
+)
+from cognite_toolkit._cdf_tk.commands._migrate.location_split import (
+    CDM_SPACE_SUFFIX,
+    CFG_SPACE_SUFFIX,
+    build_infield_instance_space_name,
+    find_shared_legacy_instance_spaces,
+)
+from cognite_toolkit._cdf_tk.utils.text import fix_invalid_space_name
+
+
+def _apm_config(*roots: RootLocationConfiguration) -> APMConfigResponse:
+    return APMConfigResponse(
+        space="APM_Config",
+        external_id="test_config",
+        version=1,
+        created_time=0,
+        last_updated_time=0,
+        feature_configuration=FeatureConfiguration(root_location_configurations=list(roots)),
+    )
+
+
+class TestFindSharedLegacyInstanceSpaces:
+    def test_returns_empty_when_each_location_has_distinct_spaces(self) -> None:
+        config = _apm_config(
+            RootLocationConfiguration(
+                external_id="loc1",
+                asset_external_id="ASSET_1",
+                app_data_instance_space="app_a",
+                source_data_instance_space="source_a",
+            ),
+            RootLocationConfiguration(
+                external_id="loc2",
+                asset_external_id="ASSET_2",
+                app_data_instance_space="app_b",
+                source_data_instance_space="source_b",
+            ),
+        )
+        assert find_shared_legacy_instance_spaces([config]) == set()
+
+    def test_detects_shared_app_and_source_spaces(self) -> None:
+        config = _apm_config(
+            RootLocationConfiguration(
+                external_id="loc1",
+                asset_external_id="ASSET_1",
+                app_data_instance_space="shared_app",
+                source_data_instance_space="shared_source",
+            ),
+            RootLocationConfiguration(
+                external_id="loc2",
+                asset_external_id="ASSET_2",
+                app_data_instance_space="shared_app",
+                source_data_instance_space="shared_source",
+            ),
+        )
+        assert find_shared_legacy_instance_spaces([config]) == {"shared_app", "shared_source"}
+
+    def test_same_space_as_app_and_source_for_one_location_is_not_shared(self) -> None:
+        config = _apm_config(
+            RootLocationConfiguration(
+                external_id="loc1",
+                asset_external_id="ASSET_1",
+                app_data_instance_space="same_space",
+                source_data_instance_space="same_space",
+            )
+        )
+        assert find_shared_legacy_instance_spaces([config]) == set()
+
+
+class TestBuildInfieldInstanceSpaceName:
+    def test_unshared_keeps_legacy_suffix(self) -> None:
+        assert (
+            build_infield_instance_space_name("sp_infield_oid_app_data", CDM_SPACE_SUFFIX)
+            == "sp_infield_oid_app_data_cdm"
+        )
+        assert (
+            build_infield_instance_space_name("sp_infield_oid_app_data", CFG_SPACE_SUFFIX)
+            == "sp_infield_oid_app_data_cfg"
+        )
+
+    def test_shared_inserts_sanitized_asset_external_id(self) -> None:
+        assert (
+            build_infield_instance_space_name(
+                "shared_app",
+                CDM_SPACE_SUFFIX,
+                asset_external_id="WMT:VAL",
+                shared=True,
+            )
+            == "shared_app_WMTVAL_cdm"
+        )
+
+    def test_shared_truncates_to_dms_space_limit(self) -> None:
+        legacy = "sp_very_long_legacy_space_name"
+        asset = "VERY_LONG_ROOT_ASSET_EXTERNAL_ID"
+        result = build_infield_instance_space_name(
+            legacy,
+            CDM_SPACE_SUFFIX,
+            asset_external_id=asset,
+            shared=True,
+        )
+        expected_candidate = f"{legacy}_{asset}{CDM_SPACE_SUFFIX}"
+        assert len(expected_candidate) > 43
+        assert result == fix_invalid_space_name(expected_candidate)
+        assert len(result) <= 43


### PR DESCRIPTION
# Description

When multiple classic Infield root locations share the same `appDataInstanceSpace` / `sourceDataInstanceSpace`, `cdf migrate infield-configs` previously naively migrated them onto the same single `{space}_cdm` / `{space}_cfg` target. THis will however not be sufficient for InfieldOnCDM as the `rootLocation` concept that is typically used for filtering in the Infield UI is getting deprecated. This must be solved during migrations and not later as to avoid complicated workarounds with rekeying instances to new spaces. This PR makes source Infield locations using shared legacy spaces emit InfieldOnCDM config iwth per-location names using the root asset external ID (`{legacy}_{rootAsset}_cdm`), sanitized to the DMS 43-character limit. Unshared locations keep the existing `{legacy}_cdm` / `_cfg` naming.

This is **part 1** of a stacked series and a prerequisite for part 2 which will resolve and fan out instance data at migrate time into these distinct spaces.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Changed

- [alpha] `cdf migrate infield-configs` now creates distinct per-location CDM instance spaces when multiple root locations share a legacy app/source data space. Sharing the same `appInstanceSpace` or APM_SourceData / IDM data across multiple Infield locations is no longer recommended and will be deprecated in the future.