### PR TITLE
(fix): cdf modules add command -d flag multiple package error fix 🛠️

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_modules_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_modules_app.py
@@ -148,7 +148,11 @@ class ModulesApp(typer.Typer):
             typer.Option(
                 "--deployment-pack",
                 "-d",
-                help="Name of a specific module to download and install from the library without interactive prompts.",
+                help=(
+                    "Name of a specific package or module to download and install from the library "
+                    "without interactive prompts. If a module name exists in more than one package, "
+                    "use the '<package>:<module>' syntax to disambiguate, for example 'contextualization:cdf_entity_matching'."
+                ),
             ),
         ] = None,
         verbose: Annotated[

--- a/cognite_toolkit/_cdf_tk/apps/_modules_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_modules_app.py
@@ -151,7 +151,8 @@ class ModulesApp(typer.Typer):
                 help=(
                     "Name of a specific package or module to download and install from the library "
                     "without interactive prompts. If a module name exists in more than one package, "
-                    "use the '<package>:<module>' syntax to disambiguate, for example 'contextualization:cdf_entity_matching'."
+                    "use the '<package>:<module>' syntax to disambiguate, "
+                    "for example 'contextualization:cdf_entity_matching'."
                 ),
             ),
         ] = None,

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -620,6 +620,14 @@ class ModulesCommand(ToolkitCommand):
         """
         Find a module in a specific package using the '<package>:<module>' syntax and
         return it as a Packages selection.
+
+        Args:
+            packages (Packages): Available packages
+            package_and_module (str): Package and module name
+            existing (set[str]): Installed module names
+
+        Returns:
+            Packages: Selected package and module
         """
         package_part, _, module_part = package_and_module.partition(":")
         if not package_part or not module_part:

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -536,8 +536,15 @@ class ModulesCommand(ToolkitCommand):
         """
         Find a package or module by name and return it as a Packages selection.
         Raises ToolkitError if nothing is found or every matched module is already installed.
+
+        The module_name may use the '<package>:<module>' syntax to disambiguate a module
+        that exists in more than one package.
         """
         existing = set(existing_module_names)
+
+        if ":" in module_name:
+            return self._find_and_select_module_in_package(packages, module_name, existing)
+
         name_lower = module_name.casefold()
 
         by_package = {name.casefold(): pkg for name, pkg in packages.items()}
@@ -569,9 +576,10 @@ class ModulesCommand(ToolkitCommand):
             matches = by_module[name_lower]
             if len(matches) > 1:
                 pkg_names = ", ".join(f"'{pkg.name}'" for pkg, _ in matches)
+                examples = ", ".join(f"'{pkg.name}:{module_name}'" for pkg, _ in matches)
                 raise ToolkitError(
                     f"Module '{module_name}' exists in multiple packages: {pkg_names}. "
-                    f"Use the full package name instead."
+                    f"Use the '<package>:<module>' syntax to disambiguate, for example {examples}."
                 )
             found_package, found_module = matches[0]
             if found_module.name in existing:
@@ -594,6 +602,43 @@ class ModulesCommand(ToolkitCommand):
         raise ToolkitError(
             f"'{module_name}' not found as a package name or module name in any cherry-pickable package."
         )
