### PR TITLE
[CDF-28550] Topologically sort agents by subagent references on deploy and delete

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/agent.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/agent.py
@@ -1,15 +1,17 @@
 from collections.abc import Hashable, Iterable, Sequence
-from typing import Any, Literal, final
+from graphlib import CycleError, TopologicalSorter
+from typing import Any, Literal, TypeVar, final
 
 from cognite_toolkit._cdf_tk.client._resource_base import Identifier
 from cognite_toolkit._cdf_tk.client.identifiers import DataModelId, ExternalId
-from cognite_toolkit._cdf_tk.client.resource_classes.agent import AgentRequest, AgentResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.agent import Agent, AgentRequest, AgentResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.group import (
     AclType,
     AgentsAcl,
     AllScope,
     ScopeDefinition,
 )
+from cognite_toolkit._cdf_tk.exceptions import ToolkitCycleError
 from cognite_toolkit._cdf_tk.feature_flags import FeatureFlag, Flags
 from cognite_toolkit._cdf_tk.resource_ios._base_ios import ResourceIO
 from cognite_toolkit._cdf_tk.resource_ios._resource_ios.datamodel import DataModelIO
@@ -25,6 +27,8 @@ from cognite_toolkit._cdf_tk.yaml_classes.agent import (
     Query,
     QueryKnowledgeGraph,
 )
+
+T_Agent = TypeVar("T_Agent", bound=Agent)
 
 
 @final
@@ -148,17 +152,53 @@ class AgentIO(ResourceIO[ExternalId, AgentRequest, AgentResponse]):
         if isinstance(scope, AllScope):
             yield AgentsAcl(actions=sorted(actions), scope=scope)
 
+    @classmethod
+    def topological_sort(cls, items: Sequence[T_Agent]) -> list[T_Agent]:
+        """Sorts the agents in topological order based on their subagent references.
+
+        Subagents must exist before the agents that reference them, as the agents service
+        validates that subagent references point to existing agents.
+        """
+        agent_by_id: dict[ExternalId, T_Agent] = {item.as_id(): item for item in items}
+        dependencies: dict[ExternalId, set[ExternalId]] = {}
+        for item_id, item in agent_by_id.items():
+            dependencies[item_id] = {
+                subagent_id
+                for subagent in item.subagents or []
+                if (subagent_id := ExternalId(external_id=subagent.agent_external_id)) in agent_by_id
+            }
+        try:
+            return [
+                agent_by_id[item_id]
+                for item_id in TopologicalSorter(dependencies).static_order()
+                if item_id in agent_by_id
+            ]
+        except CycleError as e:
+            raise ToolkitCycleError(
+                f"Cannot deploy agents. Cycle detected {e.args} in the 'subagents' references of the agents.",
+                *e.args[1:],
+            ) from None
+
     def create(self, items: Sequence[AgentRequest]) -> list[AgentResponse]:
-        return self.client.tool.agents.create(items)
+        return self.client.tool.agents.create(self.topological_sort(items))
 
     def retrieve(self, ids: Sequence[ExternalId]) -> list[AgentResponse]:
         return self.client.tool.agents.retrieve(list(ids), ignore_unknown_ids=True)
 
     def update(self, items: Sequence[AgentRequest]) -> list[AgentResponse]:
-        return self.client.tool.agents.update(items)
+        return self.client.tool.agents.update(self.topological_sort(items))
 
     def delete(self, ids: Sequence[ExternalId]) -> int:
