### PR TITLE
[CDF-28496] Validate agent models and runtime capabilities against the /ai/services/availability endpoint

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/api/agents.py
+++ b/cognite_toolkit/_cdf_tk/client/api/agents.py
@@ -9,9 +9,9 @@ Note: This is an alpha API and may change in future releases.
 from collections.abc import Iterable, Sequence
 
 from cognite_toolkit._cdf_tk.client.cdf_client import CDFResourceAPI, Endpoint, PagedResponse
-from cognite_toolkit._cdf_tk.client.http_client import HTTPClient, ItemsSuccessResponse, SuccessResponse
+from cognite_toolkit._cdf_tk.client.http_client import HTTPClient, ItemsSuccessResponse, RequestMessage, SuccessResponse
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
-from cognite_toolkit._cdf_tk.client.resource_classes.agent import AgentRequest, AgentResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.agent import AgentRequest, AgentResponse, ServicesAvailability
 
 
 class AgentsAPI(CDFResourceAPI[AgentResponse]):
@@ -104,3 +104,19 @@ class AgentsAPI(CDFResourceAPI[AgentResponse]):
             List of AgentResponse objects.
         """
         return self._list(limit=limit)
+
+    def service_availability(self) -> ServicesAvailability:
+        """Get the availability of AI services in the CDF project.
+
+        This includes which language models and agent runtime version capabilities are available.
+
+        Returns:
+            ServicesAvailability object describing the AI services available in the project.
+        """
+        request = RequestMessage(
+            endpoint_url=self._make_url("/ai/services/availability"),
+            method="GET",
+            api_version="20230101-alpha",
+        )
+        response = self._http_client.request_single_retries(request).get_success_or_raise(request)
+        return ServicesAvailability.model_validate_json(response.body)

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/agent.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/agent.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, ClassVar, Literal
 
 from pydantic import BeforeValidator, ConfigDict, Field
 
@@ -267,3 +267,74 @@ class AgentResponse(Agent, ResponseResource[AgentRequest]):
     @classmethod
     def request_cls(cls) -> type[AgentRequest]:
         return AgentRequest
+
+
+class AgentRuntimeVersionInfo(AgentObject):
+    """A single agent runtime version and the capabilities it supports."""
+
+    version: str
+    release_stage: Literal["stable", "preview"] | str
+    visibility: Literal["hidden", "public"] | str | None = None
+    capabilities: list[str] = Field(default_factory=list)
+
+
+class AIServiceAvailability(AgentObject):
+    """A single AI service (e.g. Agent CRUD, Chat completions) and its availability in the CDF project."""
+
+    name: str
+    path: str
+    available: bool
+    supported_language_models: list[str] = Field(default_factory=list)
+    default_language_model: str | None = None
+    default_advanced_language_model: str | None = None
+    default_fast_language_model: str | None = None
+    agent_runtime_versions: list[AgentRuntimeVersionInfo] = Field(default_factory=list)
+    default_runtime_version: str | None = None
+    additional_parameters: dict[str, Any] = Field(default_factory=dict)
+
+
+class AILanguageModel(AgentObject):
+    """A language model available in the CDF project, independent of which AI service supports it."""
+
+    name: str
+    native: bool
+    max_tokens: int | None = None
+    max_output_tokens: int | None = None
+    earliest_retirement_date: int | None = None
+
+
+class ServicesAvailability(AgentObject):
+    """Response of the `/ai/services/availability` endpoint."""
+
+    items: list[AIServiceAvailability]
+    language_models: list[AILanguageModel]
+
+    AGENT_CRUD_SERVICE_NAME: ClassVar[str] = "Agent CRUD"
+    SUBAGENTS_CAPABILITY: ClassVar[str] = "SUBAGENTS"
+
+    @property
+    def agent_service(self) -> AIServiceAvailability | None:
+        return next((item for item in self.items if item.name == self.AGENT_CRUD_SERVICE_NAME), None)
+
+    @property
+    def supported_agent_models(self) -> list[str] | None:
+        agent_service = self.agent_service
+        return agent_service.supported_language_models if agent_service else None
+
+    @property
+    def max_tools_per_agent(self) -> int | None:
+        agent_service = self.agent_service
+        if agent_service is None:
+            return None
+        limit = agent_service.additional_parameters.get("maxToolsPerAgentLimit")
+        return limit if isinstance(limit, int) else None
+
+    def runtime_version_supports_subagents(self, runtime_version: str) -> bool | None:
+        """Returns whether the given runtime version supports subagents, or None if unknown."""
+        agent_service = self.agent_service
+        if agent_service is None:
+            return None
+        for version_info in agent_service.agent_runtime_versions:
+            if version_info.version == runtime_version:
+                return self.SUBAGENTS_CAPABILITY in version_info.capabilities
+        return None

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/agent.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/agent.py
@@ -335,6 +335,11 @@ class ServicesAvailability(AgentObject):
         limit = agent_service.additional_parameters.get("maxToolsPerAgentLimit")
         return limit if isinstance(limit, int) else None
 
+    @property
+    def default_agent_runtime_version(self) -> str | None:
+        agent_service = self.agent_service
+        return agent_service.default_runtime_version if agent_service else None
+
     def runtime_version_has_capability(self, runtime_version: str, capability: str) -> bool | None:
         """Returns whether the given runtime version has the given capability, or None if unknown.
 

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/agent.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/agent.py
@@ -321,6 +321,13 @@ class ServicesAvailability(AgentObject):
         return agent_service.supported_language_models if agent_service else None
 
     @property
+    def supported_agent_runtime_versions(self) -> list[str] | None:
+        agent_service = self.agent_service
+        if agent_service is None:
+            return None
+        return [version_info.version for version_info in agent_service.agent_runtime_versions]
+
+    @property
     def max_tools_per_agent(self) -> int | None:
         agent_service = self.agent_service
         if agent_service is None:

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/agent.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/agent.py
@@ -310,7 +310,6 @@ class ServicesAvailability(AgentObject):
     language_models: list[AILanguageModel]
 
     AGENT_CRUD_SERVICE_NAME: ClassVar[str] = "Agent CRUD"
-    SUBAGENTS_CAPABILITY: ClassVar[str] = "SUBAGENTS"
 
     @property
     def agent_service(self) -> AIServiceAvailability | None:
@@ -329,12 +328,17 @@ class ServicesAvailability(AgentObject):
         limit = agent_service.additional_parameters.get("maxToolsPerAgentLimit")
         return limit if isinstance(limit, int) else None
 
-    def runtime_version_supports_subagents(self, runtime_version: str) -> bool | None:
-        """Returns whether the given runtime version supports subagents, or None if unknown."""
+    def runtime_version_has_capability(self, runtime_version: str, capability: str) -> bool | None:
+        """Returns whether the given runtime version has the given capability, or None if unknown.
+
+        Args:
+            runtime_version: The agent runtime version to check, e.g. "1.3.0".
+            capability: The capability to check for, e.g. "SUBAGENTS" or "SKILLS".
+        """
         agent_service = self.agent_service
         if agent_service is None:
             return None
         for version_info in agent_service.agent_runtime_versions:
             if version_info.version == runtime_version:
-                return self.SUBAGENTS_CAPABILITY in version_info.capabilities
+                return capability in version_info.capabilities
         return None

--- a/cognite_toolkit/_cdf_tk/rules/__init__.py
+++ b/cognite_toolkit/_cdf_tk/rules/__init__.py
@@ -1,3 +1,4 @@
+from ._agents import AgentRules
 from ._auth import CheckDataSetMissing
 from ._base import ToolkitGlobalRuleSet, ToolkitLocalRule
 from ._dependencies import DependencyRuleSet
