### PR TITLE
[CDF-28492] Suppress IgnoredFileWarning for function_config.yaml in function code folders

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/_module_parser.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/_module_parser.py
@@ -19,7 +19,7 @@ from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._module import (
     MisplacedModule,
     NonExistingModuleName,
 )
-from cognite_toolkit._cdf_tk.constants import EXCL_FILES, MODULES
+from cognite_toolkit._cdf_tk.constants import EXCL_FILES, MODULES, RESOURCE_FOLDERS_WITH_CODE_BUNDLES
 from cognite_toolkit._cdf_tk.resource_ios import CRUDS_BY_FOLDER_NAME_INCLUDE_ALPHA, ResourceTypes
 
 
@@ -104,6 +104,8 @@ class ModuleParser:
                 continue
             relative_module_path, resource_folder = cls._get_module_path_from_resource_file_path(yaml_file)
             if relative_module_path and resource_folder:
+                if cls._is_in_code_bundle_subdirectory(yaml_file, resource_folder):
+                    continue
                 if relative_module_path not in source_by_module_id:
                     source_by_module_id[relative_module_path] = ModuleSource(
                         path=organization_dir / relative_module_path,
@@ -116,6 +118,20 @@ class ModuleParser:
             else:
                 orphan_files.append(yaml_file)
         return source_by_module_id, orphan_files
+
+    @staticmethod
+    def _is_in_code_bundle_subdirectory(yaml_file: Path, resource_folder: ResourceTypes) -> bool:
+        """Return True when YAML lives inside a code-bundle subdirectory of a resource folder.
+
+        For example, ``function_config.yaml`` under ``functions/<externalId>/`` is function code,
+        not a CDF resource definition.
+        """
+        if resource_folder not in RESOURCE_FOLDERS_WITH_CODE_BUNDLES:
+            return False
+        for parent in yaml_file.parents:
+            if parent.name == resource_folder:
+                return yaml_file.parent != parent
+        return False
 
     @staticmethod
     def _get_module_path_from_resource_file_path(resource_file: Path) -> tuple[Path | None, ResourceTypes | None]:

--- a/cognite_toolkit/_cdf_tk/constants.py
+++ b/cognite_toolkit/_cdf_tk/constants.py
@@ -57,6 +57,9 @@ DEV_ONLY_MODULES = frozenset(["cdf_auth_readwrite_all"])
 DEFAULT_ENV = "dev"
 # Add any other files below that should be included in a build
 EXCL_FILES = ["README.md", DEFAULT_CONFIG_FILE]
+# Resource folders that ship code in subdirectories (e.g. functions/<externalId>/handler.py).
+# YAML files in those subdirectories are code artifacts, not CDF resource definitions.
+RESOURCE_FOLDERS_WITH_CODE_BUNDLES = frozenset({"functions", "apps", "streamlit"})
 # Files to search for variables.
 SEARCH_VARIABLES_SUFFIX = frozenset([".yaml", "yml", ".sql", ".csv"])
 YAML_SUFFIX = frozenset([".yaml", ".yml"])

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_module_parser.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_module_parser.py
@@ -51,6 +51,19 @@ class TestModuleSourceParser:
                 [],
                 id="Single module with multiple valid YAML files and one excluded file",
             ),
+            pytest.param(
+                [
+                    "modules/moduleA/functions/my_function.Function.yaml",
+                    "modules/moduleA/functions/my_function/function_config.yaml",
+                ],
+                {
+                    "modules/moduleA": {
+                        "functions": ["modules/moduleA/functions/my_function.Function.yaml"],
+                    },
+                },
+                [],
+                id="Function code folder YAML is not resource-classified",
+            ),
         ],
     )
     def test_find_modules(
@@ -182,6 +195,40 @@ class TestModuleSourceParser:
         assert actual_error_messages == error_messages
         actual_variables = {path.as_posix(): iteration_dict for path, iteration_dict in build_variables.items()}
         assert actual_variables == expected_variables
+
+
+class TestIsInCodeBundleSubdirectory:
+    @pytest.mark.parametrize(
+        "yaml_file, resource_folder, expected",
+        [
+            pytest.param(
+                Path("modules/moduleA/functions/my_function/function_config.yaml"),
+                "functions",
+                True,
+                id="function_config in function code folder",
+            ),
+            pytest.param(
+                Path("modules/moduleA/functions/my_function.Function.yaml"),
+                "functions",
+                False,
+                id="function resource definition",
+            ),
+            pytest.param(
+                Path("modules/moduleA/data_modeling/containers/my.Container.yaml"),
+                "data_modeling",
+                False,
+                id="data modeling subfolder is still a resource path",
+            ),
+            pytest.param(
+                Path("modules/moduleA/apps/my_app/config.yaml"),
+                "apps",
+                True,
+                id="yaml in app code folder",
+            ),
+        ],
+    )
+    def test_is_in_code_bundle_subdirectory(self, yaml_file: Path, resource_folder: str, expected: bool) -> None:
+        assert ModuleParser._is_in_code_bundle_subdirectory(yaml_file, resource_folder) is expected
 
 
 class TestGetModulePathFromResourceFilePath:


### PR DESCRIPTION
## Description
Build v2 was resource-classifying YAML files inside function/app/streamlit code subdirectories (e.g. `function_config.yaml`), emitting cosmetic `IgnoredFileWarning` on every build. Skip those paths during module discovery, matching deploy-time behavior in `FunctionIO`.
## Bump
- [x] Patch
- [ ] Skip
## Changelog
### Fixed
- Stop `IgnoredFileWarning` for YAML files shipped inside function, app, and streamlit code folders.