### PR TITLE
[CDF-28536, CDF-28542] 🤗Stabilize InField migrate snapshot and register external data source smoke tests

### DIFF
--- a/tests_smoke/test_client/test_cdf_resource_api.py
+++ b/tests_smoke/test_client/test_cdf_resource_api.py
@@ -108,6 +108,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.datapoint_subscription impo
 from cognite_toolkit._cdf_tk.client.resource_classes.dataset import DataSetRequest, DataSetResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.documents import DOCUMENT_PROPERTY_OPTIONS, DocumentPropertyPath
 from cognite_toolkit._cdf_tk.client.resource_classes.event import EventRequest, EventResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.externaldata import ExternalDataSourceResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.extraction_pipeline import (
     ExtractionPipelineRequest,
     ExtractionPipelineResponse,
@@ -646,6 +647,24 @@ ex:Oslo_Facility
                 "ignoreNullFields": True,
                 "query": "SELECT 1",
                 "destination": {"type": "assets"},
+            }
+        ],
+        ExternalDataSourceResponse: [
+            {
+                "externalId": "smoke-test-external-data-source",
+                "name": "Smoke Test External Data Source",
+                "dataSetId": -1,
+                "settings": {
+                    "credentials": {
+                        "clientId": "00000000-0000-0000-0000-000000000001",
+                        "tenantId": "00000000-0000-0000-0000-000000000002",
+                        "clientSecret": "smoke-test-client-secret",
+                    },
+                    "locationDescription": {
+                        "workspaceId": "00000000-0000-0000-0000-000000000003",
+                        "containerId": "00000000-0000-0000-0000-000000000004",
+                    },
+                },
             }
         ],
         TransformationScheduleResponse: [{"externalId": "smoke-test-transformation", "interval": "0 0 * * *"}],

--- a/tests_smoke/test_commands/test_migrate_infield.py
+++ b/tests_smoke/test_commands/test_migrate_infield.py
@@ -327,10 +327,14 @@ class TestMigrateInfield:
                     exclude={"last_updated_time", "version", "created_time"},
                 )
                 for view_properties in dumped.get("properties", {}).values():
-                    for properties in view_properties.values():
+                    for view_name, properties in view_properties.items():
                         # These also change for each run.
                         properties.pop("sourceCreatedTime", None)
                         properties.pop("sourceUpdatedTime", None)
+                        # FieldObservation.startTime is populated with the current time when
+                        # missing on the source instance.
+                        if "FieldObservation" in view_name:
+                            properties.pop("startTime", None)
                 destination_instances.append(dumped)
 
         log_files = [file for file in tmp_path.rglob("*.ndjson") if file.is_file()]

--- a/tests_smoke/test_commands/test_migrate_infield.py
+++ b/tests_smoke/test_commands/test_migrate_infield.py
@@ -331,8 +331,6 @@ class TestMigrateInfield:
                         # These also change for each run.
                         properties.pop("sourceCreatedTime", None)
                         properties.pop("sourceUpdatedTime", None)
-                        # FieldObservation.startTime is populated with the current time when
-                        # missing on the source instance.
                         if "FieldObservation" in view_name:
                             properties.pop("startTime", None)
                 destination_instances.append(dumped)


### PR DESCRIPTION
## Description

Fix two failing greenfield smoke tests:

- Ignore `FieldObservation.startTime` in the InField migrate snapshot comparison. It is set to the current time when missing on the source instance, so it changes on every run.
- Register `TransformationExternalDataSourcesAPI` in the generic `test_crudl` smoke tests by adding `ExternalDataSourceResponse` example data, following the existing CDFResourceAPI pattern.

## Bump

- [ ] Patch
- [x] Skip
