### PR TITLE
Switch toolkit skills from Atlassian MCP to acli

### DIFF
--- a/.cursor/skills/acli-atlassian/SKILL.md
+++ b/.cursor/skills/acli-atlassian/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: acli-atlassian
+description: Read and search Cognite Jira and Confluence via the official Atlassian CLI (acli). Use instead of the user-atlassian MCP whenever the user mentions Confluence, Jira, wiki pages, tickets, or Atlassian URLs.
+---
+
+# Atlassian via acli
+
+Do not use the `user-atlassian` MCP. It hangs. Use `acli` through the Shell tool.
+
+Site: `cognitedata.atlassian.net`
+
+## Auth
+
+If a command returns `unauthorized`, stop and tell the user to run:
+
+```bash
+acli auth login
+```
+
+That OAuth login covers both Jira and Confluence. Do not prompt for an API token unless they ask. Recheck with `acli confluence auth status` and `acli jira auth status`.
+
+## Confluence
+
+Page ID is the number after `/pages/` in the URL.
+
+```bash
+acli confluence page view --id 6141215047 --body-format storage
+acli confluence page view --id 6141215047 --json
+acli confluence space list
+acli confluence space view --key PD
+```
+
+`--body-format storage` for HTML-ish source. `--body-format view` for readable text. `--json` when parsing.
+
+Confluence **page write is not in acli** (only `page view`). For create/update, say so and wait; do not fall back to the Atlassian MCP.
+
+## Jira
+
+```bash
+acli jira workitem view CDF-12345
+acli jira workitem view CDF-12345 --json
+acli jira workitem view CDF-12345 --fields summary,description,status,issuetype,components,comment
+acli jira workitem search --jql "project = CDF AND text ~ \"toolkit\"" --limit 20
+acli jira workitem create --summary "..." --project CDF --type Task
+```
+
+Default site after login is Cognite. Pass `--json` when the output will be parsed.
+
+## Failures
+
+- `command not found`: install with `brew tap atlassian/homebrew-acli && brew install acli` (trust the tap if Homebrew asks).
+- Timeout or MCP tools appearing: ignore them; retry with `acli`.

--- a/.cursor/skills/create-jira-ticket/SKILL.md
+++ b/.cursor/skills/create-jira-ticket/SKILL.md
@@ -5,11 +5,13 @@ description: Create a Jira ticket in the CDF project at cognitedata.atlassian.ne
 
 # Create Jira Ticket
 
+Read `.cursor/skills/acli-atlassian/SKILL.md` first. **Do not use the `user-atlassian` MCP.**
+
 ## Defaults
 
 | Field        | Default value                                  |
 |--------------|------------------------------------------------|
-| cloudId      | `cognitedata.atlassian.net`                    |
+| site         | `cognitedata.atlassian.net`                    |
 | projectKey   | `CDF`                                          |
 | issueType    | `Task` (or `Bug` if it's a bug)                |
 | component    | `velocity:tooling`                             |
@@ -25,20 +27,36 @@ Override any default when the user specifies otherwise.
    - Description (optional but recommended)
    - Any overrides to the defaults above
 1. **Confirm** — show a brief summary of what will be created and ask the user to confirm before proceeding.
-1. **Create the ticket** using the Atlassian MCP `createJiraIssue` tool:
+1. **Create the ticket** with `acli` via the Shell tool.
 
-   ```yaml
-   cloudId:       cognitedata.atlassian.net
-   projectKey:    CDF
-   issueTypeName: Task   (or Bug)
-   summary:       <user-provided>
-   description:   <user-provided, if any>
-   parent:        CDF-28398
-   contentFormat: markdown
-   additional_fields:
-     components:
-       - name: velocity:tooling
+   Simple create (preferred when defaults apply):
+
+   ```bash
+   acli jira workitem create \
+     --summary "<user-provided>" \
+     --project CDF \
+     --type Task \
+     --description "<user-provided, if any>" \
+     --parent CDF-28398 \
+     --json
    ```
+
+   If you also need component or epic-link fields that `--parent` does not set, use `--from-json`:
+
+   ```bash
+   acli jira workitem create --generate-json > /tmp/jira-create.json
+   ```
+
+   Edit the JSON (summary, type, projectKey, description, and `additionalAttributes` as needed), then:
+
+   ```bash
+   acli jira workitem create --from-json /tmp/jira-create.json --json
+   ```
+
+   Epic link field: `customfield_10014` = `"CDF-28398"`.
+   Component: set via `additionalAttributes` if required by the project schema.
+
+1. **Handle auth failures** — if the command returns `unauthorized`, stop and tell the user to run `acli auth login`. Do not fall back to the Atlassian MCP.
 
 1. **Report back** — share the new ticket key and URL so the user can open it directly.
    URL format: `https://cognitedata.atlassian.net/browse/<KEY>`

--- a/.cursor/skills/start-it/SKILL.md
+++ b/.cursor/skills/start-it/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: start-it
 description: >-
-  Fetch Jira via Atlassian MCP (server user-atlassian), branch, plan, code.
+  Fetch Jira via acli, branch, plan, code.
   Use when the user says "start it" or "start" with a Jira URL.
 ---
 
 # Start It
+
+Read `.cursor/skills/acli-atlassian/SKILL.md` first. **Do not use the `user-atlassian` MCP.**
 
 When the user says **"start it"** (or **"start"** with a Jira URL):
 
@@ -17,14 +19,21 @@ When the user says **"start it"** (or **"start"** with a Jira URL):
 
 ## 2. Fetch task details
 
-- Use the **Atlassian MCP** server. In Cursor the server id is typically **`user-atlassian`**
-  (not `atlassian`). Read the MCP tool schema if invocation fails.
-- **Flow:**
-  1. Call **`getAccessibleAtlassianResources`** on `user-atlassian` and pick the site’s **`id`**
-     as `cloudId` (e.g. Cognite: `cognitedata.atlassian.net`).
-  2. Call **`getJiraIssue`** with `cloudId` and `issueIdOrKey` set to the ticket key (e.g. `CDF-1234`).
+- Use **`acli`** via the Shell tool:
+
+  ```bash
+  acli jira workitem view CDF-1234 --json
+  ```
+
+  Or, for a narrower field set:
+
+  ```bash
+  acli jira workitem view CDF-1234 --fields summary,description,status,issuetype,components,comment
+  ```
+
 - Use the response for summary, description, status, parent epic, components, subtasks, and comments.
 - Present a brief summary so the user can confirm it is the right ticket.
+- If the command returns `unauthorized`, stop and tell the user to run `acli auth login`. Do not fall back to the Atlassian MCP.
 
 ## 3. Create a working branch
 


### PR DESCRIPTION
# Description

Move toolkit agent skills off the unreliable `user-atlassian` MCP and onto `acli` for Jira operations.

## Bump

- [ ] Patch
- [x] Skip

## Changelog

### Improved

- Toolkit skills now use `acli` for Jira ticket create/fetch instead of Atlassian MCP.