### PR TITLE
🐛fix: missing use action

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/externaldata.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/externaldata.py
@@ -48,7 +48,12 @@ class ExternalDataSourceIO(
     @classmethod
     def create_acl(cls, actions: set[Literal["READ", "WRITE"]], scope: ScopeDefinition) -> Iterable[AclType]:
         if isinstance(scope, AllScope | DataSetScope):
-            yield TransformationsExternalDataSourcesAcl(actions=sorted(actions), scope=scope)
+            acl_actions: set[Literal["READ", "WRITE", "USE"]] = set()
+            if "READ" in actions:
+                acl_actions.update({"READ", "USE"})
+            if "WRITE" in actions:
+                acl_actions.add("WRITE")
+            yield TransformationsExternalDataSourcesAcl(actions=sorted(acl_actions), scope=scope)
 
     @classmethod
     def get_id(cls, item: ExternalDataSourceRequest | ExternalDataSourceResponse | dict) -> ExternalId:


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- When running `cdf auth verify` the `transformationsExternalDataSourcesAcl` include `USE` action.
