### PR TITLE
[prep CDF-28524]🏞 Extend build v2 to cover v1 functionality

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/_module_parser.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/_module_parser.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import (
-    BuildSourceFiles,
+    BuildInput,
     ModelSyntaxError,
     ModuleSource,
     RelativeDirPath,
@@ -13,10 +13,10 @@ from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import (
 )
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._module import (
     AmbiguousSelection,
-    BuildSource,
     BuildVariable,
     InvalidBuildVariable,
     MisplacedModule,
+    ModuleScanResult,
     NonExistingModuleName,
 )
 from cognite_toolkit._cdf_tk.constants import EXCL_FILES, MODULES, RESOURCE_FOLDERS_WITH_CODE_BUNDLES
@@ -29,11 +29,11 @@ class ModuleParser:
     @classmethod
     def parse(
         cls,
-        build: BuildSourceFiles,
+        build: BuildInput,
         user_selected_modules: set[RelativeDirPath | str],
         source_by_module_id: dict[RelativeDirPath, ModuleSource],
         orphan_yaml_files: list[RelativeFilePath],
-    ) -> BuildSource:
+    ) -> ModuleScanResult:
         module_ids = list(source_by_module_id.keys())
         available_paths = cls._expand_parents(module_ids)
         selected_modules = cls._select_modules(module_ids, user_selected_modules)
@@ -58,7 +58,7 @@ class ModuleParser:
             else:
                 module_sources.append(source)
 
