### PR TITLE
[CDF-28431] Improve migration progress messages and fix custom mapper dry-run/logging propagation

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/command.py
@@ -264,7 +264,7 @@ class MigrationCommand(ToolkitCommand):
             total_count += step.total_count if step.total_count is not None else 0
             total_completed += step.completed_count if step.completed_count is not None else 0
             item_count = f"{step.total_count:,}" if step.total_count is not None else "Unknown"
-            table.add_row(str(step.selector), f"{step.completed_count:,}", item_count)
+            table.add_row(step.selector.display_name, f"{step.completed_count:,}", item_count)
 
         table.add_section()
         table.add_row("Total", f"{total_completed:,}", f"{total_count:,}")

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1392,14 +1392,17 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
 
     def process_description(self, source_selector: InstanceSelector) -> str:
         destination_view = self._get_destination_view(source_selector)
-        if destination_view is None:
+        if destination_view is None or not isinstance(source_selector, InstanceViewSelector):
             return "Converting"
-        message = f"Converting into view {destination_view!s}"
+        message = f"Converting into {source_selector.instance_type}s"
         source_spaces = source_selector.get_instance_spaces()
         if source_spaces:
             destination_spaces = self._connection_creator.get_destination_spaces(source_spaces)
-            if destination_spaces:
-                message += f" with {humanize_collection(destination_spaces)} instance spaces"
+            if len(destination_spaces) == 1:
+                message += f" in instance space {destination_spaces[0]}"
+            elif len(destination_spaces) > 1:
+                message += f" in {len(destination_spaces)} instance spaces"
+        message += f" in view {destination_view!s}"
         return message
 
     def _get_destination_view(self, source_selector: InstanceSelector) -> ViewId | None:
@@ -1437,7 +1440,10 @@ class FDMtoCDMMapper(DataMapper[InstanceSelector, NodeOrEdgeResponse, NodeOrEdge
         ):
             if len(intersecting_view_ids) == 1:
                 intersection_view_id = next(iter(intersecting_view_ids))
-                custom_mapped = self._custom_instance_mappings[intersection_view_id].map(source)
+                custom_mapper = self._custom_instance_mappings[intersection_view_id]
+                custom_mapper.logger = self.logger
+                custom_mapper.dry_run = self.dry_run
+                custom_mapped = custom_mapper.map(source)
                 if self.dry_run:
                     for data_item in custom_mapped:
                         if isinstance(data_item.item, NodeRequest):

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1950,6 +1950,23 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, NodeOrEdgeRe
         result = convert_container_properties(source_properties, context)
         created_properties = result.container_properties
 
+        for schedule in duplicated_schedules:
+            incoming_item_edges = template_item_edges_by_schedule_id.get(schedule.as_id(), [])
+            distinct_items = {edge.other_side for edge in incoming_item_edges}
+            if len(distinct_items) > 1:
+                issue.errors.append(
+                    f"Schedule {schedule.as_id()!s} has incoming referenceSchedules edges from "
+                    f"{len(distinct_items)} distinct template items {humanize_collection([str(item) for item in distinct_items])}, expected exactly 1."
+                )
+            elif len(incoming_item_edges) > 1:
+                # Same template item, multiple edge instances. Logging edge_ids (rather than
+                # other_side, which would be identical) to determine whether this is a genuine
+                # duplicate edge in the source data, or the same edge being read twice.
+                issue.errors.append(
+                    f"Schedule {schedule.as_id()!s} has {len(incoming_item_edges)} incoming referenceSchedules "
+                    f"edges {humanize_collection([str(edge.edge_id) for edge in incoming_item_edges])} from the same template item, expected exactly 1."
+                )
+
         template_edges, template_item_edges = self._find_schedule_edges(
             duplicated_schedules, template_edges_by_item_id, template_item_edges_by_schedule_id
         )
@@ -1980,7 +1997,11 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, NodeOrEdgeRe
                 template_item_edges.append(template_item_edge)
                 for template_edge in template_edges_by_item_id.get(template_item_edge.other_side, []):
                     template_edges.append(template_edge)
-        return template_edges, template_item_edges
+        # Deduplicate by target: multiple edges to the same template/template item is expected
+        # and not a real conversion ambiguity.
+        deduped_template_edges = list({edge.other_side: edge for edge in template_edges}.values())
+        deduped_template_item_edges = list({edge.other_side: edge for edge in template_item_edges}.values())
+        return deduped_template_edges, deduped_template_item_edges
 
     def _create_template_relations(
         self,

--- a/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
+++ b/cognite_toolkit/_cdf_tk/commands/_migrate/data_mapper.py
@@ -1950,23 +1950,6 @@ class InFieldLegacyToCDMScheduleMapper(DataMapper[InstanceSelector, NodeOrEdgeRe
         result = convert_container_properties(source_properties, context)
         created_properties = result.container_properties
 
-        for schedule in duplicated_schedules:
-            incoming_item_edges = template_item_edges_by_schedule_id.get(schedule.as_id(), [])
-            distinct_items = {edge.other_side for edge in incoming_item_edges}
-            if len(distinct_items) > 1:
-                issue.errors.append(
-                    f"Schedule {schedule.as_id()!s} has incoming referenceSchedules edges from "
-                    f"{len(distinct_items)} distinct template items {humanize_collection([str(item) for item in distinct_items])}, expected exactly 1."
-                )
-            elif len(incoming_item_edges) > 1:
-                # Same template item, multiple edge instances. Logging edge_ids (rather than
-                # other_side, which would be identical) to determine whether this is a genuine
-                # duplicate edge in the source data, or the same edge being read twice.
-                issue.errors.append(
-                    f"Schedule {schedule.as_id()!s} has {len(incoming_item_edges)} incoming referenceSchedules "
-                    f"edges {humanize_collection([str(edge.edge_id) for edge in incoming_item_edges])} from the same template item, expected exactly 1."
-                )
-
         template_edges, template_item_edges = self._find_schedule_edges(
             duplicated_schedules, template_edges_by_item_id, template_item_edges_by_schedule_id
         )

--- a/cognite_toolkit/_cdf_tk/dataio/selectors/_instances.py
+++ b/cognite_toolkit/_cdf_tk/dataio/selectors/_instances.py
@@ -207,6 +207,11 @@ class InstanceQuerySelector(InstanceSelector):
     def __str__(self) -> str:
         return f"query_{self.root}_{'_'.join(self.subselections)}"
 
+    @property
+    def display_name(self) -> str:
+        selections = (self.root, *self.subselections)
+        return f"instances from a query selecting {humanize_collection(selections)}"
+
     def create_query(self) -> QueryRequest:
         data = json.loads(self.query)
         data["root"] = self.root


### PR DESCRIPTION
# Description

Cleans up migration UX: progress table now shows the selector's `display_name` instead of `str()`, and the FDM-to-CDM conversion description clarifies instance type/space/view info. Also fixes custom instance mappers not inheriting `logger` and `dry_run` from the parent mapper, causing them to log incorrectly and (hypothetically, but not in practice currently) always apply writes even during dry runs.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Improved

- [alpha] Show clearer progress descriptions during instance migration, including instance type, space, and destination view.

### Fixed

- [alpha] Fix Infield Schedules migrations not logging migration results correctly.