### PR TITLE
[CDF-28474] Improvements to migration / download log flushing and producer-worker progress bar UX

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -192,7 +192,7 @@ class MigrationCommand(ToolkitCommand):
             else:
                 executor.raise_on_error()
 
-            action = "Would migrate" if dry_run else "Migrated"
+            action = "Would have migrated" if dry_run else "Migrated"
             target = "records" if isinstance(data, RecordsMigrationIO) else "instances"
             # Here we use logger totals instead of the actual number of downladed items. For some selectors,
             # download pages can include auxiliary edges that are, for example, converted to direct relations

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -173,6 +173,7 @@ class MigrationCommand(ToolkitCommand):
                 logger.force_write()
 
             items_results = logger.finalize(dry_run)
+            logger.force_write()
             results_by_selector[str(selected)] = items_results
 
             display_item_results(items_results, title=f"Finished {selected.display_name}", console=console)

--- a/cognite_toolkit/_cdf_tk/dataio/logger.py
+++ b/cognite_toolkit/_cdf_tk/dataio/logger.py
@@ -1,3 +1,4 @@
+import time
 from abc import ABC, abstractmethod
 from collections import Counter
 from collections.abc import Sequence
@@ -112,12 +113,14 @@ class ItemsResult:
 
 class FileWithAggregationLogger(DataLogger):
     BATCH_SIZE: int = 1000
+    FLUSH_INTERVAL_SECONDS: float = 30.0
     NO_WARNINGS: int = 0
 
     def __init__(self, writer: NDJsonWriter) -> None:
         self._writer = writer
         self._lock = Lock()
         self._batch: list[LogEntryV2] = []
+        self._last_flush = time.monotonic()
         self.aggregations_by_ids: dict[str, list[LogAggregation]] = {}
 
     @property
@@ -173,7 +176,9 @@ class FileWithAggregationLogger(DataLogger):
         entries = list(entry) if isinstance(entry, Sequence) else [entry]
         self._update_aggregation_unlocked(entries)
         self._batch.extend(entries)
-        if len(self._batch) >= self.BATCH_SIZE:
+        if len(self._batch) >= self.BATCH_SIZE or (
+            self._batch and time.monotonic() - self._last_flush >= self.FLUSH_INTERVAL_SECONDS
+        ):
             self._write_to_file_unlocked()
 
     def log(self, entry: LogEntryV2 | Sequence[LogEntryV2]) -> None:
@@ -185,6 +190,8 @@ class FileWithAggregationLogger(DataLogger):
         if self._batch:
             self._writer.write_chunks([e.model_dump(by_alias=True, mode="json") for e in self._batch])
             self._batch.clear()
+        self._writer.flush()
+        self._last_flush = time.monotonic()
 
     def _write_to_file(self) -> None:
         with self._lock:

--- a/cognite_toolkit/_cdf_tk/dataio/selectors/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/selectors/_instances.py
@@ -83,9 +83,10 @@ class InstanceViewSelector(InstanceSelector):
 
     @property
     def display_name(self) -> str:
-        message = f"{self.instance_type}s in view {self.view!s}"
+        message = f"{self.instance_type}s from view {self.view!s}"
         if self.instance_spaces:
-            message += f" with {humanize_collection(self.instance_spaces)} instance spaces"
+            space_label = "instance space" if len(self.instance_spaces) == 1 else "instance spaces"
+            message += f" in {space_label} {humanize_collection(self.instance_spaces)}"
         return message
 
 

--- a/cognite_toolkit/_cdf_tk/utils/fileio/_writers.py
+++ b/cognite_toolkit/_cdf_tk/utils/fileio/_writers.py
@@ -115,12 +115,6 @@ class FileWriter(FileIO, ABC, Generic[T_IO]):
             self._file_count_by_filename.clear()
             return None
 
-    def flush(self) -> None:
-        """Flush all open file handles to disk."""
-        with self._lock:
-            for writer in self._writer_by_filepath.values():
-                writer.flush()
-
     def _is_above_file_size_limit(self, filepath: Path, writer: T_IO) -> bool:
         """Check if the file size is above the limit."""
         try:
@@ -194,6 +188,12 @@ class NDJsonWriter(FileWriter[TextIOWrapper]):
         writer.writelines(
             f"{json.dumps(chunk, cls=self._DateTimeEncoder)}{self.compression_cls.newline}" for chunk in chunks
         )
