### PR TITLE
[CDF-28493] Fix migrating annotations when the file is a native CogniteFile or migrated without Toolkit

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py
@@ -173,16 +173,45 @@ class DirectRelationCache:
                     cache[source_system.source] = source_reference
                     if original_str := missing.get(source_system.source):
                         cache[original_str] = source_reference
-        if file_ids:
-            self._update_cache(self._client.migration.lookup.files(id=list(file_ids)), self.TableName.FILE_ID)
+        if file_ids or file_external_ids:
+            self._update_file_cache(file_ids, file_external_ids)
         if asset_external_ids:
             self._update_cache(
                 self._client.migration.lookup.assets(external_id=list(asset_external_ids)),
                 self.TableName.ASSET_EXTERNAL_ID,
             )
-        if file_external_ids:
+
+    def _update_file_cache(self, file_ids: set[int], file_external_ids: set[str]) -> None:
+        """Resolve file references (by id and/or external ID) to NodeIds.
+
+        Files that are (or have been migrated to) a CogniteFile carry their instance ID directly on
+        the classic FileMetadata response (hybrid dual-write), so we try that first. This works even
+        when the file was never migrated through Toolkit's own asset-centric migration, e.g. for
+        CogniteFile instances created natively. Only files without a native instance ID need to fall
+        back to the Toolkit-tracked InstanceSource migration mapping.
+        """
+        unresolved_ids = set(file_ids)
+        unresolved_external_ids = set(file_external_ids)
+        if unresolved_ids or unresolved_external_ids:
+            items: list[InternalId | ExternalId] = [
+                *(InternalId(id=id_) for id_ in unresolved_ids),
+                *(ExternalId(external_id=ext_id) for ext_id in unresolved_external_ids),
+            ]
+            id_cache = cast(dict[int, NodeId], self._cache_map[self.TableName.FILE_ID])
+            external_id_cache = cast(dict[str, NodeId], self._cache_map[self.TableName.FILE_EXTERNAL_ID])
+            for file in self._client.tool.filemetadata.retrieve(items, ignore_unknown_ids=True):
+                if file.instance_id is None:
+                    continue
+                id_cache[file.id] = file.instance_id
+                unresolved_ids.discard(file.id)
+                if file.external_id is not None:
+                    external_id_cache[file.external_id] = file.instance_id
+                    unresolved_external_ids.discard(file.external_id)
+        if unresolved_ids:
+            self._update_cache(self._client.migration.lookup.files(id=list(unresolved_ids)), self.TableName.FILE_ID)
+        if unresolved_external_ids:
             self._update_cache(
-                self._client.migration.lookup.files(external_id=list(file_external_ids)),
+                self._client.migration.lookup.files(external_id=list(unresolved_external_ids)),
                 self.TableName.FILE_EXTERNAL_ID,
             )
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -597,6 +597,25 @@ class TestMigrationCommand:
                 json={"items": [annotation.dump() for annotation in annotations]},
             )
         )
+        # None of the referenced files carry a native instanceId, so resolution falls back to the
+        # InstanceSource lookup below.
+        respx_mock.post(config.create_api_url("/files/byids")).mock(
+            return_value=httpx.Response(
+                status_code=200,
+                json={
+                    "items": [
+                        {
+                            "id": file_id,
+                            "name": f"file_{file_id}",
+                            "uploaded": True,
+                            "createdTime": 0,
+                            "lastUpdatedTime": 0,
+                        }
+                        for file_id in (3000, 3001, 5000)
+                    ]
+                },
+            )
+        )
         # Lookup asset and file instance ID
         query_responses = []
         for items in [

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_conversion.py
@@ -77,6 +77,8 @@ def direct_relation_cache() -> DirectRelationCache:
             1: NodeId(space="instance_space", external_id="MyFirstAsset"),
         }
         client.migration.lookup.files.return_value = {42: NodeId(space="test_space", external_id="file_456_instance")}
+        # No native instance ID on the classic file, so resolution falls back to the InstanceSource lookup above.
+        client.tool.filemetadata.retrieve.return_value = []
         client.migration.created_source_system.retrieve.return_value = [
             CreatedSourceSystem(
                 space="test_space",
@@ -116,6 +118,88 @@ def direct_relation_cache() -> DirectRelationCache:
             ]
         )
     return cache
