### PR TITLE
[CDF-28467] Dump hosted extractors with related jobs and mappings

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -19,6 +19,7 @@ from cognite_toolkit._cdf_tk.commands.dump_resource import (
     ExtractionPipelineFinder,
     FunctionFinder,
     GroupFinder,
+    HostedExtractorFinder,
     LocationFilterFinder,
     NodeFinder,
     ResourceViewMappingFinder,
@@ -46,6 +47,7 @@ class DumpApp(typer.Typer):
 
         self.command("location-filter")(DumpConfigApp.dump_location_filters)
         self.command("extraction-pipeline")(DumpConfigApp.dump_extraction_pipeline)
+        self.command("hosted-extractor")(DumpConfigApp.dump_hosted_extractor)
         self.command("functions")(DumpConfigApp.dump_functions)
         self.command("datasets")(DumpConfigApp.dump_datasets)
         self.command("streamlit")(DumpConfigApp.dump_streamlit)
@@ -77,6 +79,7 @@ class DumpConfigApp(typer.Typer):
         self.command("spaces")(self.dump_spaces)
         self.command("location-filters")(self.dump_location_filters)
         self.command("extraction-pipeline")(self.dump_extraction_pipeline)
+        self.command("hosted-extractor")(self.dump_hosted_extractor)
         self.command("datasets")(DumpConfigApp.dump_datasets)
         self.command("functions")(self.dump_functions)
         self.command("streamlit")(DumpConfigApp.dump_streamlit)
@@ -518,6 +521,55 @@ class DumpConfigApp(typer.Typer):
         cmd.run(
             lambda: cmd.dump_to_yamls(
                 ExtractionPipelineFinder(client, tuple(external_id) if external_id else None),
+                output_dir=output_dir,
+                clean=clean,
+                verbose=verbose,
+            )
+        )
+
+    @staticmethod
+    def dump_hosted_extractor(
+        ctx: typer.Context,
+        external_id: Annotated[
+            list[str] | None,
+            typer.Argument(
+                help="The external ID(s) of the hosted extractor source(s) you want to dump. "
+                "Related jobs, destinations, and mappings are included. "
+                "If nothing is provided, an interactive prompt will be shown to select the source.",
+            ),
+        ] = None,
+        output_dir: Annotated[
+            Path,
+            typer.Option(
+                "--output-dir",
+                "-o",
+                help="Where to dump the hosted extractor files.",
+                allow_dash=True,
+            ),
+        ] = Path("tmp"),
+        clean: Annotated[
+            bool,
+            typer.Option(
+                "--clean",
+                "-c",
+                help="Delete the output directory before dumping the hosted extractor.",
+            ),
+        ] = False,
+        verbose: Annotated[
+            bool,
+            typer.Option(
+                "--verbose",
+                "-v",
+                help="Turn on to get more verbose output when running the command",
+            ),
+        ] = False,
+    ) -> None:
+        """This command will dump the selected hosted extractor source, plus related jobs, destinations, and mappings, as yaml to the folder specified, defaults to /tmp."""
+        client = EnvironmentVariables.create_from_environment().get_client()
+        cmd = DumpResourceCommand(client=client)
+        cmd.run(
+            lambda: cmd.dump_to_yamls(
+                HostedExtractorFinder(client, tuple(external_id) if external_id else None),
                 output_dir=output_dir,
                 clean=clean,
                 verbose=verbose,

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -998,7 +998,6 @@ class DumpResourceCommand(ToolkitCommand):
             output_dir.mkdir(exist_ok=True)
 
         dumped_ids: list[Hashable] = []
-        dumped_folders: set[Path] = set()
         for identifiers, resources, loader, subfolder in finder:
             if not identifiers and not resources:
                 # No resources to dump
@@ -1029,17 +1028,14 @@ class DumpResourceCommand(ToolkitCommand):
                 for filepath, subpart in loader.split_resource(base_filepath, dumped):
                     content = subpart if isinstance(subpart, str) else yaml_safe_dump(subpart)
                     safe_write(filepath, content, encoding="utf-8")
-                    dumped_folders.add(resource_folder)
                     if verbose:
                         self.console(f"Dumped {loader.kind} {name} to {filepath!s}")
                 if isinstance(finder, FunctionFinder) and isinstance(resource, FunctionResponse):
                     finder.dump_function_code(resource, resource_folder)
-                    dumped_folders.add(resource_folder)
                 if isinstance(finder, StreamlitFinder) and isinstance(resource, StreamlitResponse):
                     finder.dump_code(resource, resource_folder)
-                    dumped_folders.add(resource_folder)
                 dumped_ids.append(resource_id)
         success_message = f"Dumped {humanize_collection(dumped_ids)}"
-        if dumped_folders:
-            success_message = f"{success_message}\nWritten to {humanize_collection(sorted(folder.as_posix() for folder in dumped_folders))}"
+        if dumped_ids:
+            success_message = f"{success_message}\nWritten to {output_dir.as_posix()}"
         print(Panel(success_message, title="Success", style="green", expand=False))

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -645,7 +645,7 @@ class HostedExtractorFinder(ResourceFinder[tuple[str, ...]]):
         if jobs:
             yield [], jobs, HostedExtractorJobIO.create_loader(self.client), None
 
-        destination_ids = sorted({job.destination_id for job in jobs})
+        destination_ids = sorted({job.destination_id for job in jobs if job.destination_id})
         if destination_ids:
             yield (
                 [ExternalId(external_id=external_id) for external_id in destination_ids],

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -46,6 +46,9 @@ from cognite_toolkit._cdf_tk.client.resource_classes.dataset import DataSetRespo
 from cognite_toolkit._cdf_tk.client.resource_classes.extraction_pipeline import ExtractionPipelineResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.function import FunctionResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.group import GroupResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.hosted_extractor_source import (
+    HostedExtractorSourceResponseUnion,
+)
 from cognite_toolkit._cdf_tk.client.resource_classes.location_filter import LocationFilterResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.resource_view_mapping import ResourceViewMappingResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.search_config import SearchConfigResponse
@@ -72,6 +75,10 @@ from cognite_toolkit._cdf_tk.resource_ios import (
     FunctionIO,
     FunctionScheduleIO,
     GroupIO,
+    HostedExtractorDestinationIO,
+    HostedExtractorJobIO,
+    HostedExtractorMappingIO,
+    HostedExtractorSourceIO,
     LocationFilterIO,
     NodeCRUD,
     ResourceIO,
@@ -598,6 +605,65 @@ class ExtractionPipelineFinder(ResourceFinder[tuple[str, ...]]):
         yield [], configs, config_loader, None
 
 
+class HostedExtractorFinder(ResourceFinder[tuple[str, ...]]):
+    def __init__(self, client: ToolkitClient, identifier: tuple[str, ...] | None = None):
+        super().__init__(client, identifier)
+        self.sources: list[HostedExtractorSourceResponseUnion] | None = None
+
+    def _interactive_select(self) -> tuple[str, ...]:
+        self.sources = self.client.tool.hosted_extractors.sources.list(limit=None)
+        if not self.sources:
+            raise ToolkitMissingResourceError("No hosted extractor sources found")
+        choices = [
+            Choice(f"{source.external_id} ({source.type})", value=source.external_id)
+            for source in sorted(self.sources, key=lambda s: s.external_id)
+        ]
+        selected_source_ids: tuple[str, ...] | None = questionary.checkbox(
+            "Which hosted extractor source(s) would you like to dump?",
+            choices=choices,
+            validate=lambda choices: True if choices else "You must select at least one source.",
+        ).unsafe_ask()
+        if not selected_source_ids:
+            raise ToolkitValueError(
+                f"No hosted extractor sources selected for dumping.{_INTERACTIVE_SELECT_HELPER_TEXT}"
+            )
+        return tuple(selected_source_ids)
+
+    def __iter__(
+        self,
+    ) -> Iterator[tuple[Sequence[Hashable], Sequence[ResourceResponseProtocol] | None, ResourceIO, None | str]]:
+        self.identifier = self._selected()
+        source_ids = set(self.identifier)
+        source_loader = HostedExtractorSourceIO.create_loader(self.client)
+        if self.sources:
+            selected_sources = [source for source in self.sources if source.external_id in source_ids]
+            yield [], selected_sources, source_loader, None
+        else:
+            yield [ExternalId(external_id=external_id) for external_id in self.identifier], None, source_loader, None
+
+        jobs = [job for job in self.client.tool.hosted_extractors.jobs.list(limit=None) if job.source_id in source_ids]
+        if jobs:
+            yield [], jobs, HostedExtractorJobIO.create_loader(self.client), None
+
+        destination_ids = sorted({job.destination_id for job in jobs})
+        if destination_ids:
+            yield (
+                [ExternalId(external_id=external_id) for external_id in destination_ids],
+                None,
+                HostedExtractorDestinationIO.create_loader(self.client),
+                None,
+            )
+
+        mapping_ids = sorted({mapping_id for job in jobs if (mapping_id := getattr(job.format, "mapping_id", None))})
+        if mapping_ids:
+            yield (
+                [ExternalId(external_id=external_id) for external_id in mapping_ids],
+                None,
+                HostedExtractorMappingIO.create_loader(self.client),
+                None,
+            )
+
+
 class DataSetFinder(ResourceFinder[tuple[str, ...]]):
     """Finds data sets to dump."""
 
@@ -932,6 +998,7 @@ class DumpResourceCommand(ToolkitCommand):
             output_dir.mkdir(exist_ok=True)
 
         dumped_ids: list[Hashable] = []
+        dumped_folders: set[Path] = set()
         for identifiers, resources, loader, subfolder in finder:
             if not identifiers and not resources:
                 # No resources to dump
@@ -962,11 +1029,17 @@ class DumpResourceCommand(ToolkitCommand):
                 for filepath, subpart in loader.split_resource(base_filepath, dumped):
                     content = subpart if isinstance(subpart, str) else yaml_safe_dump(subpart)
                     safe_write(filepath, content, encoding="utf-8")
+                    dumped_folders.add(resource_folder)
                     if verbose:
                         self.console(f"Dumped {loader.kind} {name} to {filepath!s}")
                 if isinstance(finder, FunctionFinder) and isinstance(resource, FunctionResponse):
                     finder.dump_function_code(resource, resource_folder)
+                    dumped_folders.add(resource_folder)
                 if isinstance(finder, StreamlitFinder) and isinstance(resource, StreamlitResponse):
                     finder.dump_code(resource, resource_folder)
+                    dumped_folders.add(resource_folder)
                 dumped_ids.append(resource_id)
-        print(Panel(f"Dumped {humanize_collection(dumped_ids)}", title="Success", style="green", expand=False))
+        success_message = f"Dumped {humanize_collection(dumped_ids)}"
+        if dumped_folders:
+            success_message = f"{success_message}\nWritten to {humanize_collection(sorted(folder.as_posix() for folder in dumped_folders))}"
+        print(Panel(success_message, title="Success", style="green", expand=False))

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/externaldata.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/externaldata.py
@@ -89,7 +89,7 @@ class ExternalDataSourceIO(
         # when a local YAML exists makes deploy always upsert, matching hosted extractor sources.
         if local:
             HighSeverityWarning(
-                "External data sources will always be considered different, and thus will always be redeployed."
+                "External data sources that contain credentials are always considered as changed and will be redeployed every time"
             ).print_warning(console=self.client.console)
             return self.dump_id(self.get_id(resource))
         dumped = resource.dump()

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/hosted_extractors.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/hosted_extractors.py
@@ -43,6 +43,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.hosted_extractor_source imp
 from cognite_toolkit._cdf_tk.exceptions import ToolkitNotSupported
 from cognite_toolkit._cdf_tk.resource_ios._base_ios import ResourceIO
 from cognite_toolkit._cdf_tk.tk_warnings import HighSeverityWarning
+from cognite_toolkit._cdf_tk.utils.file import sanitize_filename
 from cognite_toolkit._cdf_tk.yaml_classes import (
     HostedExtractorDestinationYAML,
     HostedExtractorJobYAML,
@@ -81,6 +82,10 @@ class HostedExtractorSourceIO(
         return id.dump()
 
     @classmethod
+    def as_str(cls, id: ExternalId) -> str:
+        return sanitize_filename(id.external_id)
+
+    @classmethod
     def get_minimum_scope(cls, items: Sequence[HostedExtractorSourceRequestUnion]) -> ScopeDefinition:
         return AllScope()
 
@@ -116,10 +121,20 @@ class HostedExtractorSourceIO(
     def dump_resource(
         self, resource: HostedExtractorSourceResponseUnion, local: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        HighSeverityWarning(
-            "Sources will always be considered different, and thus will always be redeployed."
-        ).print_warning(console=self.client.console)
-        return self.dump_id(self.get_id(resource))
+        # Secrets and certificates cannot be compared (API never returns them). Dumping only
+        # the identifier when a local YAML exists makes deploy always upsert.
+        if local:
+            HighSeverityWarning(
+                "Sources that contain credentials are always considered as changed and will be redeployed every time"
+            ).print_warning(console=self.client.console)
+            return self.dump_id(self.get_id(resource))
+        dumped = resource.dump()
+        dumped.pop("createdTime", None)
+        dumped.pop("lastUpdatedTime", None)
+        # API returns certificate metadata (thumbprint/expiry) that cannot be redeployed.
+        dumped.pop("caCertificate", None)
+        dumped.pop("authCertificate", None)
+        return dumped
 
     def load_resource(self, resource: dict[str, Any], is_dry_run: bool = False) -> HostedExtractorSourceRequestUnion:
         loaded = HostedExtractorSourceRequest.validate_python(resource)
@@ -195,6 +210,10 @@ class HostedExtractorDestinationIO(
         return id.dump()
 
     @classmethod
+    def as_str(cls, id: ExternalId) -> str:
+        return sanitize_filename(id.external_id)
+
+    @classmethod
     def get_minimum_scope(cls, items: Sequence[HostedExtractorDestinationRequest]) -> ScopeDefinition:
         return AllScope()
 
@@ -243,10 +262,17 @@ class HostedExtractorDestinationIO(
     def dump_resource(
         self, resource: HostedExtractorDestinationResponse, local: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        HighSeverityWarning(
-            "Destinations will always be considered different, and thus will always be redeployed."
-        ).print_warning(console=self.client.console)
-        return self.dump_id(self.get_id(resource))
+        # Credentials cannot be compared (API never returns them). Dumping only the identifier
+        # when a local YAML exists makes deploy always upsert.
+        if local:
+            HighSeverityWarning(
+                "Destinations that contain credentials are always considered as changed and will be redeployed every time"
+            ).print_warning(console=self.client.console)
+            return self.dump_id(self.get_id(resource))
+        dumped = resource.as_request_resource().dump()
+        if data_set_id := dumped.pop("targetDataSetId", None):
+            dumped["targetDataSetExternalId"] = self.client.lookup.data_sets.external_id(data_set_id)
+        return dumped
 
     @classmethod
     def get_dependencies(
@@ -292,6 +318,10 @@ class HostedExtractorJobIO(ResourceIO[ExternalId, HostedExtractorJobRequest, Hos
     @classmethod
     def dump_id(cls, id: ExternalId) -> dict[str, Any]:
         return id.dump()
+
+    @classmethod
+    def as_str(cls, id: ExternalId) -> str:
+        return sanitize_filename(id.external_id)
 
     @classmethod
     def get_minimum_scope(cls, items: Sequence[HostedExtractorJobRequest]) -> ScopeDefinition:
@@ -375,6 +405,10 @@ class HostedExtractorMappingIO(ResourceIO[ExternalId, HostedExtractorMappingRequ
     @classmethod
     def dump_id(cls, id: ExternalId) -> dict[str, Any]:
         return id.dump()
+
+    @classmethod
+    def as_str(cls, id: ExternalId) -> str:
+        return sanitize_filename(id.external_id)
 
     @classmethod
     def get_minimum_scope(cls, items: Sequence[HostedExtractorMappingRequest]) -> ScopeDefinition:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
@@ -30,6 +30,19 @@ from cognite_toolkit._cdf_tk.client.resource_classes.externaldata import (
 from cognite_toolkit._cdf_tk.client.resource_classes.extraction_pipeline import ExtractionPipelineResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.function import FunctionResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.group import GroupResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.hosted_extractor_destination import (
+    HostedExtractorDestinationResponse,
+)
+from cognite_toolkit._cdf_tk.client.resource_classes.hosted_extractor_job import (
+    CustomFormat,
+    HostedExtractorJobResponse,
+)
+from cognite_toolkit._cdf_tk.client.resource_classes.hosted_extractor_mapping import (
+    HostedExtractorMappingResponse,
+    JSONInput,
+    Mapping,
+)
+from cognite_toolkit._cdf_tk.client.resource_classes.hosted_extractor_source import MQTTSourceResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.location_filter import LocationFilterResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.resource_view_mapping import ResourceViewMappingResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.search_config import SearchConfigResponse
@@ -44,6 +57,7 @@ from cognite_toolkit._cdf_tk.commands.dump_resource import (
     ExtractionPipelineFinder,
     FunctionFinder,
     GroupFinder,
+    HostedExtractorFinder,
     LocationFilterFinder,
     ResourceViewMappingFinder,
     SearchConfigFinder,
@@ -59,6 +73,10 @@ from cognite_toolkit._cdf_tk.resource_ios import (
     ExtractionPipelineIO,
     FunctionIO,
     GroupAllScopedCRUD,
+    HostedExtractorDestinationIO,
+    HostedExtractorJobIO,
+    HostedExtractorMappingIO,
+    HostedExtractorSourceIO,
     LocationFilterIO,
     ResourceViewMappingIO,
     SearchConfigIO,
@@ -504,6 +522,147 @@ class TestDumpExtractionPipeline:
                 key=lambda d: d.get("external_id", d.get("externalId")),
             )
             assert items == expected
+
+
+@pytest.fixture()
+def three_hosted_extractor_sources() -> list[MQTTSourceResponse]:
+    return [
+        MQTTSourceResponse(
+            type="mqtt5",
+            external_id=f"source{character}",
+            host="localhost",
+            created_time=1,
+            last_updated_time=1,
+        )
+        for character in ["A", "B", "C"]
+    ]
+
+
+class TestHostedExtractorFinder:
+    def test_select_hosted_extractor_sources(
+        self, three_hosted_extractor_sources: list[MQTTSourceResponse], monkeypatch: MonkeyPatch
+    ) -> None:
+        def select_sources(choices: list[Choice]) -> list[str]:
+            assert len(choices) == len(three_hosted_extractor_sources)
+            return [choices[1].value, choices[2].value]
+
+        answers = [select_sources]
+
+        with (
+            monkeypatch_toolkit_client() as client,
+            MockQuestionary(HostedExtractorFinder.__module__, monkeypatch, answers),
+        ):
+            client.tool.hosted_extractors.sources.list.return_value = three_hosted_extractor_sources
+            finder = HostedExtractorFinder(client, None)
+            selected = finder._interactive_select()
+
+        assert selected == ("sourceB", "sourceC")
+
+
+class TestDumpHostedExtractor:
+    def test_dump_hosted_extractor_with_related_resources(
+        self, three_hosted_extractor_sources: list[MQTTSourceResponse], tmp_path: Path
+    ) -> None:
+        selected_sources = three_hosted_extractor_sources[1:]
+        jobs = [
+            HostedExtractorJobResponse(
+                external_id="jobB",
+                destination_id="destB",
+                source_id="sourceB",
+                format=CustomFormat(mapping_id="mappingB"),
+                created_time=1,
+                last_updated_time=1,
+            ),
+            HostedExtractorJobResponse(
+                external_id="jobOther",
+                destination_id="destOther",
+                source_id="sourceA",
+                format=CustomFormat(mapping_id="mappingOther"),
+                created_time=1,
+                last_updated_time=1,
+            ),
+        ]
+        destinations = [
+            HostedExtractorDestinationResponse(external_id="destB", created_time=1, last_updated_time=1),
+        ]
+        mappings = [
+            HostedExtractorMappingResponse(
+                external_id="mappingB",
+                mapping=Mapping(expression="concat(['site', 'id'])"),
+                published=True,
+                input=JSONInput(),
+                created_time=1,
+                last_updated_time=1,
+            ),
+        ]
+        with monkeypatch_toolkit_client() as client:
+            client.tool.hosted_extractors.sources.retrieve.return_value = selected_sources
+            client.tool.hosted_extractors.jobs.list.return_value = jobs
+            client.tool.hosted_extractors.destinations.retrieve.return_value = destinations
+            client.tool.hosted_extractors.mappings.retrieve.return_value = mappings
+
+            cmd = DumpResourceCommand(silent=True)
+            cmd.dump_to_yamls(
+                HostedExtractorFinder(client, ("sourceB", "sourceC")),
+                output_dir=tmp_path,
+                clean=False,
+                verbose=False,
+            )
+            source_loader = HostedExtractorSourceIO(client, None, None)
+            job_loader = HostedExtractorJobIO(client, None, None)
+            dest_loader = HostedExtractorDestinationIO(client, None, None)
+            mapping_loader = HostedExtractorMappingIO(client, None, None)
+
+            source_items = [read_yaml_file(path) for path in source_loader.find_files(tmp_path)]
+            job_items = [read_yaml_file(path) for path in job_loader.find_files(tmp_path)]
+            dest_items = [read_yaml_file(path) for path in dest_loader.find_files(tmp_path)]
+            mapping_items = [read_yaml_file(path) for path in mapping_loader.find_files(tmp_path)]
+
+        assert sorted(source_items, key=lambda item: item["externalId"]) == [
+            source_loader.dump_resource(source) for source in selected_sources
+        ]
+        assert job_items == [job_loader.dump_resource(jobs[0])]
+        assert dest_items == [dest_loader.dump_resource(destinations[0])]
+        assert mapping_items == [mapping_loader.dump_resource(mappings[0])]
+        assert mapping_items[0]["mapping"]["expression"] == "concat(['site', 'id'])"
+
+    def test_dump_source_without_local_omits_metadata(self) -> None:
+        source = MQTTSourceResponse(
+            type="mqtt5",
+            external_id="sourceA",
+            host="localhost",
+            created_time=1,
+            last_updated_time=1,
+        )
+        with monkeypatch_toolkit_client() as client:
+            dumped = HostedExtractorSourceIO.create_loader(client).dump_resource(source)
+        assert dumped == {"type": "mqtt5", "externalId": "sourceA", "host": "localhost"}
+
+    def test_dump_source_with_local_returns_identifier(self) -> None:
+        source = MQTTSourceResponse(
+            type="mqtt5",
+            external_id="sourceA",
+            host="localhost",
+            created_time=1,
+            last_updated_time=1,
+        )
+        with monkeypatch_toolkit_client() as client:
+            dumped = HostedExtractorSourceIO.create_loader(client).dump_resource(
+                source, local={"externalId": "sourceA"}
+            )
+        assert dumped == {"externalId": "sourceA"}
+
+    def test_dump_destination_without_local_translates_dataset(self) -> None:
+        destination = HostedExtractorDestinationResponse(
+            external_id="destA",
+            target_data_set_id=123,
+            created_time=1,
+            last_updated_time=1,
+        )
+        with monkeypatch_toolkit_client() as client:
+            client.lookup.data_sets.external_id.return_value = "ds_files"
+            dumped = HostedExtractorDestinationIO.create_loader(client).dump_resource(destination)
+        assert dumped == {"externalId": "destA", "targetDataSetExternalId": "ds_files"}
 
 
 @pytest.fixture()


### PR DESCRIPTION
# Description

Add `cdf dump hosted-extractor` to dump hosted extractor sources plus related jobs, destinations, and mappings (including mapping expressions) to YAML. Secrets and credentials are omitted from the dump since CDF does not return them.

Unrelated quality of life improvements:
Also show the output folder path in all `dump_to_yamls` success messages, and clarify redeploy warnings for resources with credentials.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- `cdf dump hosted-extractor` command to dump sources with related jobs, destinations, and mappings

### Changed

- Dump success message now includes the folder path files were written to
- Clarified credential redeploy warnings for hosted extractor sources/destinations and external data sources