+
+    @staticmethod
+    def _find_and_select_module_in_package(
+        packages: Packages,
+        package_and_module: str,
+        existing: set[str],
+    ) -> Packages:
+        """
+        Find a module in a specific package using the '<package>:<module>' syntax and
+        return it as a Packages selection.
+        """
+        package_part, _, module_part = package_and_module.partition(":")
+        if not package_part or not module_part:
+            raise ToolkitError(f"Invalid syntax '{package_and_module}'. Expected format '<package>:<module>'.")
+
+        by_package = {name.casefold(): pkg for name, pkg in packages.items()}
+        package = by_package.get(package_part.casefold())
+        if package is None:
+            raise ToolkitError(f"Package '{package_part}' not found.")
+
+        module_lower = module_part.casefold()
+        module = next((m for m in package.modules if m.name.casefold() == module_lower), None)
+        if module is None:
+            raise ToolkitError(f"Module '{module_part}' not found in package '{package.name}'.")
+
+        if module.name in existing:
+            raise ToolkitError(f"Module '{module.name}' is already installed in this project.")
+
+        print(f"[green]Selected module '{module.name}' from package '{package.name}'.[/]")
+        selected = Packages()
+        selected[package.name] = Package(
+            name=package.name,
+            title=package.title,
+            description=package.description,
+            modules=[module],
+        )
+        return selected
 
     @staticmethod
     def _verify_clean(modules_root_dir: Path, clean: bool) -> Literal["new", "clean"]:

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -539,6 +539,14 @@ class ModulesCommand(ToolkitCommand):
 
         The module_name may use the '<package>:<module>' syntax to disambiguate a module
         that exists in more than one package.
+
+        Args:
+            packages (Packages): Available packages
+            module_name (str): Module name or package name
+            existing_module_names (list[str]): Already installed module names
+
+        Returns:
+            Packages: Selected package and module(s)
         """
         existing = set(existing_module_names)
 

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -629,6 +629,11 @@ class ModulesCommand(ToolkitCommand):
         Returns:
             Packages: Selected package and module
         """
+        if package_and_module.count(":") != 1:
+            raise ToolkitError(
+                f"Invalid syntax '{package_and_module}'. Expected exactly one ':' separating "
+                f"'<package>:<module>', found {package_and_module.count(':')}."
+            )
         package_part, _, module_part = package_and_module.partition(":")
         if not package_part or not module_part:
             raise ToolkitError(f"Invalid syntax '{package_and_module}'. Expected format '<package>:<module>'.")
@@ -636,14 +641,19 @@ class ModulesCommand(ToolkitCommand):
         by_package = {name.casefold(): pkg for name, pkg in packages.items()}
         package = by_package.get(package_part.casefold())
         if package is None:
-            raise ToolkitError(f"Package '{package_part}' not found.")
+            close = difflib.get_close_matches(package_part.casefold(), list(by_package), n=1)
+            suggestion = f" Did you mean '{by_package[close[0]].name}'?" if close else ""
+            raise ToolkitError(f"Package '{package_part}' not found.{suggestion}")
         if not package.can_cherry_pick:
             raise ToolkitError(f"Package '{package.name}' does not support cherry-picking individual modules.")
 
         module_lower = module_part.casefold()
-        module = next((m for m in package.modules if m.name.casefold() == module_lower), None)
+        by_package_module = {m.name.casefold(): m for m in package.modules}
+        module = by_package_module.get(module_lower)
         if module is None:
-            raise ToolkitError(f"Module '{module_part}' not found in package '{package.name}'.")
+            close = difflib.get_close_matches(module_lower, list(by_package_module), n=1)
+            suggestion = f" Did you mean '{by_package_module[close[0]].name}'?" if close else ""
+            raise ToolkitError(f"Module '{module_part}' not found in package '{package.name}'.{suggestion}")
 
         if module.name in existing:
             raise ToolkitError(f"Module '{module.name}' is already installed in this project.")

--- a/cognite_toolkit/_cdf_tk/commands/modules.py
+++ b/cognite_toolkit/_cdf_tk/commands/modules.py
@@ -621,6 +621,8 @@ class ModulesCommand(ToolkitCommand):
         package = by_package.get(package_part.casefold())
         if package is None:
             raise ToolkitError(f"Package '{package_part}' not found.")
+        if not package.can_cherry_pick:
+            raise ToolkitError(f"Package '{package.name}' does not support cherry-picking individual modules.")
 
         module_lower = module_part.casefold()
         module = next((m for m in package.modules if m.name.casefold() == module_lower), None)

