### PR TITLE
[CDF-28497] Validate Cognite Function runtimes dynamically against project limits

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/function.py
@@ -405,10 +405,6 @@ class FunctionIO(ResourceIO[ExternalId, FunctionRequest, FunctionResponse]):
             if key in local and local[key] in {None, ""} and key not in dumped:
                 dumped[key] = local[key]
 
-        if dumped.get("runtime") == "py312" and "runtime" not in local:
-            # Remove the default value of the runtime for Python 3.12, as it is the default runtime and does not need to be specified.
-            dumped.pop("runtime", None)
-
         return dumped
 
     def _is_activated(self, action: str) -> bool:

--- a/cognite_toolkit/_cdf_tk/rules/_functions.py
+++ b/cognite_toolkit/_cdf_tk/rules/_functions.py
@@ -7,7 +7,7 @@ from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltR
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import ConsistencyError, FailedValidation
 from cognite_toolkit._cdf_tk.resource_ios import FunctionIO
 from cognite_toolkit._cdf_tk.rules._base import RuleSetStatus, ToolkitGlobalRuleSet
-from cognite_toolkit._cdf_tk.utils import validate_requirements_with_pip
+from cognite_toolkit._cdf_tk.utils import humanize_collection, validate_requirements_with_pip
 from cognite_toolkit._cdf_tk.utils.file import format_insight_source_file, read_yaml_file
 from cognite_toolkit._cdf_tk.yaml_classes.functions import FunctionsYAML
 
@@ -29,7 +29,7 @@ class FunctionRules(ToolkitGlobalRuleSet):
 
         return RuleSetStatus(
             code="ready",
-            message="Will validate function limits and requirement txt.",
+            message="Will validate function limits, runtime, and requirement txt.",
         )
 
     def validate(self) -> Iterable[ConsistencyError | FailedValidation]:
@@ -91,6 +91,20 @@ class FunctionRules(ToolkitGlobalRuleSet):
                     ),
                     code=f"{self.CODE_PREFIX}-MEMORY",
                     fix=f"Ensure that memory is between {limits.memory_gb.min} and {limits.memory_gb.max} GB.",
+                    source_file=source_file,
+                )
+
+        # Validate runtime
+        if function_def.runtime is not None and limits is not None:
+            if function_def.runtime not in limits.runtimes:
+                yield ConsistencyError(
+                    message=(
+                        f"Function '{function_def.external_id}' runtime {function_def.runtime!r} is not "
+                        f"available in this CDF project. "
+                        f"Available runtimes: {humanize_collection(limits.runtimes)}."
+                    ),
+                    code=f"{self.CODE_PREFIX}-RUNTIME",
+                    fix=f"Use one of the available runtimes: {humanize_collection(limits.runtimes)}.",
                     source_file=source_file,
                 )
 

--- a/cognite_toolkit/_cdf_tk/rules/_functions.py
+++ b/cognite_toolkit/_cdf_tk/rules/_functions.py
@@ -23,13 +23,13 @@ class FunctionRules(ToolkitGlobalRuleSet):
                 message=(
                     "Function limits validation requires a client. "
                     "Provide client credentials to validate function CPU and MEMORY limits."
-                    "Will only validate the requirement txt."
+                    "Will only validate the requirements.txt."
                 ),
             )
 
         return RuleSetStatus(
             code="ready",
-            message="Will validate function limits, runtime, and requirement txt.",
+            message="Will validate function limits, runtime, and requirements.txt.",
         )
 
     def validate(self) -> Iterable[ConsistencyError | FailedValidation]:

