### PR TITLE
[CDF-26932] Show CLI group help when no subcommand is given

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_auth_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_auth_app.py
@@ -1,10 +1,11 @@
 from typing import Annotated, Any
 
 import typer
-from rich import print
 
 from cognite_toolkit._cdf_tk.commands import AuthCommand
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
+
+from ._helpers import print_help_if_no_subcommand
 
 
 class AuthApp(typer.Typer):
@@ -16,8 +17,7 @@ class AuthApp(typer.Typer):
 
     def main(self, ctx: typer.Context) -> None:
         """Commands to auth setup"""
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf auth --help[/] for more information.")
+        print_help_if_no_subcommand(ctx)
 
     def init(
         self,

--- a/cognite_toolkit/_cdf_tk/apps/_data_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_data_app.py
@@ -1,9 +1,9 @@
 from typing import Any
 
 import typer
-from rich import print
 
 from ._download_app import DownloadApp
+from ._helpers import print_help_if_no_subcommand
 from ._purge import PurgeApp
 from ._upload_app import UploadApp
 
@@ -19,6 +19,4 @@ class DataApp(typer.Typer):
     @staticmethod
     def main(ctx: typer.Context) -> None:
         """Plugin to work with data in CDF"""
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf data --help[/] for more information.")
-        return None
+        print_help_if_no_subcommand(ctx)

--- a/cognite_toolkit/_cdf_tk/apps/_dev_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dev_app.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Annotated, Any
 
 import typer
-from rich import print
 
 from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 from cognite_toolkit._cdf_tk.client import ToolkitClient
@@ -12,6 +11,7 @@ from cognite_toolkit._cdf_tk.feature_flags import FeatureFlag, Flags
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 
 from ._entity_matching_app import EntityMatchingApp
+from ._helpers import print_help_if_no_subcommand
 from ._run import RunApp
 
 CDF_TOML = CDFToml.load(Path.cwd())
@@ -30,9 +30,7 @@ class DevApp(typer.Typer):
     @staticmethod
     def main(ctx: typer.Context) -> None:
         """Commands to work with development."""
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf dev --help[/] for more information.")
-        return None
+        print_help_if_no_subcommand(ctx)
 
     def create(
         self,

--- a/cognite_toolkit/_cdf_tk/apps/_download_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_download_app.py
@@ -5,7 +5,6 @@ from typing import Annotated, Any
 import questionary
 import typer
 from questionary import Choice
-from rich import print
 
 from cognite_toolkit._cdf_tk.client.identifiers import EdgeTypeId, RawTableId, ViewNoVersionId
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import EdgeProperty
@@ -69,6 +68,8 @@ from cognite_toolkit._cdf_tk.utils.interactive_select import (
     TimeSeriesInteractiveSelect,
     ViewSelectFilter,
 )
+
+from ._helpers import print_help_if_no_subcommand
 
 
 class RawFormats(str, Enum):
@@ -162,9 +163,7 @@ class DownloadApp(typer.Typer):
     @staticmethod
     def download_main(ctx: typer.Context) -> None:
         """Commands to download data from CDF into a temporary directory."""
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf data download --help[/] for more information.")
-        return None
+        print_help_if_no_subcommand(ctx)
 
     @staticmethod
     def download_raw_cmd(

--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import Annotated, Any
 
 import typer
-from rich import print
 
 from cognite_toolkit._cdf_tk.client.identifiers import WorkflowVersionId
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
@@ -32,6 +31,8 @@ from cognite_toolkit._cdf_tk.exceptions import ToolkitRequiredValueError
 from cognite_toolkit._cdf_tk.feature_flags import Flags
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 
+from ._helpers import print_help_if_no_subcommand
+
 
 class DumpApp(typer.Typer):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -59,9 +60,7 @@ class DumpApp(typer.Typer):
     @staticmethod
     def dump_main(ctx: typer.Context) -> None:
         """Commands to dump resource configurations from CDF into a temporary directory."""
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf dump --help[/] for more information.")
-        return None
+        print_help_if_no_subcommand(ctx)
 
 
 class DumpConfigApp(typer.Typer):
@@ -88,9 +87,7 @@ class DumpConfigApp(typer.Typer):
     @staticmethod
     def dump_config_main(ctx: typer.Context) -> None:
         """Commands to dump resource configurations from CDF into a temporary directory."""
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf dump config --help[/] for more information.")
-        return None
+        print_help_if_no_subcommand(ctx)
 
     @staticmethod
     def dump_datamodel_cmd(

--- a/cognite_toolkit/_cdf_tk/apps/_entity_matching_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_entity_matching_app.py
@@ -2,10 +2,11 @@ from pathlib import Path
 from typing import Annotated, Any
 
 import typer
-from rich import print
 
 from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 from cognite_toolkit._cdf_tk.commands.entity_matching import EntityMatchingCommand
+
+from ._helpers import print_help_if_no_subcommand
 
 CDF_TOML = CDFToml.load(Path.cwd())
 
@@ -19,8 +20,7 @@ class EntityMatchingApp(typer.Typer):
     @staticmethod
     def main(ctx: typer.Context) -> None:
         """Commands for entity matching."""
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf dev entity-matching --help[/] for more information.")
+        print_help_if_no_subcommand(ctx)
 
     def generate_aliasing_workflow(
         self,

--- a/cognite_toolkit/_cdf_tk/apps/_helpers.py
+++ b/cognite_toolkit/_cdf_tk/apps/_helpers.py
@@ -1,0 +1,8 @@
+import typer
+
+
+def print_help_if_no_subcommand(ctx: typer.Context) -> None:
+    """Print this group's help and exit when no subcommand was given."""
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
+        raise typer.Exit()

--- a/cognite_toolkit/_cdf_tk/apps/_import_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_import_app.py
@@ -7,6 +7,8 @@ from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.commands._import_cmd import ImportTransformationCLI
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 
+from ._helpers import print_help_if_no_subcommand
+
 
 class ImportApp(typer.Typer):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -16,9 +18,7 @@ class ImportApp(typer.Typer):
 
     def main(self, ctx: typer.Context) -> None:
         """PREVIEW FEATURE Import resources into Cognite-Toolkit."""
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf-tk import --help[/] for more information.")
-        return None
+        print_help_if_no_subcommand(ctx)
 
     @staticmethod
     def transformation_cli(

--- a/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_migrate_app.py
@@ -113,6 +113,8 @@ from cognite_toolkit._cdf_tk.utils.interactive_select import (
 from cognite_toolkit._cdf_tk.utils.text import warn_invalid_space_name
 from cognite_toolkit._cdf_tk.utils.useful_types import AssetCentricKind
 
+from ._helpers import print_help_if_no_subcommand
+
 TODAY = date.today()
 
 
@@ -142,8 +144,7 @@ class MigrateApp(typer.Typer):
 
     def main(self, ctx: typer.Context) -> None:
         """Migrate resources from Asset-Centric to data modeling in CDF."""
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf migrate --help[/] for more information.")
+        print_help_if_no_subcommand(ctx)
 
     @staticmethod
     def prepare(

--- a/cognite_toolkit/_cdf_tk/apps/_modules_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_modules_app.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
-from rich import print
 
 from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 from cognite_toolkit._cdf_tk.client import ToolkitClient
@@ -12,6 +11,8 @@ from cognite_toolkit._cdf_tk.commands import ModulesCommand, PullCommand
 from cognite_toolkit._cdf_tk.feature_flags import Flags
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 from cognite_toolkit._version import __version__
+
+from ._helpers import print_help_if_no_subcommand
 
 CDF_TOML = CDFToml.load(Path.cwd())
 
@@ -33,8 +34,7 @@ class ModulesApp(typer.Typer):
 
     def main(self, ctx: typer.Context) -> None:
         """Commands to manage modules"""
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf modules --help[/] for more information.")
+        print_help_if_no_subcommand(ctx)
 
     def init(
         self,

--- a/cognite_toolkit/_cdf_tk/apps/_profile_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_profile_app.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import Annotated, Any
 
 import typer
-from rich import print
 
 from cognite_toolkit._cdf_tk.commands import (
     ProfileAssetCentricCommand,
@@ -11,6 +10,8 @@ from cognite_toolkit._cdf_tk.commands import (
     ProfileTransformationCommand,
 )
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
+
+from ._helpers import print_help_if_no_subcommand
 
 
 class ProfileApp(typer.Typer):
@@ -24,8 +25,7 @@ class ProfileApp(typer.Typer):
 
     def main(self, ctx: typer.Context) -> None:
         """Commands profile functionality"""
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf profile --help[/] for more information.")
+        print_help_if_no_subcommand(ctx)
 
     @staticmethod
     def assets(

--- a/cognite_toolkit/_cdf_tk/apps/_purge.py
+++ b/cognite_toolkit/_cdf_tk/apps/_purge.py
@@ -5,7 +5,6 @@ from typing import Annotated, Any
 
 import questionary
 import typer
-from rich import print
 
 from cognite_toolkit._cdf_tk.commands import PurgeCommand
 from cognite_toolkit._cdf_tk.dataio.selectors import (
@@ -25,6 +24,8 @@ from cognite_toolkit._cdf_tk.utils.interactive_select import (
 )
 from cognite_toolkit._cdf_tk.utils.validate_access import ValidateAccess
 
+from ._helpers import print_help_if_no_subcommand
+
 TODAY = date.today()
 
 
@@ -43,8 +44,7 @@ class PurgeApp(typer.Typer):
 
     def main(self, ctx: typer.Context) -> None:
         """Commands deleting data from Cognite Data Fusion."""
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf purge --help[/] for more information.")
+        print_help_if_no_subcommand(ctx)
 
     @staticmethod
     def purge_dataset(

--- a/cognite_toolkit/_cdf_tk/apps/_repo_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_repo_app.py
@@ -3,13 +3,14 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
-from rich import print
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.commands import RepoCommand
 from cognite_toolkit._cdf_tk.commands.repo import REPOSITORY_HOSTING
 from cognite_toolkit._cdf_tk.utils import humanize_collection
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
+
+from ._helpers import print_help_if_no_subcommand
 
 
 class RepoApp(typer.Typer):
@@ -20,8 +21,7 @@ class RepoApp(typer.Typer):
 
     def main(self, ctx: typer.Context) -> None:
         """Commands to repo management"""
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf repo --help[/] for more information.")
+        print_help_if_no_subcommand(ctx)
 
     def init(
         self,

--- a/cognite_toolkit/_cdf_tk/apps/_run.py
+++ b/cognite_toolkit/_cdf_tk/apps/_run.py
@@ -12,6 +12,8 @@ from cognite_toolkit._cdf_tk.commands import (
 )
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 
+from ._helpers import print_help_if_no_subcommand
+
 CDF_TOML = CDFToml.load(Path.cwd())
 
 
@@ -33,8 +35,7 @@ class RunApp(typer.Typer):
         """Commands to execute processes in CDF."""
         if ctx.parent is None or ctx.parent.info_name != "dev":
             RunApp._print_deprecation_warning()
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf run --help[/] for more information.")
+        print_help_if_no_subcommand(ctx)
 
     @staticmethod
     def run_transformation(
@@ -131,8 +132,7 @@ class RunFunctionApp(typer.Typer):
     @staticmethod
     def main(ctx: typer.Context) -> None:
         """Commands to execute function."""
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf run function --help[/] for more information.")
+        print_help_if_no_subcommand(ctx)
 
     @staticmethod
     def run_local(

--- a/cognite_toolkit/_cdf_tk/apps/_upload_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_upload_app.py
@@ -10,6 +10,8 @@ from cognite_toolkit._cdf_tk.constants import DATA_DEFAULT_DIR, DATA_MANIFEST_SU
 from cognite_toolkit._cdf_tk.feature_flags import Flags
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 
+from ._helpers import print_help_if_no_subcommand
+
 DEFAULT_INPUT_DIR = Path.cwd() / DATA_DEFAULT_DIR
 
 
@@ -22,9 +24,7 @@ class UploadApp(typer.Typer):
     @staticmethod
     def upload_main(ctx: typer.Context) -> None:
         """Commands to upload data to CDF."""
-        if ctx.invoked_subcommand is None:
-            print("Use [bold yellow]cdf upload --help[/] for more information.")
-        return None
+        print_help_if_no_subcommand(ctx)
 
     @staticmethod
     def upload_dir(

--- a/tests/test_unit/test_cdf_tk/test_apps/test_group_help.py
+++ b/tests/test_unit/test_cdf_tk/test_apps/test_group_help.py
@@ -1,0 +1,27 @@
+import pytest
+from typer.testing import CliRunner
+
+from cognite_toolkit._cdf_tk.apps import AuthApp, CoreApp, DumpApp, ModulesApp
+
+
+class TestGroupHelp:
+    @pytest.mark.parametrize(
+        "app_cls, expected_fragment",
+        [
+            (DumpApp, "datamodel"),
+            (AuthApp, "init"),
+            (ModulesApp, "init"),
+        ],
+    )
+    def test_group_without_subcommand_prints_help(self, app_cls: type, expected_fragment: str) -> None:
+        result = CliRunner().invoke(app_cls(), [])
+
+        assert result.exit_code == 0
+        assert expected_fragment in result.output
+        assert "for more information" not in result.output
+
+    def test_root_without_subcommand_still_shows_getting_started(self) -> None:
+        result = CliRunner().invoke(CoreApp(), [])
+
+        assert result.exit_code == 0
+        assert "Getting started" in result.output


### PR DESCRIPTION
# Description

Fixed a minor nuisance: When users run a group command without a subcommand (e.g. `cdf dump`), the CLI now prints the full help text immediately instead of `Use cdf dump --help for more information.`

Before: 
<img width="571" height="49" alt="Screenshot 2026-08-14 at 10 00 08" src="https://github.com/user-attachments/assets/dc0f0ede-f213-4e45-bc69-1980ab96b792" />


After:
<img width="571" height="620" alt="Screenshot 2026-08-14 at 13 19 58" src="https://github.com/user-attachments/assets/9c0ab3af-0e22-47c8-b478-1562996ff21e" />


The root `cdf` command still shows the Getting started panel.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Improved

- CLI group commands now show full help when invoked without a subcommand