### PR TITLE
[CDF-28546] ✨ Support multi-select on cdf dump workflow

### DIFF
--- a/cognite_toolkit/_cdf_tk/apps/_dump_app.py
+++ b/cognite_toolkit/_cdf_tk/apps/_dump_app.py
@@ -170,7 +170,7 @@ class DumpConfigApp(typer.Typer):
             list[str] | None,
             typer.Argument(
                 help="Workflow ID to dump. Format: external_id version. Example: 'my_external_id v1'. "
-                "If nothing is provided, an interactive prompt will be shown to select the workflow",
+                "If nothing is provided, an interactive prompt will be shown to select the workflow(s).",
             ),
         ] = None,
         output_dir: Annotated[
@@ -200,13 +200,13 @@ class DumpConfigApp(typer.Typer):
         ] = False,
     ) -> None:
         """This command will dump the selected workflow as yaml to the folder specified, defaults to /tmp."""
-        selected_workflow: WorkflowVersionId | None = None
+        selected_workflow: tuple[WorkflowVersionId, ...] | None = None
         if workflow_id is not None:
             if len(workflow_id) <= 1:
                 raise ToolkitRequiredValueError(
                     "Workflow ID must have at least 1 part: external_id and, optionally, version."
                 )
-            selected_workflow = WorkflowVersionId(workflow_external_id=workflow_id[0], version=workflow_id[1])
+            selected_workflow = (WorkflowVersionId(workflow_external_id=workflow_id[0], version=workflow_id[1]),)
         client = EnvironmentVariables.create_from_environment().get_client()
 
         cmd = DumpResourceCommand(client=client)

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -250,68 +250,72 @@ class DataModelFinder(ResourceFinder[DataModelNoVersionId]):
             yield [], spaces, space_loader, None
 
 
-class WorkflowFinder(ResourceFinder[WorkflowVersionId]):
-    def __init__(self, client: ToolkitClient, identifier: WorkflowVersionId | None = None):
+class WorkflowFinder(ResourceFinder[tuple[WorkflowVersionId, ...]]):
+    def __init__(self, client: ToolkitClient, identifier: tuple[WorkflowVersionId, ...] | None = None):
         super().__init__(client, identifier)
-        self._workflow: WorkflowResponse | None = None
-        self._workflow_version: WorkflowVersionResponse | None = None
+        self._workflows: list[WorkflowResponse] | None = None
+        self._workflow_versions: list[WorkflowVersionResponse] | None = None
 
-    def _interactive_select(self) -> WorkflowVersionId:
+    def _interactive_select(self) -> tuple[WorkflowVersionId, ...]:
         workflows = self.client.tool.workflows.list(limit=None)
         if not workflows:
             raise ToolkitMissingResourceError("No workflows found")