--- a/cognite_toolkit/_cdf_tk/yaml_classes/functions.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/functions.py
@@ -45,11 +45,7 @@ class FunctionsYAML(ToolkitResource):
     memory: float | None = Field(default=None, description="Memory per function measured in GB.")
     runtime: str | None = Field(
         default=None,
-        description=(
-            "Runtime of the function. Defaults to the CDF project's default runtime if not set. "
-            "The set of valid runtimes is validated dynamically against the CDF project's function "
-            "limits, since it may change over time."
-        ),
+        description=("Runtime of the function. Defaults to the CDF project's default runtime if not set."),
     )
     metadata: dict[str, str] | None = Field(
         default=None, description="Custom, application-specific metadata.", max_length=16

--- a/cognite_toolkit/_cdf_tk/yaml_classes/functions.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/functions.py
@@ -1,5 +1,3 @@
-from typing import Literal
-
 from pydantic import Field
 
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
@@ -45,8 +43,13 @@ class FunctionsYAML(ToolkitResource):
     )
     cpu: float | None = Field(default=None, description="Number of CPU cores per function.")
     memory: float | None = Field(default=None, description="Memory per function measured in GB.")
-    runtime: Literal["py39", "py310", "py311", "py312", "py313", "py314"] | None = Field(
-        default="py311", description="Runtime of the function."
+    runtime: str | None = Field(
+        default=None,
+        description=(
+            "Runtime of the function. Defaults to the CDF project's default runtime if not set. "
+            "The set of valid runtimes is validated dynamically against the CDF project's function "
+            "limits, since it may change over time."
+        ),
     )
     metadata: dict[str, str] | None = Field(
         default=None, description="Custom, application-specific metadata.", max_length=16

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_function.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_function.py
@@ -172,6 +172,63 @@ secrets:
         assert "indexUrl" in dumped
         assert dumped["indexUrl"] == "http://my-index-url"
 
+    def test_dump_resource_strips_runtime_not_set_locally(
+        self, env_vars_with_client: EnvironmentVariables, tmp_path: Path
+    ) -> None:
+        """The server-applied default runtime should not be treated as a diff when not set locally."""
+        local_dict = FunctionWrite(
+            name="my_function",
+            file_id=123,
+            external_id="my_function",
+        ).dump()
+        cdf_function = FunctionResponse(
+            id=123,
+            name="my_function",
+            file_id=123,
+            external_id="my_function",
+            created_time=0,
+            runtime="py314",
+            metadata={
+                FunctionIO._MetadataKey.function_hash: calculate_directory_hash(
+                    tmp_path / "my_function", exclude_prefixes={".DS_Store"}
+                ),
+            },
+        )
+        loader = FunctionIO.create_loader(env_vars_with_client.get_client(), tmp_path)
+
+        dumped = loader.dump_resource(cdf_function, local_dict)
+
+        assert "runtime" not in dumped
+
+    def test_dump_resource_keeps_runtime_set_locally(
+        self, env_vars_with_client: EnvironmentVariables, tmp_path: Path
+    ) -> None:
+        """A runtime explicitly set locally should still be compared against the server value."""
+        local_dict = FunctionWrite(
+            name="my_function",
+            file_id=123,
+            external_id="my_function",
+            runtime="py311",
+        ).dump()
+        cdf_function = FunctionResponse(
+            id=123,
+            name="my_function",
+            file_id=123,
+            external_id="my_function",
+            created_time=0,
+            runtime="py311",
+            metadata={
+                FunctionIO._MetadataKey.function_hash: calculate_directory_hash(
+                    tmp_path / "my_function", exclude_prefixes={".DS_Store"}
+                ),
+            },
+        )
+        loader = FunctionIO.create_loader(env_vars_with_client.get_client(), tmp_path)
+
+        dumped = loader.dump_resource(cdf_function, local_dict)
+
+        assert dumped["runtime"] == "py311"
+
     def test_get_function_required_capabilities(self, env_vars_with_client: EnvironmentVariables) -> None:
         loader = FunctionIO.create_loader(env_vars_with_client.get_client(), None)
         loader.data_set_id_by_external_id = {"function1": 123, "function2": 456}

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_functions.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_functions.py
@@ -19,14 +19,12 @@ def invalid_function_test_cases() -> Iterable:
         {
             "externalId": "my_function",
             "name": "my_function",
-            "runtime": "py36",
             "secrets": {f"secret_name{i}": f"super_secret{i}" for i in range(31)},
         },
         {
-            "In field runtime input should be 'py39', 'py310', 'py311', 'py312', 'py313' or 'py314'. Got 'py36'.",
             "In field secrets dictionary should have at most 30 items after validation, not 31",
         },
-        id="Invalid runtime",
+        id="Too many secrets",
     )
 
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_functions.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_functions.py
@@ -15,6 +15,17 @@ def invalid_function_test_cases() -> Iterable:
         {"Missing required field: 'externalId'"},
         id="Missing externalId",
     )
