### PR TITLE
Mark TestSkillIO integration test as flaky

### DIFF
--- a/tests/test_integration/test_cruds/test_resource_cruds.py
+++ b/tests/test_integration/test_cruds/test_resource_cruds.py
@@ -1235,6 +1235,8 @@ Used by toolkit integration tests{body_suffix}.
 
 
 class TestSkillIO:
+    # Skills upload can intermittently fail with "Files not uploaded" against live CDF.
+    @pytest.mark.flaky(reruns=3, reruns_delay=10, only_rerun=["ToolkitAPIError"])
     def test_create_update_retrieve_delete(self, toolkit_client: ToolkitClient) -> None:
         loader = SkillIO(toolkit_client, None)
         external_id = f"toolkit_integration_skill_{RUN_UNIQUE_ID}".replace("-", "_")


### PR DESCRIPTION
# Description

Add `@pytest.mark.flaky` to `TestSkillIO::test_create_update_retrieve_delete` so transient `ToolkitAPIError` responses from the skills upload endpoint (e.g. `Files not uploaded`) are retried. Matches the pattern used for other unstable integration tests against live CDF.

The test failed intermittently in CI after #3218 switched skill create/update to `POST /ai/skills/upload`, while passing on adjacent commits with no related code changes.

## Bump

- [ ] Patch
- [x] Skip