### PR TITLE
fix: route CogIdP auth to dev instance for dev clusters (AUTH-4275)

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/config.py
+++ b/cognite_toolkit/_cdf_tk/client/config.py
@@ -4,6 +4,10 @@ from urllib.parse import urljoin
 from cognite.client import ClientConfig
 from cognite.client.credentials import CredentialProvider
 
+COGIDP_PROD_API_BASE = "https://auth.cognite.com/api/v1"
+COGIDP_DEV_API_BASE = "https://auth-dev.cognitedata-development.cognite.ai/api/v1"
+_DEV_CLUSTER_MARKER = "-dev"
+
 
 class ToolkitClientConfig(ClientConfig):
     def __init__(
@@ -119,12 +123,21 @@ class ToolkitClientConfig(ClientConfig):
         base_path = f"/apps/v1/projects/{self.project}{endpoint}"
         return urljoin(self.base_url, base_path)
 
+    @property
+    def _is_dev_cluster(self) -> bool:
+        cluster = self.cdf_cluster or ""
+        return _DEV_CLUSTER_MARKER in cluster.lower()
+
     def create_auth_url(self, endpoint: str) -> str:
         """Create a full Auth URL for the given endpoint.
+
+        Routes to the CogIdP dev instance for dev clusters (cluster names containing '-dev'),
+        e.g. az-arn-dev-002, aws-dub-dev, gc-bru-dev-003.
 
         Args:
             endpoint (str): The Auth endpoint to append to the base URL.
         """
         if not endpoint.startswith("/"):
             endpoint = f"/{endpoint}"
-        return f"https://auth.cognite.com/api/v1{endpoint}"
+        base = COGIDP_DEV_API_BASE if self._is_dev_cluster else COGIDP_PROD_API_BASE
+        return f"{base}{endpoint}"

--- a/cognite_toolkit/_cdf_tk/utils/auth.py
+++ b/cognite_toolkit/_cdf_tk/utils/auth.py
@@ -27,6 +27,11 @@ LoginFlow: TypeAlias = Literal["client_credentials", "token", "device_code", "in
 VALID_PROVIDERS = get_args(Provider)
 VALID_LOGIN_FLOWS = get_args(LoginFlow)
 
+COGIDP_PROD_TOKEN_URL = "https://auth.cognite.com/oauth2/token"
+COGIDP_DEV_TOKEN_URL = "https://auth-dev.cognitedata-development.cognite.ai/oauth2/token"
+# Clusters whose names contain this substring route to CogIdP dev.
+_DEV_CLUSTER_MARKER = "-dev"
+
 CLIENT_NAME = f"CDF-Toolkit:{__version__}"
 PROVIDER_DESCRIPTION = {
     "entra_id": "Use Microsoft Entra ID to authenticate",
@@ -197,9 +202,13 @@ class EnvironmentVariables:
         raise ToolkitMissingValueError("IDP_TENANT_ID is missing", "IDP_TENANT_ID")
 
     @property
+    def _is_dev_cluster(self) -> bool:
+        return _DEV_CLUSTER_MARKER in self.CDF_CLUSTER.lower()
+
+    @property
     def idp_token_url(self) -> str:
         if self.PROVIDER == "cdf":
-            return "https://auth.cognite.com/oauth2/token"
+            return COGIDP_DEV_TOKEN_URL if self._is_dev_cluster else COGIDP_PROD_TOKEN_URL
         if self.IDP_TOKEN_URL:
             return self.IDP_TOKEN_URL
         if self.PROVIDER == "entra_id" and self.IDP_TENANT_ID:


### PR DESCRIPTION
## Summary

- When `PROVIDER=cdf`, the OAuth token URL and CogIdP admin API base were hardcoded to the **production** CogIdP instance (`https://auth.cognite.com`), even for dev clusters.
- After the Auth team's migration (AUTH-4275), `cog-dev-*` orgs on dev clusters (`az-arn-dev-002`, `aws-dub-dev`, `gc-bru-dev-003`) now require the **CogIdP dev** instance (`https://auth-dev.cognitedata-development.cognite.ai`).
- This PR auto-detects dev clusters by checking whether the `CDF_CLUSTER` name contains `-dev` and routes accordingly — no env-var changes needed from the user.

## Changed files

- `cognite_toolkit/_cdf_tk/utils/auth.py` — `idp_token_url` now returns the CogIdP dev token URL for dev clusters
- `cognite_toolkit/_cdf_tk/client/config.py` — `create_auth_url()` now builds URLs against the CogIdP dev API base for dev clusters

## Test plan

- [ ] Unit test: `EnvironmentVariables(CDF_CLUSTER="az-arn-dev-002", ..., PROVIDER="cdf").idp_token_url` returns `https://auth-dev.cognitedata-development.cognite.ai/oauth2/token`
- [ ] Unit test: `EnvironmentVariables(CDF_CLUSTER="westeurope-1", ..., PROVIDER="cdf").idp_token_url` returns `https://auth.cognite.com/oauth2/token` (no regression)
- [ ] Unit test: `config.create_auth_url("/principals/me")` returns the correct base URL based on cluster
- [ ] Manual: run `cdf auth verify` against a `cog-dev-ai` project on `az-arn-dev-002`

## Context

Jeremy St. Ange flagged in Slack that the CLI breaks for users of the `cog-dev-ai` org after the Auth team switched dev clusters to CogIdP dev as primary source of truth. Related Jira: [AUTH-4275](https://cognitedata.atlassian.net/browse/AUTH-4275).

Made with [Cursor](https://cursor.com)

[AUTH-4275]: https://cognitedata.atlassian.net/browse/AUTH-4275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