+
+
+class TestDirectRelationCacheFileResolution:
+    """Resolving file references should prefer the native instanceId on the classic FileMetadata
+    response, only falling back to the Toolkit-tracked InstanceSource lookup when it is unset."""
+
+    def test_resolves_file_via_native_instance_id_without_instance_source_lookup(self) -> None:
+        with monkeypatch_toolkit_client() as client:
+            client.tool.filemetadata.retrieve.return_value = [
+                FileMetadataResponse(
+                    id=1,
+                    external_id="my_file",
+                    name="file.txt",
+                    uploaded=True,
+                    created_time=0,
+                    last_updated_time=0,
+                    instance_id=NodeId(space="my_space", external_id="my_file_node"),
+                )
+            ]
+            cache = DirectRelationCache(client)
+            cache.update(
+                [
+                    AnnotationResponse(
+                        annotation_type="diagrams.FileLink",
+                        data={},
+                        status="approved",
+                        creating_app="app",
+                        creating_app_version="app-version",
+                        creating_user="me",
+                        annotated_resource_type="file",
+                        annotated_resource_id=1,
+                        id=99,
+                        created_time=0,
+                        last_updated_time=0,
+                    )
+                ]
+            )
+
+            assert cache.get_cache("annotation", "annotatedResourceId") == {
+                1: NodeId(space="my_space", external_id="my_file_node")
+            }
+            client.migration.lookup.files.assert_not_called()
+
+    def test_falls_back_to_instance_source_lookup_when_file_has_no_native_instance_id(self) -> None:
+        with monkeypatch_toolkit_client() as client:
+            client.tool.filemetadata.retrieve.return_value = [
+                FileMetadataResponse(
+                    id=2,
+                    external_id="classic_file",
+                    name="file.txt",
+                    uploaded=True,
+                    created_time=0,
+                    last_updated_time=0,
+                )
+            ]
+            client.migration.lookup.files.return_value = {
+                2: NodeId(space="migrated_space", external_id="migrated_file")
+            }
+            cache = DirectRelationCache(client)
+            cache.update(
+                [
+                    AnnotationResponse(
+                        annotation_type="diagrams.FileLink",
+                        data={},
+                        status="approved",
+                        creating_app="app",
+                        creating_app_version="app-version",
+                        creating_user="me",
+                        annotated_resource_type="file",
+                        annotated_resource_id=2,
+                        id=100,
+                        created_time=0,
+                        last_updated_time=0,
+                    )
+                ]
+            )
+
+            assert cache.get_cache("annotation", "annotatedResourceId") == {
+                2: NodeId(space="migrated_space", external_id="migrated_file")
+            }
+            client.migration.lookup.files.assert_called_once()
+            assert client.migration.lookup.files.call_args.kwargs == {"id": [2]}
 
 
 class TestCreateProperties:


### PR DESCRIPTION
# Description

`DirectRelationCache` resolved file references for `cdf migrate annotations` only via the Toolkit-tracked `InstanceSource` mapping, which is only populated when Toolkit itself migrated the file. This broke migrating file-linked annotations (`diagrams.FileLink`) whose target file was either migrated by other means or created as a native `CogniteFile`. Native DM files are accepted by the classic annotations API without any validation to disallow DM native files, so we need to account for this exception.

After this PR, the file's native `instanceId` (returned by the files API) is checked first, falling back to `InstanceSource` only when this is not set. The latter is a fallback in the case where someone has ran a migration with `cdf migrate files --skip-linking`, which is generally not recommended and means the file needs to be reuploaded. This somewhat mirrors the pattern already used by `ConnectionCreator._update_property_caches` (used by `infield-data`/`infield-source-data` for resolving file/timeseries references), although it also ensures the existing logic is not broken if someone has depended on `--skip-linking`:
https://github.com/cognitedata/toolkit/blob/c58c81351fce16392cd291c9a3853c54589f0621/cognite_toolkit/_cdf_tk/commands/_migrate/conversion.py#L745-L762

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- [alpha] Fix `cdf migrate annotations` failing to link file-linked annotations to files that are native `CogniteFile` instances or were migrated to CDM by other means than Toolkit.
