### PR TITLE
Clarify charts migration logs for unmigrated timeseries

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -521,8 +521,8 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
                 log_entries.append(
                     MigrationEntryV2(
                         id=identifier,
-                        label="Missing timeseries IDs",
-                        message="One or more timeseries are missing internal IDs",
+                        label="Missing CogniteTimeSeries for ID",
+                        message="No migrated instance found for classic timeseries internal ID(s)",
                         severity=Severity.warning,
                         source=chart_src,
                         destination=chart_dest,
@@ -534,8 +534,8 @@ class ChartMapper(DataMapper[ChartSelector, ChartResponse, ChartRequest]):
                 log_entries.append(
                     MigrationEntryV2(
                         id=identifier,
-                        label="Missing timeseries external IDs",
-                        message="One or more timeseries are missing external IDs",
+                        label="Missing CogniteTimeSeries for external ID",
+                        message="No migrated instance found for classic timeseries external ID(s)",
                         severity=Severity.warning,
                         source=chart_src,
                         destination=chart_dest,


### PR DESCRIPTION
# Description

Charts migration logs said "Missing timeseries IDs" when a classic timeseries had no migrated CogniteTimeSeries instance. That read as if the timeseries lacked an ID. Relabel for this as well as the externalId to make the actual failure obvious.

## Bump

- [ ] Patch
- [x] Skip