-        workflow_external_ids = [wf.external_id for wf in workflows]
-        selected_workflow_id: str = questionary.select(
-            "Which workflow would you like to dump?",
-            [Choice(workflow_id, value=workflow_id) for workflow_id in workflow_external_ids],
+        workflows_by_id = {workflow.external_id: workflow for workflow in workflows}
+        choices = [Choice(external_id, value=external_id) for external_id in sorted(workflows_by_id)]
+        selected_workflow_ids: list[str] | None = questionary.checkbox(
+            "Which workflow(s) would you like to dump?",
+            choices=choices,
+            validate=lambda choices: True if choices else "You must select at least one workflow.",
         ).unsafe_ask()
-        for workflow in workflows:
-            if workflow.external_id == selected_workflow_id:
-                self._workflow = workflow
-                break
+        if not selected_workflow_ids:
+            raise ToolkitValueError(f"No workflows selected for dumping.{_INTERACTIVE_SELECT_HELPER_TEXT}")
+        self._workflows = [workflows_by_id[external_id] for external_id in selected_workflow_ids]
 
-        versions = [
-            v
-            for page in self.client.tool.workflows.versions.iterate(workflow_external_id=selected_workflow_id)
-            for v in page
-        ]
-        if len(versions) == 0:
-            raise ToolkitMissingResourceError(f"No versions found for workflow {selected_workflow_id}")
-        if len(versions) == 1:
-            self._workflow_version = versions[0]
-            return self._workflow_version.as_id()
+        selected_id_set = set(selected_workflow_ids)
+        versions_by_workflow: dict[str, list[WorkflowVersionResponse]] = defaultdict(list)
+        for version in self.client.tool.workflows.versions.list(limit=None):
+            if version.workflow_external_id in selected_id_set:
+                versions_by_workflow[version.workflow_external_id].append(version)
 
-        version_ids = [v.as_id() for v in versions]
-        selected_version: WorkflowVersionId = questionary.select(
-            "Which version would you like to dump?",
-            [Choice(f"{version!r}", value=version) for version in version_ids],
-        ).unsafe_ask()
-        for version in versions:
-            if version.version == selected_version.version:
-                self._workflow_version = version
-                break
-        return selected_version
+        selected_versions: list[WorkflowVersionResponse] = []
+        for workflow_id in selected_workflow_ids:
+            versions = versions_by_workflow.get(workflow_id, [])
+            if not versions:
+                raise ToolkitMissingResourceError(f"No versions found for workflow {workflow_id}")
+            if len(versions) == 1:
+                selected_versions.append(versions[0])
+                continue
+
+            chosen: list[WorkflowVersionId] | None = questionary.checkbox(
+                f"Which version(s) of {workflow_id} would you like to dump?",
+                choices=[Choice(f"{version.as_id()!r}", value=version.as_id()) for version in versions],
+                validate=lambda choices: True if choices else "You must select at least one version.",
+            ).unsafe_ask()
+            if not chosen:
+                raise ToolkitValueError(
+                    f"No versions selected for dumping workflow {workflow_id}.{_INTERACTIVE_SELECT_HELPER_TEXT}"
+                )
+            chosen_set = set(chosen)
+            selected_versions.extend(version for version in versions if version.as_id() in chosen_set)
+
+        self._workflow_versions = selected_versions
+        return tuple(version.as_id() for version in selected_versions)
 
     def __iter__(
         self,
     ) -> Iterator[tuple[Sequence[Hashable], Sequence[ResourceResponseProtocol] | None, ResourceIO, None | str]]:
         self.identifier = self._selected()
-        workflow_id = ExternalId(external_id=self.identifier.workflow_external_id)
-        if self._workflow:
-            yield [], [self._workflow], WorkflowIO.create_loader(self.client), None
+        workflow_ids = list(dict.fromkeys(ExternalId(external_id=id_.workflow_external_id) for id_ in self.identifier))
+        if self._workflows:
+            yield [], self._workflows, WorkflowIO.create_loader(self.client), None
         else:
-            yield [workflow_id], None, WorkflowIO.create_loader(self.client), None
-        if self._workflow_version:
-            yield (
-                [],
-                [self._workflow_version],
-                WorkflowVersionIO.create_loader(self.client),
-                None,
-            )
+            yield workflow_ids, None, WorkflowIO.create_loader(self.client), None
+        if self._workflow_versions:
+            yield [], self._workflow_versions, WorkflowVersionIO.create_loader(self.client), None
         else:
-            yield [self.identifier], None, WorkflowVersionIO.create_loader(self.client), None
+            yield list(self.identifier), None, WorkflowVersionIO.create_loader(self.client), None
         trigger_loader = WorkflowTriggerIO.create_loader(self.client)
-        trigger_list = list(trigger_loader.iterate(parent_ids=[workflow_id]))
+        trigger_list = list(trigger_loader.iterate(parent_ids=workflow_ids))
         yield [], trigger_list, trigger_loader, None
 
 

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -281,7 +281,10 @@ class WorkflowFinder(ResourceFinder[tuple[WorkflowVersionId, ...]]):
         for workflow_id in selected_workflow_ids:
             versions = versions_by_workflow.get(workflow_id, [])
             if not versions:
-                raise ToolkitMissingResourceError(f"No versions found for workflow {workflow_id}")
+                HighSeverityWarning(f"No versions found for workflow {workflow_id}. Skipping.").print_warning(
+                    console=self.client.console
+                )
+                continue
             if len(versions) == 1:
                 selected_versions.append(versions[0])
                 continue

--- a/cognite_toolkit/_cdf_tk/commands/dump_resource.py
+++ b/cognite_toolkit/_cdf_tk/commands/dump_resource.py
@@ -271,15 +271,9 @@ class WorkflowFinder(ResourceFinder[tuple[WorkflowVersionId, ...]]):
             raise ToolkitValueError(f"No workflows selected for dumping.{_INTERACTIVE_SELECT_HELPER_TEXT}")
         self._workflows = [workflows_by_id[external_id] for external_id in selected_workflow_ids]
 
-        selected_id_set = set(selected_workflow_ids)
-        versions_by_workflow: dict[str, list[WorkflowVersionResponse]] = defaultdict(list)
-        for version in self.client.tool.workflows.versions.list(limit=None):
-            if version.workflow_external_id in selected_id_set:
-                versions_by_workflow[version.workflow_external_id].append(version)
-
         selected_versions: list[WorkflowVersionResponse] = []
         for workflow_id in selected_workflow_ids:
-            versions = versions_by_workflow.get(workflow_id, [])
+            versions = self.client.tool.workflows.versions.list(workflow_external_id=workflow_id, limit=None)
             if not versions:
                 HighSeverityWarning(f"No versions found for workflow {workflow_id}. Skipping.").print_warning(
                     console=self.client.console

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
@@ -13,6 +13,7 @@ from cognite.client.exceptions import CogniteAPIError
 from questionary import Choice
 from rich.console import Console
 
+from cognite_toolkit._cdf_tk.client.identifiers import WorkflowVersionId
 from cognite_toolkit._cdf_tk.client.resource_classes.agent import AgentResponse, AskDocument
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     DataModelResponse,
@@ -48,6 +49,11 @@ from cognite_toolkit._cdf_tk.client.resource_classes.resource_view_mapping impor
 from cognite_toolkit._cdf_tk.client.resource_classes.search_config import SearchConfigResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.streamlit_ import StreamlitResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.transformation import TransformationResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.workflow import WorkflowResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.workflow_version import (
+    WorkflowDefinition,
+    WorkflowVersionResponse,
+)
 from cognite_toolkit._cdf_tk.client.testing import monkeypatch_toolkit_client
 from cognite_toolkit._cdf_tk.commands.dump_resource import (
     AgentFinder,
@@ -64,6 +70,7 @@ from cognite_toolkit._cdf_tk.commands.dump_resource import (
     SpaceFinder,
     StreamlitFinder,
     TransformationFinder,
+    WorkflowFinder,
 )
 from cognite_toolkit._cdf_tk.feature_flags import FeatureFlag, Flags
 from cognite_toolkit._cdf_tk.resource_ios import (
@@ -240,6 +247,73 @@ class TestDumpTransformations:
         _, external_data_list, loader, _ = batches[2]
         assert isinstance(loader, ExternalDataSourceIO)
         assert external_data_list == [external_source]
+
+
+@pytest.fixture()
+def three_workflows() -> list[WorkflowResponse]:
+    return [
+        WorkflowResponse(external_id="workflowA", created_time=1, last_updated_time=1),
+        WorkflowResponse(external_id="workflowB", created_time=1, last_updated_time=1),
+        WorkflowResponse(external_id="workflowC", created_time=1, last_updated_time=1),
+    ]
+
+
+def _workflow_version(workflow_external_id: str, version: str) -> WorkflowVersionResponse:
+    return WorkflowVersionResponse(
+        workflow_external_id=workflow_external_id,
+        version=version,
+        workflow_definition=WorkflowDefinition(tasks=[]),
+        created_time=1,
+        last_updated_time=1,
+    )
+
+
+class TestWorkflowFinder:
+    def test_select_workflows(self, three_workflows: list[WorkflowResponse], monkeypatch: MonkeyPatch) -> None:
+        def select_workflows(choices: list[Choice]) -> list[str]:
+            assert len(choices) == len(three_workflows)
+            return [choices[1].value, choices[2].value]
+
+        answers = [select_workflows]
+        versions = [_workflow_version("workflowB", "v1"), _workflow_version("workflowC", "v1")]
+
+        with (
+            monkeypatch_toolkit_client() as client,
+            MockQuestionary(WorkflowFinder.__module__, monkeypatch, answers),
+        ):
+            client.tool.workflows.list.return_value = three_workflows
+            client.tool.workflows.versions.list.return_value = versions
+            finder = WorkflowFinder(client, None)
+            selected = finder._interactive_select()
+
+        assert selected == (
+            WorkflowVersionId(workflow_external_id="workflowB", version="v1"),
+            WorkflowVersionId(workflow_external_id="workflowC", version="v1"),
+        )
+
+    def test_select_workflow_multiple_versions(
+        self, three_workflows: list[WorkflowResponse], monkeypatch: MonkeyPatch
+    ) -> None:
+        def select_workflows(choices: list[Choice]) -> list[str]:
+            return [choices[0].value]
+
+        def select_versions(choices: list[Choice]) -> list[WorkflowVersionId]:
+            assert len(choices) == 2
+            return [choices[1].value]
+
+        answers = [select_workflows, select_versions]
+        versions = [_workflow_version("workflowA", "v1"), _workflow_version("workflowA", "v2")]
+
+        with (
+            monkeypatch_toolkit_client() as client,
+            MockQuestionary(WorkflowFinder.__module__, monkeypatch, answers),
+        ):
+            client.tool.workflows.list.return_value = three_workflows
+            client.tool.workflows.versions.list.return_value = versions
+            finder = WorkflowFinder(client, None)
+            selected = finder._interactive_select()
+
+        assert selected == (WorkflowVersionId(workflow_external_id="workflowA", version="v2"),)
 
 
 @pytest.fixture()

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
@@ -282,7 +282,11 @@ class TestWorkflowFinder:
             MockQuestionary(WorkflowFinder.__module__, monkeypatch, answers),
         ):
             client.tool.workflows.list.return_value = three_workflows
-            client.tool.workflows.versions.list.return_value = versions
+            client.tool.workflows.versions.list.side_effect = (
+                lambda workflow_external_id, limit=None: [
+                    v for v in versions if v.workflow_external_id == workflow_external_id
+                ]
+            )
             finder = WorkflowFinder(client, None)
             selected = finder._interactive_select()
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
@@ -313,7 +313,11 @@ class TestWorkflowFinder:
             MockQuestionary(WorkflowFinder.__module__, monkeypatch, answers),
         ):
             client.tool.workflows.list.return_value = three_workflows
-            client.tool.workflows.versions.list.return_value = versions
+            client.tool.workflows.versions.list.side_effect = (
+                lambda workflow_external_id, limit=None: [
+                    v for v in versions if v.workflow_external_id == workflow_external_id
+                ]
+            )
             finder = WorkflowFinder(client, None)
             selected = finder._interactive_select()
 

--- a/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_dump_resource.py
@@ -282,11 +282,9 @@ class TestWorkflowFinder:
             MockQuestionary(WorkflowFinder.__module__, monkeypatch, answers),
         ):
             client.tool.workflows.list.return_value = three_workflows
-            client.tool.workflows.versions.list.side_effect = (
-                lambda workflow_external_id, limit=None: [
-                    v for v in versions if v.workflow_external_id == workflow_external_id
-                ]
-            )
+            client.tool.workflows.versions.list.side_effect = lambda workflow_external_id, limit=None: [
+                v for v in versions if v.workflow_external_id == workflow_external_id
+            ]
             finder = WorkflowFinder(client, None)
             selected = finder._interactive_select()
 
@@ -313,11 +311,9 @@ class TestWorkflowFinder:
             MockQuestionary(WorkflowFinder.__module__, monkeypatch, answers),
         ):
             client.tool.workflows.list.return_value = three_workflows
