### PR TITLE
[CDF-28431] Block instance purge through Cognite Migration views sharing instances with other views

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_model.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_model.py
@@ -230,10 +230,12 @@ SPACE_SOURCE_VIEW = ViewRequest(
 )
 
 INSTANCE_SOURCE_VIEW_ID = INSTANCE_SOURCE_VIEW.as_id()
-INSTANCE_SPACE_RELOCATION_SOURCE_VIEW_ID = ViewId(  # Not implemented yet, will be implemented in a future PR
-    space=SPACE.space,
-    external_id="InstanceSpaceRelocationSource",
-    version="v1",
+INSTANCE_SPACE_RELOCATION_SOURCE_VIEW_ID = (
+    ViewId(  # This view does not exist in the CogniteMigration mode yet, it will be implemented in a future PR
+        space=SPACE.space,
+        external_id="InstanceSpaceRelocationSource",
+        version="v1",
+    )
 )
 RESOURCE_VIEW_MAPPING_VIEW_ID = RESOURCE_VIEW_MAPPING_VIEW.as_id()
 CREATED_SOURCE_SYSTEM_VIEW_ID = CREATED_SOURCE_SYSTEM_VIEW.as_id()

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_model.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_model.py
@@ -12,6 +12,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     TextProperty,
     UniquenessConstraintDefinition,
     ViewCorePropertyRequest,
+    ViewId,
     ViewRequest,
 )
 
@@ -229,6 +230,11 @@ SPACE_SOURCE_VIEW = ViewRequest(
 )
 
 INSTANCE_SOURCE_VIEW_ID = INSTANCE_SOURCE_VIEW.as_id()
+INSTANCE_SPACE_RELOCATION_SOURCE_VIEW_ID = ViewId(  # Not implemented yet, will be implemented in a future PR
+    space=SPACE.space,
+    external_id="InstanceSpaceRelocationSource",
+    version="v1",
+)
 RESOURCE_VIEW_MAPPING_VIEW_ID = RESOURCE_VIEW_MAPPING_VIEW.as_id()
 CREATED_SOURCE_SYSTEM_VIEW_ID = CREATED_SOURCE_SYSTEM_VIEW.as_id()
 SPACE_SOURCE_VIEW_ID = SPACE_SOURCE_VIEW.as_id()

--- a/cognite_toolkit/_cdf_tk/commands/_purge.py
+++ b/cognite_toolkit/_cdf_tk/commands/_purge.py
@@ -31,9 +31,11 @@ from cognite_toolkit._cdf_tk.client.identifiers import (
     InstanceDefinitionId,
     InstanceId,
     InternalId,
+    ViewId,
 )
 from cognite_toolkit._cdf_tk.client.request_classes.filters import ContainerFilter
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import NodeId, SpaceId
+from cognite_toolkit._cdf_tk.constants import HINT_LEAD_TEXT
 from cognite_toolkit._cdf_tk.data_classes import DeployResults, ResourceDeployResult
 from cognite_toolkit._cdf_tk.data_classes._tracking_info import DataTracking
 from cognite_toolkit._cdf_tk.dataio import InstanceIO, Page
@@ -45,10 +47,16 @@ from cognite_toolkit._cdf_tk.dataio.logger import (
     Severity,
     display_item_results,
 )