+
+    def flush(self) -> None:
+        """Flush all open file handles to disk."""
+        with self._lock:
+            for writer in self._writer_by_filepath.values():
+                writer.flush()
 
 
 class YAMLBaseWriter(FileWriter[TextIOWrapper], ABC):

--- a/cognite_toolkit/_cdf_tk/utils/fileio/_writers.py
+++ b/cognite_toolkit/_cdf_tk/utils/fileio/_writers.py
@@ -115,6 +115,12 @@ class FileWriter(FileIO, ABC, Generic[T_IO]):
             self._file_count_by_filename.clear()
             return None
 
+    def flush(self) -> None:
+        """Flush all open file handles to disk."""
+        with self._lock:
+            for writer in self._writer_by_filepath.values():
+                writer.flush()
+
     def _is_above_file_size_limit(self, filepath: Path, writer: T_IO) -> bool:
         """Check if the file size is above the limit."""
         try:

--- a/cognite_toolkit/_cdf_tk/utils/producer_worker.py
+++ b/cognite_toolkit/_cdf_tk/utils/producer_worker.py
@@ -183,9 +183,7 @@ class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
         """
         self.console.print()
         columns = self._get_progress_columns()
-        with ProgressWithFooter(
-            *columns, console=self.console, expand=True, footer="Press 'q' to stop."
-        ) as progress:
+        with ProgressWithFooter(*columns, console=self.console, expand=True, footer="Press 'q' to stop.") as progress:
             task_args: dict[str, Any] = (
                 {"item_count": start_item, "total": None}
                 if self.total_item_count is None

--- a/cognite_toolkit/_cdf_tk/utils/producer_worker.py
+++ b/cognite_toolkit/_cdf_tk/utils/producer_worker.py
@@ -7,7 +7,7 @@ import typing
 from collections.abc import Callable, Iterable, Sized
 from typing import Any, Generic, TypeVar
 
-from rich.console import Console
+from rich.console import Console, RenderableType
 from rich.markup import escape
 from rich.panel import Panel
 from rich.progress import (
@@ -22,6 +22,8 @@ from rich.progress import (
     TimeElapsedColumn,
     TimeRemainingColumn,
 )
+from rich.table import Column
+from rich.text import Text
 
 from cognite_toolkit._cdf_tk.exceptions import ToolkitRepeatedUploadFailureError, ToolkitRuntimeError
 
@@ -37,6 +39,17 @@ WRITE_FINISH_SENTINEL = object()
 class ItemCountColumn(ProgressColumn):
     def render(self, task: Task) -> str:
         return f"[green]{int(task.fields.get('item_count', 0)):,} items"
+
+
+class ProgressWithFooter(Progress):
+    def __init__(self, *args: Any, footer: str = "", **kwargs: Any) -> None:
+        self.footer = footer
+        super().__init__(*args, **kwargs)
+
+    def get_renderables(self) -> Iterable[RenderableType]:
+        yield from super().get_renderables()
+        if self.footer:
+            yield Text(self.footer, style="blue")
 
 
 class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
@@ -126,16 +139,20 @@ class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
 
     def _get_progress_columns(self) -> list[ProgressColumn]:
         """Helper to set up the progress bar and tasks based on iteration_count."""
+        description = TextColumn(
+            "[bold blue]{task.description}",
+            table_column=Column(no_wrap=True, overflow="ellipsis", ratio=1),
+        )
         if self.total_item_count is None:
             return [
                 SpinnerColumn(),
-                TextColumn("[bold blue]{task.description}"),
+                description,
                 ItemCountColumn(),
                 TimeElapsedColumn(),
             ]
         else:
             return [
-                TextColumn("[bold blue]{task.description}"),
+                description,
                 BarColumn(),
                 TaskProgressColumn(),
                 TimeRemainingColumn(),
@@ -164,9 +181,11 @@ class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
         Args:
             start_item (int): The initial item count to start the progress from, used for resuming operations.
         """
-        self.console.print(f"[blue]Starting {self.download_description} (Press 'q' to stop)...[/blue]")
+        self.console.print()
         columns = self._get_progress_columns()