-        self.client.tool.agents.delete(list(ids), ignore_unknown_ids=True)
+        # The agents service rejects deleting an agent that is still referenced as a subagent by
+        # another agent, so the referencing agents must be deleted before the subagents they reference,
+        # i.e. the reverse of the create/update order.
+        retrieved = self.retrieve(ids)
+        retrieved_ids = {agent.as_id() for agent in retrieved}
+        ordered_ids = [agent.as_id() for agent in reversed(self.topological_sort(retrieved))]
+        # Ids that could not be retrieved (e.g. already deleted) are appended at the end.
+        ordered_ids.extend(id_ for id_ in ids if id_ not in retrieved_ids)
+
+        self.client.tool.agents.delete(ordered_ids, ignore_unknown_ids=True)
         return len(ids)
 
     def _iterate(

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_agent.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_agent.py
@@ -3,8 +3,9 @@ from collections.abc import Hashable
 import pytest
 
 from cognite_toolkit._cdf_tk.client.identifiers import DataModelId, ExternalId
-from cognite_toolkit._cdf_tk.client.resource_classes.agent import AgentResponse
+from cognite_toolkit._cdf_tk.client.resource_classes.agent import AgentRequest, AgentResponse, SubagentConfig
 from cognite_toolkit._cdf_tk.client.testing import ToolkitClientMock
+from cognite_toolkit._cdf_tk.exceptions import ToolkitCycleError
 from cognite_toolkit._cdf_tk.feature_flags import FeatureFlag, Flags
 from cognite_toolkit._cdf_tk.resource_ios import DataModelIO, FunctionIO, ResourceIO, SkillIO
 from cognite_toolkit._cdf_tk.resource_ios._resource_ios.agent import AgentIO
@@ -386,3 +387,60 @@ class TestAgentIODiffList:
 
         assert local_by_cdf == {0: 0}
         assert added == [1]
+
+
+class TestAgentIOTopologicalSort:
+    def test_topological_sort_orders_subagents_before_referencing_agent(self) -> None:
+        supervisor = AgentRequest(
+            external_id="supervisor",
+            name="Supervisor",
+            subagents=[SubagentConfig(agent_external_id="weather-specialist")],
+        )
+        subagent = AgentRequest(external_id="weather-specialist", name="Weather Specialist")
+
+        actual = AgentIO.topological_sort([supervisor, subagent])
+
+        assert [agent.external_id for agent in actual] == ["weather-specialist", "supervisor"]
+
+    def test_topological_sort_raises_on_cycle(self) -> None:
+        agent_a = AgentRequest(external_id="a", name="A", subagents=[SubagentConfig(agent_external_id="b")])
+        agent_b = AgentRequest(external_id="b", name="B", subagents=[SubagentConfig(agent_external_id="a")])
+
+        with pytest.raises(ToolkitCycleError):
+            AgentIO.topological_sort([agent_a, agent_b])
+
+
+class TestAgentIODelete:
+    def test_delete_sorts_referencing_agent_before_subagent(self) -> None:
+        supervisor = AgentResponse.model_validate(
+            {
+                "externalId": "supervisor",
+                "name": "Supervisor",
+                "createdTime": 0,
+                "lastUpdatedTime": 0,
+                "ownerId": "owner",
+                "runtimeVersion": "1.3.0",
+                "subagents": [{"agentExternalId": "weather-specialist"}],
+            }
+        )
+        subagent = AgentResponse.model_validate(
+            {
+                "externalId": "weather-specialist",
+                "name": "Weather Specialist",
+                "createdTime": 0,
+                "lastUpdatedTime": 0,
+                "ownerId": "owner",
+                "runtimeVersion": "1.3.0",
+            }
+        )
+        client = ToolkitClientMock()
+        client.tool.agents.retrieve.return_value = [supervisor, subagent]
+        io = AgentIO(client, None, None)
+
+        io.delete([ExternalId(external_id="weather-specialist"), ExternalId(external_id="supervisor")])
+
+        deleted_ids = client.tool.agents.delete.call_args[0][0]
+        assert deleted_ids == [
+            ExternalId(external_id="supervisor"),
+            ExternalId(external_id="weather-specialist"),
+        ]

--- a/tests/test_unit/test_cli/test_behavior.py
+++ b/tests/test_unit/test_cli/test_behavior.py
@@ -14,6 +14,7 @@ from pytest import MonkeyPatch
 from cognite_toolkit._cdf_tk import cdf_toml
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.identifiers import NameId, WorkflowVersionId
+from cognite_toolkit._cdf_tk.client.resource_classes.agent import AgentResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.data_modeling import (
     ContainerId,
     ContainerPropertyDefinition,
@@ -62,7 +63,7 @@ from cognite_toolkit._cdf_tk.commands.dump_resource import DataModelFinder, Work
 from cognite_toolkit._cdf_tk.constants import MODULES
 from cognite_toolkit._cdf_tk.data_classes import BuildConfigYAML, Environment
 from cognite_toolkit._cdf_tk.exceptions import ToolkitDuplicatedModuleError
-from cognite_toolkit._cdf_tk.resource_ios import RESOURCE_CRUD_LIST, LocationFilterIO, WorkflowVersionIO
+from cognite_toolkit._cdf_tk.resource_ios import RESOURCE_CRUD_LIST, AgentIO, LocationFilterIO, WorkflowVersionIO
 from cognite_toolkit._cdf_tk.tk_warnings import MissingDependencyWarning
 from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
 from cognite_toolkit._cdf_tk.utils.file import yaml_safe_dump
@@ -995,6 +996,64 @@ def test_workflow_deployment_order(
         subworkflow.workflow_external_id,
         main_workflow.workflow_external_id,
     ]
+
+
+def test_agent_deployment_order(
+    build_tmp_path: Path,
+    toolkit_client_approval: ApprovalToolkitClient,
+    env_vars_with_client: EnvironmentVariables,
+) -> None:
+    # Skip the agent runtime/capability consistency checks, which require a real service availability response.
+    toolkit_client_approval.mock_client.tool.agents.service_availability.return_value = None
+    supervisor = """externalId: supervisor
+name: Supervisor
+runtimeVersion: "1.3.0"
+subagents:
+  - agentExternalId: weather-specialist
+"""
+    subagent = """externalId: weather-specialist
+name: Weather Specialist
+runtimeVersion: "1.3.0"
+"""
+    org = build_tmp_path.parent / "org"
+    resource_folder = org / MODULES / "my_agent_module" / AgentIO.folder_name
+    # Default behavior of Toolkit is to respect the order of the files, however, this tests ensures
+    # that Toolkit does a topological sort of the agents before deploying them.
+    supervisor_file = resource_folder / f"1.supervisor.{AgentIO.kind}.yaml"
+    subagent_file = resource_folder / f"2.weather-specialist.{AgentIO.kind}.yaml"
+    supervisor_file.parent.mkdir(parents=True, exist_ok=True)
+    supervisor_file.write_text(supervisor, encoding="utf-8")
+    subagent_file.write_text(subagent, encoding="utf-8")
+
+    BuildV2Command(silent=True, skip_tracking=True).build(
+        client=env_vars_with_client.get_client(),
+        parameters=BuildParameters(
+            organization_dir=org,
+            build_dir=build_tmp_path,
+            config_yaml=None,
+            user_selected_modules=["my_agent_module"],
+        ),
+    )
+
+    DeployV2Command(silent=True, skip_tracking=True).deploy(
+        user_build_dir=build_tmp_path,
+        env_vars=env_vars_with_client,
+        options=DeployOptions(
+            cdf_project=env_vars_with_client.CDF_PROJECT,
+            dry_run=False,
+            drop=False,
+            drop_data=False,
+            include=None,
+            force_update=False,
+            verbose=False,
+            environment_variables=env_vars_with_client.dump(),
+        ),
+    )
+
+    # Verify that the agents were created in the correct order, subagent before the supervisor referencing it.
+    agents = toolkit_client_approval.created_resources_of_type(AgentResponse)
+    assert len(agents) == 2
+    assert [agent.external_id for agent in agents] == ["weather-specialist", "supervisor"]
 
 
 def test_warning_missing_dependency(


### PR DESCRIPTION
# Description

The agents service validates that `subagents` references point to existing agents on upsert, and rejects deleting an agent still referenced as a subagent by another agent. `AgentIO` previously deployed/deleted agents in build/file order, so an agent depending on another agent as a subagent could be sent to the API before the subagents it references, causing deployment failures. Similarly, a delete will fail if the agents referencing it as a subagent isn't deleted first. Added `AgentIO.topological_sort`, used on `create`/`update` to deploy subagents before referencing agents, and reversed on `delete` to remove referencing agents before their subagents.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Fixed

- [alpha] Fixes sporadic `400` and `409` HTTP errors in `cdf deploy` and `cdf clean` when an agent references a subagent