--- a/tests/test_unit/test_cdf_tk/test_commands/test_modules.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_modules.py
@@ -490,6 +490,9 @@ class TestModulesCommand:
             ("cherry_pkg:", [], "Invalid syntax"),  # missing module part
             (":mod_a", [], "Invalid syntax"),  # missing package part
             ("fixed_pkg:mod_locked", [], "does not support cherry-picking"),  # non-cherry-pickable package
+            ("dp:contextualization:cdf_entity_matching", [], "Invalid syntax"),  # more than one ':'
+            ("cherry_pk:mod_a", [], "Did you mean 'cherry_pkg'"),  # package typo, close match suggested
+            ("cherry_pkg:mod_bb", [], "Did you mean 'mod_b'"),  # module typo, close match suggested
         ],
     )
     def test_find_and_select_module_errors(

--- a/tests/test_unit/test_cdf_tk/test_commands/test_modules.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_modules.py
@@ -489,6 +489,7 @@ class TestModulesCommand:
             ("cherry_pkg:no_such_mod", [], "Module 'no_such_mod' not found in package 'cherry_pkg'"),
             ("cherry_pkg:", [], "Invalid syntax"),  # missing module part
             (":mod_a", [], "Invalid syntax"),  # missing package part
+            ("fixed_pkg:mod_locked", [], "does not support cherry-picking"),  # non-cherry-pickable package
         ],
     )
     def test_find_and_select_module_errors(
@@ -615,3 +616,17 @@ class TestModulesCommand:
 
         with pytest.raises(ToolkitError, match="Module 'no_such_mod' not found in package 'cherry_pkg'"):
             cmd.add(my_org, deployment_pack="cherry_pkg:no_such_mod")
+
+    def test_add_with_deployment_pack_non_cherry_pickable_package_raises(
+        self, lookup_packages: Packages, tmp_path: Path, monkeypatch: MonkeyPatch
+    ) -> None:
+        my_org = tmp_path / "my_org"
+        stub_file = my_org / "modules" / "stub" / "data_models" / "stub.Space.yaml"
+        stub_file.parent.mkdir(parents=True, exist_ok=True)
+        stub_file.write_text("space: stub_space")
+
+        cmd = ModulesCommand(print_warning=False, skip_tracking=True, module_source_dir=COMPLETE_ORG_MODULES)
+        monkeypatch.setattr(cmd, "_get_available_packages", lambda: (lookup_packages, COMPLETE_ORG_MODULES))
+
+        with pytest.raises(ToolkitError, match="does not support cherry-picking"):
+            cmd.add(my_org, deployment_pack="fixed_pkg:mod_locked")

--- a/tests/test_unit/test_cdf_tk/test_commands/test_modules.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_modules.py
@@ -456,6 +456,9 @@ class TestModulesCommand:
             ("mod_a", "cherry_pkg", {"mod_a"}),
             ("MOD_A", "cherry_pkg", {"mod_a"}),
             ("mod_c", "other_cherry_pkg", {"mod_c"}),
+            ("cherry_pkg:mod_b", "cherry_pkg", {"mod_b"}),
+            ("other_cherry_pkg:mod_b", "other_cherry_pkg", {"mod_b"}),
+            ("CHERRY_PKG:MOD_B", "cherry_pkg", {"mod_b"}),
         ],
     )
     def test_find_and_select_module_lookup(
@@ -481,6 +484,11 @@ class TestModulesCommand:
             ("mod_b", [], "multiple packages"),  # ambiguous: exists in cherry_pkg and other_cherry_pkg
             ("cherry_pk", [], "Did you mean"),  # typo
             ("zzz_completely_unrelated_xyz", [], "not found"),
+            ("cherry_pkg:mod_b", ["mod_b"], "already installed"),
+            ("no_such_pkg:mod_a", [], "Package 'no_such_pkg' not found"),  # unknown package prefix
+            ("cherry_pkg:no_such_mod", [], "Module 'no_such_mod' not found in package 'cherry_pkg'"),
+            ("cherry_pkg:", [], "Invalid syntax"),  # missing module part
+            (":mod_a", [], "Invalid syntax"),  # missing package part
         ],
     )
     def test_find_and_select_module_errors(
@@ -528,3 +536,82 @@ class TestModulesCommand:
 
         with pytest.raises(ToolkitError, match="not found"):
             cmd.add(my_org, deployment_pack="nonexistent_module")
+
+    def test_add_with_deployment_pack_ambiguous_module_raises(
+        self, lookup_packages: Packages, tmp_path: Path, monkeypatch: MonkeyPatch
+    ) -> None:
+        my_org = tmp_path / "my_org"
+        stub_file = my_org / "modules" / "stub" / "data_models" / "stub.Space.yaml"
+        stub_file.parent.mkdir(parents=True, exist_ok=True)
+        stub_file.write_text("space: stub_space")
+
+        cmd = ModulesCommand(print_warning=False, skip_tracking=True, module_source_dir=COMPLETE_ORG_MODULES)
+        monkeypatch.setattr(cmd, "_get_available_packages", lambda: (lookup_packages, COMPLETE_ORG_MODULES))
+
+        with pytest.raises(ToolkitError, match="multiple packages"):
+            cmd.add(my_org, deployment_pack="mod_b")
+
+    @pytest.mark.parametrize(
+        "deployment_pack, expected_pkg",
+        [
+            ("cherry_pkg:mod_b", "cherry_pkg"),
+            ("other_cherry_pkg:mod_b", "other_cherry_pkg"),
+        ],
+    )
+    def test_add_with_deployment_pack_package_prefix_disambiguates(
+        self,
+        lookup_packages: Packages,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+        deployment_pack: str,
+        expected_pkg: str,
+    ) -> None:
+        my_org = tmp_path / "my_org"
+        stub_file = my_org / "modules" / "stub" / "data_models" / "stub.Space.yaml"
+        stub_file.parent.mkdir(parents=True, exist_ok=True)
+        stub_file.write_text("space: stub_space")
+
+        cmd = ModulesCommand(print_warning=False, skip_tracking=True, module_source_dir=COMPLETE_ORG_MODULES)
+        monkeypatch.setattr(cmd, "_get_available_packages", lambda: (lookup_packages, COMPLETE_ORG_MODULES))
+        monkeypatch.setattr(cmd, "_get_download_data", lambda _: False)
+
+        captured: dict = {}
+
+        def capture_create(**kwargs: object) -> None:
+            captured.update(kwargs)
+
+        monkeypatch.setattr(cmd, "_create", capture_create)
+        cmd.add(my_org, deployment_pack=deployment_pack)
+
+        assert "selected_packages" in captured, "_create was not called"
+        assert expected_pkg in captured["selected_packages"]
+        assert len(captured["selected_packages"][expected_pkg].modules) == 1
+        assert captured["selected_packages"][expected_pkg].modules[0].name == "mod_b"
+
+    def test_add_with_deployment_pack_invalid_package_prefix_raises(
+        self, lookup_packages: Packages, tmp_path: Path, monkeypatch: MonkeyPatch
+    ) -> None:
+        my_org = tmp_path / "my_org"
+        stub_file = my_org / "modules" / "stub" / "data_models" / "stub.Space.yaml"
+        stub_file.parent.mkdir(parents=True, exist_ok=True)
+        stub_file.write_text("space: stub_space")
+
+        cmd = ModulesCommand(print_warning=False, skip_tracking=True, module_source_dir=COMPLETE_ORG_MODULES)
+        monkeypatch.setattr(cmd, "_get_available_packages", lambda: (lookup_packages, COMPLETE_ORG_MODULES))
+
+        with pytest.raises(ToolkitError, match="Package 'no_such_pkg' not found"):
+            cmd.add(my_org, deployment_pack="no_such_pkg:mod_a")
+
+    def test_add_with_deployment_pack_invalid_module_in_package_raises(
+        self, lookup_packages: Packages, tmp_path: Path, monkeypatch: MonkeyPatch
+    ) -> None:
+        my_org = tmp_path / "my_org"
+        stub_file = my_org / "modules" / "stub" / "data_models" / "stub.Space.yaml"
+        stub_file.parent.mkdir(parents=True, exist_ok=True)
+        stub_file.write_text("space: stub_space")
+
+        cmd = ModulesCommand(print_warning=False, skip_tracking=True, module_source_dir=COMPLETE_ORG_MODULES)
+        monkeypatch.setattr(cmd, "_get_available_packages", lambda: (lookup_packages, COMPLETE_ORG_MODULES))
+
+        with pytest.raises(ToolkitError, match="Module 'no_such_mod' not found in package 'cherry_pkg'"):
+            cmd.add(my_org, deployment_pack="cherry_pkg:no_such_mod")

--- a/tests/test_unit/test_cdf_tk/test_commands/test_modules.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_modules.py
@@ -538,34 +538,8 @@ class TestModulesCommand:
         with pytest.raises(ToolkitError, match="not found"):
             cmd.add(my_org, deployment_pack="nonexistent_module")
 
-    def test_add_with_deployment_pack_ambiguous_module_raises(
-        self, lookup_packages: Packages, tmp_path: Path, monkeypatch: MonkeyPatch
-    ) -> None:
-        my_org = tmp_path / "my_org"
-        stub_file = my_org / "modules" / "stub" / "data_models" / "stub.Space.yaml"
-        stub_file.parent.mkdir(parents=True, exist_ok=True)
-        stub_file.write_text("space: stub_space")
-
-        cmd = ModulesCommand(print_warning=False, skip_tracking=True, module_source_dir=COMPLETE_ORG_MODULES)
-        monkeypatch.setattr(cmd, "_get_available_packages", lambda: (lookup_packages, COMPLETE_ORG_MODULES))
-
-        with pytest.raises(ToolkitError, match="multiple packages"):
-            cmd.add(my_org, deployment_pack="mod_b")
-
-    @pytest.mark.parametrize(
-        "deployment_pack, expected_pkg",
-        [
-            ("cherry_pkg:mod_b", "cherry_pkg"),
-            ("other_cherry_pkg:mod_b", "other_cherry_pkg"),
-        ],
-    )
     def test_add_with_deployment_pack_package_prefix_disambiguates(
-        self,
-        lookup_packages: Packages,
-        tmp_path: Path,
-        monkeypatch: MonkeyPatch,
-        deployment_pack: str,
-        expected_pkg: str,
+        self, lookup_packages: Packages, tmp_path: Path, monkeypatch: MonkeyPatch
     ) -> None:
         my_org = tmp_path / "my_org"
         stub_file = my_org / "modules" / "stub" / "data_models" / "stub.Space.yaml"
@@ -582,51 +556,9 @@ class TestModulesCommand:
             captured.update(kwargs)
 
         monkeypatch.setattr(cmd, "_create", capture_create)
-        cmd.add(my_org, deployment_pack=deployment_pack)
+        cmd.add(my_org, deployment_pack="other_cherry_pkg:mod_b")
 
         assert "selected_packages" in captured, "_create was not called"
-        assert expected_pkg in captured["selected_packages"]
-        assert len(captured["selected_packages"][expected_pkg].modules) == 1
-        assert captured["selected_packages"][expected_pkg].modules[0].name == "mod_b"
-
-    def test_add_with_deployment_pack_invalid_package_prefix_raises(
-        self, lookup_packages: Packages, tmp_path: Path, monkeypatch: MonkeyPatch
-    ) -> None:
-        my_org = tmp_path / "my_org"
-        stub_file = my_org / "modules" / "stub" / "data_models" / "stub.Space.yaml"
-        stub_file.parent.mkdir(parents=True, exist_ok=True)
-        stub_file.write_text("space: stub_space")
-
-        cmd = ModulesCommand(print_warning=False, skip_tracking=True, module_source_dir=COMPLETE_ORG_MODULES)
-        monkeypatch.setattr(cmd, "_get_available_packages", lambda: (lookup_packages, COMPLETE_ORG_MODULES))
-
-        with pytest.raises(ToolkitError, match="Package 'no_such_pkg' not found"):
-            cmd.add(my_org, deployment_pack="no_such_pkg:mod_a")
-
-    def test_add_with_deployment_pack_invalid_module_in_package_raises(
-        self, lookup_packages: Packages, tmp_path: Path, monkeypatch: MonkeyPatch
-    ) -> None:
-        my_org = tmp_path / "my_org"
-        stub_file = my_org / "modules" / "stub" / "data_models" / "stub.Space.yaml"
-        stub_file.parent.mkdir(parents=True, exist_ok=True)
-        stub_file.write_text("space: stub_space")
-
-        cmd = ModulesCommand(print_warning=False, skip_tracking=True, module_source_dir=COMPLETE_ORG_MODULES)
-        monkeypatch.setattr(cmd, "_get_available_packages", lambda: (lookup_packages, COMPLETE_ORG_MODULES))
-
-        with pytest.raises(ToolkitError, match="Module 'no_such_mod' not found in package 'cherry_pkg'"):
-            cmd.add(my_org, deployment_pack="cherry_pkg:no_such_mod")
-
-    def test_add_with_deployment_pack_non_cherry_pickable_package_raises(
-        self, lookup_packages: Packages, tmp_path: Path, monkeypatch: MonkeyPatch
-    ) -> None:
-        my_org = tmp_path / "my_org"
-        stub_file = my_org / "modules" / "stub" / "data_models" / "stub.Space.yaml"
-        stub_file.parent.mkdir(parents=True, exist_ok=True)
-        stub_file.write_text("space: stub_space")
-
-        cmd = ModulesCommand(print_warning=False, skip_tracking=True, module_source_dir=COMPLETE_ORG_MODULES)
-        monkeypatch.setattr(cmd, "_get_available_packages", lambda: (lookup_packages, COMPLETE_ORG_MODULES))
-
-        with pytest.raises(ToolkitError, match="does not support cherry-picking"):
-            cmd.add(my_org, deployment_pack="fixed_pkg:mod_locked")
+        assert "other_cherry_pkg" in captured["selected_packages"]
+        assert len(captured["selected_packages"]["other_cherry_pkg"].modules) == 1
+        assert captured["selected_packages"]["other_cherry_pkg"].modules[0].name == "mod_b"


### PR DESCRIPTION
# Description

`cdf modules add -d <module>` now supports a `<package>:<module>` syntax to select a specific module when its name exists in more than one package.

- `cdf modules add -d <module>` — works as before when the module exists in exactly one package.
- `cdf modules add -d <package>:<module>` — installs that module from the specified package only.
- `cdf modules add -d <module>` (unprefixed, module exists in multiple packages) — fails with an error naming the conflicting packages and showing the exact `<package>:<module>` syntax to resolve it.
- `cdf modules add -d <package>:<module>` where the package doesn't exist, or exists but doesn't contain that module — fails with a specific error identifying which of the two is wrong.
- Whole-package selection (`cdf modules add -d <package>`) is unchanged.

This makes non-interactive module installation fully deterministic and scriptable, which is especially useful for AI agents driving the Toolkit CLI — they can now resolve and install any module in a single, unambiguous command without needing a human to interactively pick between conflicting packages.

Updated the `--help` text for `-d/--deployment-pack` to document the new syntax.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- `cdf modules add -d <package>:<module>` syntax to disambiguate and install a module that exists in more than one deployment package, enabling fully non-interactive installs (e.g. for AI agents) even in ambiguous cases.
