### PR TITLE
[CDF-28527]🛗 Reduce size mixpanel events

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -1063,26 +1063,20 @@ class BuildV2Command(ToolkitCommand):
         # Aggregate per (resource_folder, kind) — carried as a nested list under
         # `resource_stats` rather than dynamic top-level properties. This keeps
         # the Mixpanel schema fixed as Toolkit adds new resource kinds.
-        stats_by_type: dict[ResourceType, dict[str, int]] = {}
+        stats_by_type: dict[ResourceType, ResourceBuildStat] = {}
         for resource in built_resources:
-            bucket = stats_by_type.setdefault(
-                resource.type, {"built_count": 0, "dependency_total": 0, "syntax_error_count": 0}
-            )
-            bucket["built_count"] += 1
-            bucket["dependency_total"] += len(resource.dependencies)
+            if resource.type not in stats_by_type:
+                stats_by_type[resource.type] = ResourceBuildStat(
+                    resource_folder=resource.type.resource_folder,
+                    kind=resource.type.kind,
+                )
+            stat = stats_by_type[resource.type]
+            stat.built_count += 1
+            stat.dependency_total += len(resource.dependencies)
             if resource.has_syntax_error:
-                bucket["syntax_error_count"] += 1
+                stat.syntax_error_count += 1
 
-        resource_stats = [
-            ResourceBuildStat(
-                resource_folder=rtype.resource_folder,
-                kind=rtype.kind,
-                built_count=bucket["built_count"],
-                dependency_total=bucket["dependency_total"],
-                syntax_error_count=bucket["syntax_error_count"],
-            )
-            for rtype, bucket in sorted(stats_by_type.items(), key=lambda item: (item[0].resource_folder, item[0].kind))
-        ]
+        resource_stats = sorted(stats_by_type.values(), key=lambda s: (s.resource_folder, s.kind))
 
         dependency_total = sum(len(resource.dependencies) for resource in built_resources)
         built_count = len(built_resources)

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -54,7 +54,7 @@ from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._module import (
 )
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._types import AbsoluteFilePath
 from cognite_toolkit._cdf_tk.constants import BUILD_FOLDER_ENCODING, HINT_LEAD_TEXT, MODULES
