### PR TITLE
[CDF-28499] Include "Missing" and "Duplicated" API responses in error messages

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/api/instances.py
+++ b/cognite_toolkit/_cdf_tk/client/api/instances.py
@@ -485,7 +485,7 @@ class InstancesAPI(CDFResourceAPI[InstanceResponse]):
         if isinstance(response, FailedResponse) and response.status_code == 408:
             raise ReduceLoadException(
                 source_exception=ToolkitAPIError(
-                    f"Request failed with status code {response.status_code}: {response.error.message}",
+                    f"Request failed with status code {response.status_code}: {response.error.full_message}",
                     missing=response.error.missing,  # type: ignore[arg-type]
                     duplicated=response.error.duplicated,  # type: ignore[arg-type]
                     code=response.error.code,

--- a/cognite_toolkit/_cdf_tk/client/http_client/_data_classes.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_data_classes.py
@@ -98,14 +98,14 @@ class ErrorDetails(HTTPBaseModel):
     @property
     def full_message(self) -> str:
         """The error message with missing/duplicated referenced resources and the request ID appended, if present."""
-        message = self.message
+        parts = [self.message] if self.message else []
         if self.missing:
-            message = f"{message} | Missing: {self.missing}"
+            parts.append(f"Missing: {self.missing}")
         if self.duplicated:
-            message = f"{message} | Duplicated: {self.duplicated}"
-        if self.x_request_id is not None and self.x_request_id not in message:
-            message = f"{message} | X-Request-ID: {self.x_request_id}"
-        return message
+            parts.append(f"Duplicated: {self.duplicated}")
+        if self.x_request_id is not None and self.x_request_id not in self.message:
+            parts.append(f"X-Request-ID: {self.x_request_id}")
+        return " | ".join(parts)
 
     @classmethod
     def from_response(cls, response: httpx.Response) -> "ErrorDetails":

--- a/cognite_toolkit/_cdf_tk/client/http_client/_data_classes.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_data_classes.py
@@ -26,7 +26,7 @@ class HTTPResult(HTTPBaseModel):
             return self
         elif isinstance(self, FailedResponse):
             raise ToolkitAPIError(
-                f"Request failed with status code {self.status_code}: {self.error.message}",
+                f"Request failed with status code {self.status_code}: {self.error.full_message}",
                 missing=self.error.missing,  # type: ignore[arg-type]
                 duplicated=self.error.duplicated,  # type: ignore[arg-type]
                 code=self.error.code,
@@ -94,6 +94,18 @@ class ErrorDetails(HTTPBaseModel):
     duplicated: list[JsonValue] | None = None
     is_auto_retryable: bool | None = None
     x_request_id: str | None = None
+
+    @property
+    def full_message(self) -> str:
+        """The error message with missing/duplicated referenced resources and the request ID appended, if present."""
+        message = self.message
+        if self.missing:
+            message = f"{message} | Missing: {self.missing}"
+        if self.duplicated:
+            message = f"{message} | Duplicated: {self.duplicated}"
+        if self.x_request_id is not None and self.x_request_id not in message:
+            message = f"{message} | X-Request-ID: {self.x_request_id}"
+        return message
 
     @classmethod
     def from_response(cls, response: httpx.Response) -> "ErrorDetails":

--- a/cognite_toolkit/_cdf_tk/client/http_client/_exception.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_exception.py
@@ -20,8 +20,6 @@ class ToolkitAPIError(Exception):
         debug_file: Path | None = None,
         x_request_id: str | None = None,
     ) -> None:
-        if x_request_id is not None and x_request_id not in message:
-            message = f"{message} | X-Request-ID: {x_request_id}"
         super().__init__(message)
         self.message = message
         self.missing = missing

--- a/cognite_toolkit/_cdf_tk/client/http_client/_item_classes.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_item_classes.py
@@ -39,7 +39,7 @@ class ItemsFailedResponse(ItemsResultMessage):
 
     @property
     def error_message(self) -> str:
-        return self.error.message
+        return self.error.full_message
 
 
 def _set_default_tracker(data: dict[str, Any]) -> ItemsRequestTracker:
@@ -97,11 +97,7 @@ class ItemsResultList(UserList[ItemsResultMessage]):
         failed_requests = [resp for resp in self.data if isinstance(resp, ItemsFailedRequest)]
         if not failed_responses and not failed_requests:
             return
-        error_messages = "; ".join(
-            f"Status {err.status_code}: {err.error.message}"
-            + (f" | X-Request-ID: {err.error.x_request_id}" if err.error.x_request_id else "")
-            for err in failed_responses
-        )
+        error_messages = "; ".join(f"Status {err.status_code}: {err.error.full_message}" for err in failed_responses)
         if failed_requests:
             if error_messages:
                 error_messages += "; "

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/chart_monitoring_job.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/chart_monitoring_job.py
@@ -78,7 +78,13 @@ class ChartMonitoringJobResponse(ChartMonitoringJob, ResponseResource[ChartMonit
         return ChartMonitoringJobRequest
 
     def as_request_resource(self) -> ChartMonitoringJobRequest:
-        dump = self.model_dump(mode="json", by_alias=True, exclude_unset=True, exclude={"user_identifier"})
+        # status is server-computed execution status and not valid on create/update.
+        dump = self.model_dump(
+            mode="json",
+            by_alias=True,
+            exclude_unset=True,
+            exclude={"user_identifier", "status"},
+        )
         dump["nonce"] = MISSING_NONCE
         dump["id"] = self.id
         return ChartMonitoringJobRequest.model_validate(dump, extra="allow")

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/chart_monitoring_job.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/chart_monitoring_job.py
@@ -78,13 +78,7 @@ class ChartMonitoringJobResponse(ChartMonitoringJob, ResponseResource[ChartMonit
         return ChartMonitoringJobRequest
 
     def as_request_resource(self) -> ChartMonitoringJobRequest:
-        # status is server-computed execution status and not valid on create/update.
-        dump = self.model_dump(
-            mode="json",
-            by_alias=True,
-            exclude_unset=True,
-            exclude={"user_identifier", "status"},
-        )
+        dump = self.model_dump(mode="json", by_alias=True, exclude_unset=True, exclude={"user_identifier"})
         dump["nonce"] = MISSING_NONCE
         dump["id"] = self.id
         return ChartMonitoringJobRequest.model_validate(dump, extra="allow")

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -335,7 +335,7 @@ class MigrationCommand(ToolkitCommand):
                                 id=id_,
                                 severity=Severity.failure,
                                 label=f"Failed to write to CDF: {error.code}",
-                                message=error.message,
+                                message=error.full_message,
                                 source=str(selected),
                                 destination=destination,
                             )


### PR DESCRIPTION
# Description

This PR consolidates error-message formatting (missing/duplicated resources, X-Request-ID) into a single `ErrorDetails.full_message` property so these details are consistently surfaced across all error paths (item responses, HTTP results, instances API, migration command). Previously, the "missing"/"duplicated" fields were mostly suppressed by Toolkit.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Improved

- Include missing/duplicated resource details and request ID consistently in API error messages.