-        return BuildSource(
+        return ModuleScanResult(
             module_dir=build.module_dir,
             modules=module_sources,
             invalid_variables=invalid_variables,

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -2,7 +2,7 @@ import os
 import re
 import shutil
 import sys
-from collections import Counter
+from collections import Counter, defaultdict
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -68,7 +68,13 @@ from cognite_toolkit._cdf_tk.resource_ios._base_ios import FailedReadExtra, Read
 from cognite_toolkit._cdf_tk.rules import LocalRulesOrchestrator, ToolkitGlobalRuleSet, get_global_rules_registry
 from cognite_toolkit._cdf_tk.rules._base import RuleSetStatus
 from cognite_toolkit._cdf_tk.ui import AuraColor, ToolkitPanel, ToolkitPanelSection, ToolkitTable, hanging_indent
-from cognite_toolkit._cdf_tk.utils import calculate_hash, humanize_collection, safe_write
+from cognite_toolkit._cdf_tk.utils import (
+    calculate_directory_hash,
+    calculate_hash,
+    humanize_collection,
+    safe_write,
+    tmp_build_directory,
+)
 from cognite_toolkit._cdf_tk.utils.file import (
     read_yaml_content,
     relative_to_if_possible,
@@ -88,17 +94,10 @@ class ValidationStep:
 SelectionSource = Literal["modules", "config", "interactive"]
 
 
-@dataclass
-class BuildResult:
-    source_files: BuildInput
-    source: ModuleScanResult
-    build_folder: BuildFolder
-
-
 class BuildV2Command(ToolkitCommand):
     def build(
         self, parameters: BuildParameters, client: ToolkitClient | None = None, display: bool = True
-    ) -> BuildResult:
+    ) -> BuildFolder:
         """Builds modules from the source system and returns the results.
 
         Args:
@@ -108,7 +107,7 @@ class BuildV2Command(ToolkitCommand):
             display: Whether to display the build progress and results in the console. If False,
                 only progress bars will be printed.
         Returns:
-            BuildResult: The result of the build, including the source files, source modules, and build folder.
+            BuildFolder: The result of the build, including the source files, source modules, and build folder.
 
         """
         console = client.console if client else Console(markup=True)
@@ -159,7 +158,124 @@ class BuildV2Command(ToolkitCommand):
 
         self._write_results(insights, build_folder, parameters, client.config.project if client else None)
 
-        return BuildResult(source_files=build_files, source=module_scan_result, build_folder=build_folder)
+        return build_folder
+
+    def tmp_build(
+        self, organization_dir: Path, config_yaml: Path | None = None, client: ToolkitClient | None = None
+    ) -> BuildLineage:
+        """Build modules to a temporary directory and cache lineage for incremental rebuilds.
+
+        On the first run, all selected modules are built and lineage is written to
+        ``build_cache.yaml`` (or ``build_cache.<env>.yaml`` when a config file is used).
+        Subsequent runs compare module directory hashes against the cache and only rebuild
+        modules that have changed since the last run.
+        """
+        console = client.console if client else Console(markup=True)
+        self._validate_build_parameters(
+            BuildParameters(organization_dir=organization_dir, config_yaml=config_yaml), console, sys.argv
+        )
+
+        organization_dir = organization_dir.resolve()
+        config_yaml_path = config_yaml.resolve() if config_yaml else None
+        base_parameters = BuildParameters(
+            organization_dir=organization_dir, config_yaml=config_yaml_path, user_selected_modules=[f"{MODULES}/"]
+        )
+
+        cache_path = self._build_cache_path(organization_dir, config_yaml_path)
+        cached_lineage: BuildLineage | None = None
+        if cache_path.exists():
+            cached_lineage = BuildLineage.from_yaml_file(cache_path)
+
+        needs_rebuild = self._modules_needing_rebuild(base_parameters, cached_lineage)
+        if needs_rebuild is not None and not needs_rebuild and cached_lineage is not None:
+            # There is a cached lineage file and needs_rebuild is an empty set.
+            return cached_lineage
+
+        with tmp_build_directory() as build_dir:
+            if needs_rebuild is None:
+                user_selected_modules = [f"{MODULES}/"]
+            else:
+                user_selected_modules = [module_path.as_posix() for module_path in needs_rebuild]
+
+            build_parameters = BuildParameters(
+                organization_dir=organization_dir,
+                build_dir=build_dir,
+                config_yaml=config_yaml_path,
+                user_selected_modules=user_selected_modules,
+            )
+            build_folder = self.build(build_parameters, client, display=False)
+            cdf_project = client.config.project if client else None
+            lineage = BuildLineage.from_build(build_folder, cdf_project)
+            if cached_lineage is not None and needs_rebuild is not None:
+                lineage = self._merge_build_lineage(cached_lineage, lineage)
+
+        safe_write(cache_path, lineage.to_yaml())
+        return lineage
+
+    @staticmethod
+    def _build_cache_path(organization_dir: Path, config_yaml: Path | None) -> Path:
+        if config_yaml is None:
+            return organization_dir / "build_cache.yaml"
+        config_name = config_yaml.name
+        if config_name.startswith("config.") and config_name.endswith(".yaml"):
+            env = config_name[len("config.") : -len(".yaml")]
+            return organization_dir / f"build_cache.{env}.yaml"
+        return organization_dir / "build_cache.yaml"
+
+    def _modules_needing_rebuild(
+        self, parameters: BuildParameters, cached_lineage: BuildLineage | None
+    ) -> set[RelativeDirPath] | None:
+        if cached_lineage is None:
+            return None
+
+        build_files = self._read_file_system(parameters)
+        source_by_module_id, _ = ModuleParser.find_modules(build_files.yaml_files, build_files.organization_dir)
+        module_scan = ModuleParser.parse(build_files, {Path(MODULES)}, source_by_module_id, [])
+
+        cached_hash_by_path = {item.module_path.resolve(): item.module_hash for item in cached_lineage.module_lineage}
+
+        needs_rebuild: set[RelativeDirPath] = set()
+        seen_module_ids: set[RelativeDirPath] = set()
+        for source in module_scan.modules:
+            if source.id in seen_module_ids:
+                continue
+            seen_module_ids.add(source.id)
+            module_path = Path(source.path).resolve()
+            current_hash = calculate_directory_hash(module_path, shorten=True)
+            cached_hash = cached_hash_by_path.get(module_path)
+            if not cached_hash or cached_hash != current_hash:
+                needs_rebuild.add(source.id)
+
+        return needs_rebuild
+
+    @staticmethod
+    def _merge_build_lineage(cached_lineage: BuildLineage, new_lineage: BuildLineage) -> BuildLineage:
+        rebuilt_paths = {item.module_path.resolve() for item in new_lineage.module_lineage}
+        merged_modules = list(new_lineage.module_lineage)
+        for item in cached_lineage.module_lineage:
+            if item.module_path.resolve() not in rebuilt_paths:
+                merged_modules.append(item)
+
+        modules_summary = {
+            "processed": len(merged_modules),
+            "succeeded": sum(1 for module in merged_modules if module.is_success),
+            "failed": sum(1 for module in merged_modules if not module.is_success),
+        }
+        insights_summary: dict[str, int] = defaultdict(int)
+        for module in merged_modules:
+            for insight_type, count in module.insights_summary.items():
+                insights_summary[insight_type] += count
+
+        return BuildLineage(
+            timestamp=new_lineage.timestamp,
+            duration=new_lineage.duration,
+            organization_dir=new_lineage.organization_dir,
+            build_dir=new_lineage.build_dir,
+            cdf_project=new_lineage.cdf_project,
+            module_lineage=merged_modules,
+            modules_summary=modules_summary,
+            insights_summary=dict(insights_summary),
+        )
 
     @classmethod
     def _validate_build_parameters(cls, parameters: BuildParameters, console: Console, user_args: list[str]) -> None:

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -24,9 +24,9 @@ from cognite_toolkit._cdf_tk.commands._base import ToolkitCommand
 from cognite_toolkit._cdf_tk.commands.build_v2._module_parser import ModuleParser
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import (
     BuildFolder,
+    BuildInput,
     BuildLineage,
     BuildParameters,
-    BuildSourceFiles,
     BuiltModule,
     ConfigYAML,
     InsightList,
@@ -44,10 +44,10 @@ from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import (
 )
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._module import (
     SUPPORTS_VARIABLE_REPLACEMENT,
-    BuildSource,
     BuildVariable,
     FailedReadYAMLFile,
     IgnoredFile,
+    ModuleScanResult,
     ReadResource,
     ReadYAMLFile,
     SuccessfulReadYAMLFile,
@@ -90,8 +90,8 @@ SelectionSource = Literal["modules", "config", "interactive"]
 
 @dataclass
 class BuildResult:
-    source_files: BuildSourceFiles
-    source: BuildSource
+    source_files: BuildInput
+    source: ModuleScanResult
     build_folder: BuildFolder
 
 
@@ -126,14 +126,14 @@ class BuildV2Command(ToolkitCommand):
             else "interactive"
         )
 
-        build_source = self._find_modules(build_files)
+        module_scan_result = self._find_modules(build_files)
         if display:
             self._display_module_sources(
-                build_source, console, parameters.verbose, selection_source, parameters.config_file_name
+                module_scan_result, console, parameters.verbose, selection_source, parameters.config_file_name
             )
 
         self._prepare_build_directory(parameters.build_dir)
-        built_modules = self._build_modules(build_source.modules, parameters.build_dir.resolve(), console)
+        built_modules = self._build_modules(module_scan_result.modules, parameters.build_dir.resolve(), console)
 
         plan = self._create_validation_plan(built_modules, client)
         if display:
@@ -145,7 +145,7 @@ class BuildV2Command(ToolkitCommand):
             build_dir=parameters.build_dir.resolve(),
             built_modules=built_modules,
             validation_results=validation_results,
-            all_variables=build_source.all_variables,
+            all_variables=module_scan_result.all_variables,
             started_at=build_start_time,
             finished_at=datetime.now(timezone.utc),
         )
@@ -159,7 +159,7 @@ class BuildV2Command(ToolkitCommand):
 
         self._write_results(insights, build_folder, parameters, client.config.project if client else None)
 
-        return BuildResult(source_files=build_files, source=build_source, build_folder=build_folder)
+        return BuildResult(source_files=build_files, source=module_scan_result, build_folder=build_folder)
 
     @classmethod
     def _validate_build_parameters(cls, parameters: BuildParameters, console: Console, user_args: list[str]) -> None:
@@ -241,7 +241,7 @@ class BuildV2Command(ToolkitCommand):
             suggestion.append(f"-o {display_path}")
         return f"'{' '.join(suggestion)}'"
 
-    def _find_modules(self, build: BuildSourceFiles) -> BuildSource:
+    def _find_modules(self, build: BuildInput) -> ModuleScanResult:
         source_by_module_id, orphan_files = ModuleParser.find_modules(build.yaml_files, build.organization_dir)
 
         if build.selected_modules is None:
@@ -269,7 +269,7 @@ class BuildV2Command(ToolkitCommand):
 
     def _display_module_sources(
         self,
-        build_source: BuildSource,
+        build_source: ModuleScanResult,
         console: Console,
         verbose: bool,
         selection_source: SelectionSource,
@@ -419,7 +419,7 @@ class BuildV2Command(ToolkitCommand):
         return "interactive"
 
     @classmethod
-    def _read_file_system(cls, parameters: BuildParameters) -> BuildSourceFiles:
+    def _read_file_system(cls, parameters: BuildParameters) -> BuildInput:
         """Reads the file system to find the YAML files to build along with config.<name>.yaml if it exists."""
         selected: set[RelativeDirPath | str] | None = None
         variables: dict[str, JsonValue] = {}
@@ -451,7 +451,7 @@ class BuildV2Command(ToolkitCommand):
             yaml_file.relative_to(parameters.organization_dir)
             for yaml_file in parameters.modules_directory.rglob("*.y*ml")
         ]
-        return BuildSourceFiles(
+        return BuildInput(
             yaml_files=yaml_files,
             selected_modules=selected,
             variables=variables,

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -168,7 +168,8 @@ class BuildV2Command(ToolkitCommand):
         On the first run, all selected modules are built and lineage is written to
         ``build_cache.yaml`` (or ``build_cache.<env>.yaml`` when a config file is used).
         Subsequent runs compare module directory hashes against the cache and only rebuild
-        modules that have changed since the last run.
+        modules that have changed since the last run. If a config YAML is passed and its
+        content has changed, the entire cache is invalidated and all modules are rebuilt.
         """
         console = client.console if client else Console(markup=True)
         self._validate_build_parameters(
@@ -209,7 +210,7 @@ class BuildV2Command(ToolkitCommand):
             )
             build_folder = self.build(build_parameters, client, display=False)
             cdf_project = client.config.project if client else None
-            lineage = BuildLineage.from_build(build_folder, cdf_project)
+            lineage = BuildLineage.from_build(build_folder, cdf_project, config_yaml_path)
             if cached_lineage is not None and needs_rebuild is not None:
                 lineage = self._merge_build_lineage(cached_lineage, lineage)
 
@@ -231,6 +232,11 @@ class BuildV2Command(ToolkitCommand):
     ) -> tuple[set[RelativeDirPath] | None, bool]:
         if cached_lineage is None:
             return None, False
+
+        if parameters.config_yaml is not None:
+            current_config_hash = calculate_hash(parameters.config_yaml, shorten=True)
+            if cached_lineage.config_hash != current_config_hash:
+                return None, False
 
         build_files = self._read_file_system(parameters)
         source_by_module_id, _ = ModuleParser.find_modules(build_files.yaml_files, build_files.organization_dir)
@@ -291,6 +297,7 @@ class BuildV2Command(ToolkitCommand):
             organization_dir=template.organization_dir,
             build_dir=template.build_dir,
             cdf_project=template.cdf_project,
+            config_hash=template.config_hash,
             module_lineage=merged_modules,
             modules_summary=modules_summary,
             insights_summary=dict(insights_summary),
@@ -1271,5 +1278,5 @@ class BuildV2Command(ToolkitCommand):
 
         if parameters.write_lineage:
             lineage_file = build.build_dir / BuildLineage.filename
-            lineage = BuildLineage.from_build(build, cdf_project).to_yaml()
+            lineage = BuildLineage.from_build(build, cdf_project, parameters.config_yaml).to_yaml()
             safe_write(lineage_file, lineage)

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -99,7 +99,18 @@ class BuildV2Command(ToolkitCommand):
     def build(
         self, parameters: BuildParameters, client: ToolkitClient | None = None, display: bool = True
     ) -> BuildResult:
-        """"""
+        """Builds modules from the source system and returns the results.
+
+        Args:
+            parameters: The build parameters.
+            client: The ToolkitClient to use for validation. If None, no validation that depends on
+                the client will be performed.
+            display: Whether to display the build progress and results in the console. If False,
+                only progress bars will be printed.
+        Returns:
+            BuildResult: The result of the build, including the source files, source modules, and build folder.
+
+        """
         console = client.console if client else Console(markup=True)
 
         # Track build duration

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -186,9 +186,13 @@ class BuildV2Command(ToolkitCommand):
         if cache_path.exists():
             cached_lineage = BuildLineage.from_yaml_file(cache_path)
 
-        needs_rebuild = self._modules_needing_rebuild(base_parameters, cached_lineage)
+        needs_rebuild, has_deletions = self._modules_needing_rebuild(base_parameters, cached_lineage)
         if needs_rebuild is not None and not needs_rebuild and cached_lineage is not None:
-            # There is a cached lineage file and needs_rebuild is an empty set.
+            # There is a cached lineage file,
+            if has_deletions:
+                lineage = self._merge_build_lineage(cached_lineage, None)
+                safe_write(cache_path, lineage.to_yaml())
+                return lineage
             return cached_lineage
 
         with tmp_build_directory() as build_dir:
@@ -224,9 +228,9 @@ class BuildV2Command(ToolkitCommand):
 
     def _modules_needing_rebuild(
         self, parameters: BuildParameters, cached_lineage: BuildLineage | None
-    ) -> set[RelativeDirPath] | None:
+    ) -> tuple[set[RelativeDirPath] | None, bool]:
         if cached_lineage is None:
-            return None
+            return None, False
 
         build_files = self._read_file_system(parameters)
         source_by_module_id, _ = ModuleParser.find_modules(build_files.yaml_files, build_files.organization_dir)
@@ -236,25 +240,39 @@ class BuildV2Command(ToolkitCommand):
 
         needs_rebuild: set[RelativeDirPath] = set()
         seen_module_ids: set[RelativeDirPath] = set()
+        current_module_paths: set[Path] = set()
         for source in module_scan.modules:
             if source.id in seen_module_ids:
                 continue
             seen_module_ids.add(source.id)
             module_path = Path(source.path).resolve()
+            current_module_paths.add(module_path)
             current_hash = calculate_directory_hash(module_path, shorten=True)
             cached_hash = cached_hash_by_path.get(module_path)
             if not cached_hash or cached_hash != current_hash:
                 needs_rebuild.add(source.id)
 
-        return needs_rebuild
+        has_deletions = any(cached_path not in current_module_paths for cached_path in cached_hash_by_path)
+
+        return needs_rebuild, has_deletions
 
     @staticmethod
-    def _merge_build_lineage(cached_lineage: BuildLineage, new_lineage: BuildLineage) -> BuildLineage:
-        rebuilt_paths = {item.module_path.resolve() for item in new_lineage.module_lineage}
-        merged_modules = list(new_lineage.module_lineage)
+    def _merge_build_lineage(cached_lineage: BuildLineage, new_lineage: BuildLineage | None) -> BuildLineage:
+        if new_lineage is not None:
+            rebuilt_paths = {item.module_path.resolve() for item in new_lineage.module_lineage}
+            merged_modules = list(new_lineage.module_lineage)
+        else:
+            rebuilt_paths = set()
+            merged_modules = []
+
         for item in cached_lineage.module_lineage:
-            if item.module_path.resolve() not in rebuilt_paths:
-                merged_modules.append(item)
+            resolved_path = item.module_path.resolve()
+            if resolved_path in rebuilt_paths:
+                continue
+            # Filter out cached modules whose directories no longer exist on disk.
+            if not resolved_path.exists():
+                continue
+            merged_modules.append(item)
 
         modules_summary = {
             "processed": len(merged_modules),
@@ -266,12 +284,13 @@ class BuildV2Command(ToolkitCommand):
             for insight_type, count in module.insights_summary.items():
                 insights_summary[insight_type] += count
 
+        template = new_lineage if new_lineage is not None else cached_lineage
         return BuildLineage(
-            timestamp=new_lineage.timestamp,
-            duration=new_lineage.duration,
-            organization_dir=new_lineage.organization_dir,
-            build_dir=new_lineage.build_dir,
-            cdf_project=new_lineage.cdf_project,
+            timestamp=template.timestamp,
+            duration=template.duration,
+            organization_dir=template.organization_dir,
+            build_dir=template.build_dir,
+            cdf_project=template.cdf_project,
             module_lineage=merged_modules,
             modules_summary=modules_summary,
             insights_summary=dict(insights_summary),

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -1125,14 +1125,16 @@ class BuildV2Command(ToolkitCommand):
     ) -> None:
         """Write build results including lineage information and insights to the build folder."""
 
-        insight_file = parameters.insight_path
-        if parameters.insight_format == "csv":
-            insight_file_content = insights.to_csv()
-        else:
-            insight_file_content = insights.to_json()
-        if insight_file_content.strip():
-            safe_write(insight_file, insight_file_content)
+        if parameters.write_insights:
+            insight_file = parameters.insight_path
+            if parameters.insight_format == "csv":
+                insight_file_content = insights.to_csv()
+            else:
+                insight_file_content = insights.to_json()
+            if insight_file_content.strip():
+                safe_write(insight_file, insight_file_content)
 
-        lineage_file = build.build_dir / BuildLineage.filename
-        lineage = BuildLineage.from_build(build, cdf_project).to_yaml()
-        safe_write(lineage_file, lineage)
+        if parameters.write_lineage:
+            lineage_file = build.build_dir / BuildLineage.filename
+            lineage = BuildLineage.from_build(build, cdf_project).to_yaml()
+            safe_write(lineage_file, lineage)

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -88,8 +88,18 @@ class ValidationStep:
 SelectionSource = Literal["modules", "config", "interactive"]
 
 
+@dataclass
+class BuildResult:
+    source_files: BuildSourceFiles
+    source: BuildSource
+    build_folder: BuildFolder
+
+
 class BuildV2Command(ToolkitCommand):
-    def build(self, parameters: BuildParameters, client: ToolkitClient | None = None) -> BuildFolder:
+    def build(
+        self, parameters: BuildParameters, client: ToolkitClient | None = None, display: bool = True
+    ) -> BuildResult:
+        """"""
         console = client.console if client else Console(markup=True)
 
         # Track build duration
@@ -106,15 +116,17 @@ class BuildV2Command(ToolkitCommand):
         )
 
         build_source = self._find_modules(build_files)
-        self._display_module_sources(
-            build_source, console, parameters.verbose, selection_source, parameters.config_file_name
-        )
+        if display:
+            self._display_module_sources(
+                build_source, console, parameters.verbose, selection_source, parameters.config_file_name
+            )
 
         self._prepare_build_directory(parameters.build_dir)
         built_modules = self._build_modules(build_source.modules, parameters.build_dir.resolve(), console)
 
         plan = self._create_validation_plan(built_modules, client)
-        self._display_validation_plan(plan, console)
+        if display:
+            self._display_validation_plan(plan, console)
         validation_results = self._run_validation(plan, console)
 
         build_folder = BuildFolder(
@@ -128,14 +140,15 @@ class BuildV2Command(ToolkitCommand):
         )
 
         insights = build_folder.all_insights
-        self._display_insights(insights, parameters.insight_path, console, parameters.verbose)
-        self._display_build_summary(build_folder, insights, console, parameters.verbose)
+        if display:
+            self._display_insights(insights, parameters.insight_path, console, parameters.verbose)
+            self._display_build_summary(build_folder, insights, console, parameters.verbose)
 
         self._track_build_results(build_folder, insights, client)
 
         self._write_results(insights, build_folder, parameters, client.config.project if client else None)
 
-        return build_folder
+        return BuildResult(source_files=build_files, source=build_source, build_folder=build_folder)
 
     @classmethod
     def _validate_build_parameters(cls, parameters: BuildParameters, console: Console, user_args: list[str]) -> None:

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/__init__.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/__init__.py
@@ -1,7 +1,7 @@
 from ._build import (
     BuildFolder,
+    BuildInput,
     BuildParameters,
-    BuildSourceFiles,
     BuiltModule,
 )
 from ._config import ConfigYAML
@@ -29,9 +29,9 @@ from ._types import AbsoluteDirPath, RelativeDirPath, RelativeFilePath, Validati
 __all__ = [
     "AbsoluteDirPath",
     "BuildFolder",
+    "BuildInput",
     "BuildLineage",
     "BuildParameters",
-    "BuildSourceFiles",
     "BuildVariable",
     "BuiltModule",
     "ConfigYAML",

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
@@ -64,8 +64,8 @@ class BuildParameters(BaseModel):
         return self.config_yaml.name if self.config_yaml else ""
 
 
-class BuildSourceFiles(BaseModel):
-    """The output of reading the source system.
+class BuildInput(BaseModel):
+    """The input files after reading the source system.
 
     All yaml files found in the modules/ directory.
     If available, the config.<name>.yaml file, which specifies which modules to build, variables available,
@@ -92,6 +92,8 @@ class BuildSourceFiles(BaseModel):
 
 
 class BuiltResource(BaseModel):
+    """Represents a resource that has been built from the source system."""
+
     model_config = ConfigDict(arbitrary_types_allowed=True)
     identifier: Identifier
     source_hash: str

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
@@ -42,6 +42,14 @@ class BuildParameters(BaseModel):
         default="csv",
         description="Format for the insights file written to the build directory.",
     )
+    write_insights: bool = Field(
+        default=True,
+        description="Whether to write insights to a file in the build directory.",
+    )
+    write_lineage: bool = Field(
+        default=True,
+        description="Whether to write lineage information to a file in the build directory.",
+    )
 
     @property
     def modules_directory(self) -> Path:

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_lineage.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_lineage.py
@@ -25,7 +25,7 @@ from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import (
 )
 from cognite_toolkit._cdf_tk.constants import BUILD_FOLDER_ENCODING
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValidationError, ToolkitYAMLFormatError
-from cognite_toolkit._cdf_tk.utils import calculate_hash, read_yaml_content
+from cognite_toolkit._cdf_tk.utils import calculate_directory_hash, calculate_hash, read_yaml_content
 from cognite_toolkit._cdf_tk.validation import humanize_validation_error
 
 from ._module import ResourceType
@@ -68,6 +68,10 @@ class ModuleLineageItem(_BaseLineageModel):
 
     module_id: str = Field(description="Module identifier (e.g., modules/my_module)")
     module_path: AbsoluteDirPath = Field(description="Absolute path to module source directory")
+    module_hash: str = Field(
+        default="",
+        description="Hash of the module source directory at build time, used for incremental rebuilds.",
+    )
     insights_summary: dict[str, int] = Field(description="Breakdown of insights by type for this module")
     resource_lineage: list[ResourceLineageItem] = Field(
         default_factory=list, description="List of resource lineage items for this module"
@@ -109,9 +113,11 @@ class ModuleLineageItem(_BaseLineageModel):
                     identifier=resource.identifier,
                 )
             )
+        module_path = module.module_id.path.resolve()
         return cls(
             module_id=module.module_id.id.as_posix(),
-            module_path=module.module_id.path.resolve(),
+            module_path=module_path,
+            module_hash=calculate_directory_hash(module_path, shorten=True),
             resource_lineage=resource_lineage,
             insights_summary=module.all_insights.summary,
         )

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_lineage.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_lineage.py
@@ -132,6 +132,10 @@ class BuildLineage(_BaseLineageModel):
     organization_dir: Path
     build_dir: Path
     cdf_project: str | None = None
+    config_hash: str | None = Field(
+        default=None,
+        description="Hash of the config YAML file at build time. Used to invalidate the incremental rebuild cache when the config changes.",
+    )
     modules_summary: dict[str, int] = Field(description="Summary of modules by build status")
     insights_summary: dict[str, int] = Field(description="Summary of insights by type across all modules")
 
@@ -160,7 +164,9 @@ class BuildLineage(_BaseLineageModel):
         return round(value, 2) if value is not None else None
 
     @classmethod
-    def from_build(cls, build: BuildFolder, cdf_project: str | None = None) -> "BuildLineage":
+    def from_build(
+        cls, build: BuildFolder, cdf_project: str | None = None, config_yaml: Path | None = None
+    ) -> "BuildLineage":
         """Construct lineage from build output folder."""
 
         module_lineage = [ModuleLineageItem.from_built_module(module) for module in build.built_modules]
@@ -183,6 +189,7 @@ class BuildLineage(_BaseLineageModel):
             modules_summary=modules_summary,
             insights_summary=insights_summary,
             cdf_project=cdf_project,
+            config_hash=calculate_hash(config_yaml, shorten=True) if config_yaml is not None else None,
         )
 
     def to_yaml(self) -> str:

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_module.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_module.py
@@ -168,7 +168,7 @@ class NonExistingModuleName(BaseModel):
     closest_matches: list[str]
 
 
-class BuildSource(BaseModel):
+class ModuleScanResult(BaseModel):
     """Class used to describe source for build"""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_types.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_types.py
@@ -3,6 +3,12 @@ from typing import Annotated, Literal, TypeAlias
 
 from pydantic import AfterValidator
 
+KNOWN_FILE_EXTENSIONS = {".json", ".yaml", ".yml", ".py", ".sql"}
+
+
+def _is_likely_dir(p: Path) -> bool:
+    return p.suffix.lower() not in KNOWN_FILE_EXTENSIONS
+
 
 def _is_relative_file_path(p: Path) -> Path:
     if not p.suffix:
@@ -29,7 +35,7 @@ def _is_relative_dir_path(p: Path) -> Path:
 
 
 def _is_absolute_dir_path(p: Path) -> Path:
-    if p.suffix:
+    if not _is_likely_dir(p):
         raise ValueError(f"{p.as_posix()!r} is not a directory.")
     if not p.is_absolute():
         raise ValueError(f"{p.as_posix()!r} is not an absolute path.")

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
@@ -16,10 +16,10 @@ from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltM
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import InsightList, ModelSyntaxWarning
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._module import (
     AmbiguousSelection,
-    BuildSource,
     FailedReadYAMLFile,
     MisplacedModule,
     ModuleId,
+    ModuleScanResult,
     NonExistingModuleName,
     ResourceType,
     SuccessfulReadYAMLFile,
@@ -468,7 +468,7 @@ class TestDisplayModuleSourcesOutput:
 
     def test_non_verbose_non_existing_module_prints_summary_and_raises(self, tmp_path: Path) -> None:
         console, output = self._console()
-        build_source = BuildSource(
+        build_source = ModuleScanResult(
             module_dir=tmp_path,
             modules=[],
             non_existing_module_names=[NonExistingModuleName(name="missing_module", closest_matches=[])],
@@ -490,7 +490,7 @@ class TestDisplayModuleSourcesOutput:
 
     def test_verbose_ambiguous_module_prints_details_and_raises(self, tmp_path: Path) -> None:
         console, output = self._console()
-        build_source = BuildSource(
+        build_source = ModuleScanResult(
             module_dir=tmp_path,
             modules=[],
             ambiguous_selection=[
@@ -519,7 +519,7 @@ class TestDisplayModuleSourcesOutput:
 
     def test_verbose_misplaced_module_prints_warning_details_without_raising(self, tmp_path: Path) -> None:
         console, output = self._console()
-        build_source = BuildSource(
+        build_source = ModuleScanResult(
             module_dir=tmp_path,
             modules=[],
             misplaced_modules=[

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
@@ -814,6 +814,38 @@ class TestTmpBuild:
         assert cache_path.exists()
         assert not (org / "build_cache.yaml").exists()
 
+    def test_tmp_build_invalidates_cache_when_config_changes(self, tmp_path: Path, tlk_client: ToolkitClient) -> None:
+        cmd = BuildV2Command()
+        org = tmp_path / "org"
+        org.mkdir()
+        config_yaml = org / "config.dev.yaml"
+        config_yaml.write_text(
+            """environment:
+  name: dev
+  project: my-project
+  validation-type: dev
+  selected:
+  - modules/
+"""
+        )
+        create_resource_file(org, SpaceCRUD, SPACE_YAML)
+
+        first_lineage = cmd.tmp_build(org, config_yaml=config_yaml, client=tlk_client)
+        assert first_lineage.config_hash
+
+        config_yaml.write_text(
+            """environment:
+  name: dev
+  project: other-project
+  validation-type: dev
+  selected:
+  - modules/
+"""
+        )
+        second_lineage = cmd.tmp_build(org, config_yaml=config_yaml, client=tlk_client)
+        assert second_lineage.config_hash != first_lineage.config_hash
+        assert second_lineage.config_hash == BuildLineage.from_yaml_file(org / "build_cache.dev.yaml").config_hash
+
     def test_tmp_build_removes_deleted_module_from_cache(self, tmp_path: Path, tlk_client: ToolkitClient) -> None:
         cmd = BuildV2Command()
         org = tmp_path / "org"

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
@@ -11,7 +11,7 @@ from cognite_toolkit._cdf_tk.client._toolkit_client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.config import ToolkitClientConfig
 from cognite_toolkit._cdf_tk.client.identifiers import ViewId, ViewNoVersionId
 from cognite_toolkit._cdf_tk.commands import BuildV2Command
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import BuildParameters, RelativeDirPath
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import BuildLineage, BuildParameters, RelativeDirPath
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._build import BuiltModule, BuiltResource
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._insights import InsightList, ModelSyntaxWarning
 from cognite_toolkit._cdf_tk.commands.build_v2.data_classes._module import (
@@ -757,3 +757,58 @@ views:
     )
     def test_find_unresolved_variables(self, content: str, expected: list[str]) -> None:
         assert BuildV2Command._find_unresolved_variables(content) == expected
+
+
+@pytest.mark.usefixtures("empty_cdf")
+class TestTmpBuild:
+    def test_tmp_build_writes_cache_and_skips_unchanged_modules(
+        self, tmp_path: Path, tlk_client: ToolkitClient
+    ) -> None:
+        cmd = BuildV2Command()
+        org = tmp_path / "org"
+        create_resource_file(org, SpaceCRUD, SPACE_YAML)
+        cache_path = org / "build_cache.yaml"
+
+        first_lineage = cmd.tmp_build(org, client=tlk_client)
+        assert cache_path.exists()
+        assert first_lineage.module_lineage[0].module_hash
+
+        second_lineage = cmd.tmp_build(org, client=tlk_client)
+        assert second_lineage.module_lineage[0].module_hash == first_lineage.module_lineage[0].module_hash
+        assert (
+            BuildLineage.from_yaml_file(cache_path).module_lineage[0].module_hash
+            == first_lineage.module_lineage[0].module_hash
+        )
+
+    def test_tmp_build_rebuilds_changed_module(self, tmp_path: Path, tlk_client: ToolkitClient) -> None:
+        cmd = BuildV2Command()
+        org = tmp_path / "org"
+        space_file = create_resource_file(org, SpaceCRUD, SPACE_YAML)
+
+        first_lineage = cmd.tmp_build(org, client=tlk_client)
+        first_hash = first_lineage.module_lineage[0].module_hash
+
+        space_file.write_text(SPACE_YAML + "description: Updated\n")
+        second_lineage = cmd.tmp_build(org, client=tlk_client)
+        assert second_lineage.module_lineage[0].module_hash != first_hash
+
+    def test_tmp_build_uses_config_specific_cache_file(self, tmp_path: Path, tlk_client: ToolkitClient) -> None:
+        cmd = BuildV2Command()
+        org = tmp_path / "org"
+        org.mkdir()
+        config_yaml = org / "config.dev.yaml"
+        config_yaml.write_text(
+            """environment:
+  name: dev
+  project: my-project
+  validation-type: dev
+  selected:
+  - modules/
+"""
+        )
+        create_resource_file(org, SpaceCRUD, SPACE_YAML)
+
+        cache_path = org / "build_cache.dev.yaml"
+        _ = cmd.tmp_build(org, config_yaml=config_yaml, client=tlk_client)
+        assert cache_path.exists()
+        assert not (org / "build_cache.yaml").exists()

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
@@ -1,3 +1,4 @@
+import shutil
 from io import StringIO
 from pathlib import Path
 from typing import Any
@@ -812,3 +813,36 @@ class TestTmpBuild:
         _ = cmd.tmp_build(org, config_yaml=config_yaml, client=tlk_client)
         assert cache_path.exists()
         assert not (org / "build_cache.yaml").exists()
+
+    def test_tmp_build_removes_deleted_module_from_cache(self, tmp_path: Path, tlk_client: ToolkitClient) -> None:
+        cmd = BuildV2Command()
+        org = tmp_path / "org"
+
+        # Create two modules.
+        module_a_file = org / MODULES / "module_a" / SpaceCRUD.folder_name / f"a.{SpaceCRUD.kind}.yaml"
+        module_a_file.parent.mkdir(parents=True, exist_ok=True)
+        module_a_file.write_text("space: space_a\nname: Space A\n")
+
+        module_b_dir = org / MODULES / "module_b"
+        module_b_file = module_b_dir / SpaceCRUD.folder_name / f"b.{SpaceCRUD.kind}.yaml"
+        module_b_file.parent.mkdir(parents=True, exist_ok=True)
+        module_b_file.write_text("space: space_b\nname: Space B\n")
+
+        cache_path = org / "build_cache.yaml"
+
+        first_lineage = cmd.tmp_build(org, client=tlk_client)
+        cached_module_names = {item.module_path.name for item in first_lineage.module_lineage}
+        assert cached_module_names == {"module_a", "module_b"}
+
+        # Delete module_b entirely and rebuild. module_a is unchanged, so
+        # needs_rebuild will be empty but a deletion has occurred.
+        shutil.rmtree(module_b_dir)
+
+        second_lineage = cmd.tmp_build(org, client=tlk_client)
+
+        remaining_names = {item.module_path.name for item in second_lineage.module_lineage}
+        assert remaining_names == {"module_a"}
+
+        # The cache file on disk must be updated to reflect the deletion.
+        cached_on_disk = BuildLineage.from_yaml_file(cache_path)
+        assert {item.module_path.name for item in cached_on_disk.module_lineage} == {"module_a"}


### PR DESCRIPTION
# Description

Preparation for replacing build v1 in `cdf modules list/pull` and `cdf dev run`

Introducing a method `tmp_build` that allows to build to get an overview over all resources and modules that are available. It has caching to avoid rebuilding everything if thhere has been no changes to the source file. 

In addition, a few renaming for clarity. 

## Bump

- [ ] Patch
- [x] Skip


