### PR TITLE
[CDF-28191] Remove (space,externalId) sort from all instance download queries 🧹 

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/api/instances.py
+++ b/cognite_toolkit/_cdf_tk/client/api/instances.py
@@ -40,7 +40,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._query import
     QueryResponseUntyped,
     QuerySelect,
     QuerySelectSource,
-    QuerySortSpec,
 )
 from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 from cognite_toolkit._cdf_tk.utils.file import create_logfile_stem, sanitize_filename
@@ -167,22 +166,6 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
     ) -> QueryRequest:
         """Create a query from the instance filter"""
 
-        # We sort by space and externalId to get a stable sort order.
-        # This is also more performant than sorting by using the default sort, which will sort on
-        # internal CDF IDs. This will be slow if you have deleted a lot of instances, as they will be counted.
-        # By sorting on space and externalId, we avoid this issue.
-        # Exception: when pinned to exactly one space, omit the sort so the server uses
-        # its internal-node-id order. This was observed to be provide a better performance
-        # compromise across different projects compared to the (space, externalId) sort.
-        # filter_spaces = filter.space if filter is not None else None
-        space_ext_id_sort: list[QuerySortSpec] | None = None
-        # if filter is None or filter_spaces is None or len(filter_spaces) > 1:
-        #     instance_type = filter.instance_type if filter is not None else None
-        #     instance_type = instance_type or "node"
-        #     space_ext_id_sort = [
-        #         QuerySortSpec(property=[instance_type, "space"], direction="ascending"),
-        #         QuerySortSpec(property=[instance_type, "externalId"], direction="ascending"),
-        #     ]
         sync_mode: Literal["onePhase", "twoPhase", "noBackfill"] | None = "twoPhase" if endpoint == "sync" else None
 
         if filter is None:
@@ -191,9 +174,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
                     "root": QueryNodeExpression(
                         limit=limit,
                         nodes=QueryNodeTableExpression(),
-                        # sort=space_ext_id_sort,
                         mode=sync_mode,
-                        # backfill_sort=space_ext_id_sort,
                     )
                 },
                 select={"root": QuerySelect()},
@@ -207,17 +188,13 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
             expression: QueryNodeExpression | QueryEdgeExpression = QueryEdgeExpression(
                 limit=limit,
                 edges=QueryEdgeTableExpression(filter=filter.dump_filter(include_has_data=True)),
-                # sort=space_ext_id_sort,
                 mode=sync_mode,
-                # backfill_sort=space_ext_id_sort,
             )
         else:  # Node or none
             expression = QueryNodeExpression(
                 limit=limit,
                 nodes=QueryNodeTableExpression(filter=filter.dump_filter(include_has_data=True)),
-                # sort=space_ext_id_sort,
                 mode=sync_mode,
-                # backfill_sort=space_ext_id_sort,
             )
         sources: list[QuerySelectSource] = []
         if filter.source:

--- a/cognite_toolkit/_cdf_tk/client/api/instances.py
+++ b/cognite_toolkit/_cdf_tk/client/api/instances.py
@@ -174,15 +174,15 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         # Exception: when pinned to exactly one space, omit the sort so the server uses
         # its internal-node-id order. This was observed to be provide a better performance
         # compromise across different projects compared to the (space, externalId) sort.
-        filter_spaces = filter.space if filter is not None else None
+        # filter_spaces = filter.space if filter is not None else None
         space_ext_id_sort: list[QuerySortSpec] | None = None
-        if filter is None or filter_spaces is None or len(filter_spaces) > 1:
-            instance_type = filter.instance_type if filter is not None else None
-            instance_type = instance_type or "node"
-            space_ext_id_sort = [
-                QuerySortSpec(property=[instance_type, "space"], direction="ascending"),
-                QuerySortSpec(property=[instance_type, "externalId"], direction="ascending"),
-            ]
+        # if filter is None or filter_spaces is None or len(filter_spaces) > 1:
+        #     instance_type = filter.instance_type if filter is not None else None
+        #     instance_type = instance_type or "node"
+        #     space_ext_id_sort = [
+        #         QuerySortSpec(property=[instance_type, "space"], direction="ascending"),
+        #         QuerySortSpec(property=[instance_type, "externalId"], direction="ascending"),
+        #     ]
         sync_mode: Literal["onePhase", "twoPhase", "noBackfill"] | None = "twoPhase" if endpoint == "sync" else None
 
         if filter is None:
