### PR TITLE
[CDF-28541] Fix workflow YAML schema to use cdf task type

### DIFF
--- a/cognite_toolkit/_cdf_tk/yaml_classes/workflow_version.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/workflow_version.py
@@ -196,7 +196,7 @@ class TransformationTask(TaskDefinition):
 
 
 class CDFTask(TaskDefinition):
-    type: Literal["cdfRequest"] = "cdfRequest"
+    type: Literal["cdf"] = "cdf"
     parameters: CDFTaskParameters
 
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_workflow_version.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_workflow_version.py
@@ -85,7 +85,7 @@ def invalid_workflow_version_test_cases() -> Iterable:
         {
             "Invalid value at workflowDefinition.tasks[1]: Input tag 'unknownType' found using 'type' "
             "does not match any of the expected tags: 'function', 'transformation', "
-            "'cdfRequest', 'dynamic', 'subworkflow', 'simulation', 'functionApp'"
+            "'cdf', 'dynamic', 'subworkflow', 'simulation', 'functionApp'"
         },
         id="Invalid task type",
     )
@@ -189,6 +189,31 @@ class TestWorkflowVersionYAML:
     @pytest.mark.parametrize("data", list(valid_subworkflow_test_cases()))
     def test_valid_subworkflow_formats(self, data: dict[str, object]) -> None:
         """Test that both subworkflow reference and inline tasks formats are valid (CDF-26812)."""
+        warning_list = validate_resource_yaml_pydantic(data, WorkflowVersionYAML, Path("some_file.yaml"))
+        assert len(warning_list) == 0, f"Expected no warnings, got: {warning_list}"
+
+        loaded = WorkflowVersionYAML.model_validate(data)
+        assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    def test_cdf_task_type(self) -> None:
+        data = {
+            "workflowExternalId": "wf1",
+            "version": "v1",
+            "workflowDefinition": {
+                "tasks": [
+                    {
+                        "externalId": "cdfTask",
+                        "type": "cdf",
+                        "parameters": {
+                            "cdfRequest": {
+                                "resourcePath": "/timeseries/list",
+                                "method": "GET",
+                            }
+                        },
+                    }
+                ]
+            },
+        }
         warning_list = validate_resource_yaml_pydantic(data, WorkflowVersionYAML, Path("some_file.yaml"))
         assert len(warning_list) == 0, f"Expected no warnings, got: {warning_list}"
 


### PR DESCRIPTION
# Description

The workflow YAML schema used `cdfRequest` as the task type discriminator, but the CDF API expects `type: cdf` (with `cdfRequest` as the parameter object). Toolkit therefore rejected valid configs and accepted configs the API then rejected.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- When building a workflow with task of CDF request type, Toolkit no longer gives a syntax warning.