-            client.tool.workflows.versions.list.side_effect = (
-                lambda workflow_external_id, limit=None: [
-                    v for v in versions if v.workflow_external_id == workflow_external_id
-                ]
-            )
+            client.tool.workflows.versions.list.side_effect = lambda workflow_external_id, limit=None: [
+                v for v in versions if v.workflow_external_id == workflow_external_id
+            ]
             finder = WorkflowFinder(client, None)
             selected = finder._interactive_select()
 

--- a/tests/test_unit/test_cli/test_behavior.py
+++ b/tests/test_unit/test_cli/test_behavior.py
@@ -719,7 +719,8 @@ def test_dump_workflow(
     cmd = DumpResourceCommand(silent=True)
     cmd.dump_to_yamls(
         WorkflowFinder(
-            env_vars_with_client.get_client(), WorkflowVersionId(workflow_external_id="myWorkflow", version="v1")
+            env_vars_with_client.get_client(),
+            (WorkflowVersionId(workflow_external_id="myWorkflow", version="v1"),),
         ),
         output_dir=output_dir,
         clean=True,


### PR DESCRIPTION
# Description

`cdf dump workflow` previously used a single-select prompt, so you could not dump all workflows at once the way `cdf dump transformation` already allows. The interactive workflow dump now uses a checkbox, including version selection when a workflow has more than one version.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Added

- Support multiselect on `cdf dump workflow`