@@ -191,9 +191,9 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
                     "root": QueryNodeExpression(
                         limit=limit,
                         nodes=QueryNodeTableExpression(),
-                        sort=space_ext_id_sort,
+                        # sort=space_ext_id_sort,
                         mode=sync_mode,
-                        backfill_sort=space_ext_id_sort,
+                        # backfill_sort=space_ext_id_sort,
                     )
                 },
                 select={"root": QuerySelect()},
@@ -207,17 +207,17 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
             expression: QueryNodeExpression | QueryEdgeExpression = QueryEdgeExpression(
                 limit=limit,
                 edges=QueryEdgeTableExpression(filter=filter.dump_filter(include_has_data=True)),
-                sort=space_ext_id_sort,
+                # sort=space_ext_id_sort,
                 mode=sync_mode,
-                backfill_sort=space_ext_id_sort,
+                # backfill_sort=space_ext_id_sort,
             )
         else:  # Node or none
             expression = QueryNodeExpression(
                 limit=limit,
                 nodes=QueryNodeTableExpression(filter=filter.dump_filter(include_has_data=True)),
-                sort=space_ext_id_sort,
+                # sort=space_ext_id_sort,
                 mode=sync_mode,
-                backfill_sort=space_ext_id_sort,
+                # backfill_sort=space_ext_id_sort,
             )
         sources: list[QuerySelectSource] = []
         if filter.source:

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/image_360_mappings.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/image_360_mappings.py
@@ -10,7 +10,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     QueryRequest,
     QuerySelect,
     QuerySelectSource,
-    QuerySortSpec,
     QueryThrough,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.view_to_view_mapping import ViewToViewMapping