@@ -7,6 +8,7 @@ from ._neat import NeatRuleSet
 from ._orchestrator import LocalRulesOrchestrator, get_global_rules_registry
 
 __all__ = [
+    "AgentRules",
     "CheckDataSetMissing",
     "DependencyRuleSet",
     "FunctionRules",

--- a/cognite_toolkit/_cdf_tk/rules/_agents.py
+++ b/cognite_toolkit/_cdf_tk/rules/_agents.py
@@ -8,6 +8,7 @@ from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltR
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import ConsistencyError, FailedValidation
 from cognite_toolkit._cdf_tk.resource_ios import AgentIO
 from cognite_toolkit._cdf_tk.rules._base import RuleSetStatus, ToolkitGlobalRuleSet
+from cognite_toolkit._cdf_tk.utils import humanize_collection
 from cognite_toolkit._cdf_tk.utils.file import format_insight_source_file, read_yaml_file
 from cognite_toolkit._cdf_tk.yaml_classes.agent import AgentYAML
 
@@ -31,13 +32,6 @@ RUNTIME_CAPABILITY_REQUIREMENTS: tuple[RuntimeCapabilityRequirement, ...] = (
 
 
 class AgentRules(ToolkitGlobalRuleSet):
-    """Validate agent definitions against the CDF project's AI service availability.
-
-    The availability endpoint is used on a best-effort basis: if it cannot be reached, e.g. because
-    no client is available or the endpoint is not yet enabled for the project, any model and runtime
-    version is accepted rather than falling back to a hardcoded list that would go stale over time.
-    """
-
     CODE_PREFIX = "AGENT"
     DISPLAY_NAME = "Agents checks"
 
@@ -99,7 +93,7 @@ class AgentRules(ToolkitGlobalRuleSet):
             yield ConsistencyError(
                 message=(
                     f"Agent '{agent_def.external_id}' model {agent_def.model!r} is not available in this "
-                    f"CDF project. Available models: {sorted(supported_models)}."
+                    f"CDF project. Available models: {humanize_collection(supported_models)}."
                 ),
                 code=f"{self.CODE_PREFIX}-MODEL",
                 fix="Use one of the available models for this CDF project.",
@@ -112,7 +106,8 @@ class AgentRules(ToolkitGlobalRuleSet):
                 yield ConsistencyError(
                     message=(
                         f"Agent '{agent_def.external_id}' runtime version {agent_def.runtime_version!r} is not "
-                        f"available in this CDF project. Available runtime versions: {sorted(supported_runtime_versions)}."
+                        f"available in this CDF project. "
+                        f"Available runtime versions: {humanize_collection(supported_runtime_versions)}."
                     ),
                     code=f"{self.CODE_PREFIX}-RUNTIME-VERSION",
                     fix="Use one of the available runtime versions for this CDF project.",

--- a/cognite_toolkit/_cdf_tk/rules/_agents.py
+++ b/cognite_toolkit/_cdf_tk/rules/_agents.py
@@ -1,0 +1,122 @@
+from collections.abc import Iterable
+from functools import cached_property
+
+from cognite_toolkit._cdf_tk.client.resource_classes.agent import ServicesAvailability
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import ResourceType
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltResource
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import ConsistencyError, FailedValidation
+from cognite_toolkit._cdf_tk.resource_ios import AgentIO
+from cognite_toolkit._cdf_tk.rules._base import RuleSetStatus, ToolkitGlobalRuleSet
+from cognite_toolkit._cdf_tk.utils.file import format_insight_source_file, read_yaml_file
+from cognite_toolkit._cdf_tk.yaml_classes.agent import AgentYAML
+
+
+class AgentRules(ToolkitGlobalRuleSet):
+    """Validate agent definitions against the CDF project's AI service availability.
+
+    The availability endpoint is used on a best-effort basis: if it cannot be reached, e.g. because
+    no client is available or the endpoint is not yet enabled for the project, any model and runtime
+    version is accepted rather than falling back to a hardcoded list that would go stale over time.
+    """
+
+    CODE_PREFIX = "AGENT"
+    DISPLAY_NAME = "Agents checks"
+
+    def get_status(self) -> RuleSetStatus:
+        if not self.client:
+            return RuleSetStatus(
+                code="reduced",
+                message=(
+                    "Agent model and runtime version validation requires a client. "
+                    "Provide client credentials to validate these against the CDF project's AI service availability."
+                ),
+            )
+        if self.service_availability is None:
+            return RuleSetStatus(
+                code="reduced",
+                message="Could not fetch AI service availability for the CDF project. Will allow any model and runtime version.",
+            )
+        return RuleSetStatus(
+            code="ready",
+            message="Will validate agent models and runtime versions against the CDF project's AI service availability.",
+        )
+
+    def validate(self) -> Iterable[ConsistencyError | FailedValidation]:
+        agent_type = ResourceType(resource_folder=AgentIO.folder_name, kind=AgentIO.kind)
+        for module in self.modules:
+            for resource in module.resources:
+                if not resource.can_verify:
+                    # We do not do further validation if there are syntax errors.
+                    continue
+                if resource.type == agent_type:
+                    try:
+                        yield from self._validate_agent(resource)
+                    except Exception as e:
+                        yield FailedValidation(
+                            message=f"Agent validation failed for agent definition {resource.build_path.name!r}: {e}",
+                            source=str(resource.identifier),
+                            source_file=format_insight_source_file(resource.source_path),
+                        )
+
+    def _validate_agent(self, resource: BuiltResource) -> Iterable[ConsistencyError]:
+        """Validate an agent definition against the CDF project's AI service availability.
+
+        Args:
+            resource: The built agent resource to validate.
+
+        Yields:
+            ConsistencyError for any violations found.
+        """
+        source_file = format_insight_source_file(resource.source_path)
+        raw_data = read_yaml_file(resource.build_path, expected_output="dict")
+        agent_def = AgentYAML.model_validate(raw_data)
+
+        availability = self.service_availability
+        if availability is None:
+            return
+
+        supported_models = availability.supported_agent_models
+        if supported_models is not None and agent_def.model not in supported_models:
+            yield ConsistencyError(
+                message=(
+                    f"Agent '{agent_def.external_id}' model {agent_def.model!r} is not available in this "
+                    f"CDF project. Available models: {sorted(supported_models)}."
+                ),
+                code=f"{self.CODE_PREFIX}-MODEL",
+                fix="Use one of the available models for this CDF project.",
+                source_file=source_file,
+            )
+
+        if agent_def.subagents and agent_def.runtime_version:
+            supports_subagents = availability.runtime_version_supports_subagents(agent_def.runtime_version)
+            if supports_subagents is False:
+                yield ConsistencyError(
+                    message=(
+                        f"Agent '{agent_def.external_id}' runtime version {agent_def.runtime_version!r} "
+                        "does not support subagents."
+                    ),
+                    code=f"{self.CODE_PREFIX}-SUBAGENTS-RUNTIME-VERSION",
+                    fix="Use a runtime version that supports subagents, or remove the 'subagents' field.",
+                    source_file=source_file,
+                )
+
+        max_tools = availability.max_tools_per_agent
+        if agent_def.tools is not None and max_tools is not None and len(agent_def.tools) > max_tools:
+            yield ConsistencyError(
+                message=(
+                    f"Agent '{agent_def.external_id}' has {len(agent_def.tools)} tools, "
+                    f"which exceeds the maximum of {max_tools} tools per agent for this CDF project."
+                ),
+                code=f"{self.CODE_PREFIX}-TOOLS-LIMIT",
+                fix=f"Reduce the number of tools to at most {max_tools}.",
+                source_file=source_file,
+            )
+
+    @cached_property
+    def service_availability(self) -> ServicesAvailability | None:
+        if not self.client:
+            return None
+        try:
+            return self.client.tool.agents.service_availability()
+        except Exception:
+            return None

--- a/cognite_toolkit/_cdf_tk/rules/_agents.py
+++ b/cognite_toolkit/_cdf_tk/rules/_agents.py
@@ -89,7 +89,7 @@ class AgentRules(ToolkitGlobalRuleSet):
             return
 
         supported_models = availability.supported_agent_models
-        if supported_models is not None and agent_def.model not in supported_models:
+        if agent_def.model is not None and supported_models is not None and agent_def.model not in supported_models:
             yield ConsistencyError(
                 message=(
                     f"Agent '{agent_def.external_id}' model {agent_def.model!r} is not available in this "

--- a/cognite_toolkit/_cdf_tk/rules/_agents.py
+++ b/cognite_toolkit/_cdf_tk/rules/_agents.py
@@ -107,6 +107,18 @@ class AgentRules(ToolkitGlobalRuleSet):
             )
 
         if agent_def.runtime_version:
+            supported_runtime_versions = availability.supported_agent_runtime_versions
+            if supported_runtime_versions is not None and agent_def.runtime_version not in supported_runtime_versions:
+                yield ConsistencyError(
+                    message=(
+                        f"Agent '{agent_def.external_id}' runtime version {agent_def.runtime_version!r} is not "
+                        f"available in this CDF project. Available runtime versions: {sorted(supported_runtime_versions)}."
+                    ),
+                    code=f"{self.CODE_PREFIX}-RUNTIME-VERSION",
+                    fix="Use one of the available runtime versions for this CDF project.",
+                    source_file=source_file,
+                )
+
             for requirement in RUNTIME_CAPABILITY_REQUIREMENTS:
                 if not requirement.is_used(agent_def):
                     continue

--- a/cognite_toolkit/_cdf_tk/rules/_agents.py
+++ b/cognite_toolkit/_cdf_tk/rules/_agents.py
@@ -44,11 +44,6 @@ class AgentRules(ToolkitGlobalRuleSet):
                     "Provide client credentials to validate these against the CDF project's AI service availability."
                 ),
             )
-        if self.service_availability is None:
-            return RuleSetStatus(
-                code="reduced",
-                message="Could not fetch AI service availability for the CDF project. Will allow any model and runtime version.",
-            )
         return RuleSetStatus(
             code="ready",
             message="Will validate agent models and runtime versions against the CDF project's AI service availability.",
@@ -114,16 +109,20 @@ class AgentRules(ToolkitGlobalRuleSet):
                     source_file=source_file,
                 )
 
+        # If no runtime version is set, the agent runs on the project's default, so capabilities
+        # must be checked against that rather than skipped.
+        effective_runtime_version = agent_def.runtime_version or availability.default_agent_runtime_version
+        if effective_runtime_version:
             for requirement in RUNTIME_CAPABILITY_REQUIREMENTS:
                 if not requirement.is_used(agent_def):
                     continue
                 has_capability = availability.runtime_version_has_capability(
-                    agent_def.runtime_version, requirement.capability
+                    effective_runtime_version, requirement.capability
                 )
                 if has_capability is False:
                     yield ConsistencyError(
                         message=(
-                            f"Agent '{agent_def.external_id}' runtime version {agent_def.runtime_version!r} "
+                            f"Agent '{agent_def.external_id}' runtime version {effective_runtime_version!r} "
                             f"does not support the '{requirement.field_name}' field."
                         ),
                         code=f"{self.CODE_PREFIX}-RUNTIME-UNSUPPORTED-CAPABILITY",
@@ -150,7 +149,4 @@ class AgentRules(ToolkitGlobalRuleSet):
     def service_availability(self) -> ServicesAvailability | None:
         if not self.client:
             return None
-        try:
-            return self.client.tool.agents.service_availability()
-        except Exception:
-            return None
+        return self.client.tool.agents.service_availability()

--- a/cognite_toolkit/_cdf_tk/rules/_agents.py
+++ b/cognite_toolkit/_cdf_tk/rules/_agents.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterable
 from functools import cached_property
+from typing import NamedTuple
 
 from cognite_toolkit._cdf_tk.client.resource_classes.agent import ServicesAvailability
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import ResourceType
@@ -9,6 +10,24 @@ from cognite_toolkit._cdf_tk.resource_ios import AgentIO
 from cognite_toolkit._cdf_tk.rules._base import RuleSetStatus, ToolkitGlobalRuleSet
 from cognite_toolkit._cdf_tk.utils.file import format_insight_source_file, read_yaml_file
 from cognite_toolkit._cdf_tk.yaml_classes.agent import AgentYAML
+
+
+class RuntimeCapabilityRequirement(NamedTuple):
+    """An AgentYAML field that is gated behind a runtime version capability."""
+
+    field_name: str
+    capability: str
+
+    def is_used(self, agent_def: AgentYAML) -> bool:
+        return bool(getattr(agent_def, self.field_name))
+
+
+# Fields whose usage requires the runtime version to advertise the matching capability. Add
+# to this list as the API exposes more per-field capabilities under agentRuntimeVersions[].capabilities.
+RUNTIME_CAPABILITY_REQUIREMENTS: tuple[RuntimeCapabilityRequirement, ...] = (
+    RuntimeCapabilityRequirement(field_name="subagents", capability="SUBAGENTS"),
+    RuntimeCapabilityRequirement(field_name="skills", capability="SKILLS"),
+)
 
 
 class AgentRules(ToolkitGlobalRuleSet):
@@ -87,18 +106,26 @@ class AgentRules(ToolkitGlobalRuleSet):
                 source_file=source_file,
             )
 
-        if agent_def.subagents and agent_def.runtime_version:
-            supports_subagents = availability.runtime_version_supports_subagents(agent_def.runtime_version)
-            if supports_subagents is False:
-                yield ConsistencyError(
-                    message=(
-                        f"Agent '{agent_def.external_id}' runtime version {agent_def.runtime_version!r} "
-                        "does not support subagents."
-                    ),
-                    code=f"{self.CODE_PREFIX}-SUBAGENTS-RUNTIME-VERSION",
-                    fix="Use a runtime version that supports subagents, or remove the 'subagents' field.",
-                    source_file=source_file,
+        if agent_def.runtime_version:
+            for requirement in RUNTIME_CAPABILITY_REQUIREMENTS:
+                if not requirement.is_used(agent_def):
+                    continue
+                has_capability = availability.runtime_version_has_capability(
+                    agent_def.runtime_version, requirement.capability
                 )
+                if has_capability is False:
+                    yield ConsistencyError(
+                        message=(
+                            f"Agent '{agent_def.external_id}' runtime version {agent_def.runtime_version!r} "
+                            f"does not support the '{requirement.field_name}' field."
+                        ),
+                        code=f"{self.CODE_PREFIX}-RUNTIME-UNSUPPORTED-CAPABILITY",
+                        fix=(
+                            f"Use a runtime version that supports '{requirement.field_name}', "
+                            f"or remove the '{requirement.field_name}' field."
+                        ),
+                        source_file=source_file,
+                    )
 
         max_tools = availability.max_tools_per_agent
         if agent_def.tools is not None and max_tools is not None and len(agent_def.tools) > max_tools:

--- a/cognite_toolkit/_cdf_tk/yaml_classes/agent.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/agent.py
@@ -17,7 +17,6 @@ else:
 MAX_SUB_AGENTS_PER_AGENT = 20
 EXAMPLE_QUESTIONS_MAX_LENGTH = 5
 EXAMPLE_QUESTIONS_MAX_SERIALIZED_SIZE = 40960
-RUNTIME_VERSIONS_SUPPORTING_SUBAGENTS = frozenset({"1.3.0", "1.4.0"})
 
 
 class AgentToolModelResource(BaseModelResource, extra="allow"): ...
@@ -259,71 +258,6 @@ class ExampleQuestion(BaseModelResource):
     )
 
 
-Model = Literal[
-    # Legacy model names without the azure/model naming convention
-    "gpt-35-turbo",
-    "gpt-35-turbo-16k",
-    "gpt-4",
-    "gpt-4-turbo",
-    "gpt-4-32k",
-    "gpt-4-vision",
-    "gpt-4o-2024-05-13",
-    "gpt-4o-2024-08-06",
-    "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
-    "bedrock/anthropic.claude-3-haiku-20240307-v1:0",
-    "gpt-4o-mini",
-    "gemini-1.5-pro",
-    # Azure models
-    "azure/o1",
-    "azure/o3-mini",
-    "azure/o3",
-    "azure/o4-mini",
-    "azure/gpt-3.5-turbo",
-    "azure/gpt-3.5-turbo-16k",
-    "azure/gpt-4",
-    "azure/gpt-4-turbo",
-    "azure/gpt-4-32k",
-    "azure/gpt-4-vision",
-    "azure/gpt-4o",
-    "azure/gpt-4o-mini",
-    "azure/gpt-4.1",
-    "azure/gpt-4.1-nano",
-    "azure/gpt-4.1-mini",
-    "azure/gpt-5",
-    "azure/gpt-5-mini",
-    "azure/gpt-5-nano",
-    "azure/gpt-5.1",
-    "azure/gpt-5.2",
-    "azure/gpt-5.4",
-    "azure/gpt-5.4-mini",
-    "azure/gpt-5.4-nano",
-    "azure/gpt-5.5",
-    # GCP models
-    "gcp/claude-4-sonnet",
-    "gcp/claude-4.5-sonnet",
-    "gcp/claude-4.5-haiku",
-    "gcp/claude-4-opus",
-    "gcp/gemini-1.5-pro",
-    "gcp/gemini-1.5-flash",
-    "gcp/gemini-2.0-flash",
-    "gcp/gemini-2.5-pro",
-    "gcp/gemini-2.5-flash",
-    "gcp/gemini-2.5-flash-lite",
-    "gcp/gemini-3-pro-preview",
-    "gcp/gemini-3.1-pro-preview",
-    # AWS models
-    "aws/claude-4.6-sonnet",
-    "aws/claude-4.7-opus",
-    "aws/claude-4.5-sonnet",
-    "aws/claude-4.5-haiku",
-    "aws/claude-4-sonnet",
-    "aws/claude-4-opus",
-    "aws/claude-4.1-opus",
-    "aws/claude-3.5-sonnet",
-    "aws/claude-3-haiku",
-]
-
-
 class AgentYAML(ToolkitResource):
     """Atlas AI Agent"""
 
@@ -350,10 +284,10 @@ class AgentYAML(ToolkitResource):
         "the agent's goals and how to achieve them.",
         max_length=32000,
     )
-    model: Model = Field(
+    model: str = Field(
         "azure/gpt-4o-mini", description="The name of the model to use. Defaults to your CDF project's default model."
     )
-    tools: list[AgentTool] | None = Field(None, description="A list of tools available to the agent.", max_length=20)
+    tools: list[AgentTool] | None = Field(None, description="A list of tools available to the agent.")
     subagents: list[SubagentConfig] | None = Field(
         None,
         description="List of agents to expose as subagents on this agent.",
@@ -396,11 +330,6 @@ class AgentYAML(ToolkitResource):
             return self
         if any(ref.agent_external_id == self.external_id for ref in self.subagents):
             raise ValueError("An agent cannot reference itself as a subagent.")
-        if self.runtime_version and self.runtime_version not in RUNTIME_VERSIONS_SUPPORTING_SUBAGENTS:
-            raise ValueError(
-                f"Runtime version '{self.runtime_version}' does not support subagents. "
-                "Use a runtime version where supports_subagents is enabled, or remove the 'subagents' field."
-            )
         if self.tools and any(tool.name == "delegate_to_subagent" for tool in self.tools):
             raise ValueError(
                 "Tool name 'delegate_to_subagent' is reserved for the system sub-agent delegate tool. Rename the tool."

--- a/cognite_toolkit/_cdf_tk/yaml_classes/agent.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/agent.py
@@ -103,7 +103,9 @@ class AgentDataModel(AgentToolModelResource):
         max_length=43,
         pattern=DM_VERSION_PATTERN,
     )
-    view_external_ids: list[str] = Field(description="The views of the data model.", min_length=1, max_length=10)
+    view_external_ids: list[str] | None = Field(
+        None, description="The views of the data model.", min_length=1, max_length=20
+    )
 
 
 class AgentInstanceSpacesDefinition(AgentToolModelResource):

--- a/cognite_toolkit/_cdf_tk/yaml_classes/agent.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/agent.py
@@ -286,8 +286,8 @@ class AgentYAML(ToolkitResource):
         "the agent's goals and how to achieve them.",
         max_length=32000,
     )
-    model: str = Field(
-        "azure/gpt-4o-mini", description="The name of the model to use. Defaults to your CDF project's default model."
+    model: str | None = Field(
+        None, description="The name of the model to use. Defaults to your CDF project's default model."
     )
     tools: list[AgentTool] | None = Field(None, description="A list of tools available to the agent.")
     subagents: list[SubagentConfig] | None = Field(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_agents.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_agents.py
@@ -7,7 +7,7 @@ import pytest
 from cognite_toolkit._cdf_tk.constants import MODULES
 from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
 from cognite_toolkit._cdf_tk.utils import humanize_collection
-from cognite_toolkit._cdf_tk.utils._auxiliary import get_concrete_subclasses, literal_string_values_from_annotation
+from cognite_toolkit._cdf_tk.utils._auxiliary import get_concrete_subclasses
 from cognite_toolkit._cdf_tk.validation import validate_resource_yaml_pydantic
 from cognite_toolkit._cdf_tk.yaml_classes.agent import (
     EXAMPLE_QUESTIONS_MAX_LENGTH,
@@ -19,17 +19,9 @@ from cognite_toolkit._cdf_tk.yaml_classes.agent import (
     AgentTool,
     AgentToolDefinition,
     AgentYAML,
-    Model,
 )
 from tests.data import COMPLETE_ORG_ALPHA_FLAGS
 from tests.test_unit.utils import find_resources
-
-
-def _model_literal_error_message(invalid_value: object) -> str:
-    models = literal_string_values_from_annotation(Model)
-    quoted = ", ".join(f"'{model}'" for model in models[:-1])
-    options = f"{quoted} or '{models[-1]}'" if len(models) > 1 else f"'{models[0]}'"
-    return f"In field model input should be {options}. Got {invalid_value!r}."
 
 
 def invalid_test_cases() -> Iterable:
@@ -45,15 +37,11 @@ def invalid_test_cases() -> Iterable:
             "externalId": "",  # Empty string - violates min_length=1
             "name": "",  # Empty string - violates min_length=1
             "description": "a" * 1025,  # Too long - violates max_length=1024
-            "model": "invalid-model",  # Not in Model literal enum
-            "tools": [{"type": "invalid"}] * 21,  # Too many tools - violates max_length=20
         },
         {
             "In field description string should have at most 1024 characters",
             "In field externalId string should have at least 1 character",
-            _model_literal_error_message("invalid-model"),
             "In field name string should have at least 1 character",
-            "In field tools list should have at most 20 items after validation, not 21",
         },
         id="multiple-validation-errors",
     )
@@ -146,7 +134,7 @@ def invalid_test_cases() -> Iterable:
             "name": None,  # Wrong type - should be string
             "description": 456,  # Wrong type - should be string or None
             "instructions": [],  # Wrong type - should be string or None
-            "model": True,  # Wrong type - should be Model literal
+            "model": True,  # Wrong type - should be a string
             "tools": "not_a_list",  # Wrong type - should be list
         },
         {
@@ -154,7 +142,8 @@ def invalid_test_cases() -> Iterable:
             "Hint: Use double quotes to force string.",
             "In field instructions input should be a valid string. Got [] of type list. "
             "Hint: Use double quotes to force string.",
-            _model_literal_error_message(True),
+            "In field model input should be a valid string. Got True of type bool. "
+            "Hint: Use double quotes to force string.",
             "In field name input should be a valid string. Got None of type NoneType. "
             "Hint: Use double quotes to force string.",
             "In field tools input should be a valid list. Got 'not_a_list'.",
@@ -337,17 +326,6 @@ class TestAgentYAML:
                 },
                 "In subagents[1].agentExternalId string should have at least 1 character",
                 id="empty-subagent-external-id",
-            ),
-            pytest.param(
-                {
-                    "externalId": "supervisor",
-                    "name": "Supervisor",
-                    "runtimeVersion": "1.0.0",
-                    "subagents": [{"agentExternalId": "weather-specialist"}],
-                },
-                "Runtime version '1.0.0' does not support subagents. "
-                "Use a runtime version where supports_subagents is enabled, or remove the 'subagents' field.",
-                id="unsupported-runtime-version",
             ),
             pytest.param(
                 {

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_agents.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_agents.py
@@ -110,7 +110,7 @@ def invalid_test_cases() -> Iterable:
                                 "space": "invalid space!",  # Invalid pattern - contains space and special char
                                 "external_id": "123invalid",  # Invalid pattern - starts with number
                                 "version": "v@1",  # Invalid pattern - contains special char
-                                "viewExternalIds": ["valid_view"] * 11,  # Too many items - violates max_length=10
+                                "viewExternalIds": ["valid_view"] * 21,  # Too many items - violates max_length=20
                             }
                         ]
                         * 81,  # Too many data models - violates max_length=80

--- a/tests/test_unit/test_cdf_tk/test_rules/test_agents.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_agents.py
@@ -63,67 +63,80 @@ class TestAgentRules:
         )
 
     @staticmethod
-    def _create_rule_with_client(service_availability: ServicesAvailability) -> AgentRules:
+    def _create_rule_with_client(service_availability: ServicesAvailability, raises: bool = False) -> AgentRules:
         """Create an AgentRules with a mocked client."""
         mock_client = MagicMock()
-        mock_client.tool.agents.service_availability.return_value = service_availability
+        if raises:
+            mock_client.tool.agents.service_availability.side_effect = Exception("boom")
+        else:
+            mock_client.tool.agents.service_availability.return_value = service_availability
         return AgentRules(modules=[], client=mock_client)
 
-    def test_get_status_with_client(self, service_availability: ServicesAvailability) -> None:
-        rule = self._create_rule_with_client(service_availability)
-        status = rule.get_status()
-        assert status.code == "ready"
-        assert "validate agent models" in status.message.lower()
-
-    def test_get_status_without_client(self) -> None:
-        rule = AgentRules(modules=[])
-        status = rule.get_status()
-        assert status.code == "reduced"
-        assert "requires a client" in status.message.lower()
-
-    def test_get_status_when_endpoint_unavailable(self) -> None:
-        mock_client = MagicMock()
-        mock_client.tool.agents.service_availability.side_effect = Exception("boom")
-        rule = AgentRules(modules=[], client=mock_client)
-        status = rule.get_status()
-        assert status.code == "reduced"
-        assert "could not fetch" in status.message.lower()
-
-    def test_validate_agent_unknown_model(self, tmp_path: Path, service_availability: ServicesAvailability) -> None:
-        yaml_file = tmp_path / "agents" / "agent.yaml"
-        self._write_agent_yaml(
-            yaml_file,
-            {"externalId": "my_agent", "name": "My Agent", "model": "gcp/claude-5-opus"},
+    @pytest.mark.parametrize(
+        "with_client, availability_raises, expected_code, expected_message_part",
+        [
+            pytest.param(False, False, "reduced", "requires a client", id="no-client"),
+            pytest.param(True, True, "reduced", "could not fetch", id="endpoint-unavailable"),
+            pytest.param(True, False, "ready", "validate agent models", id="client-and-availability-ok"),
+        ],
+    )
+    def test_get_status(
+        self,
+        service_availability: ServicesAvailability,
+        with_client: bool,
+        availability_raises: bool,
+        expected_code: str,
+        expected_message_part: str,
+    ) -> None:
+        rule = (
+            self._create_rule_with_client(service_availability, raises=availability_raises)
+            if with_client
+            else AgentRules(modules=[])
         )
-        resource = self._create_built_resource(yaml_file, yaml_file)
-        rule = self._create_rule_with_client(service_availability)
-        errors = list(rule._validate_agent(resource))
-        assert len(errors) == 1
-        assert isinstance(errors[0], ConsistencyError)
-        assert errors[0].code == "AGENT-MODEL"
-        assert "gcp/claude-5-opus" in errors[0].message
+        status = rule.get_status()
+        assert status.code == expected_code
+        assert expected_message_part in status.message.lower()
 
-    def test_validate_agent_known_model(self, tmp_path: Path, service_availability: ServicesAvailability) -> None:
-        yaml_file = tmp_path / "agents" / "agent.yaml"
-        self._write_agent_yaml(
-            yaml_file,
-            {"externalId": "my_agent", "name": "My Agent", "model": "azure/gpt-4.1"},
-        )
-        resource = self._create_built_resource(yaml_file, yaml_file)
-        rule = self._create_rule_with_client(service_availability)
-        errors = list(rule._validate_agent(resource))
-        assert len(errors) == 0
+    @pytest.mark.parametrize(
+        "with_client, raises",
+        [
+            pytest.param(False, False, id="no-client"),
+            pytest.param(True, True, id="client-raises"),
+        ],
+    )
+    def test_service_availability_returns_none(
+        self, service_availability: ServicesAvailability, with_client: bool, raises: bool
+    ) -> None:
+        rule = self._create_rule_with_client(service_availability, raises=raises) if with_client else AgentRules(modules=[])
+        assert rule.service_availability is None
 
-    def test_validate_agent_no_client_allows_any_model(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "model, with_client, expected_codes",
+        [
+            pytest.param("gcp/claude-5-opus", True, ["AGENT-MODEL"], id="unknown-model"),
+            pytest.param("azure/gpt-4.1", True, [], id="known-model"),
+            pytest.param(None, True, [], id="unset-model-is-allowed"),
+            pytest.param("some-brand-new-model", False, [], id="no-client-allows-any-model"),
+        ],
+    )
+    def test_validate_agent_model(
+        self,
+        tmp_path: Path,
+        service_availability: ServicesAvailability,
+        model: str | None,
+        with_client: bool,
+        expected_codes: list[str],
+    ) -> None:
+        content = {"externalId": "my_agent", "name": "My Agent"}
+        if model is not None:
+            content["model"] = model
         yaml_file = tmp_path / "agents" / "agent.yaml"
-        self._write_agent_yaml(
-            yaml_file,
-            {"externalId": "my_agent", "name": "My Agent", "model": "some-brand-new-model"},
-        )
+        self._write_agent_yaml(yaml_file, content)
         resource = self._create_built_resource(yaml_file, yaml_file)
-        rule = AgentRules(modules=[])
+        rule = self._create_rule_with_client(service_availability) if with_client else AgentRules(modules=[])
         errors = list(rule._validate_agent(resource))
-        assert len(errors) == 0
+        assert [error.code for error in errors] == expected_codes
+        assert all(isinstance(error, ConsistencyError) for error in errors)
 
     def test_validate_agent_too_many_tools(self, tmp_path: Path, service_availability: ServicesAvailability) -> None:
         yaml_file = tmp_path / "agents" / "agent.yaml"
@@ -146,8 +159,43 @@ class TestAgentRules:
         assert len(errors) == 1
         assert errors[0].code == "AGENT-TOOLS-LIMIT"
 
-    def test_validate_agent_subagents_unsupported_runtime_version(
-        self, tmp_path: Path, service_availability: ServicesAvailability
+    @pytest.mark.parametrize(
+        "runtime_version, extra_fields, with_client, expected_codes",
+        [
+            pytest.param("1.0.0", {}, True, [], id="known-runtime-version-no-gated-fields"),
+            pytest.param("9.9.9", {}, True, ["AGENT-RUNTIME-VERSION"], id="unknown-runtime-version"),
+            pytest.param("9.9.9", {}, False, [], id="no-client-allows-any-runtime-version"),
+            pytest.param(
+                "1.0.0",
+                {"subagents": [{"agentExternalId": "specialist"}]},
+                True,
+                ["AGENT-RUNTIME-UNSUPPORTED-CAPABILITY"],
+                id="subagents-unsupported-runtime-version",
+            ),
+            pytest.param(
+                "1.3.0",
+                {"subagents": [{"agentExternalId": "specialist"}]},
+                True,
+                [],
+                id="subagents-supported-runtime-version",
+            ),
+            pytest.param(
+                "1.0.0",
+                {"skills": ["my_skill"]},
+                True,
+                ["AGENT-RUNTIME-UNSUPPORTED-CAPABILITY"],
+                id="skills-unsupported-runtime-version",
+            ),
+        ],
+    )
+    def test_validate_agent_runtime_version_and_capabilities(
+        self,
+        tmp_path: Path,
+        service_availability: ServicesAvailability,
+        runtime_version: str,
+        extra_fields: dict,
+        with_client: bool,
+        expected_codes: list[str],
     ) -> None:
         yaml_file = tmp_path / "agents" / "agent.yaml"
         self._write_agent_yaml(
@@ -156,108 +204,11 @@ class TestAgentRules:
                 "externalId": "supervisor",
                 "name": "Supervisor",
                 "model": "azure/gpt-4.1",
-                "runtimeVersion": "1.0.0",
-                "subagents": [{"agentExternalId": "specialist"}],
+                "runtimeVersion": runtime_version,
+                **extra_fields,
             },
         )
         resource = self._create_built_resource(yaml_file, yaml_file, external_id="supervisor")
-        rule = self._create_rule_with_client(service_availability)
+        rule = self._create_rule_with_client(service_availability) if with_client else AgentRules(modules=[])
         errors = list(rule._validate_agent(resource))
-        assert len(errors) == 1
-        assert errors[0].code == "AGENT-RUNTIME-UNSUPPORTED-CAPABILITY"
-
-    def test_validate_agent_subagents_supported_runtime_version(
-        self, tmp_path: Path, service_availability: ServicesAvailability
-    ) -> None:
-        yaml_file = tmp_path / "agents" / "agent.yaml"
-        self._write_agent_yaml(
-            yaml_file,
-            {
-                "externalId": "supervisor",
-                "name": "Supervisor",
-                "model": "azure/gpt-4.1",
-                "runtimeVersion": "1.3.0",
-                "subagents": [{"agentExternalId": "specialist"}],
-            },
-        )
-        resource = self._create_built_resource(yaml_file, yaml_file, external_id="supervisor")
-        rule = self._create_rule_with_client(service_availability)
-        errors = list(rule._validate_agent(resource))
-        assert len(errors) == 0
-
-    def test_validate_agent_unknown_runtime_version_is_flagged(
-        self, tmp_path: Path, service_availability: ServicesAvailability
-    ) -> None:
-        """A runtime version not present in the availability response should be flagged directly."""
-        yaml_file = tmp_path / "agents" / "agent.yaml"
-        self._write_agent_yaml(
-            yaml_file,
-            {
-                "externalId": "supervisor",
-                "name": "Supervisor",
-                "model": "azure/gpt-4.1",
-                "runtimeVersion": "9.9.9",
-                "subagents": [{"agentExternalId": "specialist"}],
-            },
-        )
-        resource = self._create_built_resource(yaml_file, yaml_file, external_id="supervisor")
-        rule = self._create_rule_with_client(service_availability)
-        errors = list(rule._validate_agent(resource))
-        assert len(errors) == 1
-        assert errors[0].code == "AGENT-RUNTIME-VERSION"
-        assert "9.9.9" in errors[0].message
-
-    def test_validate_agent_known_runtime_version(
-        self, tmp_path: Path, service_availability: ServicesAvailability
-    ) -> None:
-        yaml_file = tmp_path / "agents" / "agent.yaml"
-        self._write_agent_yaml(
-            yaml_file,
-            {"externalId": "my_agent", "name": "My Agent", "model": "azure/gpt-4.1", "runtimeVersion": "1.0.0"},
-        )
-        resource = self._create_built_resource(yaml_file, yaml_file)
-        rule = self._create_rule_with_client(service_availability)
-        errors = list(rule._validate_agent(resource))
-        assert len(errors) == 0
-
-    def test_validate_agent_no_client_allows_any_runtime_version(self, tmp_path: Path) -> None:
-        yaml_file = tmp_path / "agents" / "agent.yaml"
-        self._write_agent_yaml(
-            yaml_file,
-            {"externalId": "my_agent", "name": "My Agent", "runtimeVersion": "9.9.9"},
-        )
-        resource = self._create_built_resource(yaml_file, yaml_file)
-        rule = AgentRules(modules=[])
-        errors = list(rule._validate_agent(resource))
-        assert len(errors) == 0
-
-    def test_validate_agent_skills_unsupported_runtime_version(
-        self, tmp_path: Path, service_availability: ServicesAvailability
-    ) -> None:
-        yaml_file = tmp_path / "agents" / "agent.yaml"
-        self._write_agent_yaml(
-            yaml_file,
-            {
-                "externalId": "my_agent",
-                "name": "My Agent",
-                "model": "azure/gpt-4.1",
-                "runtimeVersion": "1.0.0",
-                "skills": ["my_skill"],
-            },
-        )
-        resource = self._create_built_resource(yaml_file, yaml_file)
-        rule = self._create_rule_with_client(service_availability)
-        errors = list(rule._validate_agent(resource))
-        assert len(errors) == 1
-        assert errors[0].code == "AGENT-RUNTIME-UNSUPPORTED-CAPABILITY"
-        assert "skills" in errors[0].message
-
-    def test_service_availability_returns_none_without_client(self) -> None:
-        rule = AgentRules(modules=[])
-        assert rule.service_availability is None
-
-    def test_service_availability_returns_none_on_error(self) -> None:
-        mock_client = MagicMock()
-        mock_client.tool.agents.service_availability.side_effect = Exception("boom")
-        rule = AgentRules(modules=[], client=mock_client)
-        assert rule.service_availability is None
+        assert [error.code for error in errors] == expected_codes

--- a/tests/test_unit/test_cdf_tk/test_rules/test_agents.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_agents.py
@@ -1,0 +1,216 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.client.resource_classes.agent import (
+    AgentRuntimeVersionInfo,
+    AIServiceAvailability,
+    ServicesAvailability,
+)
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltResource
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import ConsistencyError
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._module import ResourceType
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._types import AbsoluteFilePath
+from cognite_toolkit._cdf_tk.resource_ios import AgentIO
+from cognite_toolkit._cdf_tk.rules._agents import AgentRules
+
+
+class TestAgentRules:
+    """Test suite for AgentRules validation."""
+
+    @pytest.fixture
+    def service_availability(self) -> ServicesAvailability:
+        """Create a sample ServicesAvailability object for testing."""
+        return ServicesAvailability(
+            items=[
+                AIServiceAvailability(
+                    name="Agent CRUD",
+                    path="/ai/agents",
+                    available=True,
+                    supported_language_models=["azure/gpt-4.1", "gcp/claude-5-sonnet"],
+                    additional_parameters={"maxToolsPerAgentLimit": 2},
+                    agent_runtime_versions=[
+                        AgentRuntimeVersionInfo(version="1.0.0", release_stage="stable", capabilities=[]),
+                        AgentRuntimeVersionInfo(version="1.3.0", release_stage="preview", capabilities=["SUBAGENTS"]),
+                    ],
+                )
+            ],
+            language_models=[],
+        )
+
+    @staticmethod
+    def _write_agent_yaml(filepath: Path, content: dict) -> None:
+        """Helper to write agent YAML content."""
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        with open(filepath, "w") as f:
+            yaml.safe_dump(content, f)
+
+    @staticmethod
+    def _create_built_resource(source_path: Path, build_path: Path, external_id: str = "my_agent") -> BuiltResource:
+        """Create a BuiltResource for testing."""
+        return BuiltResource(
+            identifier=ExternalId(external_id=external_id),
+            source_hash="test-hash",
+            type=ResourceType(resource_folder=AgentIO.folder_name, kind=AgentIO.kind),
+            source_path=AbsoluteFilePath(source_path.resolve()),
+            build_path=AbsoluteFilePath(build_path.resolve()),
+            crud_cls=AgentIO,
+            dependencies=set(),
+            has_syntax_error=False,
+        )
+
+    @staticmethod
+    def _create_rule_with_client(service_availability: ServicesAvailability) -> AgentRules:
+        """Create an AgentRules with a mocked client."""
+        mock_client = MagicMock()
+        mock_client.tool.agents.service_availability.return_value = service_availability
+        return AgentRules(modules=[], client=mock_client)
+
+    def test_get_status_with_client(self, service_availability: ServicesAvailability) -> None:
+        rule = self._create_rule_with_client(service_availability)
+        status = rule.get_status()
+        assert status.code == "ready"
+        assert "validate agent models" in status.message.lower()
+
+    def test_get_status_without_client(self) -> None:
+        rule = AgentRules(modules=[])
+        status = rule.get_status()
+        assert status.code == "reduced"
+        assert "requires a client" in status.message.lower()
+
+    def test_get_status_when_endpoint_unavailable(self) -> None:
+        mock_client = MagicMock()
+        mock_client.tool.agents.service_availability.side_effect = Exception("boom")
+        rule = AgentRules(modules=[], client=mock_client)
+        status = rule.get_status()
+        assert status.code == "reduced"
+        assert "could not fetch" in status.message.lower()
+
+    def test_validate_agent_unknown_model(self, tmp_path: Path, service_availability: ServicesAvailability) -> None:
+        yaml_file = tmp_path / "agents" / "agent.yaml"
+        self._write_agent_yaml(
+            yaml_file,
+            {"externalId": "my_agent", "name": "My Agent", "model": "gcp/claude-5-opus"},
+        )
+        resource = self._create_built_resource(yaml_file, yaml_file)
+        rule = self._create_rule_with_client(service_availability)
+        errors = list(rule._validate_agent(resource))
+        assert len(errors) == 1
+        assert isinstance(errors[0], ConsistencyError)
+        assert errors[0].code == "AGENT-MODEL"
+        assert "gcp/claude-5-opus" in errors[0].message
+
+    def test_validate_agent_known_model(self, tmp_path: Path, service_availability: ServicesAvailability) -> None:
+        yaml_file = tmp_path / "agents" / "agent.yaml"
+        self._write_agent_yaml(
+            yaml_file,
+            {"externalId": "my_agent", "name": "My Agent", "model": "azure/gpt-4.1"},
+        )
+        resource = self._create_built_resource(yaml_file, yaml_file)
+        rule = self._create_rule_with_client(service_availability)
+        errors = list(rule._validate_agent(resource))
+        assert len(errors) == 0
+
+    def test_validate_agent_no_client_allows_any_model(self, tmp_path: Path) -> None:
+        yaml_file = tmp_path / "agents" / "agent.yaml"
+        self._write_agent_yaml(
+            yaml_file,
+            {"externalId": "my_agent", "name": "My Agent", "model": "some-brand-new-model"},
+        )
+        resource = self._create_built_resource(yaml_file, yaml_file)
+        rule = AgentRules(modules=[])
+        errors = list(rule._validate_agent(resource))
+        assert len(errors) == 0
+
+    def test_validate_agent_too_many_tools(self, tmp_path: Path, service_availability: ServicesAvailability) -> None:
+        yaml_file = tmp_path / "agents" / "agent.yaml"
+        self._write_agent_yaml(
+            yaml_file,
+            {
+                "externalId": "my_agent",
+                "name": "My Agent",
+                "model": "azure/gpt-4.1",
+                "tools": [
+                    {"type": "askDocument", "name": "tool_one", "description": "A valid tool description"},
+                    {"type": "askDocument", "name": "tool_two", "description": "A valid tool description"},
+                    {"type": "askDocument", "name": "tool_three", "description": "A valid tool description"},
+                ],
+            },
+        )
+        resource = self._create_built_resource(yaml_file, yaml_file)
+        rule = self._create_rule_with_client(service_availability)
+        errors = list(rule._validate_agent(resource))
+        assert len(errors) == 1
+        assert errors[0].code == "AGENT-TOOLS-LIMIT"
+
+    def test_validate_agent_subagents_unsupported_runtime_version(
+        self, tmp_path: Path, service_availability: ServicesAvailability
+    ) -> None:
+        yaml_file = tmp_path / "agents" / "agent.yaml"
+        self._write_agent_yaml(
+            yaml_file,
+            {
+                "externalId": "supervisor",
+                "name": "Supervisor",
+                "model": "azure/gpt-4.1",
+                "runtimeVersion": "1.0.0",
+                "subagents": [{"agentExternalId": "specialist"}],
+            },
+        )
+        resource = self._create_built_resource(yaml_file, yaml_file, external_id="supervisor")
+        rule = self._create_rule_with_client(service_availability)
+        errors = list(rule._validate_agent(resource))
+        assert len(errors) == 1
+        assert errors[0].code == "AGENT-SUBAGENTS-RUNTIME-VERSION"
+
+    def test_validate_agent_subagents_supported_runtime_version(
+        self, tmp_path: Path, service_availability: ServicesAvailability
+    ) -> None:
+        yaml_file = tmp_path / "agents" / "agent.yaml"
+        self._write_agent_yaml(
+            yaml_file,
+            {
+                "externalId": "supervisor",
+                "name": "Supervisor",
+                "model": "azure/gpt-4.1",
+                "runtimeVersion": "1.3.0",
+                "subagents": [{"agentExternalId": "specialist"}],
+            },
+        )
+        resource = self._create_built_resource(yaml_file, yaml_file, external_id="supervisor")
+        rule = self._create_rule_with_client(service_availability)
+        errors = list(rule._validate_agent(resource))
+        assert len(errors) == 0
+
+    def test_validate_agent_subagents_unknown_runtime_version_is_allowed(
+        self, tmp_path: Path, service_availability: ServicesAvailability
+    ) -> None:
+        """A runtime version not present in the availability response should not be blocked."""
+        yaml_file = tmp_path / "agents" / "agent.yaml"
+        self._write_agent_yaml(
+            yaml_file,
+            {
+                "externalId": "supervisor",
+                "name": "Supervisor",
+                "model": "azure/gpt-4.1",
+                "runtimeVersion": "9.9.9",
+                "subagents": [{"agentExternalId": "specialist"}],
+            },
+        )
+        resource = self._create_built_resource(yaml_file, yaml_file, external_id="supervisor")
+        rule = self._create_rule_with_client(service_availability)
+        errors = list(rule._validate_agent(resource))
+        assert len(errors) == 0
+
+    def test_service_availability_returns_none_without_client(self) -> None:
+        rule = AgentRules(modules=[])
+        assert rule.service_availability is None
+
+    def test_service_availability_returns_none_on_error(self) -> None:
+        mock_client = MagicMock()
+        mock_client.tool.agents.service_availability.side_effect = Exception("boom")
+        rule = AgentRules(modules=[], client=mock_client)
+        assert rule.service_availability is None

--- a/tests/test_unit/test_cdf_tk/test_rules/test_agents.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_agents.py
@@ -32,6 +32,7 @@ class TestAgentRules:
                     available=True,
                     supported_language_models=["azure/gpt-4.1", "gcp/claude-5-sonnet"],
                     additional_parameters={"maxToolsPerAgentLimit": 2},
+                    default_runtime_version="1.0.0",
                     agent_runtime_versions=[
                         AgentRuntimeVersionInfo(version="1.0.0", release_stage="stable", capabilities=[]),
                         AgentRuntimeVersionInfo(version="1.3.0", release_stage="preview", capabilities=["SUBAGENTS"]),
@@ -63,51 +64,33 @@ class TestAgentRules:
         )
 
     @staticmethod
-    def _create_rule_with_client(service_availability: ServicesAvailability, raises: bool = False) -> AgentRules:
+    def _create_rule_with_client(service_availability: ServicesAvailability) -> AgentRules:
         """Create an AgentRules with a mocked client."""
         mock_client = MagicMock()
-        if raises:
-            mock_client.tool.agents.service_availability.side_effect = Exception("boom")
-        else:
-            mock_client.tool.agents.service_availability.return_value = service_availability
+        mock_client.tool.agents.service_availability.return_value = service_availability
         return AgentRules(modules=[], client=mock_client)
 
     @pytest.mark.parametrize(
-        "with_client, availability_raises, expected_code, expected_message_part",
+        "with_client, expected_code, expected_message_part",
         [
-            pytest.param(False, False, "reduced", "requires a client", id="no-client"),
-            pytest.param(True, True, "reduced", "could not fetch", id="endpoint-unavailable"),
-            pytest.param(True, False, "ready", "validate agent models", id="client-and-availability-ok"),
+            pytest.param(False, "reduced", "requires a client", id="no-client"),
+            pytest.param(True, "ready", "validate agent models", id="with-client"),
         ],
     )
     def test_get_status(
         self,
         service_availability: ServicesAvailability,
         with_client: bool,
-        availability_raises: bool,
         expected_code: str,
         expected_message_part: str,
     ) -> None:
-        rule = (
-            self._create_rule_with_client(service_availability, raises=availability_raises)
-            if with_client
-            else AgentRules(modules=[])
-        )
+        rule = self._create_rule_with_client(service_availability) if with_client else AgentRules(modules=[])
         status = rule.get_status()
         assert status.code == expected_code
         assert expected_message_part in status.message.lower()
 
-    @pytest.mark.parametrize(
-        "with_client, raises",
-        [
-            pytest.param(False, False, id="no-client"),
-            pytest.param(True, True, id="client-raises"),
-        ],
-    )
-    def test_service_availability_returns_none(
-        self, service_availability: ServicesAvailability, with_client: bool, raises: bool
-    ) -> None:
-        rule = self._create_rule_with_client(service_availability, raises=raises) if with_client else AgentRules(modules=[])
+    def test_service_availability_returns_none_without_client(self) -> None:
+        rule = AgentRules(modules=[])
         assert rule.service_availability is None
 
     @pytest.mark.parametrize(
@@ -186,13 +169,27 @@ class TestAgentRules:
                 ["AGENT-RUNTIME-UNSUPPORTED-CAPABILITY"],
                 id="skills-unsupported-runtime-version",
             ),
+            pytest.param(
+                None,
+                {"subagents": [{"agentExternalId": "specialist"}]},
+                True,
+                ["AGENT-RUNTIME-UNSUPPORTED-CAPABILITY"],
+                id="unset-runtime-version-falls-back-to-unsupported-default",
+            ),
+            pytest.param(
+                None,
+                {},
+                True,
+                [],
+                id="unset-runtime-version-no-gated-fields",
+            ),
         ],
     )
     def test_validate_agent_runtime_version_and_capabilities(
         self,
         tmp_path: Path,
         service_availability: ServicesAvailability,
-        runtime_version: str,
+        runtime_version: str | None,
         extra_fields: dict,
         with_client: bool,
         expected_codes: list[str],

--- a/tests/test_unit/test_cdf_tk/test_rules/test_agents.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_agents.py
@@ -185,10 +185,10 @@ class TestAgentRules:
         errors = list(rule._validate_agent(resource))
         assert len(errors) == 0
 
-    def test_validate_agent_subagents_unknown_runtime_version_is_allowed(
+    def test_validate_agent_unknown_runtime_version_is_flagged(
         self, tmp_path: Path, service_availability: ServicesAvailability
     ) -> None:
-        """A runtime version not present in the availability response should not be blocked."""
+        """A runtime version not present in the availability response should be flagged directly."""
         yaml_file = tmp_path / "agents" / "agent.yaml"
         self._write_agent_yaml(
             yaml_file,
@@ -202,6 +202,32 @@ class TestAgentRules:
         )
         resource = self._create_built_resource(yaml_file, yaml_file, external_id="supervisor")
         rule = self._create_rule_with_client(service_availability)
+        errors = list(rule._validate_agent(resource))
+        assert len(errors) == 1
+        assert errors[0].code == "AGENT-RUNTIME-VERSION"
+        assert "9.9.9" in errors[0].message
+
+    def test_validate_agent_known_runtime_version(
+        self, tmp_path: Path, service_availability: ServicesAvailability
+    ) -> None:
+        yaml_file = tmp_path / "agents" / "agent.yaml"
+        self._write_agent_yaml(
+            yaml_file,
+            {"externalId": "my_agent", "name": "My Agent", "model": "azure/gpt-4.1", "runtimeVersion": "1.0.0"},
+        )
+        resource = self._create_built_resource(yaml_file, yaml_file)
+        rule = self._create_rule_with_client(service_availability)
+        errors = list(rule._validate_agent(resource))
+        assert len(errors) == 0
+
+    def test_validate_agent_no_client_allows_any_runtime_version(self, tmp_path: Path) -> None:
+        yaml_file = tmp_path / "agents" / "agent.yaml"
+        self._write_agent_yaml(
+            yaml_file,
+            {"externalId": "my_agent", "name": "My Agent", "runtimeVersion": "9.9.9"},
+        )
+        resource = self._create_built_resource(yaml_file, yaml_file)
+        rule = AgentRules(modules=[])
         errors = list(rule._validate_agent(resource))
         assert len(errors) == 0
 

--- a/tests/test_unit/test_cdf_tk/test_rules/test_agents.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_agents.py
@@ -164,7 +164,7 @@ class TestAgentRules:
         rule = self._create_rule_with_client(service_availability)
         errors = list(rule._validate_agent(resource))
         assert len(errors) == 1
-        assert errors[0].code == "AGENT-SUBAGENTS-RUNTIME-VERSION"
+        assert errors[0].code == "AGENT-RUNTIME-UNSUPPORTED-CAPABILITY"
 
     def test_validate_agent_subagents_supported_runtime_version(
         self, tmp_path: Path, service_availability: ServicesAvailability
@@ -204,6 +204,27 @@ class TestAgentRules:
         rule = self._create_rule_with_client(service_availability)
         errors = list(rule._validate_agent(resource))
         assert len(errors) == 0
+
+    def test_validate_agent_skills_unsupported_runtime_version(
+        self, tmp_path: Path, service_availability: ServicesAvailability
+    ) -> None:
+        yaml_file = tmp_path / "agents" / "agent.yaml"
+        self._write_agent_yaml(
+            yaml_file,
+            {
+                "externalId": "my_agent",
+                "name": "My Agent",
+                "model": "azure/gpt-4.1",
+                "runtimeVersion": "1.0.0",
+                "skills": ["my_skill"],
+            },
+        )
+        resource = self._create_built_resource(yaml_file, yaml_file)
+        rule = self._create_rule_with_client(service_availability)
+        errors = list(rule._validate_agent(resource))
+        assert len(errors) == 1
+        assert errors[0].code == "AGENT-RUNTIME-UNSUPPORTED-CAPABILITY"
+        assert "skills" in errors[0].message
 
     def test_service_availability_returns_none_without_client(self) -> None:
         rule = AgentRules(modules=[])


### PR DESCRIPTION
# Description

Replaces the hardcoded list of supported agent language models (and the hardcoded runtime-version-supports-subagents set) with a live check against the `/ai/services/availability` endpoint. `model` is no longer a strict enum in the local schema, so new models no longer trigger a syntax error; instead, a new `AgentRules` global rule validates model, tools-per-agent limit, and runtime capabilities (subagents, skills) against the CDF project's actual availability, falling back to allowing any value when the endpoint can't be reached. This mirrors the existing limits validation functionality used for the Functions service.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Improved

- Agent `model` values are now validated against your CDF project's actual available models, tools-per-agent limit, and runtime version capabilities (e.g. subagents, skills) when a client is available, and accepts any value if that check can't be performed.

### Fixed

- Agent `dataModels.dataModels[].viewExternalIds` is no longer incorrectly required, and its max length is now 20 instead of 10.