### PR TITLE
[CDF-28532]🪟 Support record views

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_view.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_view.py
@@ -26,6 +26,7 @@ class View(BaseModelObject, ABC):
     description: str | None = None
     filter: JsonValue | None = None
     implements: list[ViewId] | None = None
+    stream_id: list[str] | None = None
 
     def as_id(self) -> ViewId:
         return ViewId(space=self.space, external_id=self.external_id, version=self.version)
@@ -69,6 +70,11 @@ class View(BaseModelObject, ABC):
             dumped["type"] = "view"
             output.append(dumped)
         return output
+
+    @property
+    def is_record_view(self) -> bool:
+        """Check if the view is a record view based on its properties."""
+        return self.stream_id is not None
 
 
 class ViewRequest(View, RequestResource):

--- a/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_view.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/data_modeling/_view.py
@@ -98,7 +98,7 @@ class ViewResponse(View, ResponseResource[ViewRequest]):
     last_updated_time: int
     writable: bool
     queryable: bool
-    used_for: Literal["node", "edge", "all"]
+    used_for: Literal["node", "edge", "all", "record"]
     is_global: bool
     mapped_containers: list[ContainerId]
 

--- a/cognite_toolkit/_cdf_tk/utils/interactive_select.py
+++ b/cognite_toolkit/_cdf_tk/utils/interactive_select.py
@@ -735,7 +735,7 @@ class DataModelingSelect:
         return selected_space
 
     def select_instance_type(
-        self, view_used_for: Literal["node", "edge", "all"] | None = None, message: str | None = None
+        self, view_used_for: Literal["node", "edge", "record", "all"] | None = None, message: str | None = None
     ) -> Literal["node", "edge"]:
         """Selects an instance type (node or edge) interactively.
 
@@ -746,6 +746,8 @@ class DataModelingSelect:
         Returns:
             The selected instance type, either 'node' or 'edge'.
         """