@@ -167,10 +166,6 @@ def create_360_image_selectors(
                     "image360": QueryNodeExpression(
                         limit=SUBSELECTION_LIMIT_QUERY_ENDPOINT,
                         nodes=QueryNodeTableExpression(filter=image360_filter),
-                        sort=[
-                            QuerySortSpec(property=["node", "space"]),
-                            QuerySortSpec(property=["node", "externalId"]),
-                        ],
                     ),
                     "image360station": QueryNodeExpression(
                         limit=SUBSELECTION_LIMIT_QUERY_ENDPOINT,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/infield_data_mappings.py
@@ -14,7 +14,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     QueryRequest,
     QuerySelect,
     QuerySelectSource,
-    QuerySortSpec,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.infield import InFieldCDMLocationConfigResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.view_to_view_mapping import ViewToViewMapping
@@ -127,7 +126,6 @@ def create_infield_schedule_selector(instance_space: str | None = None) -> Insta
                 "template": QueryNodeExpression(
                     limit=1,
                     nodes=QueryNodeTableExpression(filter=template_filter),
-                    sort=[QuerySortSpec(property=["node", "space"]), QuerySortSpec(property=["node", "externalId"])],
                 ),
                 "templateEdges": QueryEdgeExpression(
                     limit=SUBSELECTION_LIMIT_QUERY_ENDPOINT,

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -25,7 +25,6 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     QueryRequest,
     QuerySelect,
     QuerySelectSource,
-    QuerySortSpec,
 )
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling._instance import (
     EdgeResponse,
@@ -351,12 +350,12 @@ class InstanceIO(
         # Exception: when pinned to exactly one space, omit the sort so the server uses
         # its internal-node-id order. This was observed to be provide a better performance
         # compromise across different projects compared to the (space, externalId) sort.
-        node_sort: list[QuerySortSpec] | None = [
-            QuerySortSpec(property=["node", "space"]),
-            QuerySortSpec(property=["node", "externalId"]),
-        ]
-        if selector.instance_spaces and len(selector.instance_spaces) == 1:
-            node_sort = None
+        # node_sort: list[QuerySortSpec] | None = [
+        #     QuerySortSpec(property=["node", "space"]),
+        #     QuerySortSpec(property=["node", "externalId"]),
+        # ]
+        # if selector.instance_spaces and len(selector.instance_spaces) == 1:
+        #     node_sort = None
         # /sync needs twoPhase with a backfillSort matching the forward-stream sort, otherwise
         # the server falls back to an expensive full-container scan/heapsort for the backfill.
         sync_mode: Literal["onePhase", "twoPhase", "noBackfill"] | None = (
@@ -366,9 +365,9 @@ class InstanceIO(
             root: QueryNodeExpression(
                 limit=min(self.CHUNK_SIZE, limit) if limit is not None else self.CHUNK_SIZE,
                 nodes=QueryNodeTableExpression(filter=instance_filter),
-                sort=node_sort,
+                # sort=node_sort,
                 mode=sync_mode,
-                backfill_sort=node_sort if sync_mode == "twoPhase" else None,
+                # backfill_sort=node_sort if sync_mode == "twoPhase" else None,
             )
         }
         select: dict[str, QuerySelect] = {

--- a/cognite_toolkit/_cdf_tk/dataio/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_instances.py
@@ -345,19 +345,6 @@ class InstanceIO(
         if not isinstance(view_id, ViewId):
             raise ToolkitValueError("ViewId is required for InstanceViewSelector")
         root = "nodes"
-        # Sort to ensure performance. If you do not sort, you get the internal index,
-        # which includes all deleted instances as well.
-        # Exception: when pinned to exactly one space, omit the sort so the server uses
-        # its internal-node-id order. This was observed to be provide a better performance
-        # compromise across different projects compared to the (space, externalId) sort.
-        # node_sort: list[QuerySortSpec] | None = [
-        #     QuerySortSpec(property=["node", "space"]),
-        #     QuerySortSpec(property=["node", "externalId"]),
-        # ]
-        # if selector.instance_spaces and len(selector.instance_spaces) == 1:
-        #     node_sort = None
-        # /sync needs twoPhase with a backfillSort matching the forward-stream sort, otherwise
-        # the server falls back to an expensive full-container scan/heapsort for the backfill.
         sync_mode: Literal["onePhase", "twoPhase", "noBackfill"] | None = (
             "twoPhase" if selector.endpoint == "sync" else None
         )
@@ -365,9 +352,7 @@ class InstanceIO(
             root: QueryNodeExpression(
                 limit=min(self.CHUNK_SIZE, limit) if limit is not None else self.CHUNK_SIZE,
                 nodes=QueryNodeTableExpression(filter=instance_filter),
-                # sort=node_sort,
                 mode=sync_mode,
-                # backfill_sort=node_sort if sync_mode == "twoPhase" else None,
             )
         }
         select: dict[str, QuerySelect] = {


### PR DESCRIPTION
# Description

Stop sending `sort`/`backfillSort` on all instance query / sync requests (nodes, edges, view selectors, and InField/360 image migration queries). Queries now use the server default order instead of `(space, externalId)`.

Many internal sources claim that sorting by space+externalId helps mitigate 408s and the original intent of applying this filter was to avoid timeouts in cases of high amounts of soft-deletes. As demonstrated in practice when testing on certain large-scale customer projects however, this seems to in contrast be detrimental to performance in some cases: https://cognitedata.slack.com/archives/C05RW13C6TX/p1786636988060219?thread_ts=1782830091.542489&cid=C05RW13C6TX

Therefore we are removing the sort and going back to the default for now, until we have any indication that we can find any better defaults / catch-all sorts than what is given out of the box by DMS.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Improved

- Improved performance in certain cases when downloading data modeling instances through toolkit.