### PR TITLE
Topologically sort containers by constraints during deploy

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
@@ -90,6 +90,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.group import (
 )
 from cognite_toolkit._cdf_tk.constants import (
     BUILD_FOLDER_ENCODING,
+    CONTAINER_UPSERT_BATCH_LIMIT,
     HAS_DATA_FILTER_LIMIT,
     HINT_LEAD_TEXT,
     URL,
@@ -117,7 +118,7 @@ from cognite_toolkit._cdf_tk.utils import (
 )
 from cognite_toolkit._cdf_tk.utils.acl_helper import as_instance_acl_actions, space_scoped_resource
 from cognite_toolkit._cdf_tk.utils.diff_list import diff_list_identifiable, dm_identifier
-from cognite_toolkit._cdf_tk.utils.tarjan import tarjan
+from cognite_toolkit._cdf_tk.utils.tarjan import pack_into_batches
 from cognite_toolkit._cdf_tk.yaml_classes import (
     ContainerYAML,
     DataModelYAML,
@@ -418,7 +419,44 @@ class ContainerCRUD(ResourceContainerIO[ContainerId, ContainerRequest, Container
         return dumped
 
     def create(self, items: Sequence[ContainerRequest]) -> list[ContainerResponse]:
-        return self.client.tool.containers.create(items)
+        creation_order = self._compute_deploy_batches(items)
+        created: list[ContainerResponse] = []
+        for batch in creation_order:
+            created.extend(self.client.tool.containers.create(batch))
+        return created
+
+    def _compute_deploy_batches(self, items: Sequence[ContainerRequest]) -> list[list[ContainerRequest]]:
+        """Sorts containers into batches based on their dependency graph (requires constraints
+        and direct relation container references).
+
+        The API validates a container's dependencies against containers that already exist in CDF,
+        not against other containers in the same batch. Computes the strongly connected components
+        in topological order, then packs consecutive SCCs into batches up to
+        CONTAINER_UPSERT_BATCH_LIMIT, so a container is always sent in the same or an earlier batch
+        than containers depending on it.
+        """
+        containers_by_id = {self.get_id(item): item for item in items}
+
+        dependencies_by_id: dict[ContainerId, set[ContainerId]] = defaultdict(set)
+        for container_id, container in containers_by_id.items():
+            direct_dependencies: set[ContainerId] = set()
+            for constraint in (container.constraints or {}).values():
+                if isinstance(constraint, ClientRequiresConstraintDefinition) and constraint.require in (
+                    containers_by_id
+                ):
+                    direct_dependencies.add(constraint.require)
+            for property in container.properties.values():
+                if isinstance(property.type, ClientDirectNodeRelation) and property.type.container in containers_by_id:
+                    direct_dependencies.add(property.type.container)
+            dependencies_by_id[container_id].update(direct_dependencies)
+
+        batches, oversized_sccs = pack_into_batches(dependencies_by_id, containers_by_id, CONTAINER_UPSERT_BATCH_LIMIT)
+        for scc in oversized_sccs:
+            MediumSeverityWarning(
+                f"Found a strongly interdependent set of {len(scc)} containers: {humanize_collection(scc)}. "
+                "This might indicate a data model design issue, and the deployment might fail due to API batch size limits."
+            ).print_warning(console=self.console)
+        return batches
 
     def retrieve(self, ids: Sequence[ContainerId]) -> list[ContainerResponse]:
         return self.client.tool.containers.retrieve(list(ids))
@@ -853,21 +891,12 @@ class ViewIO(ResourceIO[ViewId, ViewRequest, ViewResponse]):
                     if view_property.source in views_by_id:
                         dependencies_by_id[view_id].add(view_property.source)
 
-        batches: list[list[ViewRequest]] = []
-        current_batch: list[ViewRequest] = []
-        for strongly_connected in tarjan(dependencies_by_id):
-            scc_views = [views_by_id[view_id] for view_id in strongly_connected]
-            if len(current_batch) + len(scc_views) > VIEW_UPSERT_BATCH_LIMIT and len(current_batch) > 0:
-                batches.append(current_batch)
-                current_batch = []
-            current_batch.extend(scc_views)
-            if len(scc_views) > VIEW_UPSERT_BATCH_LIMIT:
-                MediumSeverityWarning(
-                    f"Found a strongly interdependent set of {len(scc_views)} views: {humanize_collection(self.get_ids(scc_views))}. "
-                    "This might indicate a data model design issue, and the deployment might fail due to API batch size limits."
-                ).print_warning(console=self.console)
-        if len(current_batch) > 0:
-            batches.append(current_batch)
+        batches, oversized_sccs = pack_into_batches(dependencies_by_id, views_by_id, VIEW_UPSERT_BATCH_LIMIT)
+        for scc in oversized_sccs:
+            MediumSeverityWarning(
+                f"Found a strongly interdependent set of {len(scc)} views: {humanize_collection(scc)}. "
+                "This might indicate a data model design issue, and the deployment might fail due to API batch size limits."
+            ).print_warning(console=self.console)
         return batches
 
     def retrieve(self, ids: Sequence[ViewId | ViewNoVersionId]) -> list[ViewResponse]:

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
@@ -440,7 +440,9 @@ class ContainerCRUD(ResourceContainerIO[ContainerId, ContainerRequest, Container
         dependencies_by_id: dict[ContainerId, set[ContainerId]] = defaultdict(set)
         for container_id, container in containers_by_id.items():
             dependencies_by_id[container_id].update(
-                dependency for dependency in self._direct_container_references(container) if dependency in containers_by_id
+                dependency
+                for dependency in self._direct_container_references(container)
+                if dependency in containers_by_id
             )
 
         batches, oversized_sccs = pack_into_batches(dependencies_by_id, containers_by_id, CONTAINER_UPSERT_BATCH_LIMIT)

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
@@ -49,6 +49,7 @@ from cognite_toolkit._cdf_tk.client.request_classes.filters import (
     ViewFilter,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
+    Container,
     ContainerRequest,
     ContainerResponse,
     DataModelRequest,
@@ -438,16 +439,9 @@ class ContainerCRUD(ResourceContainerIO[ContainerId, ContainerRequest, Container
 
         dependencies_by_id: dict[ContainerId, set[ContainerId]] = defaultdict(set)
         for container_id, container in containers_by_id.items():
-            direct_dependencies: set[ContainerId] = set()
-            for constraint in (container.constraints or {}).values():
-                if isinstance(constraint, ClientRequiresConstraintDefinition) and constraint.require in (
-                    containers_by_id
-                ):
-                    direct_dependencies.add(constraint.require)
-            for property in container.properties.values():
-                if isinstance(property.type, ClientDirectNodeRelation) and property.type.container in containers_by_id:
-                    direct_dependencies.add(property.type.container)
-            dependencies_by_id[container_id].update(direct_dependencies)
+            dependencies_by_id[container_id].update(
+                dependency for dependency in self._direct_container_references(container) if dependency in containers_by_id
+            )
 
         batches, oversized_sccs = pack_into_batches(dependencies_by_id, containers_by_id, CONTAINER_UPSERT_BATCH_LIMIT)
         for scc in oversized_sccs:
@@ -600,20 +594,24 @@ class ContainerCRUD(ResourceContainerIO[ContainerId, ContainerRequest, Container
             if container_id in self._container_by_id
         }
 
+    @staticmethod
+    def _direct_container_references(container: Container) -> Iterable[ContainerId]:
+        """Yields the container ids directly referenced by a container's requires constraints
+        and direct relation properties."""
+        for constraint in (container.constraints or {}).values():
+            if isinstance(constraint, ClientRequiresConstraintDefinition):
+                yield constraint.require
+        for property in container.properties.values():
+            if isinstance(property.type, ClientDirectNodeRelation) and property.type.container is not None:
+                yield property.type.container
+
     def _find_direct_container_dependencies(
         self, container_ids: Sequence[ContainerId]
     ) -> dict[ContainerId, set[ContainerId]]:
         containers_by_id = self._lookup_containers(container_ids)
         container_dependencies: dict[ContainerId, set[ContainerId]] = defaultdict(set)
         for container_id, container in containers_by_id.items():
-            for constraint in (container.constraints or {}).values():
-                if not isinstance(constraint, ClientRequiresConstraintDefinition):
-                    continue
-                container_dependencies[container_id].add(constraint.require)
-            for property in container.properties.values():
-                if not isinstance(property.type, ClientDirectNodeRelation) or property.type.container is None:
-                    continue
-                container_dependencies[container_id].add(property.type.container)
+            container_dependencies[container_id].update(self._direct_container_references(container))
         return container_dependencies
 
     def _propagate_indirect_container_dependencies(

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
@@ -603,9 +603,9 @@ class ContainerCRUD(ResourceContainerIO[ContainerId, ContainerRequest, Container
         for constraint in (container.constraints or {}).values():
             if isinstance(constraint, ClientRequiresConstraintDefinition):
                 yield constraint.require
-        for property in container.properties.values():
-            if isinstance(property.type, ClientDirectNodeRelation) and property.type.container is not None:
-                yield property.type.container
+        for prop in container.properties.values():
+            if isinstance(prop.type, ClientDirectNodeRelation) and prop.type.container is not None:
+                yield prop.type.container
 
     def _find_direct_container_dependencies(
         self, container_ids: Sequence[ContainerId]

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
@@ -419,9 +419,8 @@ class ContainerCRUD(ResourceContainerIO[ContainerId, ContainerRequest, Container
         return dumped
 
     def create(self, items: Sequence[ContainerRequest]) -> list[ContainerResponse]:
-        creation_order = self._compute_deploy_batches(items)
         created: list[ContainerResponse] = []
-        for batch in creation_order:
+        for batch in self._compute_deploy_batches(items):
             created.extend(self.client.tool.containers.create(batch))
         return created
 
@@ -430,7 +429,7 @@ class ContainerCRUD(ResourceContainerIO[ContainerId, ContainerRequest, Container
         and direct relation container references).
 
         The API validates a container's dependencies against containers that already exist in CDF,
-        not against other containers in the same batch. Computes the strongly connected components
+        as well as against other containers in the same batch. Computes the strongly connected components
         in topological order, then packs consecutive SCCs into batches up to
         CONTAINER_UPSERT_BATCH_LIMIT, so a container is always sent in the same or an earlier batch
         than containers depending on it.

--- a/cognite_toolkit/_cdf_tk/utils/tarjan.py
+++ b/cognite_toolkit/_cdf_tk/utils/tarjan.py
@@ -1,6 +1,7 @@
 from typing import TypeVar
 
 T = TypeVar("T")
+V = TypeVar("V")
 
 
 def tarjan(dependencies_by_id: dict[T, set[T]]) -> list[set[T]]:
@@ -44,3 +45,39 @@ def tarjan(dependencies_by_id: dict[T, set[T]]) -> list[set[T]]:
         if view_id not in index:
             visit(view_id)
     return result
+
+
+def pack_into_batches(
+    dependencies_by_id: dict[T, set[T]], items_by_id: dict[T, V], batch_limit: int
+) -> tuple[list[list[V]], list[set[T]]]:
+    """Packs items into batches respecting their topological order, up to a maximum batch size.
+
+    Computes the strongly connected components (SCCs) of the dependency graph in topological order,
+    then packs consecutive SCCs into batches up to batch_limit. An SCC is never split across batches,
+    even if it exceeds batch_limit on its own, since its items are interdependent.
+
+    Args:
+        dependencies_by_id: A dictionary where the keys are ids and the values are sets of ids that the key
+            depends on. Every id that should be included in the output must be present as a key.
+        items_by_id: A mapping from id to the item to include in the output batches.
+        batch_limit: The maximum number of items allowed in a single batch.
+
+    Returns:
+        A tuple of (batches, oversized_sccs), where batches are the items packed into topologically
+        ordered batches, and oversized_sccs are the strongly connected components that exceeded
+        batch_limit on their own.
+    """
+    batches: list[list[V]] = []
+    oversized_sccs: list[set[T]] = []
+    current_batch: list[V] = []
+    for strongly_connected in tarjan(dependencies_by_id):
+        scc_items = [items_by_id[item_id] for item_id in strongly_connected]
+        if len(current_batch) + len(scc_items) > batch_limit and len(current_batch) > 0:
+            batches.append(current_batch)
+            current_batch = []
+        current_batch.extend(scc_items)
+        if len(scc_items) > batch_limit:
+            oversized_sccs.append(strongly_connected)
+    if len(current_batch) > 0:
+        batches.append(current_batch)
+    return batches, oversized_sccs

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_container.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_container.py
@@ -6,9 +6,14 @@ import pytest
 from cognite_toolkit._cdf_tk.client.identifiers import ContainerId
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     ContainerPropertyDefinition,
+    ContainerRequest,
     ContainerResponse,
+    DirectNodeRelation,
+    RequiresConstraintDefinition,
     TextProperty,
 )
+from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
+from cognite_toolkit._cdf_tk.constants import CONTAINER_UPSERT_BATCH_LIMIT
 from cognite_toolkit._cdf_tk.resource_ios import ContainerCRUD, ResourceWorker
 from tests.test_unit.approval_client import ApprovalToolkitClient
 
@@ -113,3 +118,109 @@ indexes: {}
         dumped = crud.dump_resource(cdf_container, local_absent)
         assert "constraints" not in dumped
         assert "indexes" not in dumped
+
+
+class TestContainerDeployTopologicalSort:
+    def test_requires_constraint_dependency_ordering(self) -> None:
+        dependency_container = ContainerRequest(
+            space="sp_space",
+            external_id="Dependency",
+            properties={"name": ContainerPropertyDefinition(type=TextProperty())},
+        )
+        dependent_container = ContainerRequest(
+            space="sp_space",
+            external_id="Dependent",
+            properties={"name": ContainerPropertyDefinition(type=TextProperty())},
+            constraints={
+                "requiresDependency": RequiresConstraintDefinition(
+                    require=ContainerId(space="sp_space", external_id="Dependency")
+                )
+            },
+        )
+
+        with monkeypatch_toolkit_client() as client:
+            loader = ContainerCRUD(client, Path("build_dir"), None)
+            batches = loader._compute_deploy_batches([dependent_container, dependency_container])
+
+        flat_ids = [container.external_id for batch in batches for container in batch]
+        assert flat_ids.index("Dependency") < flat_ids.index("Dependent")
+
+    def test_direct_relation_dependency_ordering(self) -> None:
+        dependency_container = ContainerRequest(
+            space="sp_space",
+            external_id="Dependency",
+            properties={"name": ContainerPropertyDefinition(type=TextProperty())},
+        )
+        dependent_container = ContainerRequest(
+            space="sp_space",
+            external_id="Dependent",
+            properties={
+                "ref": ContainerPropertyDefinition(
+                    type=DirectNodeRelation(container=ContainerId(space="sp_space", external_id="Dependency"))
+                )
+            },
+        )
+
+        with monkeypatch_toolkit_client() as client:
+            loader = ContainerCRUD(client, Path("build_dir"), None)
+            batches = loader._compute_deploy_batches([dependent_container, dependency_container])
+
+        flat_ids = [container.external_id for batch in batches for container in batch]
+        assert flat_ids.index("Dependency") < flat_ids.index("Dependent")
+
+    def test_many_dependents_split_across_batches_after_dependency(self) -> None:
+        # Reproduces the reported bug: a single dependency-free container, and more containers
+        # requiring it than fit in a single upsert batch.
+        container_count = CONTAINER_UPSERT_BATCH_LIMIT + 25
+        dependency_container = ContainerRequest(
+            space="sp_space",
+            external_id="Dependency",
+            properties={"name": ContainerPropertyDefinition(type=TextProperty())},
+        )
+        dependents = [
+            ContainerRequest(
+                space="sp_space",
+                external_id=f"Dependent_{i}",
+                properties={"name": ContainerPropertyDefinition(type=TextProperty())},
+                constraints={
+                    "requiresDependency": RequiresConstraintDefinition(
+                        require=ContainerId(space="sp_space", external_id="Dependency")
+                    )
+                },
+            )
+            for i in range(container_count)
+        ]
+
+        with monkeypatch_toolkit_client() as client:
+            loader = ContainerCRUD(client, Path("build_dir"), None)
+            batches = loader._compute_deploy_batches([*dependents, dependency_container])
+
+        assert len(batches) > 1, "Should split into multiple batches given the batch limit"
+        assert batches[0][0].external_id == "Dependency", "Dependency-free container must be sent first"
+        flat_ids = [container.external_id for batch in batches for container in batch]
+        for dependent in dependents:
+            assert flat_ids.index("Dependency") < flat_ids.index(dependent.external_id)
+
+    def test_large_scc_kept_in_single_batch(self) -> None:
+        container_count = CONTAINER_UPSERT_BATCH_LIMIT + 25
+        containers = [
+            ContainerRequest(
+                space="sp_space",
+                external_id=f"Container_{i}",
+                properties={"name": ContainerPropertyDefinition(type=TextProperty())},
+                constraints={
+                    "requiresNext": RequiresConstraintDefinition(
+                        # Cyclic dependency across all containers
+                        require=ContainerId(space="sp_space", external_id=f"Container_{(i + 1) % container_count}")
+                    )
+                },
+            )
+            for i in range(container_count)
+        ]
+
+        with monkeypatch_toolkit_client() as client:
+            loader = ContainerCRUD(client, Path("build_dir"), None)
+            batches = loader._compute_deploy_batches(containers)
+
+        assert len(batches) == 1, "All containers in one SCC should stay in a single batch"
+        assert len(batches[0]) == container_count

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_container.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_container.py
@@ -121,7 +121,30 @@ indexes: {}
 
 
 class TestContainerDeployTopologicalSort:
-    def test_requires_constraint_dependency_ordering(self) -> None:
+    @pytest.mark.parametrize(
+        "dependent_properties,dependent_constraints",
+        [
+            pytest.param(
+                {"name": ContainerPropertyDefinition(type=TextProperty())},
+                {
+                    "requiresDependency": RequiresConstraintDefinition(
+                        require=ContainerId(space="sp_space", external_id="Dependency")
+                    )
+                },
+                id="requires_constraint",
+            ),
+            pytest.param(
+                {
+                    "ref": ContainerPropertyDefinition(
+                        type=DirectNodeRelation(container=ContainerId(space="sp_space", external_id="Dependency"))
+                    )
+                },
+                None,
+                id="direct_relation",
+            ),
+        ],
+    )
+    def test_dependency_ordering(self, dependent_properties: dict, dependent_constraints: dict | None) -> None:
         dependency_container = ContainerRequest(
             space="sp_space",
             external_id="Dependency",
@@ -130,35 +153,8 @@ class TestContainerDeployTopologicalSort:
         dependent_container = ContainerRequest(
             space="sp_space",
             external_id="Dependent",
-            properties={"name": ContainerPropertyDefinition(type=TextProperty())},
-            constraints={
-                "requiresDependency": RequiresConstraintDefinition(
-                    require=ContainerId(space="sp_space", external_id="Dependency")
-                )
-            },
-        )
-
-        with monkeypatch_toolkit_client() as client:
-            loader = ContainerCRUD(client, Path("build_dir"), None)
-            batches = loader._compute_deploy_batches([dependent_container, dependency_container])
-
-        flat_ids = [container.external_id for batch in batches for container in batch]
-        assert flat_ids.index("Dependency") < flat_ids.index("Dependent")
-
-    def test_direct_relation_dependency_ordering(self) -> None:
-        dependency_container = ContainerRequest(
-            space="sp_space",
-            external_id="Dependency",
-            properties={"name": ContainerPropertyDefinition(type=TextProperty())},
-        )
-        dependent_container = ContainerRequest(
-            space="sp_space",
-            external_id="Dependent",
-            properties={
-                "ref": ContainerPropertyDefinition(
-                    type=DirectNodeRelation(container=ContainerId(space="sp_space", external_id="Dependency"))
-                )
-            },
+            properties=dependent_properties,
+            constraints=dependent_constraints,
         )
 
         with monkeypatch_toolkit_client() as client:
@@ -169,8 +165,6 @@ class TestContainerDeployTopologicalSort:
         assert flat_ids.index("Dependency") < flat_ids.index("Dependent")
 
     def test_many_dependents_split_across_batches_after_dependency(self) -> None:
-        # Reproduces the reported bug: a single dependency-free container, and more containers
-        # requiring it than fit in a single upsert batch.
         container_count = CONTAINER_UPSERT_BATCH_LIMIT + 25
         dependency_container = ContainerRequest(
             space="sp_space",
@@ -196,7 +190,7 @@ class TestContainerDeployTopologicalSort:
             batches = loader._compute_deploy_batches([*dependents, dependency_container])
 
         assert len(batches) > 1, "Should split into multiple batches given the batch limit"
-        assert batches[0][0].external_id == "Dependency", "Dependency-free container must be sent first"
+        assert batches[0][0].external_id == "Dependency", "Container being depended on must be sent first"
         flat_ids = [container.external_id for batch in batches for container in batch]
         for dependent in dependents:
             assert flat_ids.index("Dependency") < flat_ids.index(dependent.external_id)
@@ -222,5 +216,7 @@ class TestContainerDeployTopologicalSort:
             loader = ContainerCRUD(client, Path("build_dir"), None)
             batches = loader._compute_deploy_batches(containers)
 
-        assert len(batches) == 1, "All containers in one SCC should stay in a single batch"
+        assert len(batches) == 1, (
+            "All containers in one SCC should stay in a single batch despite exceeding the local batch limit"
+        )
         assert len(batches[0]) == container_count


### PR DESCRIPTION
# Description

`cdf deploy` batches containers by size (`CONTAINER_UPSERT_BATCH_LIMIT`), yet did not sort them by their `requires` and direct relation (w/container constraint) dependency graph.  DMS accepts a `requires` constraint or such direct relation pointing at another container included in the **same** upsert batch, but rejects it if the target isn't in the same batch and doesn't already exist in CDF. Since batching was size-based only, a container could end up in a later batch than containers that require it, causing the earlier batch(es) to fail with `Target container '...' does not exist.`. Containers are now sorted into topologically-ordered batches (extracted from the existing view SCC-batching logic into a shared `pack_into_batches` helper), so a container is always sent in the same or an earlier batch than containers depending on it via `requires` constraints or direct relations. 

As with the existing logic for views, although unlikely, the size of the SCCs can pass beyond Toolkit's local batch size limit, in which case this will be accepted and attempted to deploy though it will print a warning, since even though the real API limit is higher, oversized containers (e.g. those with increased property limits) can still lead to errors in DMS if the total payload size is too large.

Additionally reproduced and verified that this fix works locally.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- `cdf deploy` will now better handle deploying large amounts of containers with many `requires` constraints or direct relation properties pointing at other containers being deployed.