+        if view_used_for == "record":
+            raise ToolkitValueError("Instance type 'record' is not supported for instance view selection.")
         if view_used_for is not None and view_used_for != "all":
             return view_used_for
         selected_instance_type = questionary.select(

--- a/cognite_toolkit/_cdf_tk/yaml_classes/views.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/views.py
@@ -16,7 +16,7 @@ from cognite_toolkit._cdf_tk.constants import (
 from cognite_toolkit._cdf_tk.utils.collection import humanize_collection
 
 from .base import ToolkitResource
-from .view_field_definitions import ViewProperty, ViewReference
+from .view_field_definitions import ContainerViewProperty, ViewProperty, ViewReference
 
 KEY_PATTERN = re.compile(CONTAINER_AND_VIEW_PROPERTIES_IDENTIFIER_PATTERN)
 
@@ -27,6 +27,10 @@ class ViewYAML(ToolkitResource):
         min_length=1,
         max_length=43,
         pattern=SPACE_FORMAT_PATTERN,
+    )
+    stream_id: list[str] | None = Field(
+        default=None,
+        description="If set, this is a record view and list the stream ids that the view is associated with.",
     )
     external_id: str = Field(
         description="External-id of the view.",
@@ -84,6 +88,19 @@ class ViewYAML(ToolkitResource):
             if key in FORBIDDEN_CONTAINER_AND_VIEW_PROPERTIES_IDENTIFIER:
                 raise ValueError(
                     f"'{key}' is a reserved property identifier. Reserved identifiers are: {humanize_collection(FORBIDDEN_CONTAINER_AND_VIEW_PROPERTIES_IDENTIFIER)}"
+                )
+        return val
+
+    @field_validator("properties", mode="after")
+    def record_views_only_support_container_properties(
+        self, val: dict[str, ViewProperty] | None
+    ) -> dict[str, ViewProperty] | None:
+        """Validate that record views only support container properties."""
+        if self.stream_id is not None and val is not None:
+            invalid_properties = [key for key, prop in val.items() if isinstance(prop, ContainerViewProperty)]
+            if invalid_properties:
+                raise ValueError(
+                    f"Record views only support container properties. The following properties are invalid for record views: {humanize_collection(invalid_properties)}"
                 )
         return val
 

--- a/cognite_toolkit/_cdf_tk/yaml_classes/views.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/views.py
@@ -2,7 +2,7 @@ import re
 from typing import Any
 
 from pydantic import Field, field_validator, model_serializer
-from pydantic_core.core_schema import SerializationInfo, SerializerFunctionWrapHandler
+from pydantic_core.core_schema import SerializationInfo, SerializerFunctionWrapHandler, ValidationInfo
 
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import ViewId as ViewReferenceId
 from cognite_toolkit._cdf_tk.constants import (
@@ -92,12 +92,13 @@ class ViewYAML(ToolkitResource):
         return val
 
     @field_validator("properties", mode="after")
+    @classmethod
     def record_views_only_support_container_properties(
-        self, val: dict[str, ViewProperty] | None
+        cls, val: dict[str, ViewProperty] | None, info: ValidationInfo
     ) -> dict[str, ViewProperty] | None:
         """Validate that record views only support container properties."""
-        if self.stream_id is not None and val is not None:
-            invalid_properties = [key for key, prop in val.items() if isinstance(prop, ContainerViewProperty)]
+        if info.data["stream_id"] is not None and val is not None:
+            invalid_properties = [key for key, prop in val.items() if not isinstance(prop, ContainerViewProperty)]
             if invalid_properties:
                 raise ValueError(
                     f"Record views only support container properties. The following properties are invalid for record views: {humanize_collection(invalid_properties)}"

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_view.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_view.py
@@ -155,6 +155,87 @@ def view_with_filters_cases() -> Iterable:
     yield from (pytest.param(next(iter(f.values())), id=next(iter(f.keys()))) for f in view_filters)
 
 
+def invalid_view_cases() -> Iterable:
+    invalid_views = [
+        (
+            "ReservedExternalId",
+            {
+                "space": "my_space",
+                "externalId": "Query",  # Reserved name
+                "version": "1",
+                "properties": {
+                    "field": {
+                        "container": {"type": "container", "space": "my_space", "externalId": "my_container"},
+                        "containerPropertyIdentifier": "field",
+                    }
+                },
+            },
+            "is a reserved view External ID",
+        ),
+        (
+            "InvalidPropertyIdentifier",
+            {
+                "space": "my_space",
+                "externalId": "valid_view",
+                "version": "1",
+                "properties": {
+                    "invalid@": {  # Invalid character
+                        "container": {"type": "container", "space": "my_space", "externalId": "my_container"},
+                        "containerPropertyIdentifier": "field",
+                    }
+                },
+            },
+            "does not match the required pattern",
+        ),
+        (
+            "ForbiddenPropertyIdentifier",
+            {
+                "space": "my_space",
+                "externalId": "valid_view",
+                "version": "1",
+                "properties": {
+                    "edge_id": {  # Reserved property name
+                        "container": {"type": "container", "space": "my_space", "externalId": "my_container"},
+                        "containerPropertyIdentifier": "field",
+                    }
+                },
+            },
+            "is a reserved property identifier",
+        ),
+        (
+            "InvalidSpaceFormat",
+            {
+                "space": "invalid space",  # Contains a space
+                "externalId": "valid_view",
+                "version": "1",
+                "properties": {
+                    "field": {
+                        "container": {"type": "container", "space": "my_space", "externalId": "my_container"},
+                        "containerPropertyIdentifier": "field",
+                    }
+                },
+            },
+            "String should match pattern",
+        ),
+        (
+            "InvalidVersionFormat",
+            {
+                "space": "my_space",
+                "externalId": "valid_view",
+                "version": ".0.1",  # Invalid version format
+                "properties": {
+                    "field": {
+                        "container": {"type": "container", "space": "my_space", "externalId": "my_container"},
+                        "containerPropertyIdentifier": "field",
+                    }
+                },
+            },
+            "String should match pattern",
+        ),
+    ]
+    yield from (pytest.param(data, match, id=case_id) for case_id, data, match in invalid_views)
+
+
 class TestViewYAML:
     @pytest.mark.parametrize("data", list(find_resources("View")))
     def test_load_valid_view_file(self, data: dict[str, object]) -> None:
@@ -176,82 +257,7 @@ class TestViewYAML:
         loaded = ViewYAML.model_validate(data)
         assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
 
-    def test_invalid_external_id(self) -> None:
-        invalid_data = {
-            "space": "my_space",
-            "externalId": "Query",  # Reserved name
-            "version": "1",
-            "properties": {
-                "field": {
-                    "container": {"type": "container", "space": "my_space", "externalId": "my_container"},
-                    "containerPropertyIdentifier": "field",
-                }
-            },
-        }
-
-        with pytest.raises(ValueError, match="is a reserved view External ID"):
-            ViewYAML.model_validate(invalid_data)
-
-    def test_invalid_property_identifier(self) -> None:
-        invalid_data = {
-            "space": "my_space",
-            "externalId": "valid_view",
-            "version": "1",
-            "properties": {
-                "invalid@": {  # Invalid character
-                    "container": {"type": "container", "space": "my_space", "externalId": "my_container"},
-                    "containerPropertyIdentifier": "field",
-                }
-            },
-        }
-
-        with pytest.raises(ValueError, match="does not match the required pattern"):
-            ViewYAML.model_validate(invalid_data)
-
-    def test_forbidden_property_identifier(self) -> None:
-        invalid_data = {
-            "space": "my_space",
-            "externalId": "valid_view",
-            "version": "1",
-            "properties": {
-                "edge_id": {  # Reserved property name
-                    "container": {"type": "container", "space": "my_space", "externalId": "my_container"},
-                    "containerPropertyIdentifier": "field",
-                }
-            },
-        }
-
-        with pytest.raises(ValueError, match="is a reserved property identifier"):
-            ViewYAML.model_validate(invalid_data)
-
-    def test_space_format_validation(self) -> None:
-        invalid_data = {
-            "space": "invalid space",  # Contains a space
-            "externalId": "valid_view",
-            "version": "1",
-            "properties": {
-                "field": {
-                    "container": {"type": "container", "space": "my_space", "externalId": "my_container"},
-                    "containerPropertyIdentifier": "field",
-                }
-            },
-        }
-
-        with pytest.raises(ValueError):
-            ViewYAML.model_validate(invalid_data)
-
-    def test_invalid_version_format(self) -> None:
-        invalid_data = {
-            "space": "my_space",
-            "externalId": "valid_view",
-            "version": ".0.1",  # Invalid version format
-            "properties": {
-                "field": {
-                    "container": {"type": "container", "space": "my_space", "externalId": "my_container"},
-                    "containerPropertyIdentifier": "field",
-                }
-            },
-        }
-
-        with pytest.raises(ValueError):
+    @pytest.mark.parametrize("invalid_data, expected_match", list(invalid_view_cases()))
+    def test_invalid_view(self, invalid_data: dict[str, object], expected_match: str) -> None:
+        with pytest.raises(ValueError, match=expected_match):
             ViewYAML.model_validate(invalid_data)

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_view.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_view.py
@@ -232,6 +232,24 @@ def invalid_view_cases() -> Iterable:
             },
             "String should match pattern",
         ),
+        (
+            "InvalidRecordProperty",
+            {
+                "space": "my_space",
+                "externalId": "valid_view",
+                "streamId": ["stream1"],
+                "version": "1",
+                "properties": {
+                    "connectionProperty": {
+                        "connectionType": "single_edge_connection",
+                        "source": {"type": "view", "space": "my_space", "externalId": "source_view", "version": "1"},
+                        "type": {"space": "my_space", "externalId": "edge_type"},
+                        "direction": "outwards",
+                    }
+                },
+            },
+            "Record views only support container properties",
+        ),
     ]
     yield from (pytest.param(data, match, id=case_id) for case_id, data, match in invalid_views)
 
@@ -242,18 +260,10 @@ class TestViewYAML:
         loaded = ViewYAML.model_validate(data)
         assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
 
-    @pytest.mark.parametrize("data", view_property_type_cases())
-    def test_load_valid_view_property_types(self, data: dict[str, object]) -> None:
-        loaded = ViewYAML.model_validate(data)
-        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
-
-    @pytest.mark.parametrize("data", view_with_implements_cases())
-    def test_load_valid_view_implements(self, data: dict[str, object]) -> None:
-        loaded = ViewYAML.model_validate(data)
-        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
-
-    @pytest.mark.parametrize("data", view_with_filters_cases())
-    def test_load_valid_view_filters(self, data: dict[str, object]) -> None:
+    @pytest.mark.parametrize(
+        "data", [*view_property_type_cases(), *view_with_implements_cases(), *view_with_filters_cases()]
+    )
+    def test_load_valid_view(self, data: dict[str, object]) -> None:
         loaded = ViewYAML.model_validate(data)
         assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
 


### PR DESCRIPTION
# Description

Currently we get the following warnings of `streamId` is set
<img width="1570" height="523" alt="image" src="https://github.com/user-attachments/assets/326e28e9-0662-4324-b5d7-c8792edde32e" />


## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Improved

- Toolkit no longer gives a syntax warning when deploying a record view. In addition, Toolkit now checks that record view only have container properties and gives a syntax warning if it does not. 