### PR TITLE
[CDF-28433] Expose autoCreate on transformation instance destinations

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/transformation.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/transformation.py
@@ -41,6 +41,12 @@ class EdgeType(BaseModelObject):
     external_id: str
 
 
+class AutoCreateOptions(BaseModelObject):
+    start_nodes: bool | None = None
+    end_nodes: bool | None = None
+    direct_relations: bool | None = None
+
+
 class AssetCentricDataSource(DestinationDefinition):
     type: Literal[
         "assets",
@@ -61,6 +67,7 @@ class DataModelSource(DestinationDefinition):
     type: Literal["instances"] = "instances"
     data_model: DataModelInfo
     instance_space: str | None = None
+    auto_create: AutoCreateOptions | None = None
 
 
 class ViewDataSource(DestinationDefinition):
@@ -68,6 +75,7 @@ class ViewDataSource(DestinationDefinition):
     view: ViewInfo
     edge_type: EdgeType | None = None
     instance_space: str | None = None
+    auto_create: AutoCreateOptions | None = None
 
 
 class RawDataSource(DestinationDefinition):

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/transformation.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/transformation.py
@@ -127,6 +127,22 @@ from .raw import RawDatabaseCRUD, RawTableCRUD
 if TYPE_CHECKING:
     from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import BuildVariable
 
+_AUTO_CREATE_FIELDS = ("startNodes", "endNodes", "directRelations")
+
+
+def _strip_default_auto_create(cdf_destination: dict[str, Any], local_destination: dict[str, Any]) -> None:
+    auto_create = cdf_destination.get("autoCreate")
+    if not isinstance(auto_create, dict):
+        return
+    local_auto_create = local_destination.get("autoCreate", {})
+    if not isinstance(local_auto_create, dict):
+        local_auto_create = {}
+    for key in _AUTO_CREATE_FIELDS:
+        if auto_create.get(key) is True and key not in local_auto_create:
+            auto_create.pop(key, None)
+    if not auto_create:
+        cdf_destination.pop("autoCreate", None)
+
 
 @final
 class TransformationIO(ResourceIO[ExternalId, TransformationRequest, TransformationResponse]):
@@ -506,6 +522,7 @@ class TransformationIO(ResourceIO[ExternalId, TransformationRequest, Transformat
         if isinstance(cdf_destination, dict) and isinstance(local_destination, dict):
             if cdf_destination.get("instanceSpace") is None and "instanceSpace" not in local_destination:
                 cdf_destination.pop("instanceSpace", None)
+            _strip_default_auto_create(cdf_destination, local_destination)
         if not dumped.get("query") and "query" not in local:
             dumped.pop("query", None)
         if dumped.get("conflictMode") == "upsert" and "conflictMode" not in local:

--- a/cognite_toolkit/_cdf_tk/yaml_classes/transformation_destination.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/transformation_destination.py
@@ -52,6 +52,21 @@ class EdgeType(BaseModelResource):
     external_id: str = Field(description="External ID of the type.")
 
 
+class AutoCreateOptions(BaseModelResource):
+    start_nodes: bool | None = Field(
+        default=None,
+        description="Create missing start nodes when writing edges. Defaults to true.",
+    )
+    end_nodes: bool | None = Field(
+        default=None,
+        description="Create missing end nodes when writing edges. Defaults to true.",
+    )
+    direct_relations: bool | None = Field(
+        default=None,
+        description="Create missing direct-relation target nodes. Defaults to true.",
+    )
+
+
 class Destination(BaseModelResource):
     _destination_type: ClassVar[str]
     type: str
@@ -166,6 +181,10 @@ class DataModelSource(Destination):
         max_length=43,
         pattern=SPACE_FORMAT_PATTERN,
     )
+    auto_create: AutoCreateOptions | None = Field(
+        default=None,
+        description="Controls automatic creation of missing instance references.",
+    )
 
 
 class ViewDataSource(Destination):
@@ -179,6 +198,10 @@ class ViewDataSource(Destination):
         min_length=1,
         max_length=43,
         pattern=SPACE_FORMAT_PATTERN,
+    )
+    auto_create: AutoCreateOptions | None = Field(
+        default=None,
+        description="Controls automatic creation of missing instance references.",
     )
 
 

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_transformation.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_transformation.py
@@ -14,6 +14,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     ViewId,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.transformation import (
+    AutoCreateOptions,
     NonceCredentials,
     TransformationRequest,
     TransformationResponse,
@@ -264,3 +265,105 @@ authentication:
             created = crud.create(transformations)
 
             assert [t.external_id for t in created] == [t.external_id for t in transformations]
+
+    def test_load_resource_with_auto_create(self) -> None:
+        resource = {
+            "externalId": "tr_nodes",
+            "name": "Nodes transformation",
+            "ignoreNullFields": True,
+            "destination": {
+                "type": "nodes",
+                "view": {"space": "sp_space", "externalId": "my_view", "version": "v1"},
+                "autoCreate": {"directRelations": False},
+            },
+            "query": "SELECT 1",
+        }
+        with monkeypatch_toolkit_client() as client:
+            loader = TransformationIO(client, None, None)
+            loaded = loader.load_resource(resource)
+
+        assert loaded.destination is not None
+        assert loaded.destination.auto_create == AutoCreateOptions(direct_relations=False)
+
+    def test_dump_resource_strips_default_auto_create(self) -> None:
+        cdf_transformation = TransformationResponse(
+            id=1,
+            name="Nodes transformation",
+            external_id="tr_nodes",
+            query="SELECT 1",
+            ignore_null_fields=True,
+            created_time=1,
+            last_updated_time=1,
+            is_public=True,
+            conflict_mode="upsert",
+            destination={
+                "type": "nodes",
+                "view": {"space": "sp_space", "externalId": "my_view", "version": "v1"},
+                "autoCreate": {
+                    "startNodes": True,
+                    "endNodes": True,
+                    "directRelations": True,
+                },
+            },
+            owner="test",
+            owner_is_current_user=True,
+            has_source_oidc_credentials=False,
+            has_destination_oidc_credentials=False,
+        )
+        local_dumped = {
+            "externalId": "tr_nodes",
+            "name": "Nodes transformation",
+            "ignoreNullFields": True,
+            "destination": {
+                "type": "nodes",
+                "view": {"space": "sp_space", "externalId": "my_view", "version": "v1"},
+            },
+            "query": "SELECT 1",
+        }
+        with monkeypatch_toolkit_client() as client:
+            loader = TransformationIO(client, None, None)
+            dumped = loader.dump_resource(cdf_transformation, local_dumped)
+
+        assert "autoCreate" not in dumped["destination"]
+
+    def test_dump_resource_keeps_non_default_auto_create(self) -> None:
+        cdf_transformation = TransformationResponse(
+            id=1,
+            name="Nodes transformation",
+            external_id="tr_nodes",
+            query="SELECT 1",
+            ignore_null_fields=True,
+            created_time=1,
+            last_updated_time=1,
+            is_public=True,
+            conflict_mode="upsert",
+            destination={
+                "type": "nodes",
+                "view": {"space": "sp_space", "externalId": "my_view", "version": "v1"},
+                "autoCreate": {
+                    "startNodes": True,
+                    "endNodes": True,
+                    "directRelations": False,
+                },
+            },
+            owner="test",
+            owner_is_current_user=True,
+            has_source_oidc_credentials=False,
+            has_destination_oidc_credentials=False,
+        )
+        local_dumped = {
+            "externalId": "tr_nodes",
+            "name": "Nodes transformation",
+            "ignoreNullFields": True,
+            "destination": {
+                "type": "nodes",
+                "view": {"space": "sp_space", "externalId": "my_view", "version": "v1"},
+                "autoCreate": {"directRelations": False},
+            },
+            "query": "SELECT 1",
+        }
+        with monkeypatch_toolkit_client() as client:
+            loader = TransformationIO(client, None, None)
+            dumped = loader.dump_resource(cdf_transformation, local_dumped)
+
+        assert dumped["destination"]["autoCreate"] == {"directRelations": False}

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_transformations.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_transformations.py
@@ -53,6 +53,24 @@ def transformation_destination_cases() -> Iterable:
                     "type": "nodes",
                     "view": {"externalId": "my_view", "version": "1", "space": "my_space"},
                     "edgeType": {"externalId": "my_edge_type", "space": "my_space"},
+                    "autoCreate": {"directRelations": False},
+                },
+            }
+        },
+        {
+            "DataModelSourceWithAutoCreate": {
+                "externalId": "tr_first_transformation",
+                "name": "example:first:transformation",
+                "ignoreNullFields": True,
+                "destination": {
+                    "type": "instances",
+                    "dataModel": {
+                        "externalId": "my_data_model",
+                        "version": "1",
+                        "space": "my_space",
+                        "destinationType": "my_view",
+                    },
+                    "autoCreate": {"directRelations": False, "startNodes": False},
                 },
             }
         },


### PR DESCRIPTION
## Description

Expose `destination.autoCreate` on transformation YAML for instance/node/edge destinations, allowing teams to disable automatic creation of missing direct-relation targets and edge nodes.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- `autoCreate` configuration on transformation destinations targeting instances, nodes, or edges (`directRelations`, `startNodes`, `endNodes`)