### PR TITLE
feat(transformations): wire OneLake deps and dump

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/externaldata.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/externaldata.py
@@ -20,7 +20,7 @@ class OneLakeCredentialsWrite(BaseModelObject):
 
     client_id: str
     tenant_id: str
-    client_secret: str | None = None
+    client_secret: str
 
 
 class OneLakeLocationDescription(BaseModelObject):

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -65,6 +65,7 @@ from cognite_toolkit._cdf_tk.resource_ios import (
     ContainerCRUD,
     DataModelIO,
     DataSetsIO,
+    ExternalDataSourceIO,
     ExtractionPipelineConfigIO,
     ExtractionPipelineIO,
     FunctionIO,
@@ -87,6 +88,7 @@ from cognite_toolkit._cdf_tk.resource_ios import (
 )
 from cognite_toolkit._cdf_tk.tk_warnings import FileExistsWarning, HighSeverityWarning, MediumSeverityWarning
 from cognite_toolkit._cdf_tk.utils import humanize_collection
+from cognite_toolkit._cdf_tk.utils.cdf import get_ext_onelake_source_ids
 from cognite_toolkit._cdf_tk.utils.file import safe_rmtree, safe_write, sanitize_filename, yaml_safe_dump
 from cognite_toolkit._cdf_tk.utils.interactive_select import DataModelingSelect
 from cognite_toolkit._cdf_tk.utils.useful_types import T_ID
@@ -353,6 +355,23 @@ class TransformationFinder(ResourceFinder[tuple[str, ...]]):
         schedule_loader = TransformationScheduleIO.create_loader(self.client)
         schedule_list = list(schedule_loader.iterate(parent_ids=external_ids))
         yield [], schedule_list, schedule_loader, None
+        transformations = (
+            [t for t in self.transformations if t.external_id in self.identifier]
+            if self.transformations
+            else self.client.tool.transformations.retrieve(external_ids, ignore_unknown_ids=True)
+        )
+        source_ids = {
+            source_id
+            for transformation in transformations
+            if transformation.query
+            for source_id in get_ext_onelake_source_ids(transformation.query)
+        }
+        if source_ids:
+            external_data_loader = ExternalDataSourceIO.create_loader(self.client)
+            external_data_list = external_data_loader.retrieve(
+                [ExternalId(external_id=source_id) for source_id in sorted(source_ids)]
+            )
+            yield [], external_data_list, external_data_loader, None
         notification_loader = TransformationNotificationIO.create_loader(self.client)
         notification_list = list(notification_loader.iterate(parent_ids=external_ids))
         yield [], notification_list, notification_loader, None

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -356,23 +356,24 @@ class TransformationFinder(ResourceFinder[tuple[str, ...]]):
         schedule_loader = TransformationScheduleIO.create_loader(self.client)
         schedule_list = list(schedule_loader.iterate(parent_ids=external_ids))
         yield [], schedule_list, schedule_loader, None
-        transformations = (
-            [t for t in self.transformations if t.external_id in self.identifier]
-            if self.transformations
-            else self.client.tool.transformations.retrieve(external_ids, ignore_unknown_ids=True)
-        )
-        source_ids = {
-            source_id
-            for transformation in transformations
-            if transformation.query
-            for source_id in get_ext_onelake_source_ids(transformation.query)
-        }
-        if FeatureFlag.is_enabled(Flags.EXTERNAL_DATA_SOURCES) and source_ids:
-            external_data_loader = ExternalDataSourceIO.create_loader(self.client)
-            external_data_list = external_data_loader.retrieve(
-                [ExternalId(external_id=source_id) for source_id in sorted(source_ids)]
+        if FeatureFlag.is_enabled(Flags.EXTERNAL_DATA_SOURCES):
+            transformations = (
+                [t for t in self.transformations if t.external_id in self.identifier]
+                if self.transformations
+                else self.client.tool.transformations.retrieve(external_ids, ignore_unknown_ids=True)
             )
-            yield [], external_data_list, external_data_loader, None
+            source_ids = {
+                source_id
+                for transformation in transformations
+                if transformation.query
+                for source_id in get_ext_onelake_source_ids(transformation.query)
+            }
+            if source_ids:
+                external_data_loader = ExternalDataSourceIO.create_loader(self.client)
+                external_data_list = external_data_loader.retrieve(
+                    [ExternalId(external_id=source_id) for source_id in sorted(source_ids)]
+                )
+                yield [], external_data_list, external_data_loader, None
         notification_loader = TransformationNotificationIO.create_loader(self.client)
         notification_list = list(notification_loader.iterate(parent_ids=external_ids))
         yield [], notification_list, notification_loader, None

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -59,6 +59,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitResourceMissingError,
     ToolkitValueError,
 )
+from cognite_toolkit._cdf_tk.feature_flags import FeatureFlag, Flags
 from cognite_toolkit._cdf_tk.protocols import ResourceResponseProtocol
 from cognite_toolkit._cdf_tk.resource_ios import (
     AgentIO,
@@ -366,7 +367,7 @@ class TransformationFinder(ResourceFinder[tuple[str, ...]]):
             if transformation.query
             for source_id in get_ext_onelake_source_ids(transformation.query)
         }
-        if source_ids:
+        if FeatureFlag.is_enabled(Flags.EXTERNAL_DATA_SOURCES) and source_ids:
             external_data_loader = ExternalDataSourceIO.create_loader(self.client)
             external_data_list = external_data_loader.retrieve(
                 [ExternalId(external_id=source_id) for source_id in sorted(source_ids)]

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/externaldata.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/externaldata.py
@@ -17,6 +17,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.group import (
 from cognite_toolkit._cdf_tk.exceptions import ToolkitRequiredValueError
 from cognite_toolkit._cdf_tk.resource_ios._base_ios import ResourceIO
 from cognite_toolkit._cdf_tk.resource_ios._resource_ios.data_organization import DataSetsIO
+from cognite_toolkit._cdf_tk.tk_warnings import HighSeverityWarning
 from cognite_toolkit._cdf_tk.utils import sanitize_filename
 from cognite_toolkit._cdf_tk.utils.acl_helper import dataset_scoped_resource
 from cognite_toolkit._cdf_tk.yaml_classes import ExternalDataSourceYAML
@@ -84,21 +85,23 @@ class ExternalDataSourceIO(
     def dump_resource(
         self, resource: ExternalDataSourceResponse, local: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        dumped = resource.as_request_resource().dump()
-        local = local or {}
+        HighSeverityWarning(
+            "External data sources will always be considered different, and thus will always be redeployed."
+        ).print_warning(console=self.client.console)
+        # Secrets cannot be compared (API never returns clientSecret). Dumping only the identifier
+        # when a local YAML exists makes deploy always upsert, matching hosted extractor sources.
+        if local:
+            return self.dump_id(self.get_id(resource))
+        dumped = resource.dump()
+        dumped.pop("createdTime", None)
+        dumped.pop("lastUpdatedTime", None)
+        dumped.pop("format", None)
         if data_set_id := dumped.pop("dataSetId", None):
             dumped["dataSetExternalId"] = self.client.lookup.data_sets.external_id(data_set_id)
-        dumped.pop("format", None)
-        local_settings = local.get("settings", {})
-        local_credentials = local_settings.get("credentials", {}) if isinstance(local_settings, dict) else {}
-        if local_credentials and "settings" in dumped and dumped["settings"]:
-            cdf_credentials = dumped["settings"].get("credentials", {})
-            if isinstance(cdf_credentials, dict) and "clientSecret" in local_credentials:
-                cdf_credentials["clientSecret"] = local_credentials["clientSecret"]
         return dumped
 
     def sensitive_strings(self, item: ExternalDataSourceRequest) -> Iterable[str]:
-        if item.settings and item.settings.credentials and item.settings.credentials.client_secret:
+        if item.settings and item.settings.credentials:
             yield item.settings.credentials.client_secret
 
     def create(self, items: Sequence[ExternalDataSourceRequest]) -> list[ExternalDataSourceResponse]:

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/externaldata.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/externaldata.py
@@ -85,12 +85,12 @@ class ExternalDataSourceIO(
     def dump_resource(
         self, resource: ExternalDataSourceResponse, local: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        HighSeverityWarning(
-            "External data sources will always be considered different, and thus will always be redeployed."
-        ).print_warning(console=self.client.console)
         # Secrets cannot be compared (API never returns clientSecret). Dumping only the identifier
         # when a local YAML exists makes deploy always upsert, matching hosted extractor sources.
         if local:
+            HighSeverityWarning(
+                "External data sources will always be considered different, and thus will always be redeployed."
+            ).print_warning(console=self.client.console)
             return self.dump_id(self.get_id(resource))
         dumped = resource.dump()
         dumped.pop("createdTime", None)

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/transformation.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/transformation.py
@@ -91,6 +91,7 @@ from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitRequiredValueError,
     ToolkitYAMLFormatError,
 )
+from cognite_toolkit._cdf_tk.feature_flags import FeatureFlag, Flags
 from cognite_toolkit._cdf_tk.resource_ios._base_ios import ReadExtra, ResourceIO, SuccessExtra
 from cognite_toolkit._cdf_tk.tk_warnings import HighSeverityWarning, MediumSeverityWarning
 from cognite_toolkit._cdf_tk.utils import (
@@ -163,6 +164,7 @@ class TransformationIO(ResourceIO[ExternalId, TransformationRequest, Transformat
             RawTableCRUD,
             RawDatabaseCRUD,
             GroupResourceScopedCRUD,
+            *({ExternalDataSourceIO} if FeatureFlag.is_enabled(Flags.EXTERNAL_DATA_SOURCES) else set()),
         }
     )
     _doc_url = "Transformations/operation/createTransformations"
@@ -220,7 +222,7 @@ class TransformationIO(ResourceIO[ExternalId, TransformationRequest, Transformat
     def get_dependent_items(cls, item: dict) -> Iterable[tuple[type[ResourceIO], Hashable]]:
         if "dataSetExternalId" in item:
             yield DataSetsIO, ExternalId(external_id=item["dataSetExternalId"])
-        if query := item.get("query"):
+        if FeatureFlag.is_enabled(Flags.EXTERNAL_DATA_SOURCES) and (query := item.get("query")):
             for source_id in get_ext_onelake_source_ids(query):
                 yield ExternalDataSourceIO, ExternalId(external_id=source_id)
         if destination := item.get("destination", {}):
@@ -247,7 +249,7 @@ class TransformationIO(ResourceIO[ExternalId, TransformationRequest, Transformat
     def get_dependencies(cls, resource: TransformationYAML) -> Iterable[tuple[type[ResourceIO], Identifier]]:
         if resource.data_set_external_id:
             yield DataSetsIO, ExternalId(external_id=resource.data_set_external_id)
-        if resource.query:
+        if FeatureFlag.is_enabled(Flags.EXTERNAL_DATA_SOURCES) and resource.query:
             for source_id in get_ext_onelake_source_ids(resource.query):
                 yield ExternalDataSourceIO, ExternalId(external_id=source_id)
         if destination := resource.destination:

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/transformation.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/transformation.py
@@ -104,7 +104,7 @@ from cognite_toolkit._cdf_tk.utils import (
     sanitize_filename,
 )
 from cognite_toolkit._cdf_tk.utils.acl_helper import dataset_scoped_resource
-from cognite_toolkit._cdf_tk.utils.cdf import read_auth, try_find_error
+from cognite_toolkit._cdf_tk.utils.cdf import get_ext_onelake_source_ids, read_auth, try_find_error
 from cognite_toolkit._cdf_tk.utils.collection import chunker
 from cognite_toolkit._cdf_tk.utils.diff_list import diff_list_hashable
 from cognite_toolkit._cdf_tk.yaml_classes import (
@@ -121,6 +121,7 @@ from cognite_toolkit._cdf_tk.yaml_classes.transformation_destination import (
 from .auth import GroupAllScopedCRUD
 from .data_organization import DataSetsIO
 from .datamodel import DataModelIO, SpaceCRUD, ViewIO
+from .externaldata import ExternalDataSourceIO
 from .group_scoped import GroupResourceScopedCRUD
 from .raw import RawDatabaseCRUD, RawTableCRUD
 
@@ -219,6 +220,9 @@ class TransformationIO(ResourceIO[ExternalId, TransformationRequest, Transformat
     def get_dependent_items(cls, item: dict) -> Iterable[tuple[type[ResourceIO], Hashable]]:
         if "dataSetExternalId" in item:
             yield DataSetsIO, ExternalId(external_id=item["dataSetExternalId"])
+        if query := item.get("query"):
+            for source_id in get_ext_onelake_source_ids(query):
+                yield ExternalDataSourceIO, ExternalId(external_id=source_id)
         if destination := item.get("destination", {}):
             if not isinstance(destination, dict):
                 return
@@ -243,6 +247,9 @@ class TransformationIO(ResourceIO[ExternalId, TransformationRequest, Transformat
     def get_dependencies(cls, resource: TransformationYAML) -> Iterable[tuple[type[ResourceIO], Identifier]]:
         if resource.data_set_external_id:
             yield DataSetsIO, ExternalId(external_id=resource.data_set_external_id)
+        if resource.query:
+            for source_id in get_ext_onelake_source_ids(resource.query):
+                yield ExternalDataSourceIO, ExternalId(external_id=source_id)
         if destination := resource.destination:
             if isinstance(destination, RawDataSource):
                 yield RawDatabaseCRUD, RawDatabaseId(name=destination.database)

--- a/cognite_toolkit/_cdf_tk/yaml_classes/externaldata.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/externaldata.py
@@ -10,12 +10,10 @@ class OneLakeCredentialsYAML(BaseModelResource):
 
     client_id: str = Field(description="Azure application (client) ID.")
     tenant_id: str = Field(description="Azure tenant (directory) ID.")
-    client_secret: SecretStr | None = Field(default=None, description="Azure client secret.")
+    client_secret: SecretStr = Field(description="Azure client secret. Required on every write.")
 
     @field_serializer("client_secret", when_used="json")
-    def dump_client_secret(self, value: SecretStr | None) -> str | None:
-        if value is None:
-            return None
+    def dump_client_secret(self, value: SecretStr) -> str:
         return value.get_secret_value()
 
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
@@ -21,6 +21,12 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     ViewNoVersionId,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.dataset import DataSetResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.externaldata import (
+    ExternalDataSourceResponse,
+    OneLakeCredentialsRead,
+    OneLakeLocationDescription,
+    OneLakeSettingsRead,
+)
 from cognite_toolkit._cdf_tk.client.resource_classes.extraction_pipeline import ExtractionPipelineResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.function import FunctionResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.group import GroupResponse
@@ -48,6 +54,7 @@ from cognite_toolkit._cdf_tk.commands.dump_resource import (
 from cognite_toolkit._cdf_tk.resource_ios import (
     AgentIO,
     DataSetsIO,
+    ExternalDataSourceIO,
     ExtractionPipelineIO,
     FunctionIO,
     GroupAllScopedCRUD,
@@ -157,6 +164,48 @@ class TestDumpTransformations:
         assert len(filepaths) == 2
         items = [read_yaml_file(filepath) for filepath in filepaths]
         assert items == [loader.dump_resource(t) for t in three_transformations[1:]]
+
+    def test_dump_transformations_with_ext_onelake_sources(self) -> None:
+        transformation = TransformationResponse(
+            id=1,
+            external_id="transformationA",
+            name="OneLake transformation",
+            ignore_null_fields=True,
+            created_time=1,
+            last_updated_time=1,
+            query="select * from ext_onelake('fabric-prod', 'assets')",
+            is_public=True,
+            conflict_mode="upsert",
+            destination={"type": "assets"},
+            owner="test",
+            owner_is_current_user=True,
+            has_source_oidc_credentials=False,
+            has_destination_oidc_credentials=False,
+        )
+        external_source = ExternalDataSourceResponse(
+            external_id="fabric-prod",
+            format="one_lake",
+            created_time=1,
+            last_updated_time=1,
+            settings=OneLakeSettingsRead(
+                credentials=OneLakeCredentialsRead(client_id="id", tenant_id="tenant"),
+                location_description=OneLakeLocationDescription(
+                    workspace_id="workspace-guid",
+                    container_id="lakehouse-guid",
+                ),
+            ),
+        )
+        with monkeypatch_toolkit_client() as client:
+            finder = TransformationFinder(client, ("transformationA",))
+            client.tool.transformations.retrieve.return_value = [transformation]
+            client.tool.transformations.schedules.retrieve.return_value = []
+            client.tool.transformations.external_data_sources.list.return_value = [external_source]
+
+            batches = list(finder)
+
+        _, external_data_list, loader, _ = batches[2]
+        assert isinstance(loader, ExternalDataSourceIO)
+        assert external_data_list == [external_source]
 
 
 @pytest.fixture()

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
@@ -224,16 +224,14 @@ class TestDumpTransformations:
         assert external_data_list == [external_source]
 
     def test_dump_transformations_ext_onelake_flag_off(self) -> None:
-        transformation, external_source = _onelake_transformation_and_source()
         with monkeypatch_toolkit_client() as client:
             finder = TransformationFinder(client, ("transformationA",))
-            client.tool.transformations.retrieve.return_value = [transformation]
             client.tool.transformations.schedules.retrieve.return_value = []
-            client.tool.transformations.external_data_sources.list.return_value = [external_source]
 
             batches = list(finder)
 
         assert all(not isinstance(loader, ExternalDataSourceIO) for _, _, loader, _ in batches)
+        client.tool.transformations.external_data_sources.list.assert_not_called()
 
 
 @pytest.fixture()

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
@@ -51,6 +51,7 @@ from cognite_toolkit._cdf_tk.commands.dump_resource import (
     StreamlitFinder,
     TransformationFinder,
 )
+from cognite_toolkit._cdf_tk.feature_flags import FeatureFlag, Flags
 from cognite_toolkit._cdf_tk.resource_ios import (
     AgentIO,
     DataSetsIO,
@@ -68,6 +69,48 @@ from cognite_toolkit._cdf_tk.resource_ios import (
 from cognite_toolkit._cdf_tk.utils import read_yaml_file
 from tests.test_unit.approval_client import ApprovalToolkitClient
 from tests.test_unit.utils import MockQuestionary
+
+
+def _enable_external_data_sources(monkeypatch: MonkeyPatch) -> None:
+    original = FeatureFlag.is_enabled
+    monkeypatch.setattr(
+        FeatureFlag,
+        "is_enabled",
+        lambda flag: flag is Flags.EXTERNAL_DATA_SOURCES or original(flag),
+    )
+
+
+def _onelake_transformation_and_source() -> tuple[TransformationResponse, ExternalDataSourceResponse]:
+    transformation = TransformationResponse(
+        id=1,
+        external_id="transformationA",
+        name="OneLake transformation",
+        ignore_null_fields=True,
+        created_time=1,
+        last_updated_time=1,
+        query="select * from ext_onelake('fabric-prod', 'assets')",
+        is_public=True,
+        conflict_mode="upsert",
+        destination={"type": "assets"},
+        owner="test",
+        owner_is_current_user=True,
+        has_source_oidc_credentials=False,
+        has_destination_oidc_credentials=False,
+    )
+    external_source = ExternalDataSourceResponse(
+        external_id="fabric-prod",
+        format="one_lake",
+        created_time=1,
+        last_updated_time=1,
+        settings=OneLakeSettingsRead(
+            credentials=OneLakeCredentialsRead(client_id="id", tenant_id="tenant"),
+            location_description=OneLakeLocationDescription(
+                workspace_id="workspace-guid",
+                container_id="lakehouse-guid",
+            ),
+        ),
+    )
+    return transformation, external_source
 
 
 @pytest.fixture()
@@ -165,36 +208,9 @@ class TestDumpTransformations:
         items = [read_yaml_file(filepath) for filepath in filepaths]
         assert items == [loader.dump_resource(t) for t in three_transformations[1:]]
 
-    def test_dump_transformations_with_ext_onelake_sources(self) -> None:
-        transformation = TransformationResponse(
-            id=1,
-            external_id="transformationA",
-            name="OneLake transformation",
-            ignore_null_fields=True,
-            created_time=1,
-            last_updated_time=1,
-            query="select * from ext_onelake('fabric-prod', 'assets')",
-            is_public=True,
-            conflict_mode="upsert",
-            destination={"type": "assets"},
-            owner="test",
-            owner_is_current_user=True,
-            has_source_oidc_credentials=False,
-            has_destination_oidc_credentials=False,
-        )
-        external_source = ExternalDataSourceResponse(
-            external_id="fabric-prod",
-            format="one_lake",
-            created_time=1,
-            last_updated_time=1,
-            settings=OneLakeSettingsRead(
-                credentials=OneLakeCredentialsRead(client_id="id", tenant_id="tenant"),
-                location_description=OneLakeLocationDescription(
-                    workspace_id="workspace-guid",
-                    container_id="lakehouse-guid",
-                ),
-            ),
-        )
+    def test_dump_transformations_with_ext_onelake_sources(self, monkeypatch: MonkeyPatch) -> None:
+        _enable_external_data_sources(monkeypatch)
+        transformation, external_source = _onelake_transformation_and_source()
         with monkeypatch_toolkit_client() as client:
             finder = TransformationFinder(client, ("transformationA",))
             client.tool.transformations.retrieve.return_value = [transformation]
@@ -206,6 +222,18 @@ class TestDumpTransformations:
         _, external_data_list, loader, _ = batches[2]
         assert isinstance(loader, ExternalDataSourceIO)
         assert external_data_list == [external_source]
+
+    def test_dump_transformations_ext_onelake_flag_off(self) -> None:
+        transformation, external_source = _onelake_transformation_and_source()
+        with monkeypatch_toolkit_client() as client:
+            finder = TransformationFinder(client, ("transformationA",))
+            client.tool.transformations.retrieve.return_value = [transformation]
+            client.tool.transformations.schedules.retrieve.return_value = []
+            client.tool.transformations.external_data_sources.list.return_value = [external_source]
+
+            batches = list(finder)
+
+        assert all(not isinstance(loader, ExternalDataSourceIO) for _, _, loader, _ in batches)
 
 
 @pytest.fixture()

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
@@ -223,16 +223,6 @@ class TestDumpTransformations:
         assert isinstance(loader, ExternalDataSourceIO)
         assert external_data_list == [external_source]
 
-    def test_dump_transformations_ext_onelake_flag_off(self) -> None:
-        with monkeypatch_toolkit_client() as client:
-            finder = TransformationFinder(client, ("transformationA",))
-            client.tool.transformations.schedules.retrieve.return_value = []
-
-            batches = list(finder)
-
-        assert all(not isinstance(loader, ExternalDataSourceIO) for _, _, loader, _ in batches)
-        client.tool.transformations.external_data_sources.list.assert_not_called()
-
 
 @pytest.fixture()
 def three_data_models() -> list[DataModelResponse]:

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_externaldata.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_externaldata.py
@@ -79,31 +79,28 @@ class TestExternalDataSourceIO:
         loader = ExternalDataSourceIO(MagicMock(), None, None)
         assert list(loader.sensitive_strings(item)) == ["secret"]
 
-    def test_sensitive_strings_without_secret(self) -> None:
-        item = _make_request(
-            settings=OneLakeSettingsWrite(
-                credentials=OneLakeCredentialsWrite(client_id="id", tenant_id="tenant"),
-                location_description=OneLakeLocationDescription(
-                    workspace_id="workspace-guid",
-                    container_id="lakehouse-guid",
-                ),
-            )
-        )
-        loader = ExternalDataSourceIO(MagicMock(), None, None)
-        assert list(loader.sensitive_strings(item)) == []
-
-    def test_dump_resource_preserves_local_client_secret(self, toolkit_client_approval: ApprovalToolkitClient) -> None:
+    def test_dump_resource_without_local_omits_client_secret(
+        self, toolkit_client_approval: ApprovalToolkitClient
+    ) -> None:
         loader = ExternalDataSourceIO.create_loader(toolkit_client_approval.mock_client)
-        response = _make_response()
+        dumped = loader.dump_resource(_make_response())
+        credentials = dumped.get("settings", {}).get("credentials", {})
+        assert "clientSecret" not in credentials
+
+    def test_dump_resource_with_local_returns_identifier(self, toolkit_client_approval: ApprovalToolkitClient) -> None:
+        loader = ExternalDataSourceIO.create_loader(toolkit_client_approval.mock_client)
         local = {
+            "externalId": "fabric-lakehouse-prod",
             "settings": {
                 "credentials": {
+                    "clientId": "azure-client-id",
+                    "tenantId": "azure-tenant-id",
                     "clientSecret": "azure-client-secret",
                 }
-            }
+            },
         }
-        dumped = loader.dump_resource(response, local)
-        assert dumped["settings"]["credentials"]["clientSecret"] == "azure-client-secret"
+        dumped = loader.dump_resource(_make_response(), local)
+        assert dumped == {"externalId": "fabric-lakehouse-prod"}
 
     def test_prepare_resources_create(
         self, toolkit_client_approval: ApprovalToolkitClient, env_vars_with_client: EnvironmentVariables
@@ -120,6 +117,20 @@ class TestExternalDataSourceIO:
             "unchanged": len(resources.unchanged),
         } == {"create": 1, "changed": 0, "delete": 0, "unchanged": 0}
 
+    def test_prepare_resources_existing_always_updates(self, toolkit_client_approval: ApprovalToolkitClient) -> None:
+        toolkit_client_approval.append(ExternalDataSourceResponse, _make_response())
+        local_file = MagicMock(spec=Path)
+        local_file.read_text.return_value = _YAML
+        loader = ExternalDataSourceIO.create_loader(toolkit_client_approval.mock_client)
+        worker = ResourceWorker(loader, "deploy")
+        resources = worker.prepare_resources([local_file])
+        assert {
+            "create": len(resources.to_create),
+            "changed": len(resources.to_update),
+            "delete": len(resources.to_delete),
+            "unchanged": len(resources.unchanged),
+        } == {"create": 0, "changed": 1, "delete": 0, "unchanged": 0}
+
     def test_get_dependent_items_dataset(self) -> None:
         deps = list(
             ExternalDataSourceIO.get_dependent_items(
@@ -134,7 +145,7 @@ class TestExternalDataSourceIO:
                 "externalId": "fabric-lakehouse-prod",
                 "dataSetExternalId": "my_dataset",
                 "settings": {
-                    "credentials": {"clientId": "id", "tenantId": "tenant"},
+                    "credentials": {"clientId": "id", "tenantId": "tenant", "clientSecret": "secret"},
                     "locationDescription": {"workspaceId": "ws", "containerId": "lh"},
                 },
             }

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_transformation.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_transformation.py
@@ -20,6 +20,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.transformation import (
     TransformationResponse,
 )
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
+from cognite_toolkit._cdf_tk.feature_flags import FeatureFlag, Flags
 from cognite_toolkit._cdf_tk.resource_ios import (
     DataModelIO,
     DataSetsIO,
@@ -39,6 +40,27 @@ from tests.test_unit.approval_client import ApprovalToolkitClient
 
 def _return_none(*args, **kwargs) -> str | None:
     return None
+
+
+def _enable_external_data_sources(monkeypatch: MonkeyPatch) -> None:
+    original = FeatureFlag.is_enabled
+    monkeypatch.setattr(
+        FeatureFlag,
+        "is_enabled",
+        lambda flag: flag is Flags.EXTERNAL_DATA_SOURCES or original(flag),
+    )
+
+
+def _ext_onelake_transformation_yaml() -> TransformationYAML:
+    return TransformationYAML.model_validate(
+        {
+            "externalId": "my_transformation",
+            "name": "my_transformation",
+            "ignoreNullFields": True,
+            "query": "select * from ext_onelake('fabric-prod', 'assets')",
+            "destination": {"type": "assets"},
+        }
+    )
 
 
 class TestTransformationCRUD:
@@ -222,23 +244,30 @@ authentication:
             ),
         ],
     )
-    def test_get_dependent_items(self, item: dict, expected: list[tuple[type[ResourceIO], Hashable]]) -> None:
+    def test_get_dependent_items(
+        self, item: dict, expected: list[tuple[type[ResourceIO], Hashable]], monkeypatch: MonkeyPatch
+    ) -> None:
+        if any(loader is ExternalDataSourceIO for loader, _ in expected):
+            _enable_external_data_sources(monkeypatch)
         actual = TransformationIO.get_dependent_items(item)
 
         assert list(actual) == expected
 
-    def test_get_dependencies_ext_onelake(self) -> None:
-        resource = TransformationYAML.model_validate(
-            {
-                "externalId": "my_transformation",
-                "name": "my_transformation",
-                "ignoreNullFields": True,
-                "query": "select * from ext_onelake('fabric-prod', 'assets')",
-                "destination": {"type": "assets"},
-            }
+    def test_get_dependent_items_ext_onelake_flag_off(self) -> None:
+        actual = list(
+            TransformationIO.get_dependent_items({"query": "select * from ext_onelake('fabric-prod', 'assets')"})
         )
+        assert ExternalDataSourceIO not in {loader for loader, _ in actual}
+
+    def test_get_dependencies_ext_onelake(self, monkeypatch: MonkeyPatch) -> None:
+        _enable_external_data_sources(monkeypatch)
+        resource = _ext_onelake_transformation_yaml()
         deps = list(TransformationIO.get_dependencies(resource))
         assert (ExternalDataSourceIO, ExternalId(external_id="fabric-prod")) in deps
+
+    def test_get_dependencies_ext_onelake_flag_off(self) -> None:
+        deps = list(TransformationIO.get_dependencies(_ext_onelake_transformation_yaml()))
+        assert ExternalDataSourceIO not in {loader for loader, _ in deps}
 
     def test_create_session_nonce_error(self) -> None:
         transformations = [

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_transformation.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_transformation.py
@@ -23,6 +23,7 @@ from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.resource_ios import (
     DataModelIO,
     DataSetsIO,
+    ExternalDataSourceIO,
     RawDatabaseCRUD,
     RawTableCRUD,
     ResourceIO,
@@ -32,6 +33,7 @@ from cognite_toolkit._cdf_tk.resource_ios import (
 )
 from cognite_toolkit._cdf_tk.utils import calculate_secure_hash
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
+from cognite_toolkit._cdf_tk.yaml_classes import TransformationYAML
 from tests.test_unit.approval_client import ApprovalToolkitClient
 
 
@@ -213,12 +215,30 @@ authentication:
                 ],
                 id="Transformation to RAW table",
             ),
+            pytest.param(
+                {"query": "select * from ext_onelake('fabric-prod', 'assets')"},
+                [(ExternalDataSourceIO, ExternalId(external_id="fabric-prod"))],
+                id="Transformation with ext_onelake source",
+            ),
         ],
     )
     def test_get_dependent_items(self, item: dict, expected: list[tuple[type[ResourceIO], Hashable]]) -> None:
         actual = TransformationIO.get_dependent_items(item)
 
         assert list(actual) == expected
+
+    def test_get_dependencies_ext_onelake(self) -> None:
+        resource = TransformationYAML.model_validate(
+            {
+                "externalId": "my_transformation",
+                "name": "my_transformation",
+                "ignoreNullFields": True,
+                "query": "select * from ext_onelake('fabric-prod', 'assets')",
+                "destination": {"type": "assets"},
+            }
+        )
+        deps = list(TransformationIO.get_dependencies(resource))
+        assert (ExternalDataSourceIO, ExternalId(external_id="fabric-prod")) in deps
 
     def test_create_session_nonce_error(self) -> None:
         transformations = [

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_transformation.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_transformation.py
@@ -253,21 +253,11 @@ authentication:
 
         assert list(actual) == expected
 
-    def test_get_dependent_items_ext_onelake_flag_off(self) -> None:
-        actual = list(
-            TransformationIO.get_dependent_items({"query": "select * from ext_onelake('fabric-prod', 'assets')"})
-        )
-        assert ExternalDataSourceIO not in {loader for loader, _ in actual}
-
     def test_get_dependencies_ext_onelake(self, monkeypatch: MonkeyPatch) -> None:
         _enable_external_data_sources(monkeypatch)
         resource = _ext_onelake_transformation_yaml()
         deps = list(TransformationIO.get_dependencies(resource))
         assert (ExternalDataSourceIO, ExternalId(external_id="fabric-prod")) in deps
-
-    def test_get_dependencies_ext_onelake_flag_off(self) -> None:
-        deps = list(TransformationIO.get_dependencies(_ext_onelake_transformation_yaml()))
-        assert ExternalDataSourceIO not in {loader for loader, _ in deps}
 
     def test_create_session_nonce_error(self) -> None:
         transformations = [

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_externaldata.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_externaldata.py
@@ -58,31 +58,13 @@ class TestExternalDataSourceYAML:
                 },
             },
         }
-        loaded = ExternalDataSourceYAML.model_validate(data)
-        assert loaded.settings.credentials.client_secret is None
+        with pytest.raises(ValidationError):
+            ExternalDataSourceYAML.model_validate(data)
 
     def test_dump_client_secret(self) -> None:
         loaded = ExternalDataSourceYAML.model_validate(self.VALID)
         dumped = json.loads(loaded.model_dump_json(by_alias=True))
         assert dumped["settings"]["credentials"]["clientSecret"] == "azure-client-secret"
-
-    def test_dump_client_secret_none(self) -> None:
-        data = {
-            "externalId": "fabric-lakehouse-prod",
-            "settings": {
-                "credentials": {
-                    "clientId": "azure-client-id",
-                    "tenantId": "azure-tenant-id",
-                },
-                "locationDescription": {
-                    "workspaceId": "workspace-guid",
-                    "containerId": "lakehouse-guid",
-                },
-            },
-        }
-        loaded = ExternalDataSourceYAML.model_validate(data)
-        dumped = json.loads(loaded.model_dump_json(by_alias=True))
-        assert dumped["settings"]["credentials"].get("clientSecret") is None
 
     def test_as_id(self) -> None:
         loaded = ExternalDataSourceYAML.model_validate(self.VALID)
@@ -95,6 +77,23 @@ class TestExternalDataSourceYAML:
                 {"externalId": "fabric-lakehouse-prod"},
                 ["Missing required field: 'settings'"],
                 id="missing_settings",
+            ),
+            pytest.param(
+                {
+                    "externalId": "fabric-lakehouse-prod",
+                    "settings": {
+                        "credentials": {
+                            "clientId": "azure-client-id",
+                            "tenantId": "azure-tenant-id",
+                        },
+                        "locationDescription": {
+                            "workspaceId": "workspace-guid",
+                            "containerId": "lakehouse-guid",
+                        },
+                    },
+                },
+                ["In settings.credentials missing required field: 'clientSecret'"],
+                id="missing_client_secret",
             ),
         ],
     )
@@ -116,6 +115,10 @@ class TestExternalDataSourceResourceClasses:
     def test_request_rejects_invalid_format(self) -> None:
         with pytest.raises(ValidationError):
             ExternalDataSourceRequest(external_id="fabric-lakehouse-prod", format="invalid")
+
+    def test_write_credentials_require_client_secret(self) -> None:
+        with pytest.raises(ValidationError):
+            OneLakeCredentialsWrite(client_id="id", tenant_id="tenant")
 
     def test_request_as_id(self) -> None:
         request = ExternalDataSourceRequest(


### PR DESCRIPTION
# Description

Completes Toolkit support for transformation external data sources (Fabric OneLake): YAML deploy, dump, and `ext_onelake` dependencies.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- [alpha] Toolkit support for transformation external sources (Fabric).