-from cognite_toolkit._cdf_tk.data_classes._tracking_info import BuildTracking, to_tracking_key
+from cognite_toolkit._cdf_tk.data_classes._tracking_info import BuildTracking, ResourceBuildStat
 from cognite_toolkit._cdf_tk.exceptions import (
     ToolkitFileNotFoundError,
     ToolkitNotADirectoryError,
@@ -1060,10 +1060,30 @@ class BuildV2Command(ToolkitCommand):
         built_resources = [resource for module in build_folder.built_modules for resource in module.resources]
         duration_ms = int((build_folder.finished_at - build_folder.started_at).total_seconds() * 1000)
 
-        resource_counts: Counter[str] = Counter(
-            f"{to_tracking_key(f'{resource.type.resource_folder} {resource.type.kind}')}Built"
-            for resource in built_resources
-        )
+        # Aggregate per (resource_folder, kind) — carried as a nested list under
+        # `resource_stats` rather than dynamic top-level properties. This keeps
+        # the Mixpanel schema fixed as Toolkit adds new resource kinds.
+        stats_by_type: dict[ResourceType, dict[str, int]] = {}
+        for resource in built_resources:
+            bucket = stats_by_type.setdefault(
+                resource.type, {"built_count": 0, "dependency_total": 0, "syntax_error_count": 0}
+            )
+            bucket["built_count"] += 1
+            bucket["dependency_total"] += len(resource.dependencies)
+            if resource.has_syntax_error:
+                bucket["syntax_error_count"] += 1
+
+        resource_stats = [
+            ResourceBuildStat(
+                resource_folder=rtype.resource_folder,
+                kind=rtype.kind,
+                built_count=bucket["built_count"],
+                dependency_total=bucket["dependency_total"],
+                syntax_error_count=bucket["syntax_error_count"],
+            )
+            for rtype, bucket in sorted(stats_by_type.items(), key=lambda item: (item[0].resource_folder, item[0].kind))
+        ]
+
         dependency_total = sum(len(resource.dependencies) for resource in built_resources)
         built_count = len(built_resources)
         dependency_average = round((dependency_total / built_count), 6) if built_count else 0.0
@@ -1071,19 +1091,18 @@ class BuildV2Command(ToolkitCommand):
         insight_codes_set = {ins.code if ins.code is not None else "UNDEFINED" for ins in insights}
         yaml_line_count = sum(module.yaml_line_count for module in build_folder.built_modules)
 
-        payload: dict[str, Any] = {
-            "build_duration_ms": duration_ms,
-            "resource_types": sorted(resource_counts.keys()),
-            "insight_codes": sorted(insight_codes_set),
-            "dependency_total": dependency_total,
-            "dependency_average": dependency_average,
-            "built_resource_total": built_count,
-            "module_count": len(build_folder.built_modules),
-            "insight_total_count": len(insights),
-            "yaml_line_count": yaml_line_count,
-        }
-        payload.update(resource_counts)
-        event = BuildTracking.model_validate(payload)
+        event = BuildTracking(
+            build_duration_ms=duration_ms,
+            resource_types=sorted(f"{s.resource_folder}.{s.kind}" for s in resource_stats),
+            resource_stats=resource_stats,
+            insight_codes=sorted(insight_codes_set),
+            dependency_total=dependency_total,
+            dependency_average=dependency_average,
+            built_resource_total=built_count,
+            module_count=len(build_folder.built_modules),
+            insight_total_count=len(insights),
+            yaml_line_count=yaml_line_count,
+        )
         self.tracker.track(event, client)
 
     def _write_results(

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -1060,9 +1060,6 @@ class BuildV2Command(ToolkitCommand):
         built_resources = [resource for module in build_folder.built_modules for resource in module.resources]
         duration_ms = int((build_folder.finished_at - build_folder.started_at).total_seconds() * 1000)
 
-        # Aggregate per (resource_folder, kind) — carried as a nested list under
-        # `resource_stats` rather than dynamic top-level properties. This keeps
-        # the Mixpanel schema fixed as Toolkit adds new resource kinds.
         stats_by_type: dict[ResourceType, ResourceBuildStat] = {}
         for resource in built_resources:
             if resource.type not in stats_by_type:

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -31,7 +31,7 @@ from cognite_toolkit._cdf_tk.commands._utils import (
 )
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import BuildLineage
 from cognite_toolkit._cdf_tk.constants import HINT_LEAD_TEXT
-from cognite_toolkit._cdf_tk.data_classes._tracking_info import DeploymentTracking
+from cognite_toolkit._cdf_tk.data_classes._tracking_info import DeploymentTracking, ResourceDeploymentStat
 from cognite_toolkit._cdf_tk.dataio.selectors import RawTableSelector, SelectedTable
 from cognite_toolkit._cdf_tk.exceptions import (
     ResourceCreationError,
@@ -1193,25 +1193,28 @@ class DeployV2Command(ToolkitCommand):
 
         is_dry_run = results[0].is_dry_run
 
-        # Build flattened per-resource stats for Mixpanel compatibility
-        # Creates keys like "dataSets_created", "spaces_updated", etc.
-        per_resource_stats: dict[str, int] = {}
-        resource_types: list[str] = []
-        for result in results:
-            # Convert resource name to camelCase key prefix (e.g., "Data Sets" -> "dataSets")
-            key_prefix = cls._to_tracking_key(result.resource_name)
-            resource_types.append(result.resource_name)
-            per_resource_stats[f"{key_prefix}Created"] = result.created_count
-            per_resource_stats[f"{key_prefix}Updated"] = result.updated_count
-            per_resource_stats[f"{key_prefix}Deleted"] = result.deleted_count
-            per_resource_stats[f"{key_prefix}Unchanged"] = result.unchanged_count
-            per_resource_stats[f"{key_prefix}Skipped"] = result.skipped_count
-            per_resource_stats[f"{key_prefix}Total"] = result.total_count
+        # Per-resource stats are carried as a nested list under `resource_stats`
+        # (see DeploymentTracking) rather than being flattened into dynamic
+        # top-level properties. This keeps the Mixpanel schema fixed as new
+        # resource kinds are added to Toolkit.
+        resource_stats = [
+            ResourceDeploymentStat(
+                resource_name=result.resource_name,
+                created=result.created_count,
+                updated=result.updated_count,
+                deleted=result.deleted_count,
+                unchanged=result.unchanged_count,
+                skipped=result.skipped_count,
+                total=result.total_count,
+            )
+            for result in results
+        ]
 
         event = DeploymentTracking(
             is_dry_run=is_dry_run,
             operation=operation,
-            resource_types=resource_types,
+            resource_types=[result.resource_name for result in results],
+            resource_stats=resource_stats,
             total_created=sum(r.created_count for r in results),
             total_updated=sum(r.updated_count for r in results),
             total_deleted=sum(r.deleted_count for r in results),
@@ -1219,24 +1222,8 @@ class DeployV2Command(ToolkitCommand):
             total_skipped=sum(r.skipped_count for r in results),
             total_resources=sum(r.total_count for r in results),
             resource_type_count=len(results),
-            # This pydantic class allows extra
-            **per_resource_stats,  # type: ignore [arg-type]
         )
         tracker.track(event, client)
-
-    @staticmethod
-    def _to_tracking_key(resource_name: str) -> str:
-        """Convert a resource display name to a camelCase tracking key.
-
-        Examples:
-            "Data Sets" -> "dataSets"
-            "Extraction Pipelines" -> "extractionPipelines"
-            "RAW Tables" -> "rawTables"
-        """
-        words = resource_name.replace("-", " ").split()
-        if not words:
-            return resource_name.lower()
-        return words[0].lower() + "".join(word.capitalize() for word in words[1:])
 
     @classmethod
     def _find_raw_tables(cls, build_lineage: BuildLineage) -> Mapping[RawTableSelector, list[Path]]:

--- a/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
+++ b/cognite_toolkit/_cdf_tk/commands/deploy_v2/command.py
@@ -1193,10 +1193,6 @@ class DeployV2Command(ToolkitCommand):
 
         is_dry_run = results[0].is_dry_run
 
-        # Per-resource stats are carried as a nested list under `resource_stats`
-        # (see DeploymentTracking) rather than being flattened into dynamic
-        # top-level properties. This keeps the Mixpanel schema fixed as new
-        # resource kinds are added to Toolkit.
         resource_stats = [
             ResourceDeploymentStat(
                 resource_name=result.resource_name,

--- a/cognite_toolkit/_cdf_tk/data_classes/_tracking_info.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_tracking_info.py
@@ -2,18 +2,34 @@
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic.alias_generators import to_camel
 
 from cognite_toolkit._cdf_tk.dataio.logger import ItemsResult
 
+# --- Mixpanel ingestion safety limits ---------------------------------------
+# Documented Mixpanel limits we defensively guard against:
+#   * String property values are truncated at 255 chars (silently).
+#   * Nested objects/arrays deeper than 3 levels are rejected/flattened.
+#   * 255 properties per event.
+# Our events sit well within these; the caps below are belt-and-suspenders so
+# a future change (e.g. a new free-form field or an explosion in resource
+# kinds) cannot silently corrupt analytics data.
+MP_STRING_LIMIT: int = 255
+MP_MAX_LIST_ITEMS: int = 250
 
-def to_tracking_key(display_name: str) -> str:
-    """Convert a resource label to a camelCase Mixpanel key prefix (matches deploy_v2)."""
-    words = display_name.replace("-", " ").replace("_", " ").split()
-    if not words:
-        return display_name.lower()
-    return words[0].lower() + "".join(word.capitalize() for word in words[1:])
+
+def _mp_safe_str(value: str, limit: int = MP_STRING_LIMIT) -> str:
+    """Truncate a string so it will not be silently cut off by Mixpanel."""
+    if len(value) <= limit:
+        return value
+    # Reserve one char for the ellipsis so total length stays <= limit.
+    return value[: limit - 1] + "…"
+
+
+def _mp_safe_str_list(values: list[str]) -> list[str]:
+    """Truncate each element and cap the list length."""
+    return [_mp_safe_str(v) for v in values[:MP_MAX_LIST_ITEMS]]
 
 
 class TrackingEvent(BaseModel):
@@ -57,6 +73,16 @@ class CommandTracking(TrackingEvent):
     alpha_flags: list[str] = Field(default_factory=list)
     plugins: list[str] = Field(default_factory=list)
 
+    @field_validator("result", mode="after")
+    @classmethod
+    def _truncate_result(cls, v: str) -> str:
+        return _mp_safe_str(v)
+
+    @field_validator("error", mode="after")
+    @classmethod
+    def _truncate_error(cls, v: str | None) -> str | None:
+        return _mp_safe_str(v) if v is not None else None
+
 
 class DataTracking(TrackingEvent):
     """Structured tracking information for CLI commands."""
@@ -86,31 +112,46 @@ class DataTracking(TrackingEvent):
         return cls.model_validate(tracking_data)
 
 
+class ResourceDeploymentStat(BaseModel):
+    """Per-resource-type deployment counts, nested inside ``DeploymentTracking``.
+
+    Kept as a flat set of scalars — do NOT add nested lists/dicts here, as
+    Mixpanel only supports 3 levels of nesting and this model already sits at
+    level 3 (event → resource_stats[] → this).
+    """
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    resource_name: str
+    created: int = 0
+    updated: int = 0
+    deleted: int = 0
+    unchanged: int = 0
+    skipped: int = 0
+    total: int = 0
+
+    @field_validator("resource_name", mode="after")
+    @classmethod
+    def _truncate_resource_name(cls, v: str) -> str:
+        return _mp_safe_str(v)
+
+
 class DeploymentTracking(TrackingEvent):
     """Structured tracking information for deployment commands.
 
-    This model uses a flattened structure for Mixpanel compatibility.
-    Per-resource stats are stored as dynamic fields like "dataSets_created", "spaces_updated", etc.
-
-    Attributes:
-        is_dry_run: Whether this was a dry run.
-        operation: The operation performed (deploy or clean).
-        resource_types: List of resource type names that were deployed.
-        total_created: Total resources created across all types.
-        total_updated: Total resources updated across all types.
-        total_deleted: Total resources deleted across all types.
-        total_unchanged: Total unchanged resources across all types.
-        total_skipped: Total skipped resources across all types.
-        total_resources: Total resources across all types.
-        resource_type_count: Number of different resource types deployed.
+    Per-resource stats are carried in the ``resource_stats`` list rather than
+    being flattened into top-level dynamic properties. This keeps the Mixpanel
+    schema fixed regardless of how many resource kinds Toolkit adds and avoids
+    silent property-count sprawl.
     """
 
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, extra="allow")
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     event_name: Literal["DeploymentResult"] = Field("DeploymentResult", exclude=True)
     is_dry_run: bool = False
     operation: str = "deploy"
     resource_types: list[str] = Field(default_factory=list)
+    resource_stats: list[ResourceDeploymentStat] = Field(default_factory=list)
     total_created: int = 0
     total_updated: int = 0
     total_deleted: int = 0
@@ -119,24 +160,68 @@ class DeploymentTracking(TrackingEvent):
     total_resources: int = 0
     resource_type_count: int = 0
 
+    @field_validator("resource_types", mode="after")
+    @classmethod
+    def _cap_resource_types(cls, v: list[str]) -> list[str]:
+        return _mp_safe_str_list(v)
+
+    @field_validator("resource_stats", mode="after")
+    @classmethod
+    def _cap_resource_stats(cls, v: list[ResourceDeploymentStat]) -> list[ResourceDeploymentStat]:
+        return v[:MP_MAX_LIST_ITEMS]
+
+
+class ResourceBuildStat(BaseModel):
+    """Per-resource-type build counts, nested inside ``BuildTracking``.
+
+    Kept as a flat set of scalars — do NOT add nested lists/dicts here, as
+    Mixpanel only supports 3 levels of nesting and this model already sits at
+    level 3 (event → resource_stats[] → this).
+    """
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    resource_folder: str
+    kind: str
+    built_count: int = 0
+    dependency_total: int = 0
+    syntax_error_count: int = 0
+
+    @field_validator("resource_folder", "kind", mode="after")
+    @classmethod
+    def _truncate_names(cls, v: str) -> str:
+        return _mp_safe_str(v)
+
 
 class BuildTracking(TrackingEvent):
     """Structured tracking information for build v2 (`cdf build`).
 
-    Per-resource-type built counts use flattened Mixpanel fields such as ``spaceDataModelingBuilt``,
-    matching the ``DeploymentTracking`` pattern (``extra="allow"``). Populate via
-    ``BuildTracking.model_validate({...})`` in ``BuildV2Command._track_build_results``.
+    Per-resource-type built counts are carried in the ``resource_stats`` list
+    rather than being flattened into top-level dynamic properties. This keeps
+    the Mixpanel schema fixed regardless of how many resource kinds Toolkit
+    adds and avoids silent property-count sprawl.
     """
 
-    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, extra="allow")
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     event_name: Literal["BuildResult"] = Field("BuildResult", exclude=True)
     build_duration_ms: int = 0
-    resource_types: set[str] = Field(default_factory=set)
-    insight_codes: set[str] = Field(default_factory=set)
+    resource_types: list[str] = Field(default_factory=list)
+    resource_stats: list[ResourceBuildStat] = Field(default_factory=list)
+    insight_codes: list[str] = Field(default_factory=list)
     dependency_total: int = 0
     dependency_average: float = 0.0
     built_resource_total: int = 0
     module_count: int = 0
     insight_total_count: int = 0
     yaml_line_count: int = 0
+
+    @field_validator("resource_types", "insight_codes", mode="after")
+    @classmethod
+    def _cap_str_lists(cls, v: list[str]) -> list[str]:
+        return _mp_safe_str_list(v)
+
+    @field_validator("resource_stats", mode="after")
+    @classmethod
+    def _cap_resource_stats(cls, v: list[ResourceBuildStat]) -> list[ResourceBuildStat]:
+        return v[:MP_MAX_LIST_ITEMS]

--- a/cognite_toolkit/_cdf_tk/data_classes/_tracking_info.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_tracking_info.py
@@ -61,10 +61,16 @@ class CommandTracking(TrackingEvent):
 class DataTracking(TrackingEvent):
     """Structured tracking information for CLI commands."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
     event_name: Literal["DownloadResult", "UploadResult", "MigrationResult", "PurgeResult"] = Field(exclude=True)
     data_type: str
     total: int
+    success: int = Field(default=0)
+    failure: int = Field(default=0)
+    pending: int = Field(default=0)
+    skipped: int = Field(default=0)
+    success_with_warning: int = Field(default=0, alias="success-with-warning")
+    pending_with_warning: int = Field(default=0, alias="pending-with-warning")
 
     @classmethod
     def from_item_results(

--- a/cognite_toolkit/_cdf_tk/data_classes/_tracking_info.py
+++ b/cognite_toolkit/_cdf_tk/data_classes/_tracking_info.py
@@ -87,14 +87,13 @@ class CommandTracking(TrackingEvent):
 class DataTracking(TrackingEvent):
     """Structured tracking information for CLI commands."""
 
-    model_config = ConfigDict(extra="forbid")
     event_name: Literal["DownloadResult", "UploadResult", "MigrationResult", "PurgeResult"] = Field(exclude=True)
     data_type: str
     total: int
-    success: int = Field(default=0)
-    failure: int = Field(default=0)
-    pending: int = Field(default=0)
-    skipped: int = Field(default=0)
+    success: int = 0
+    failure: int = 0
+    pending: int = 0
+    skipped: int = 0
     success_with_warning: int = Field(default=0, alias="success-with-warning")
     pending_with_warning: int = Field(default=0, alias="pending-with-warning")
 

--- a/tests/auth_utils.py
+++ b/tests/auth_utils.py
@@ -233,7 +233,6 @@ class EnvironmentVariables:
             project=self.CDF_PROJECT,
             credentials=self.get_credentials(),
             base_url=self.cdf_url,
-            max_workers=self.CDF_MAX_WORKERS,
             timeout=self.CDF_TIMEOUT,
         )
         return ToolkitClient(config=config)

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_logger.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_logger.py
@@ -1,13 +1,16 @@
 from collections import Counter
+from typing import get_args
 from unittest.mock import MagicMock
 
 import pytest
 
+from cognite_toolkit._cdf_tk.data_classes._tracking_info import DataTracking
 from cognite_toolkit._cdf_tk.dataio.logger import (
     FileWithAggregationLogger,
     ItemsResult,
     LabelResult,
     LogEntryV2,
+    OperationStatus,
     Severity,
     display_item_results,
 )
@@ -114,3 +117,11 @@ class TestFileWithAggregationLogger:
                 attribute_display_name="ignored properties",
             )
         )
+
+
+class TestOperationStatus:
+    def test_operation_status_match_tracking_event(self) -> None:
+        operation_status: set[str] = set(get_args(OperationStatus))
+        trackings_keys = {field_.alias or key for key, field_ in DataTracking.model_fields.items()}
+
+        assert operation_status <= trackings_keys, "OperationStatus values should match DataTracking model fields"

--- a/tests/trigger_mixpanel_event.py
+++ b/tests/trigger_mixpanel_event.py
@@ -4,11 +4,112 @@ import sys
 
 from cognite_toolkit._cdf_tk.cdf_toml import CDFToml
 from cognite_toolkit._cdf_tk.data_classes import (
+    CommandTracking,
+    DeploymentTracking,
     TrackingEvent,
 )
+from cognite_toolkit._cdf_tk.data_classes._tracking_info import (
+    BuildTracking,
+    DataTracking,
+    ResourceBuildStat,
+    ResourceDeploymentStat,
+)
+from cognite_toolkit._cdf_tk.dataio.logger import ItemsResult
 from cognite_toolkit._cdf_tk.tracker import Tracker
 from tests.auth_utils import get_toolkit_client
 from tests.constants import REPO_ROOT, chdir
+
+
+def _mock_events() -> list[TrackingEvent]:
+    """Build one mock event per available TrackingEvent subclass."""
+    command_event = CommandTracking(
+        event_name="test",
+        installed_module_ids={"module_a", "module_b"},
+        installed_package_ids={"package_a"},
+        downloaded_library_ids={"library_a"},
+        downloaded_package_ids={"package_b"},
+        downloaded_module_ids={"module_c"},
+        warning_total_count=3,
+        result="success",
+        error=None,
+        subcommands=["build"],
+        alpha_flags=["experimental-feature"],
+        plugins=["plugin_a"],
+    )
+
+    data_event = DataTracking.from_item_results(
+        event_name="DownloadResult",
+        data_type="timeseries",
+        item_results=[
+            ItemsResult(status="success", count=42, severity=0),
+            ItemsResult(status="failure", count=2, severity=3),
+            ItemsResult(status="skipped", count=1, severity=0),
+            ItemsResult(status="success-with-warning", count=5, severity=1),
+        ],
+    )
+
+    deployment_event = DeploymentTracking(
+        is_dry_run=False,
+        operation="deploy",
+        resource_types=["timeseries", "assets"],
+        resource_stats=[
+            ResourceDeploymentStat(
+                resource_name="timeseries",
+                created=10,
+                updated=2,
+                deleted=0,
+                unchanged=5,
+                skipped=1,
+                total=18,
+            ),
+            ResourceDeploymentStat(
+                resource_name="assets",
+                created=3,
+                updated=1,
+                deleted=0,
+                unchanged=7,
+                skipped=0,
+                total=11,
+            ),
+        ],
+        total_created=13,
+        total_updated=3,
+        total_deleted=0,
+        total_unchanged=12,
+        total_skipped=1,
+        total_resources=29,
+        resource_type_count=2,
+    )
+
+    build_event = BuildTracking(
+        build_duration_ms=1234,
+        resource_types=["timeseries", "assets"],
+        resource_stats=[
+            ResourceBuildStat(
+                resource_folder="timeseries",
+                kind="TimeSeries",
+                built_count=10,
+                dependency_total=2,
+                syntax_error_count=0,
+            ),
+            ResourceBuildStat(
+                resource_folder="assets",
+                kind="Asset",
+                built_count=5,
+                dependency_total=1,
+                syntax_error_count=0,
+            ),
+        ],
+        insight_codes=["INSIGHT_001"],
+        dependency_total=3,
+        dependency_average=1.5,
+        built_resource_total=15,
+        module_count=4,
+        insight_total_count=1,
+        yaml_line_count=250,
+    )
+
+    return [command_event, data_event, deployment_event, build_event]
 
 
 def track_test_command() -> None:
@@ -18,12 +119,15 @@ def track_test_command() -> None:
         # To ensure that cdf.toml is loaded correctly
         _ = CDFToml.load()
         tracker = Tracker()
+        client = get_toolkit_client(".env")
 
-        is_sent = tracker.track(TrackingEvent(event_name="test"), get_toolkit_client(".env"))
-        if is_sent:
-            print("Event sent")
-        else:
-            print("Event not sent")
+        for event in _mock_events():
+            is_sent = tracker.track(event, client)
+            label = type(event).__name__
+            if is_sent:
+                print(f"{label} event sent")
+            else:
+                print(f"{label} event not sent")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Currently the `Build` and `Deploy` events starts to hit mixpanels max number of properties, leading to silently losing usage data.

Event in mixpanel
<img width="1050" height="852" alt="image" src="https://github.com/user-attachments/assets/6b457923-333f-412b-971d-b22516b8a019" />


## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- Changed format for how usage information is collected.
