### PR TITLE
[CDF-28575] 🐛 fix: hosted extractor jobs update

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_job.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/hosted_extractor_job.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, ClassVar, Literal
 
 from pydantic import BeforeValidator, ConfigDict, JsonValue, field_validator
 
@@ -177,6 +177,10 @@ class HostedExtractorJob(BaseModelObject):
 
 
 class HostedExtractorJobRequest(HostedExtractorJob, UpdatableRequestResource):
+    # Event Hub / Service Bus jobs have no source-specific config. The update API
+    # does not support setting config to null.
+    non_nullable_fields: ClassVar[frozenset[str]] = frozenset({"config"})
+
     def as_update(self, mode: Literal["patch", "replace"]) -> dict[str, Any]:
         update_item = super().as_update(mode=mode)
         exclude_unset = mode == "patch"

--- a/tests/test_integration/test_cruds/test_hosted_extractor_jobs.py
+++ b/tests/test_integration/test_cruds/test_hosted_extractor_jobs.py
@@ -1,0 +1,63 @@
+from cognite_toolkit._cdf_tk.client import ToolkitClient
+from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
+from cognite_toolkit._cdf_tk.client.resource_classes.hosted_extractor_destination import (
+    HostedExtractorDestinationRequest,
+)
+from cognite_toolkit._cdf_tk.client.resource_classes.hosted_extractor_job import (
+    CogniteFormat,
+    HostedExtractorJobRequest,
+)
+from cognite_toolkit._cdf_tk.client.resource_classes.hosted_extractor_source import (
+    BasicAuthenticationRequest,
+    EventHubSourceRequest,
+)
+from tests.test_integration.constants import RUN_UNIQUE_ID
+
+
+class TestHostedExtractorJobsAPI:
+    def test_update_eventhub_job_without_config(self, toolkit_client: ToolkitClient) -> None:
+        """Event Hub jobs have no source-specific config.
+
+        Redeploy uses replace-mode update. CDF rejects ``config.setNull``, which is
+        what toolkit previously emitted when ``config`` was None.
+        """
+        client = toolkit_client
+        suffix = RUN_UNIQUE_ID.lower()
+        source_id = ExternalId(external_id=f"toolkit_test_eventhub_source_{suffix}")
+        dest_id = ExternalId(external_id=f"toolkit_test_eventhub_dest_{suffix}")
+        job_id = ExternalId(external_id=f"toolkit_test_eventhub_job_{suffix}")
+
+        source = EventHubSourceRequest(
+            external_id=source_id.external_id,
+            host="toolkit-test.servicebus.windows.net",
+            event_hub_name="toolkit-test-hub",
+            authentication=BasicAuthenticationRequest(username="toolkit-test-key", password="not-a-real-secret"),
+        )
+        destination = HostedExtractorDestinationRequest(external_id=dest_id.external_id)
+        job = HostedExtractorJobRequest(
+            external_id=job_id.external_id,
+            source_id=source_id.external_id,
+            destination_id=dest_id.external_id,
+            format=CogniteFormat(),
+        )
+        assert job.config is None
+        assert "config" not in job.as_update(mode="replace")["update"], "Config should not be set to null."
+
+        try:
+            created_sources = client.tool.hosted_extractors.sources.create([source])
+            assert len(created_sources) == 1
+            created_destinations = client.tool.hosted_extractors.destinations.create([destination])
+            assert len(created_destinations) == 1
+            created_jobs = client.tool.hosted_extractors.jobs.create([job])
+            assert len(created_jobs) == 1
+            assert created_jobs[0].external_id == job.external_id
+
+            updated = client.tool.hosted_extractors.jobs.update([job], mode="replace")
+            assert len(updated) == 1
+            assert updated[0].external_id == job.external_id
+            assert updated[0].source_id == source_id.external_id
+            assert updated[0].destination_id == dest_id.external_id
+        finally:
+            client.tool.hosted_extractors.jobs.delete([job_id], ignore_unknown_ids=True)
+            client.tool.hosted_extractors.destinations.delete([dest_id], ignore_unknown_ids=True, force=True)
+            client.tool.hosted_extractors.sources.delete([source_id], ignore_unknown_ids=True, force=True)

--- a/tests/test_unit/test_cdf_tk/test_client/test_api_data_classes.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_api_data_classes.py
@@ -732,6 +732,44 @@ class TestUnknownHostedExtractorJobUnions:
         assert HostedExtractorJobRequest._load(data).dump() == data
 
 
+class TestHostedExtractorJobRequest:
+    def test_as_update_replace_omits_null_config(self) -> None:
+        request = HostedExtractorJobRequest.model_validate(
+            {
+                "externalId": "job_eventhub",
+                "destinationId": "dest_1",
+                "sourceId": "src_1",
+                "format": {"type": "cognite"},
+            }
+        )
+
+        update = request.as_update(mode="replace")
+
+        assert update == {
+            "externalId": "job_eventhub",
+            "update": {
+                "destinationId": {"set": "dest_1"},
+                "format": {"set": {"type": "cognite"}},
+                "sourceId": {"set": "src_1"},
+            },
+        }
+
+    def test_as_update_replace_sets_config_when_present(self) -> None:
+        request = HostedExtractorJobRequest.model_validate(
+            {
+                "externalId": "job_mqtt",
+                "destinationId": "dest_1",
+                "sourceId": "src_1",
+                "format": {"type": "cognite"},
+                "config": {"topicFilter": "my/topic"},
+            }
+        )
+
+        update = request.as_update(mode="replace")
+
+        assert update["update"]["config"] == {"set": {"topicFilter": "my/topic"}}
+
+
 class TestUnknownHostedExtractorSourceUnions:
     def test_unknown_source_request_type(self) -> None:
         data = {


### PR DESCRIPTION
# Description

Unlike properties such as `name` and `description`, hosted extractor jobs does not support nulling out the `config` property.

<img width="750" height="590" alt="image" src="https://github.com/user-attachments/assets/62366791-1504-4482-be5d-e9012888955a" />


## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- When upading HostedExtractorJobs that has the `config` property not set with the `cdf deploy` command, Toolkit no longer raise a `ERROR (ResourceUpdateError): Failed to update hosted extractor jobs due to API error: Request failed with status code 422: items[0].update.config.set` error.