-from cognite_toolkit._cdf_tk.dataio.selectors import InstanceSelector
+from cognite_toolkit._cdf_tk.dataio.selectors import (
+    InstanceSelector,
+    InstanceSpaceSelector,
+    InstanceViewSelector,
+    SelectedView,
+)
 from cognite_toolkit._cdf_tk.exceptions import (
     AuthorizationError,
     ToolkitMissingResourceError,
+    ToolkitValueError,
 )
 from cognite_toolkit._cdf_tk.protocols import ResourceResponseProtocol
 from cognite_toolkit._cdf_tk.resource_ios import (
@@ -91,6 +99,7 @@ from cognite_toolkit._cdf_tk.utils.useful_types import JsonVal
 from cognite_toolkit._cdf_tk.utils.validate_access import ValidateAccess
 
 from ._base import ToolkitCommand
+from ._migrate.data_model import INSTANCE_SOURCE_VIEW_ID, INSTANCE_SPACE_RELOCATION_SOURCE_VIEW_ID
 from ._utils import (
     confirm_by_typing_project_name,
     print_soft_delete_panel,
@@ -290,6 +299,7 @@ class AssetToDelete(IdResourceToDelete):
 
 class PurgeCommand(ToolkitCommand):
     BATCH_SIZE_DM = 1000
+    DENIED_VIEW_IDS: frozenset[ViewId] = frozenset({INSTANCE_SOURCE_VIEW_ID, INSTANCE_SPACE_RELOCATION_SOURCE_VIEW_ID})
 
     def space(
         self,
@@ -739,6 +749,7 @@ class PurgeCommand(ToolkitCommand):
         verbose: bool = False,
     ) -> DeleteResults:
         """Purge instances"""
+        self.validate_not_purging_through_denied_view(selector)
         io = InstanceIO(client)
         console = client.console
         validator = ValidateAccess(client, default_operation="purge")
@@ -819,6 +830,22 @@ class PurgeCommand(ToolkitCommand):
     def _log_filestem(self) -> str:
         log_filestem = f"purge_{date.today().strftime('%Y%m%d')}"
         return log_filestem
+
+    def validate_not_purging_through_denied_view(self, selector: InstanceSelector) -> None:
+        view: SelectedView | None = None
+        if isinstance(selector, InstanceViewSelector | InstanceSpaceSelector):
+            view = selector.view
+        if view is None or view.as_id() not in self.DENIED_VIEW_IDS:
+            return
+        raise ToolkitValueError(
+            f"Cannot purge instances through the [bold]{view.space}:{view.external_id}/{view.version}[/bold] view directly. "
+            "This view contains metadata for instances that [bold]also hold data in other views[/bold]. "
+            "Deleting instances through this view would irreversibly delete data in those other views as well, "
+            "which is likely not what you want.\n"
+            f"{HINT_LEAD_TEXT}You may delete these instances through other means if you know what you are doing "
+            "and are confident that you want to proceed with deleting them. For example you can use "
+            "[bold yellow]cdf data purge space[/] instead or select other views containing the same instances."
+        )
 
     def validate_instance_access(self, validator: ValidateAccess, instance_spaces: list[str] | None) -> None:
         space_ids = validator.instances(

--- a/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
@@ -291,6 +291,26 @@ class TestPurgeInstances:
         )
         assert result.deleted == 2000
 
+    @pytest.mark.parametrize(
+        "external_id",
+        [
+            pytest.param("InstanceSource", id="InstanceSource"),
+            pytest.param("InstanceSpaceRelocationSource", id="InstanceSpaceRelocationSource"),
+        ],
+    )
+    def test_blocks_denied_views(
+        self,
+        external_id: str,
+        purge_client: ToolkitClient,
+        tmp_path: Path,
+    ) -> None:
+        cmd = PurgeCommand(silent=True)
+        selector = InstanceViewSelector(
+            view=SelectedView(space="cognite_migration", external_id=external_id, version="v1")
+        )
+        with pytest.raises(ToolkitValueError, match="Cannot purge instances through"):
+            cmd.instances(purge_client, selector, log_dir=tmp_path)
+
 
 class TestPurgeSpace:
     @pytest.mark.usefixtures("disable_gzip")

--- a/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
@@ -308,7 +308,10 @@ class TestPurgeInstances:
         selector = InstanceViewSelector(
             view=SelectedView(space="cognite_migration", external_id=external_id, version="v1")
         )
-        with pytest.raises(ToolkitValueError, match="Cannot purge instances through"):
+        with pytest.raises(
+            ToolkitValueError,
+            match=f"Cannot purge instances through the .*{external_id}.*/{selector.view.version}.* view directly",
+        ):
             cmd.instances(purge_client, selector, log_dir=tmp_path)
 
 


### PR DESCRIPTION
# Description

Users have in the past accidentally deleted instances through the Cognite Migration model's `InstanceSource` view without realizing those instances **also hold production data in other views**, leading to complicated recovery processes. In an upcoming PR, we will need to add another such view, `InstanceSpaceRelocationSource`, to support moving instances to other spaces and tracking lineage between them, so this is added as a guardrail ahead of that change to avoid any accidents. `cdf data purge instances` now refuses those views and points users at safer alternatives such as the production views or `cdf data purge space`.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Added

- Toolkit will now block you from using `cdf data purge instances` when attempting to delete instances through specific special-case views, in cases where those instances also hold production data in other views.