+    yield pytest.param(
+        {
+            "externalId": "my_function",
+            "name": "my_function",
+            "secrets": {f"secret_name{i}": f"super_secret{i}" for i in range(31)},
+        },
+        {
+            "In field secrets dictionary should have at most 30 items after validation, not 31",
+        },
+        id="Too many secrets",
+    )
 
 
 class TestFunctionsYAML:

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_functions.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_functions.py
@@ -15,17 +15,6 @@ def invalid_function_test_cases() -> Iterable:
         {"Missing required field: 'externalId'"},
         id="Missing externalId",
     )
-    yield pytest.param(
-        {
-            "externalId": "my_function",
-            "name": "my_function",
-            "secrets": {f"secret_name{i}": f"super_secret{i}" for i in range(31)},
-        },
-        {
-            "In field secrets dictionary should have at most 30 items after validation, not 31",
-        },
-        id="Too many secrets",
-    )
 
 
 class TestFunctionsYAML:

--- a/tests/test_unit/test_cdf_tk/test_rules/test_functions.py
+++ b/tests/test_unit/test_cdf_tk/test_rules/test_functions.py
@@ -158,6 +158,40 @@ class TestFunctionLimitsRule:
         errors = list(rule._validate_function(resource))
         assert len(errors) == 0
 
+    def test_validate_function_unsupported_runtime(self, tmp_path: Path, function_limits: FunctionLimits) -> None:
+        """Test validation error when runtime is not in the project's available runtimes."""
+        yaml_file = tmp_path / "functions" / "func.yaml"
+        self._write_function_yaml(
+            yaml_file,
+            {
+                "externalId": "my_function",
+                "name": "My Function",
+                "runtime": "py314",
+            },
+        )
+        resource = self._create_built_resource(yaml_file, yaml_file)
+        rule = self._create_rule_with_client(function_limits)
+        errors = list(rule._validate_function(resource))
+        assert len(errors) == 1
+        assert errors[0].code == "FUNCTION-RUNTIME"
+        assert "py314" in errors[0].message
+
+    def test_validate_function_supported_runtime(self, tmp_path: Path, function_limits: FunctionLimits) -> None:
+        """Test no error when runtime is in the project's available runtimes."""
+        yaml_file = tmp_path / "functions" / "func.yaml"
+        self._write_function_yaml(
+            yaml_file,
+            {
+                "externalId": "my_function",
+                "name": "My Function",
+                "runtime": "py312",
+            },
+        )
+        resource = self._create_built_resource(yaml_file, yaml_file)
+        rule = self._create_rule_with_client(function_limits)
+        errors = list(rule._validate_function(resource))
+        assert len(errors) == 0
+
     def test_validate_function_none_resources(self, tmp_path: Path, function_limits: FunctionLimits) -> None:
         """Test no errors when resources are not specified."""
         yaml_file = tmp_path / "functions" / "func.yaml"


### PR DESCRIPTION
# Description

Cognite Functions supports new runtimes over time (e.g. `py313`, `py314`), which previously required hardcoding an updated `Literal` list in the toolkit for every release. This PR replaces that static list with dynamic validation against the `/functions/limits` endpoint's `runtimes` field, and removes the toolkit's hardcoded `py311` default for the `runtime` field so that functions without an explicit runtime always defer to CDF's own (evolving) default instead of being silently pinned to a stale version. We already used `/functions/limits` for other types of validations, so this is simply closing a gap introduced after #3121 where we temporarily allowed any string to pass through if unknown.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Changed

- Cognite Function `runtime` is now validated dynamically against the CDF project's available runtimes