### PR TITLE
[CDF-28463] Map Observation startTime from node.createdTime in infield-data migration

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/view_to_view_mapping.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/view_to_view_mapping.py
@@ -14,7 +14,7 @@ class ViewToViewMapping(BaseModelObject):
         "you can achieve the same by including the properties in the property_mapping with identical "
         " and destination IDs.",
     )
-    container_mapping: dict[str, str] = Field(
+    container_mapping: dict[str, str | list[str]] = Field(
         description="Mapping from property Ids in the source view to property Ids in the destination view."
     )
     edge_mapping: dict[EdgeTypeId, str] | None = Field(
@@ -26,11 +26,15 @@ class ViewToViewMapping(BaseModelObject):
         "These are silently dropped during conversion instead of producing an unmapped-property warning.",
     )
 
-    def get_destination_property(self, source_property: str) -> str | None:
-        dest_prop_id = self.container_mapping.get(source_property)
-        if not dest_prop_id and self.map_identical_id_properties:
-            return source_property
-        return dest_prop_id
+    def get_destination_properties(self, source_property: str) -> list[str]:
+        dest_prop_ids = self.container_mapping.get(source_property)
+        if dest_prop_ids is None:
+            if self.map_identical_id_properties:
+                return [source_property]
+            return []
+        if isinstance(dest_prop_ids, str):
+            return [dest_prop_ids]
+        return dest_prop_ids
 
     @field_serializer("edge_mapping", mode="plain")
     def serialize_edge_mapping(self, edge_mapping: dict[EdgeTypeId, str] | None) -> dict[str, str] | None:

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -1312,10 +1312,9 @@ def convert_container_properties(
     edges: list[EdgeRequest] = []
     errors: list[str] = []
     for source_prop_id, value in source_properties.items():
-        dest_prop_id = context.mapping.get_destination_property(source_prop_id)
-        if not dest_prop_id or (
-            dest_prop_id not in context.destination_properties and dest_prop_id not in context.mapping.container_mapping
-        ):
+        dest_prop_ids = context.mapping.get_destination_properties(source_prop_id)
+        is_explicit_mapping = source_prop_id in context.mapping.container_mapping
+        if not is_explicit_mapping and (not dest_prop_ids or dest_prop_ids[0] not in context.destination_properties):
             # We do not warn about the node properties, as they are typically ignored, nor about
             # source properties that are explicitly marked as intentionally unmapped.
             if (
@@ -1324,56 +1323,61 @@ def convert_container_properties(
             ):
                 errors.append(f"Source instance property {source_prop_id!r} is not mapped to any destination property.")
             continue
-        if dest_prop_id not in context.destination_properties:
-            errors.append(f"Destination instance is missing property {dest_prop_id!r}.")
-            continue
 
-        dm_prop = context.destination_properties[dest_prop_id]
-        if isinstance(dm_prop, EdgeProperty):
-            try:
-                created_edges, issues = context.connection_creator.create_edges(
-                    value,
-                    dm_prop,
-                    source_prop_id,
-                    context.source_view_id,
-                    context.new_id,
-                )
-            except ValueError as e:
+        for dest_prop_id in dest_prop_ids:
+            if dest_prop_id not in context.destination_properties:
                 if source_prop_id not in context.mapping.ignore_source_properties:
-                    errors.append(f"Failed to create edges for property {source_prop_id!r} with value {value!r}: {e!s}")
+                    errors.append(f"Destination instance is missing property {dest_prop_id!r}.")
                 continue
-            edges.extend(created_edges)
-            errors.extend(issues)
-        elif isinstance(dm_prop, ViewCorePropertyResponse) and isinstance(dm_prop.type, DirectNodeRelation):
-            try:
-                created_connection, issues = context.connection_creator.create_direct_relation(
-                    value,
-                    dm_prop.type,
-                    source_prop_id,
-                    context.source_view_id,
-                )
-            except ValueError as e:
-                if source_prop_id not in context.mapping.ignore_source_properties:
-                    errors.append(
-                        f"Failed to create direct relation for property {source_prop_id!r} with value {value!r}: {e!s}"
+
+            dm_prop = context.destination_properties[dest_prop_id]
+            if isinstance(dm_prop, EdgeProperty):
+                try:
+                    created_edges, issues = context.connection_creator.create_edges(
+                        value,
+                        dm_prop,
+                        source_prop_id,
+                        context.source_view_id,
+                        context.new_id,
                     )
-                continue
-            if source_prop_id not in context.mapping.ignore_source_properties:
+                except ValueError as e:
+                    if source_prop_id not in context.mapping.ignore_source_properties:
+                        errors.append(
+                            f"Failed to create edges for property {source_prop_id!r} with value {value!r}: {e!s}"
+                        )
+                    continue
+                edges.extend(created_edges)
                 errors.extend(issues)
-            if created_connection is not None:
-                created_properties[dest_prop_id] = created_connection
-        elif isinstance(dm_prop, ViewCorePropertyResponse):
-            try:
-                created_value = convert_to_primary_property_with_special_cases(
-                    value,
-                    dm_prop.type,
-                    dm_prop.nullable if dm_prop.nullable is not None else True,
-                    destination_container_property=(dm_prop.container, dm_prop.container_property_identifier),
-                )
-                created_properties[dest_prop_id] = serialize_dms(created_value)
-            except (ValueError, TypeError, NotImplementedError) as e:
-                errors.append(f"Failed to convert property {source_prop_id!r} with value {value!r}: {e!s}")
-        # Else reverse direct relation, which we assume is handled in the other direction and thus ignore here.
+            elif isinstance(dm_prop, ViewCorePropertyResponse) and isinstance(dm_prop.type, DirectNodeRelation):
+                try:
+                    created_connection, issues = context.connection_creator.create_direct_relation(
+                        value,
+                        dm_prop.type,
+                        source_prop_id,
+                        context.source_view_id,
+                    )
+                except ValueError as e:
+                    if source_prop_id not in context.mapping.ignore_source_properties:
+                        errors.append(
+                            f"Failed to create direct relation for property {source_prop_id!r} with value {value!r}: {e!s}"
+                        )
+                    continue
+                if source_prop_id not in context.mapping.ignore_source_properties:
+                    errors.extend(issues)
+                if created_connection is not None:
+                    created_properties[dest_prop_id] = created_connection
+            elif isinstance(dm_prop, ViewCorePropertyResponse):
+                try:
+                    created_value = convert_to_primary_property_with_special_cases(
+                        value,
+                        dm_prop.type,
+                        dm_prop.nullable if dm_prop.nullable is not None else True,
+                        destination_container_property=(dm_prop.container, dm_prop.container_property_identifier),
+                    )
+                    created_properties[dest_prop_id] = serialize_dms(created_value)
+                except (ValueError, TypeError, NotImplementedError) as e:
+                    errors.append(f"Failed to convert property {source_prop_id!r} with value {value!r}: {e!s}")
+            # Else reverse direct relation, which we assume is handled in the other direction and thus ignore here.
 
     return ConversionResult(container_properties=created_properties, edges=edges, errors=errors)
 

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.yaml
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.yaml
@@ -40,7 +40,9 @@
     version: v1
     type: view
   containerMapping:
-    node.createdTime: sourceCreatedTime
+    node.createdTime: # One source property provides the value for two target properties
+      - sourceCreatedTime
+      - startTime
     node.lastUpdatedTime: sourceUpdatedTime
     source: source
     description: description

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
@@ -1414,6 +1414,12 @@ class TestInstanceToInstanceConversion:
             type=TimestampProperty(),
             **DEFAULT_ARGS,
         ),
+        "startTime": ViewCorePropertyResponse(
+            container=CONTAINER_ID,
+            container_property_identifier="startTime",
+            type=TimestampProperty(),
+            **DEFAULT_ARGS,
+        ),
         "dateVal": ViewCorePropertyResponse(
             container=CONTAINER_ID,
             container_property_identifier="dateVal",
@@ -1571,6 +1577,55 @@ class TestInstanceToInstanceConversion:
         )
 
         results = convert_container_properties(source_properties, context)
+
+        assert results.container_properties == expected_properties
+        assert results.errors == expected_errors
+
+    @pytest.mark.parametrize(
+        "container_mapping, ignore_source_properties, expected_properties, expected_errors",
+        [
+            pytest.param(
+                {"epoch": ["timestamp", "startTime"]},
+                set(),
+                {"timestamp": "2023-11-14T22:13:20Z", "startTime": "2023-11-14T22:13:20Z"},
+                [],
+                id="maps_to_multiple_destinations",
+            ),
+            pytest.param(
+                {"epoch": ["timestamp", "missingProp"]},
+                set(),
+                {"timestamp": "2023-11-14T22:13:20Z"},
+                ["Destination instance is missing property 'missingProp'."],
+                id="missing_dest_errors",
+            ),
+            pytest.param(
+                {"epoch": ["timestamp", "missingProp"]},
+                {"epoch"},
+                {"timestamp": "2023-11-14T22:13:20Z"},
+                [],
+                id="missing_dest_ignored",
+            ),
+        ],
+    )
+    def test_convert_container_properties_multiple_destinations(
+        self,
+        container_mapping: dict[str, str | list[str]],
+        ignore_source_properties: set[str],
+        expected_properties: dict[str, str],
+        expected_errors: list[str],
+    ) -> None:
+        mapping = self.MAPPING.model_copy(
+            update={"container_mapping": container_mapping, "ignore_source_properties": ignore_source_properties},
+        )
+        context = ConversionContext(
+            mapping=mapping,
+            destination_properties=self.DESTINATION_PROPERTIES,
+            connection_creator=self._create_connection_creator(),
+            source_view_id=self.SOURCE_VIEW_ID,
+            new_id=self.NEW_ID,
+        )
+
+        results = convert_container_properties({"epoch": 1700000000000}, context)
 
         assert results.container_properties == expected_properties
         assert results.errors == expected_errors


### PR DESCRIPTION
# Description

View-to-view `containerMapping` can now map one source property to multiple destination properties. Subsequently used by `cdf migrate infield-data` such that Observation `node.createdTime` is now written to both `sourceCreatedTime` and `startTime` ("Observed At") since the same source property as the bext proxy for both targets.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Improved

- [alpha] When running `cdf migrate infield-data`, FieldObservation will now have it's `startTime`/`Observed At` property populated based on the source Observation instance by default..