### PR TITLE
[CDF-28489] Fix ValidationError in charts migration for scheduled calculations with incomplete step inputs

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/chart_scheduled_calculation.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/chart_scheduled_calculation.py
@@ -19,8 +19,8 @@ DAY_MS = HOUR_MS * 24
 
 class CalculationInput(BaseModelObject):
     # The literal is to show typical values of type.
-    type: Literal["ts", "const", "result"] | str
-    value: str | float | int | NodeUntypedId | JsonValue
+    type: Literal["ts", "const", "result"] | str | None = None
+    value: str | float | int | NodeUntypedId | JsonValue | None = None
     param: JsonValue | None = None
 
 

--- a/tests/test_unit/test_cdf_tk/test_client/test_cdf_apis.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_cdf_apis.py
@@ -1181,6 +1181,25 @@ class TestCDFResourceAPI:
         assert len(listed) == 1
         assert listed[0].dump() == list_expected
 
+    def test_chart_scheduled_calculations_api_retrieve_incomplete_step_input(
+        self, toolkit_config: ToolkitClientConfig, respx_mock: respx.MockRouter
+    ) -> None:
+        """An input on a calculation step may only have "param" set, e.g. an incomplete PASSTHROUGH
+        (output) step that is not wired to a source."""
+        resource = get_example_minimum_responses(ChartScheduledCalculationResponse)
+        resource["graph"]["steps"][0]["inputs"] = [{"param": "series"}]
+        config = toolkit_config
+        api = ChartScheduledCalculationsAPI(HTTPClient(config))
+
+        respx_mock.post(config.create_api_url("/calculations/schedules/byids")).mock(
+            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+        )
+        retrieved = api.retrieve([ExternalId(external_id=resource["externalId"])])
+        assert len(retrieved) == 1
+        assert retrieved[0].graph.steps[0].inputs[0].param == "series"
+        assert retrieved[0].graph.steps[0].inputs[0].type is None
+        assert retrieved[0].graph.steps[0].inputs[0].value is None
+
     def test_alert_channels_api_list_method(
         self, toolkit_config: ToolkitClientConfig, respx_mock: respx.MockRouter
     ) -> None:


### PR DESCRIPTION
# Description

Toolkit's `CalculationInput` Pydantic model required `type` and `value` on every calculation graph step input, but according to the the Charts calculation backend's equivalent model, it only requires `param`. Step inputs left unwired in the UI (e.g. an incomplete `PASSTHROUGH`/output step) are stored as `{"param": "series"}`, which the stricter Toolkit model rejected with a Pydantic `ValidationError`, crashing the charts migration download step. This PR makes `type` and `value` optional to match the actual API contract.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- [alpha] Fix `cdf migrate charts` failing with ValidationError when downloading a chart whose scheduled calculation has an incomplete (unwired) calculation step input.