### PR TITLE
Remove unused cache-warming call in Image360FDMtoCDMMapper

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -2057,23 +2057,6 @@ class Image360FDMtoCDMMapper(FDMtoCDMMapper):
             custom_instance_mappings=custom_instance_mappings,
         )
 
-    def map(self, source: Sequence[DataItem[NodeOrEdgeResponse]]) -> Sequence[DataItem[NodeOrEdgeRequest]]:
-        self._populate_cache([data_item.item for data_item in source])
-        return super().map(source)
-
-    def _populate_cache(self, source: Sequence[NodeOrEdgeResponse]) -> None:
-        file_external_ids: list[str] = []
-        for item in source:
-            if not isinstance(item, NodeResponse):
-                continue
-            image_props = (item.properties or {}).get(LEGACY_IMAGE360_SOURCE_VIEW) or {}
-            for source_property in CUBEMAP_SOURCE_TO_DESTINATION_PROPERTY:
-                value = image_props.get(source_property)
-                if isinstance(value, str):
-                    file_external_ids.append(value)
-        if file_external_ids:
-            self.client.migration.lookup.files(external_id=file_external_ids)
-
     @staticmethod
     def missing_cubemap_face_file_external_ids(
         source_node: NodeResponse,


### PR DESCRIPTION
# Description

`Image360FDMtoCDMMapper._populate_cache` warmed the `InstanceSource`-based `client.migration.lookup.files` cache for cubemap face file external IDs, but nothing downstream ever read from that cache for file references — `ConnectionCreator` already resolves cubemap face files via a separate, already-batched `filemetadata.retrieve(...).instance_id` lookup. The removed code was added in #3108  by copying the `_populate_cache` pattern used by `ThreeDMapper`/`ThreeDAssetMapper`/`ChartMapper`, which resolve asset/timeseries/event references through `client.migration.lookup` and do benefit from that pattern, unlike file references here.

## Bump

- [ ] Patch
- [x] Skip