### PR TITLE
[CDF-28577] Add userDataInstanceSpace to models

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/resource_classes/location_filter.py
+++ b/cognite_toolkit/_cdf_tk/client/resource_classes/location_filter.py
@@ -54,6 +54,7 @@ class LocationFilter(BaseModelObject):
     parent_id: int | None = None
     data_models: list[DataModelId] | None = None
     instance_spaces: list[str] | None = None
+    user_data_instance_space: str | None = None
     scene: LocationFilterScene | None = None
     asset_centric: AssetCentricFilter | None = None
     views: list[LocationFilterView] | None = None

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/location.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/location.py
@@ -259,6 +259,8 @@ class LocationFilterIO(ResourceIO[ExternalId, LocationFilterRequest, LocationFil
                 )
         for space in item.get("instanceSpaces", []):
             yield SpaceCRUD, SpaceId(space=space)
+        if user_data_instance_space := item.get("userDataInstanceSpace"):
+            yield SpaceCRUD, SpaceId(space=user_data_instance_space)
         for data_model in item.get("dataModels", []):
             if in_dict(["space", "externalId", "version"], data_model):
                 yield (
@@ -293,6 +295,8 @@ class LocationFilterIO(ResourceIO[ExternalId, LocationFilterRequest, LocationFil
             yield ViewIO, ViewId(space=view.space, external_id=view.external_id, version=view.version)
         for space in resource.instance_spaces or []:
             yield SpaceCRUD, SpaceId(space=space)
+        if resource.user_data_instance_space:
+            yield SpaceCRUD, SpaceId(space=resource.user_data_instance_space)
         for data_model in resource.data_models or []:
             yield (
                 DataModelIO,

--- a/cognite_toolkit/_cdf_tk/yaml_classes/location.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/location.py
@@ -74,6 +74,9 @@ class LocationYAML(ToolkitResource):
         default=None, description="The data models associated with the location."
     )
     instance_spaces: list[str] | None = Field(default=None, description="The list of spaces that instances are in")
+    user_data_instance_space: str | None = Field(
+        default=None, description="The space where user-uploaded data is stored."
+    )
     scene: Scenes | None = Field(default=None, description="The scene config for the location.")
     asset_centric: AssetCentricResource | None = Field(
         default=None,

--- a/cognite_toolkit/_cdf_tk/yaml_classes/location.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/location.py
@@ -75,7 +75,11 @@ class LocationYAML(ToolkitResource):
     )
     instance_spaces: list[str] | None = Field(default=None, description="The list of spaces that instances are in")
     user_data_instance_space: str | None = Field(
-        default=None, description="The space where user-uploaded data is stored."
+        default=None,
+        description="The space where user-uploaded data is stored.",
+        min_length=1,
+        max_length=43,
+        pattern=SPACE_FORMAT_PATTERN,
     )
     scene: Scenes | None = Field(default=None, description="The scene config for the location.")
     asset_centric: AssetCentricResource | None = Field(

--- a/tests/data/load_data/locations/exhaustive.LocationFilter.yaml
+++ b/tests/data/load_data/locations/exhaustive.LocationFilter.yaml
@@ -8,6 +8,7 @@ dataModels:
     version: v1-0-0
 instanceSpaces:
   - instance-space-main
+userDataInstanceSpace: user-data-space-345
 scene:
   externalId: scene-id-012
   space: scene-space-primary

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_locations.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_locations.py
@@ -52,6 +52,9 @@ class TestLocationFilterLoader:
         assert isinstance(exhaustive_filter.instance_spaces, list)
         assert exhaustive_filter.instance_spaces[0] == "instance-space-main"
 
+    def test_load_filter_write_user_data_instance_space(self, exhaustive_filter: LocationFilterRequest) -> None:
+        assert exhaustive_filter.user_data_instance_space == "user-data-space-345"
+
     def test_load_filter_write_scene(self, exhaustive_filter: LocationFilterRequest) -> None:
         assert isinstance(exhaustive_filter.scene, LocationFilterScene)
         assert exhaustive_filter.scene.external_id == "scene-id-012"

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_location.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_location.py
@@ -49,6 +49,14 @@ def location_yaml_cases() -> Iterable:
                 "instanceSpaces": ["space-1", "space-2"],
             }
         },
+        # With user data instance space
+        {
+            "UserDataInstanceSpaceCase": {
+                "externalId": "loc-005b",
+                "name": "Location with User Data Instance Space",
+                "userDataInstanceSpace": "user-data-space",
+            }
+        },
         # With views
         {
             "ViewsCase": {
@@ -110,6 +118,7 @@ def location_yaml_cases() -> Iterable:
                 "parentExternalId": "loc-001",
                 "dataModels": [{"externalId": "model-001", "space": "test-space", "version": "1.0"}],
                 "instanceSpaces": ["space-1", "space-2"],
+                "userDataInstanceSpace": "user-data-space",
                 "scene": {"externalId": "scene-001", "space": "test-space"},
                 "views": [
                     {"externalId": "view-001", "space": "test-space", "version": "1.0", "representsEntity": "ASSET"}


### PR DESCRIPTION
# Description

This PR ensures that we no longer issue a `ModelSyntaxWarning` for the `userDataInstanceSpace` field on Location resources. This adds the field to the `LocationYAML` and `LocationFilter` models so it is recognized during build/deploy, and includes it in dependency resolution against the space it references.

## Bump

- [x] Patch
- [ ] Skip

## Changelog
### Added

- Toolkit will now recognize the `userDataInstanceSpace` field on `LocationFilter`/Location YAML resources.