### PR TITLE
[CDF-28543] 🤨Add transformationsExternalDataSourcesAcl

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/group/acls.py
@@ -542,7 +542,7 @@ class TransformationsAcl(Acl):
 
 
 class TransformationsExternalDataSourcesAcl(Acl):
-    """ACL for Fabric OneLake external data sources used by transformations."""
+    """ACL for Transformations External Data Sources resources."""
 
     acl_name: Literal["transformationsExternalDataSourcesAcl"] = Field(
         "transformationsExternalDataSourcesAcl", exclude=True

--- a/cognite_toolkit/_cdf_tk/yaml_classes/capabilities.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/capabilities.py
@@ -402,6 +402,12 @@ class TransformationsAcl(Capability):
     scope: AllScope | DataSetScope
 
 
+class TransformationsExternalDataSourcesAcl(Capability):
+    _capability_name = "transformationsExternalDataSourcesAcl"
+    actions: list[Literal["READ", "WRITE", "USE"]]
+    scope: AllScope | DataSetScope
+
+
 class TypesAcl(Capability):
     _capability_name = "typesAcl"
     actions: list[Literal["READ", "WRITE"]]

--- a/tests/test_unit/test_cdf_tk/test_client/test_group_api_classes.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_group_api_classes.py
@@ -167,6 +167,13 @@ def all_acls() -> Iterable[tuple]:
         {"timeSeriesAcl": {"actions": ["WRITE", "READ"], "scope": {"assetRootIdScope": {"rootIds": [987]}}}},
         {"transformationsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"transformationsAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": [123]}}}},
+        {"transformationsExternalDataSourcesAcl": {"actions": ["READ", "WRITE", "USE"], "scope": {"all": {}}}},
+        {
+            "transformationsExternalDataSourcesAcl": {
+                "actions": ["READ", "WRITE", "USE"],
+                "scope": {"datasetScope": {"ids": [123]}},
+            }
+        },
         {"visionModelAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"wellsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"workflowOrchestrationAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
@@ -226,9 +233,7 @@ class TestGroupAPIClasses:
     def test_capability_in_sync(self) -> None:
         """Checks that the request/response capabilities are in sync with the YAML spec."""
         request_capabilities = {acl.model_fields["acl_name"].default for acl in get_all_subclasses(Acl)} - {
-            "unknownAcl",
-            # Until cognite-sdk publishes this capability class.
-            "transformationsExternalDataSourcesAcl",
+            "unknownAcl"
         }
         spec_capabilities = {capability._capability_name for capability in get_all_subclasses(Capability)}
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_capabilities.py
@@ -172,6 +172,13 @@ def all_acls() -> Iterable:
         {"timeSeriesAcl": {"actions": ["WRITE", "READ"], "scope": {"assetRootIdScope": {"rootIds": ["myAsset"]}}}},
         {"transformationsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"transformationsAcl": {"actions": ["READ", "WRITE"], "scope": {"datasetScope": {"ids": ["myDataSet"]}}}},
+        {"transformationsExternalDataSourcesAcl": {"actions": ["READ", "WRITE", "USE"], "scope": {"all": {}}}},
+        {
+            "transformationsExternalDataSourcesAcl": {
+                "actions": ["READ", "WRITE", "USE"],
+                "scope": {"datasetScope": {"ids": ["myDataSet"]}},
+            }
+        },
         {"visionModelAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"wellsAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},
         {"workflowOrchestrationAcl": {"actions": ["READ", "WRITE"], "scope": {"all": {}}}},


### PR DESCRIPTION
# Description
Adds support for the `transformationsExternalDataSourcesAcl` group capability so Toolkit can parse, validate, and deploy this ACL in both YAML group configs and API group resources. Actions are READ, WRITE, and USE; scopes are all and datasetScope.

## Bump
- [x] Patch
- [ ] Skip

## Changelog
### Added
- Toolkit no longer gives a syntax warning when you build a group with a `transformationsExternalDataSourcesAcl` capability in a group.