### PR TITLE
fix(transformations): external data sources are create-only

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/api/transformation_externaldata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/transformation_externaldata.py
@@ -16,7 +16,7 @@ class TransformationExternalDataSourcesAPI(CDFResourceAPI[ExternalDataSourceResp
         super().__init__(
             http_client=http_client,
             method_endpoint_map={
-                "upsert": Endpoint(method="POST", path="/transformations/externaldata", item_limit=1000),
+                "create": Endpoint(method="POST", path="/transformations/externaldata", item_limit=1000),
                 "delete": Endpoint(method="POST", path="/transformations/externaldata/delete", item_limit=1000),
                 "list": Endpoint(method="GET", path="/transformations/externaldata", item_limit=1000),
             },
@@ -28,14 +28,8 @@ class TransformationExternalDataSourcesAPI(CDFResourceAPI[ExternalDataSourceResp
     ) -> PagedResponse[ExternalDataSourceResponse]:
         return PagedResponse[ExternalDataSourceResponse].model_validate_json(response.body)
 
-    def upsert(self, items: Sequence[ExternalDataSourceRequest]) -> list[ExternalDataSourceResponse]:
-        return self._request_item_response(items, "upsert")
-
     def create(self, items: Sequence[ExternalDataSourceRequest]) -> list[ExternalDataSourceResponse]:
-        return self.upsert(items)
-
-    def update(self, items: Sequence[ExternalDataSourceRequest]) -> list[ExternalDataSourceResponse]:
-        return self.upsert(items)
+        return self._request_item_response(items, "create")
 
     def delete(self, items: Sequence[ExternalId]) -> None:
         self._request_no_response(items, "delete")

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/externaldata.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/externaldata.py
@@ -33,7 +33,9 @@ class ExternalDataSourceIO(
     kind = "ExternalDataSource"
     yaml_cls = ExternalDataSourceYAML
     dependencies = frozenset({DataSetsIO})
-    _doc_url = "Transformations-External-Data-Sources/operation/upsertExternalDataSources"
+    _doc_url = "Transformations-External-Data-Sources/operation/createExternalDataSources"
+
+    support_update = False
 
     @property
     def display_name(self) -> str:
@@ -86,10 +88,13 @@ class ExternalDataSourceIO(
         self, resource: ExternalDataSourceResponse, local: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         # Secrets cannot be compared (API never returns clientSecret). Dumping only the identifier
-        # when a local YAML exists makes deploy always upsert, matching hosted extractor sources.
+        # when a local YAML exists makes deploy always consider the resource changed. Since the API
+        # is create-only (support_update = False), an always-changed resource is deleted and
+        # recreated on every deploy, not upserted.
         if local:
             HighSeverityWarning(
-                "External data sources that contain credentials are always considered as changed and will be redeployed every time"
+                "External data sources will always be considered different, and thus will always be "
+                "deleted and re-created on deploy."
             ).print_warning(console=self.client.console)
             return self.dump_id(self.get_id(resource))
         dumped = resource.dump()
@@ -105,10 +110,7 @@ class ExternalDataSourceIO(
             yield item.settings.credentials.client_secret
 
     def create(self, items: Sequence[ExternalDataSourceRequest]) -> list[ExternalDataSourceResponse]:
-        return self.client.tool.transformations.external_data_sources.upsert(list(items))
-
-    def update(self, items: Sequence[ExternalDataSourceRequest]) -> list[ExternalDataSourceResponse]:
-        return self.client.tool.transformations.external_data_sources.upsert(list(items))
+        return self.client.tool.transformations.external_data_sources.create(list(items))
 
     def retrieve(self, ids: Sequence[ExternalId]) -> list[ExternalDataSourceResponse]:
         if not ids:

--- a/tests/test_unit/approval_client/config.py
+++ b/tests/test_unit/approval_client/config.py
@@ -1249,7 +1249,7 @@ API_RESOURCES = [
         resource_cls=ExternalDataSourceResponse,
         _write_cls=ExternalDataSourceRequest,
         methods={
-            "create": [Method(api_class_method="upsert", mock_class_method="upsert")],
+            "create": [Method(api_class_method="create", mock_class_method="create")],
             "retrieve": [
                 Method(api_class_method="list", mock_class_method="list"),
             ],

--- a/tests/test_unit/test_cdf_tk/test_client/test_transformation_externaldata.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_transformation_externaldata.py
@@ -47,25 +47,19 @@ def _make_request() -> ExternalDataSourceRequest:
 
 
 class TestTransformationExternalDataSourcesAPI:
-    def test_upsert_create_update_list_delete(
-        self, toolkit_config: ToolkitClientConfig, respx_mock: respx.MockRouter
-    ) -> None:
+    def test_create_list_delete(self, toolkit_config: ToolkitClientConfig, respx_mock: respx.MockRouter) -> None:
         client = HTTPClient(toolkit_config)
         api = TransformationExternalDataSourcesAPI(client)
         request = _make_request()
 
-        upsert_url = toolkit_config.create_api_url("/transformations/externaldata")
-        respx_mock.post(upsert_url).mock(
+        create_url = toolkit_config.create_api_url("/transformations/externaldata")
+        respx_mock.post(create_url).mock(
             return_value=httpx.Response(status_code=200, json={"items": [_EXAMPLE_RESPONSE]})
         )
-        created = api.upsert([request])
+        created = api.create([request])
         assert len(created) == 1
         assert created[0].external_id == "fabric-lakehouse-prod"
         assert respx_mock.calls[-1].request.headers["cdf-version"] == "beta"
-
-        updated = api.create([request])
-        assert len(updated) == 1
-        assert api.update([request]) == updated
 
         list_url = toolkit_config.create_api_url("/transformations/externaldata")
         respx_mock.get(list_url).mock(return_value=httpx.Response(status_code=200, json={"items": [_EXAMPLE_RESPONSE]}))

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_externaldata.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_externaldata.py
@@ -117,7 +117,7 @@ class TestExternalDataSourceIO:
             "unchanged": len(resources.unchanged),
         } == {"create": 1, "changed": 0, "delete": 0, "unchanged": 0}
 
-    def test_prepare_resources_existing_always_updates(self, toolkit_client_approval: ApprovalToolkitClient) -> None:
+    def test_prepare_resources_existing_recreates(self, toolkit_client_approval: ApprovalToolkitClient) -> None:
         toolkit_client_approval.append(ExternalDataSourceResponse, _make_response())
         local_file = MagicMock(spec=Path)
         local_file.read_text.return_value = _YAML
@@ -129,7 +129,7 @@ class TestExternalDataSourceIO:
             "changed": len(resources.to_update),
             "delete": len(resources.to_delete),
             "unchanged": len(resources.unchanged),
-        } == {"create": 0, "changed": 1, "delete": 0, "unchanged": 0}
+        } == {"create": 1, "changed": 0, "delete": 1, "unchanged": 0}
 
     def test_get_dependent_items_dataset(self) -> None:
         deps = list(
@@ -205,17 +205,16 @@ class TestExternalDataSourceIO:
             )
         assert loaded.data_set_id == 42
 
-    def test_create_update_retrieve_delete(self) -> None:
+    def test_create_retrieve_delete(self) -> None:
         with monkeypatch_toolkit_client() as client:
             loader = ExternalDataSourceIO.create_loader(client)
             item = _make_request()
             response = _make_response()
             api = client.tool.transformations.external_data_sources
-            api.upsert.return_value = [response]
+            api.create.return_value = [response]
             api.list.return_value = [response]
 
             assert loader.create([item]) == [response]
-            assert loader.update([item]) == [response]
             assert loader.retrieve([ExternalId(external_id="fabric-lakehouse-prod")]) == [response]
             assert loader.retrieve([]) == []
             assert loader.delete([ExternalId(external_id="fabric-lakehouse-prod")]) == 1


### PR DESCRIPTION
# Description

The Transformations external data sources API (Fabric OneLake) changed from upsert to create-only semantics on the backend: a request whose `externalId` already exists for the project now returns `409` instead of replacing the source. Toolkit's API wrapper and `ExternalDataSourceIO` loader still modeled this as upsert everywhere, so redeploying an existing source would now fail instead of updating it.

This aligns the toolkit with the new backend contract by mirroring the existing create-only `TransformationNotificationIO` pattern already in this codebase: `support_update = False`, a single `create()` method (no `upsert()`/`update()`), and delete+create on redeploy instead of update.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- [alpha] External data sources (Fabric OneLake) are create-only; redeploying an existing source now deletes and recreates it instead of failing with a 409.