-        with Progress(*columns, console=self.console) as progress:
+        with ProgressWithFooter(
+            *columns, console=self.console, expand=True, footer="Press 'q' to stop."
+        ) as progress:
             task_args: dict[str, Any] = (
                 {"item_count": start_item, "total": None}
                 if self.total_item_count is None
@@ -200,6 +219,8 @@ class ProducerWorkerExecutor(Generic[T_Download, T_Processed]):
             for t in [download_thread, process_thread, write_thread, input_thread]:
                 if t.is_alive():
                     t.join()
+            progress.footer = ""
+            progress.refresh()
 
     def raise_on_error(self) -> None:
         """Raises an exception if an error occurred during execution."""

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_logger.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_logger.py
@@ -1,6 +1,8 @@
 from collections import Counter
 from unittest.mock import MagicMock
 
+import pytest
+
 from cognite_toolkit._cdf_tk.dataio.logger import (
     FileWithAggregationLogger,
     ItemsResult,
@@ -10,6 +12,14 @@ from cognite_toolkit._cdf_tk.dataio.logger import (
     display_item_results,
 )
 from cognite_toolkit._cdf_tk.utils.fileio import NDJsonWriter
+
+
+class FakeMonotonic:
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def __call__(self) -> float:
+        return self.value
 
 
 class TestFileWithAggregationLogger:
@@ -44,6 +54,35 @@ class TestFileWithAggregationLogger:
 
         # Just to ensure that no exception is raised.
         display_item_results(results, "Title", MagicMock())
+
+    def test_force_write_flushes_batch_below_size(self) -> None:
+        writer = MagicMock(spec=NDJsonWriter)
+        logger = FileWithAggregationLogger(writer)
+        logger.register(["item1"])
+        logger.log(LogEntryV2(id="item1", severity=Severity.warning, label="x", message="m"))
+
+        writer.write_chunks.assert_not_called()
+
+        logger.force_write()
+
+        writer.write_chunks.assert_called_once()
+        writer.flush.assert_called()
+
+    def test_flushes_batch_after_interval(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        clock = FakeMonotonic()
+        monkeypatch.setattr("cognite_toolkit._cdf_tk.dataio.logger.time.monotonic", clock)
+        writer = MagicMock(spec=NDJsonWriter)
+        logger = FileWithAggregationLogger(writer)
+        logger.register(["item1", "item2"])
+        logger.log(LogEntryV2(id="item1", severity=Severity.warning, label="x", message="m"))
+
+        writer.write_chunks.assert_not_called()
+
+        clock.value = FileWithAggregationLogger.FLUSH_INTERVAL_SECONDS
+        logger.log(LogEntryV2(id="item2", severity=Severity.warning, label="x", message="m"))
+
+        writer.write_chunks.assert_called_once()
+        writer.flush.assert_called()
 
     def _simulate_log_entries(self, logger: FileWithAggregationLogger) -> None:
         logger.register(["item_success", "item_failure", "item_warning1", "item_warning2"])

--- a/tests/test_unit/test_cdf_tk/test_utils/test_fileio.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_fileio.py
@@ -179,6 +179,14 @@ class TestFileWriter:
             FileWriter.create_from_format("unknown_format", Path("."), "DummyKind", Uncompressed)
         assert str(excinfo.value).startswith("Unknown file format: unknown_format. Available formats: ")
 
+    def test_flush_makes_writes_visible_before_close(self, tmp_path: Path) -> None:
+        writer = NDJsonWriter(tmp_path, "test", Uncompressed)
+        with writer:
+            writer.write_chunks([{"id": "visible"}])
+            writer.flush()
+            written_file = next(tmp_path.glob("*.ndjson"))
+            assert json.loads(written_file.read_text(encoding="utf-8-sig")) == {"id": "visible"}
+
 
 class TestFileWriterThreadSafety:
     """Test thread safety of FileWriter implementations."""


### PR DESCRIPTION
# Description

Fixes a few issues with observability in migration and download processes:

Migration issue logs (`*MigrationIssues.ndjson`) were buffered in memory until 1000 entries or the entire migration command exited, so a long view with few issues showed nothing on disk until migrate finished, and multiple views could get processed without any issues reported. Issues are now written after each step, every 30 seconds while they are being logged, as well as ensuring that the file handle is flushed so the lines are visible immediately.

Producer-worker progress bars (migrate, download, upload, purge) wrapped badly when the task description includes a view ID and instance space. The description column now ellipsizes at smaller sizes instead of wrapping. Also removed the duplicated / awkwardly phrased "Starting Downloading..." text and changed it to simply "Press 'q' to stop" and moved it such that it is a footer under the bar rather than a line printed before it. The removed text content was duplicated from the download progress tracker, so this cleans it up a bit. Finally, changed some grammar to flow a bit better.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Improved

- Progress bars with long descriptions (for example view IDs and instance spaces) ellipsize instead of wrapping.

### Fixed

- [alpha] Migration issue logs now write to disk after at least every 30 seconds, such that they are visible earlier.