### PR TITLE
[CDF-28516] Fix regex patterns mangled in build insight terminal output

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -865,7 +865,7 @@ class BuildV2Command(ToolkitCommand):
 
             insight_subsections: list[RenderableType] = []
             for insight in insight_content:
-                message = self._format_insight_message_for_terminal(insight.message)
+                message = self._truncate_for_terminal(insight.message)
                 content: list[RenderableType] = [hanging_indent(icon, message, marker_style=style)]
                 if insight.fix:
                     content.append(
@@ -917,8 +917,8 @@ class BuildV2Command(ToolkitCommand):
     _MAX_TERMINAL_MESSAGE_LENGTH: ClassVar[int] = 1000
 
     @classmethod
-    def _format_insight_message_for_terminal(cls, message: str) -> RenderableType:
-        """Formats an insight message for terminal display as plain text."""
+    def _truncate_for_terminal(cls, message: str) -> RenderableType:
+        """Truncates a message for terminal display only; the full message is always written to the insights file."""
         if len(message) <= cls._MAX_TERMINAL_MESSAGE_LENGTH:
             return Text(message)
         truncated_notice = Text.from_markup("[dim italic](truncated, see full message in the insights file)[/]")

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -15,7 +15,9 @@ import yaml
 from pydantic import JsonValue, TypeAdapter, ValidationError
 from questionary import Choice
 from rich.console import Console, Group, RenderableType
+from rich.markup import escape
 from rich.progress import Progress
+from rich.text import Text
 
 from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 from cognite_toolkit._cdf_tk.client import ToolkitClient
@@ -864,10 +866,16 @@ class BuildV2Command(ToolkitCommand):
 
             insight_subsections: list[RenderableType] = []
             for insight in insight_content:
-                message = self._truncate_for_terminal(insight.message)
+                message = self._format_insight_message_for_terminal(insight.message)
                 content: list[RenderableType] = [hanging_indent(icon, message, marker_style=style)]
                 if insight.fix:
-                    content.append(hanging_indent("→", f"Fix: {insight.fix}", marker_style=AuraColor.GREEN.rich))
+                    content.append(
+                        hanging_indent(
+                            "→",
+                            Text.from_markup(escape(f"Fix: {insight.fix}")),
+                            marker_style=AuraColor.GREEN.rich,
+                        )
+                    )
                 insight_subsections.append(
                     ToolkitPanelSection(
                         title=self._insight_section_title(insight),
@@ -910,12 +918,16 @@ class BuildV2Command(ToolkitCommand):
     _MAX_TERMINAL_MESSAGE_LENGTH: ClassVar[int] = 1000
 
     @classmethod
-    def _truncate_for_terminal(cls, message: str) -> str:
-        """Truncates a message for terminal display only; the full message is always written to the insights file."""
+    def _format_insight_message_for_terminal(cls, message: str) -> RenderableType:
+        """Formats an insight message for terminal display, escaping Rich markup in user-facing text."""
         if len(message) <= cls._MAX_TERMINAL_MESSAGE_LENGTH:
-            return message
-        truncated_notice = "[dim italic](truncated, see full message in the insights file)[/]"
-        return f"{message[: cls._MAX_TERMINAL_MESSAGE_LENGTH]}... {truncated_notice}"
+            return Text.from_markup(escape(message))
+        truncated_notice = Text.from_markup("[dim italic](truncated, see full message in the insights file)[/]")
+        return Text.assemble(
+            Text.from_markup(escape(message[: cls._MAX_TERMINAL_MESSAGE_LENGTH])),
+            Text("... "),
+            truncated_notice,
+        )
 
     @staticmethod
     def _humanize_insight_code(code: str | None) -> str:

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -15,7 +15,6 @@ import yaml
 from pydantic import JsonValue, TypeAdapter, ValidationError
 from questionary import Choice
 from rich.console import Console, Group, RenderableType
-from rich.markup import escape
 from rich.progress import Progress
 from rich.text import Text
 
@@ -872,7 +871,7 @@ class BuildV2Command(ToolkitCommand):
                     content.append(
                         hanging_indent(
                             "→",
-                            Text.from_markup(escape(f"Fix: {insight.fix}")),
+                            Text(f"Fix: {insight.fix}"),
                             marker_style=AuraColor.GREEN.rich,
                         )
                     )
@@ -919,13 +918,13 @@ class BuildV2Command(ToolkitCommand):
 
     @classmethod
     def _format_insight_message_for_terminal(cls, message: str) -> RenderableType:
-        """Formats an insight message for terminal display, escaping Rich markup in user-facing text."""
+        """Formats an insight message for terminal display as plain text."""
         if len(message) <= cls._MAX_TERMINAL_MESSAGE_LENGTH:
-            return Text.from_markup(escape(message))
+            return Text(message)
         truncated_notice = Text.from_markup("[dim italic](truncated, see full message in the insights file)[/]")
         return Text.assemble(
-            Text.from_markup(escape(message[: cls._MAX_TERMINAL_MESSAGE_LENGTH])),
-            Text("... "),
+            message[: cls._MAX_TERMINAL_MESSAGE_LENGTH],
+            "... ",
             truncated_notice,
         )
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
@@ -567,6 +567,26 @@ class TestDisplayInsightsOutput:
         assert "Model syntax warning in modules/my_module/data_modeling/my_space.Space.yaml" in rendered
         assert "Unknown field: 'Name'" in rendered
 
+    def test_displays_regex_pattern_without_rich_markup_corruption(self, tmp_path: Path) -> None:
+        console, output = self._console()
+        pattern = "^[a-z]([a-z0-9_-]{0,98}[a-z0-9])?$"
+        insights = InsightList(
+            [
+                ModelSyntaxWarning(
+                    code="MODEL-SYNTAX-WARNING",
+                    message=f"In field externalId string should match pattern '{pattern}'",
+                    fix="Make sure the resource YAML content is valid and follows the expected structure.",
+                    source_file="modules/quality/data_products/Quality.DataProduct.yaml",
+                )
+            ]
+        )
+
+        BuildV2Command()._display_insights(insights, tmp_path / "build" / "insights.csv", console, verbose=False)
+
+        rendered = output.getvalue()
+        assert pattern in rendered
+        assert "^({0,98})?$" not in rendered
+
 
 def _read_resource_outcome(result: FailedReadYAMLFile | SuccessfulReadYAMLFile) -> dict[str, Any]:
     if isinstance(result, FailedReadYAMLFile):


### PR DESCRIPTION
# Description

Build Insights terminal output was corrupting regex patterns in validation error messages. Rich treated quantifiers like `{0,98}` as markup tags, so users saw a corrupted pattern instead of the actual validation rule.

This change renders insight messages as plain `Text` in the terminal. `build/insights.csv` was already correct; only terminal display was affected.

**Before** (terminal Build Insights output):

```
! The resource definition has syntax errors:
  In field externalId string should match pattern '^({0,98})?$'
```

**After**:

```
! The resource definition has syntax errors:
  In field externalId string should match pattern '^[a-z]([a-z0-9_-]{0,98}[a-z0-9])?$'
```

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Build Insights terminal output now shows the full regex pattern in validation error messages instead of a corrupted version.