### PR TITLE
[CDF-27907] Fix unrecognized fields silently suppressing build errors

### DIFF
--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -821,9 +821,7 @@ class BuildV2Command(ToolkitCommand):
             except ValidationError as errors:
                 syntax_errors, syntax_warnings = self._create_syntax_insights(errors)
                 if not syntax_errors:
-                    toolkit_resource = self._validate_ignoring_unknown_fields(
-                        crud_class.yaml_cls, parsed_yaml, errors
-                    )
+                    toolkit_resource = self._validate_ignoring_unknown_fields(crud_class.yaml_cls, parsed_yaml, errors)
                 if toolkit_resource is not None:
                     identifier = toolkit_resource.as_id()
                 else:

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -1,4 +1,3 @@
-import copy
 import os
 import re
 import shutil
@@ -9,7 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from itertools import zip_longest
 from pathlib import Path
-from typing import Any, ClassVar, Literal, TypeVar, cast
+from typing import Any, ClassVar, Literal, cast
 
 import questionary
 import yaml
@@ -85,6 +84,10 @@ from cognite_toolkit._cdf_tk.utils.file import (
 )
 from cognite_toolkit._cdf_tk.validation import humanize_validation_error, humanize_validation_error_categorized
 from cognite_toolkit._cdf_tk.yaml_classes import ToolkitResource
+from cognite_toolkit._cdf_tk.yaml_classes.base import (
+    validate_ignoring_unknown_fields,
+    validate_list_ignoring_unknown_fields,
+)
 
 
 @dataclass
@@ -94,8 +97,6 @@ class ValidationStep:
 
 
 SelectionSource = Literal["modules", "config", "interactive"]
-
-T_JsonContainer = TypeVar("T_JsonContainer", dict[str, Any], list[Any])
 
 
 class BuildV2Command(ToolkitCommand):
@@ -821,7 +822,7 @@ class BuildV2Command(ToolkitCommand):
             except ValidationError as errors:
                 syntax_errors, syntax_warnings = self._create_syntax_insights(errors)
                 if not syntax_errors:
-                    toolkit_resource = self._validate_ignoring_unknown_fields(crud_class.yaml_cls, parsed_yaml, errors)
+                    toolkit_resource = self._validate_ignoring_unknown_fields(crud_class.yaml_cls, parsed_yaml)
                 if toolkit_resource is not None:
                     identifier = toolkit_resource.as_id()
                 else:
@@ -862,7 +863,7 @@ class BuildV2Command(ToolkitCommand):
         except ValidationError as errors:
             syntax_errors, syntax_warnings = self._create_syntax_insights(errors)
             if not syntax_errors:
-                toolkit_resources = self._validate_list_ignoring_unknown_fields(adapter, parsed_yaml, errors)
+                toolkit_resources = self._validate_list_ignoring_unknown_fields(adapter, parsed_yaml)
         read_resources: list[ReadResource[ToolkitResource]] = []
         for tk_resource, raw in zip_longest(toolkit_resources, parsed_yaml, fillvalue=None):
             if tk_resource is None:
@@ -916,57 +917,31 @@ class BuildV2Command(ToolkitCommand):
             output.append(extra_file)
         return output
 
-    @classmethod
+    @staticmethod
     def _validate_ignoring_unknown_fields(
-        cls, yaml_cls: type[ToolkitResource], parsed_yaml: dict[str, Any], error: ValidationError
+        yaml_cls: type[ToolkitResource], parsed_yaml: dict[str, Any]
     ) -> ToolkitResource | None:
-        """Re-validate a resource that only failed on warning-level findings, with unknown fields removed.
+        """Re-validate a resource that only failed on warning-level findings, ignoring unknown fields.
 
         Without this, a single unrecognized field leaves the resource unvalidated, which silently disables
         all downstream validation of it (dependencies, data modeling, agents, ...) even though the finding
         is only a warning. The unknown field is still written to the build directory as-is.
         """
         try:
-            return yaml_cls.model_validate(cls._without_unknown_fields(parsed_yaml, error), extra="ignore")
+            return validate_ignoring_unknown_fields(yaml_cls, parsed_yaml)
         except ValidationError:
-            # Not all warning-level findings can be removed, e.g. an invalid enum value.
+            # Not all warning-level findings can be ignored, e.g. an invalid enum value.
             return None
 
-    @classmethod
+    @staticmethod
     def _validate_list_ignoring_unknown_fields(
-        cls, adapter: TypeAdapter[list[ToolkitResource]], parsed_yaml: list[Any], error: ValidationError
+        adapter: TypeAdapter[list[ToolkitResource]], parsed_yaml: list[Any]
     ) -> list[ToolkitResource]:
         """List equivalent of ``_validate_ignoring_unknown_fields``."""
         try:
-            return adapter.validate_python(cls._without_unknown_fields(parsed_yaml, error), extra="ignore")
+            return validate_list_ignoring_unknown_fields(adapter, parsed_yaml)
         except ValidationError:
             return []
-
-    @staticmethod
-    def _without_unknown_fields(parsed_yaml: T_JsonContainer, error: ValidationError) -> T_JsonContainer:
-        """Returns a copy of the content with the fields reported as unknown by ``error`` removed.
-
-        Passing ``extra="ignore"`` to the validation is not enough on its own: resource classes such as
-        ``GroupYAML`` dispatch to a subclass by calling ``model_validate`` themselves, which does not carry
-        the runtime override. Removing the fields up front works regardless of how validation is nested.
-        """
-        content = copy.deepcopy(parsed_yaml)
-        for item in error.errors(include_url=False):
-            if item["type"] != "extra_forbidden":
-                continue
-            parent: Any = content
-            for key in item["loc"][:-1]:
-                if isinstance(parent, dict) and isinstance(key, str):
-                    parent = parent.get(key)
-                elif isinstance(parent, list) and isinstance(key, int) and key < len(parent):
-                    parent = parent[key]
-                else:
-                    # The location may not be navigable, for instance when it contains a union tag.
-                    parent = None
-                    break
-            if isinstance(parent, dict):
-                parent.pop(item["loc"][-1], None)
-        return content
 
     def _create_syntax_insights(
         self, error: ValidationError

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/build_v2.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import re
 import shutil
@@ -8,7 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from itertools import zip_longest
 from pathlib import Path
-from typing import Any, ClassVar, Literal, cast
+from typing import Any, ClassVar, Literal, TypeVar, cast
 
 import questionary
 import yaml
@@ -93,6 +94,8 @@ class ValidationStep:
 
 
 SelectionSource = Literal["modules", "config", "interactive"]
+
+T_JsonContainer = TypeVar("T_JsonContainer", dict[str, Any], list[Any])
 
 
 class BuildV2Command(ToolkitCommand):
@@ -683,19 +686,19 @@ class BuildV2Command(ToolkitCommand):
                         resources=built_resources,
                         insights=insights,
                         syntax_errors_by_source={
-                            file.source_path: file.syntax_error
+                            file.source_path: file.syntax_errors
                             for file in module.files
                             if isinstance(file, SuccessfulReadYAMLFile)
-                            and file.syntax_error is not None
+                            and file.syntax_errors
                             # If the file has unresolved variables (e.g. "{{space}}"), the syntax error is
                             # almost certainly caused by that and is already reported as its own insight.
                             and not file.unresolved_variables
                         },
                         syntax_warnings_by_source={
-                            file.source_path: file.syntax_warning
+                            file.source_path: file.syntax_warnings
                             for file in module.files
                             if isinstance(file, SuccessfulReadYAMLFile)
-                            and file.syntax_warning is not None
+                            and file.syntax_warnings
                             and not file.unresolved_variables
                         },
                         failed_files=[file for file in module.files if isinstance(file, FailedReadYAMLFile)],
@@ -810,30 +813,37 @@ class BuildV2Command(ToolkitCommand):
 
         if isinstance(parsed_yaml, dict):
             toolkit_resource: ToolkitResource | None = None
-            syntax_error: ModelSyntaxError | None = None
-            syntax_warning: ModelSyntaxWarning | None = None
+            syntax_errors: list[ModelSyntaxError] = []
+            syntax_warnings: list[ModelSyntaxWarning] = []
             try:
                 toolkit_resource = crud_class.yaml_cls.model_validate(parsed_yaml, extra="forbid")
                 identifier = toolkit_resource.as_id()
             except ValidationError as errors:
-                syntax_error, syntax_warning = self._create_syntax_warning(errors)
-                try:
-                    identifier = crud_class.get_id(parsed_yaml)
-                except KeyError:
-                    return SuccessfulReadYAMLFile(
-                        syntax_error=syntax_error,
-                        syntax_warning=syntax_warning,
-                        resources=[],
-                        **args,
+                syntax_errors, syntax_warnings = self._create_syntax_insights(errors)
+                if not syntax_errors:
+                    toolkit_resource = self._validate_ignoring_unknown_fields(
+                        crud_class.yaml_cls, parsed_yaml, errors
                     )
+                if toolkit_resource is not None:
+                    identifier = toolkit_resource.as_id()
+                else:
+                    try:
+                        identifier = crud_class.get_id(parsed_yaml)
+                    except KeyError:
+                        return SuccessfulReadYAMLFile(
+                            syntax_errors=syntax_errors,
+                            syntax_warnings=syntax_warnings,
+                            resources=[],
+                            **args,
+                        )
 
             extra_files = self._substitute_variables_extra_content(
                 crud_class.get_extra_files(resource_file, identifier, parsed_yaml), variables
             )
 
             return SuccessfulReadYAMLFile(
-                syntax_error=syntax_error,
-                syntax_warning=syntax_warning,
+                syntax_errors=syntax_errors,
+                syntax_warnings=syntax_warnings,
                 resources=[
                     ReadResource(
                         raw=parsed_yaml, identifier=identifier, validated=toolkit_resource, extra_files=extra_files
@@ -847,12 +857,14 @@ class BuildV2Command(ToolkitCommand):
         # and thus not available to te static type checker.
         adapter = TypeAdapter[list[crud_class.yaml_cls]](list[crud_class.yaml_cls])  # type: ignore[name-defined]
         toolkit_resources: list[ToolkitResource] = []
-        syntax_error = None
-        syntax_warning = None
+        syntax_errors = []
+        syntax_warnings = []
         try:
             toolkit_resources = adapter.validate_python(parsed_yaml)
         except ValidationError as errors:
-            syntax_error, syntax_warning = self._create_syntax_warning(errors)
+            syntax_errors, syntax_warnings = self._create_syntax_insights(errors)
+            if not syntax_errors:
+                toolkit_resources = self._validate_list_ignoring_unknown_fields(adapter, parsed_yaml, errors)
         read_resources: list[ReadResource[ToolkitResource]] = []
         for tk_resource, raw in zip_longest(toolkit_resources, parsed_yaml, fillvalue=None):
             if tk_resource is None:
@@ -874,8 +886,8 @@ class BuildV2Command(ToolkitCommand):
                 )
             )
         return SuccessfulReadYAMLFile(
-            syntax_error=syntax_error,
-            syntax_warning=syntax_warning,
+            syntax_errors=syntax_errors,
+            syntax_warnings=syntax_warnings,
             resources=read_resources,
             **args,
             unresolved_variables=unresolved_variables,
@@ -906,31 +918,85 @@ class BuildV2Command(ToolkitCommand):
             output.append(extra_file)
         return output
 
-    def _create_syntax_warning(
+    @classmethod
+    def _validate_ignoring_unknown_fields(
+        cls, yaml_cls: type[ToolkitResource], parsed_yaml: dict[str, Any], error: ValidationError
+    ) -> ToolkitResource | None:
+        """Re-validate a resource that only failed on warning-level findings, with unknown fields removed.
+
+        Without this, a single unrecognized field leaves the resource unvalidated, which silently disables
+        all downstream validation of it (dependencies, data modeling, agents, ...) even though the finding
+        is only a warning. The unknown field is still written to the build directory as-is.
+        """
+        try:
+            return yaml_cls.model_validate(cls._without_unknown_fields(parsed_yaml, error), extra="ignore")
+        except ValidationError:
+            # Not all warning-level findings can be removed, e.g. an invalid enum value.
+            return None
+
+    @classmethod
+    def _validate_list_ignoring_unknown_fields(
+        cls, adapter: TypeAdapter[list[ToolkitResource]], parsed_yaml: list[Any], error: ValidationError
+    ) -> list[ToolkitResource]:
+        """List equivalent of ``_validate_ignoring_unknown_fields``."""
+        try:
+            return adapter.validate_python(cls._without_unknown_fields(parsed_yaml, error), extra="ignore")
+        except ValidationError:
+            return []
+
+    @staticmethod
+    def _without_unknown_fields(parsed_yaml: T_JsonContainer, error: ValidationError) -> T_JsonContainer:
+        """Returns a copy of the content with the fields reported as unknown by ``error`` removed.
+
+        Passing ``extra="ignore"`` to the validation is not enough on its own: resource classes such as
+        ``GroupYAML`` dispatch to a subclass by calling ``model_validate`` themselves, which does not carry
+        the runtime override. Removing the fields up front works regardless of how validation is nested.
+        """
+        content = copy.deepcopy(parsed_yaml)
+        for item in error.errors(include_url=False):
+            if item["type"] != "extra_forbidden":
+                continue
+            parent: Any = content
+            for key in item["loc"][:-1]:
+                if isinstance(parent, dict) and isinstance(key, str):
+                    parent = parent.get(key)
+                elif isinstance(parent, list) and isinstance(key, int) and key < len(parent):
+                    parent = parent[key]
+                else:
+                    # The location may not be navigable, for instance when it contains a union tag.
+                    parent = None
+                    break
+            if isinstance(parent, dict):
+                parent.pop(item["loc"][-1], None)
+        return content
+
+    def _create_syntax_insights(
         self, error: ValidationError
-    ) -> tuple[ModelSyntaxError | None, ModelSyntaxWarning | None]:
+    ) -> tuple[list[ModelSyntaxError], list[ModelSyntaxWarning]]:
+        """Creates one insight per finding, so that unrelated findings in the same file stay countable
+        and individually displayable."""
         categorized_errors = humanize_validation_error_categorized(error) or [
             ("The YAML doesn't follow the required format.", "error")
         ]
-        warning_messages = [message for message, category in categorized_errors if category == "warning"]
-        error_messages = [message for message, category in categorized_errors if category == "error"]
-
-        syntax_error = None
-        if error_messages:
-            syntax_error = ModelSyntaxError(
+        syntax_errors = [
+            ModelSyntaxError(
                 code="MODEL-SYNTAX-ERROR",
-                message="\n".join(error_messages),
+                message=message,
                 fix="Compare the YAML with reference documentation and make sure it is valid.",
             )
-
-        syntax_warning = None
-        if warning_messages:
-            syntax_warning = ModelSyntaxWarning(
+            for message, category in categorized_errors
+            if category == "error"
+        ]
+        syntax_warnings = [
+            ModelSyntaxWarning(
                 code="MODEL-SYNTAX-WARNING",
-                message="\n".join(warning_messages),
+                message=message,
                 fix="Compare the YAML with reference documentation and make sure it is valid. It will be deployed as-is, but may be ignored or rejected by CDF.",
             )
-        return syntax_error, syntax_warning
+            for message, category in categorized_errors
+            if category == "warning"
+        ]
+        return syntax_errors, syntax_warnings
 
     def _export_resources(
         self,

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_build.py
@@ -126,8 +126,8 @@ class BuiltModule(BaseModel):
     module_id: ModuleId
     resources: list[BuiltResource] = Field(default_factory=list)
     insights: list[Insight] = Field(default_factory=list)
-    syntax_errors_by_source: dict[Path, ModelSyntaxError] = Field(default_factory=dict)
-    syntax_warnings_by_source: dict[Path, ModelSyntaxWarning] = Field(default_factory=dict)
+    syntax_errors_by_source: dict[Path, list[ModelSyntaxError]] = Field(default_factory=dict)
+    syntax_warnings_by_source: dict[Path, list[ModelSyntaxWarning]] = Field(default_factory=dict)
     unresolved_variables_by_source: dict[Path, list[str]] = Field(default_factory=dict)
     failed_files: list[FailedReadYAMLFile] = Field(default_factory=list)
     ignored_files: list[IgnoredFile] = Field(default_factory=list)
@@ -157,10 +157,12 @@ class BuiltModule(BaseModel):
                         source_file=format_insight_source_file(resource.source_path),
                     )
                 )
-        for path, error in self.syntax_errors_by_source.items():
-            insights.append(error.model_copy(update={"source_file": format_insight_source_file(path)}))
-        for path, warning in self.syntax_warnings_by_source.items():
-            insights.append(warning.model_copy(update={"source_file": format_insight_source_file(path)}))
+        for path, errors in self.syntax_errors_by_source.items():
+            for error in errors:
+                insights.append(error.model_copy(update={"source_file": format_insight_source_file(path)}))
+        for path, warnings in self.syntax_warnings_by_source.items():
+            for warning in warnings:
+                insights.append(warning.model_copy(update={"source_file": format_insight_source_file(path)}))
         for path, variables in self.unresolved_variables_by_source.items():
             quoted_variables = humanize_collection([f"{variable!r}" for variable in variables])
             insights.append(

--- a/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_module.py
+++ b/cognite_toolkit/_cdf_tk/commands/build_v2/data_classes/_module.py
@@ -252,8 +252,8 @@ class SuccessfulReadYAMLFile(ReadYAMLFile):
     source_hash: str
     resource_type: ResourceType
     resources: list[ReadResource[ToolkitResource]]
-    syntax_error: ModelSyntaxError | None = None
-    syntax_warning: ModelSyntaxWarning | None = None
+    syntax_errors: list[ModelSyntaxError] = Field(default_factory=list)
+    syntax_warnings: list[ModelSyntaxWarning] = Field(default_factory=list)
     line_count: int
 
 

--- a/cognite_toolkit/_cdf_tk/validation.py
+++ b/cognite_toolkit/_cdf_tk/validation.py
@@ -219,11 +219,7 @@ def humanize_validation_error_categorized(error: ValidationError) -> list[tuple[
             )
         if unknown := group["unknown"]:
             field_word = "field" if len(unknown) == 1 else "fields"
-            if path:
-                message = f"Unrecognized {field_word} in {path}: {humanize_collection(unknown)}."
-            else:
-                message = f"Unknown {field_word}: {humanize_collection(unknown)}"
-            errors.append((message, "warning"))
+            errors.append((f"Unrecognized {field_word}{location}: {humanize_collection(unknown)}", "warning"))
     return errors
 
 

--- a/cognite_toolkit/_cdf_tk/validation.py
+++ b/cognite_toolkit/_cdf_tk/validation.py
@@ -122,7 +122,7 @@ def humanize_validation_error_categorized(error: ValidationError) -> list[tuple[
         # reported by Pydantic as "model_type" with a None input. The field is present but empty, which
         # is often caused by its properties being under-indented so they end up as siblings instead.
         is_empty_nested_object = error_type == "model_type" and item["input"] is None
-        if len(loc) > 1 and (error_type in {"missing", "extra_forbidden"} or is_empty_nested_object):
+        if len(loc) >= 1 and (error_type in {"missing", "extra_forbidden"} or is_empty_nested_object):
             group_loc = loc[:-1]
             group = field_groups_by_loc.setdefault(group_loc, {"missing": [], "unknown": [], "empty": []})
             if _GroupEntry(group_loc) not in ordered_entries:
@@ -135,12 +135,7 @@ def humanize_validation_error_categorized(error: ValidationError) -> list[tuple[
                 key = "missing"
             group[key].append(f"{loc[-1]!r}")
             continue
-        if error_type == "missing":
-            msg = f"Missing required field: {loc[-1]!r}"
-        elif error_type == "extra_forbidden":
-            msg = f"Unknown field: {loc[-1]!r}"
-            category = "warning"
-        elif error_type == "value_error":
+        if error_type == "value_error":
             msg = str(item["ctx"]["error"])
         elif error_type == "literal_error":
             expected = item.get("ctx", {}).get("expected", item["msg"].removeprefix("Input should be "))
@@ -208,21 +203,27 @@ def humanize_validation_error_categorized(error: ValidationError) -> list[tuple[
             continue
         group = field_groups_by_loc[entry.loc]
         path = as_json_path(entry.loc)
+        # Top-level fields group under the root location, which has no path to refer to.
+        location = f" in {path}" if path else ""
         if missing := group["missing"]:
             field_word = "field" if len(missing) == 1 else "fields"
-            errors.append((f"Missing required {field_word} in {path}: {humanize_collection(missing)}", "error"))
+            errors.append((f"Missing required {field_word}{location}: {humanize_collection(missing)}", "error"))
         if empty := group["empty"]:
             field_word = "field" if len(empty) == 1 else "fields"
             errors.append(
                 (
-                    f"Empty {field_word} in {path}: {humanize_collection(empty)}. "
+                    f"Empty {field_word}{location}: {humanize_collection(empty)}. "
                     "Hint: Check that its properties are properly indented underneath it.",
                     "error",
                 )
             )
         if unknown := group["unknown"]:
             field_word = "field" if len(unknown) == 1 else "fields"
-            errors.append((f"Unrecognized {field_word} in {path}: {humanize_collection(unknown)}. ", "warning"))
+            if path:
+                message = f"Unrecognized {field_word} in {path}: {humanize_collection(unknown)}."
+            else:
+                message = f"Unknown {field_word}: {humanize_collection(unknown)}"
+            errors.append((message, "warning"))
     return errors
 
 

--- a/cognite_toolkit/_cdf_tk/yaml_classes/base.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/base.py
@@ -1,10 +1,13 @@
 from abc import abstractmethod
-from typing import TypeVar
+from typing import Any, TypeVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter, ValidationInfo
 from pydantic.alias_generators import to_camel
+from pydantic.config import ExtraValues
 
 from cognite_toolkit._cdf_tk.client._resource_base import Identifier
+
+_EXTRA_FIELDS_CONTEXT_KEY = "toolkit_extra_fields"
 
 
 class BaseModelResource(BaseModel, alias_generator=to_camel, extra="forbid"): ...
@@ -18,3 +21,35 @@ class ToolkitResource(BaseModelResource):
 
 
 T_Resource = TypeVar("T_Resource", bound=ToolkitResource)
+T_BaseModelResource = TypeVar("T_BaseModelResource", bound=BaseModelResource)
+
+
+def validate_as(target: type[T_BaseModelResource], data: Any, info: ValidationInfo) -> T_BaseModelResource:
+    """Validate ``data`` as ``target``, keeping the extra-field behavior of the ongoing validation.
+
+    Resource classes that select a class based on the content of the file (``GroupYAML``, ``Capability``,
+    ``Authentication``, ...) cannot use the wrap validator handler for this, as the handler is bound to the class
+    the validation started on. They have to call ``model_validate`` on the selected class instead, which starts a
+    fresh validation that does not inherit the ``extra`` argument given to the outer call. Going through this
+    function carries that argument over, so a caller that asked for unrecognized fields to be ignored gets that
+    behavior for the whole file and not just its top level.
+    """
+    return target.model_validate(data, extra=_extra_from_context(info.context), context=info.context)
+
+
+def validate_ignoring_unknown_fields(model: type[T_BaseModelResource], data: dict[str, Any]) -> T_BaseModelResource:
+    """Validate ``data`` as ``model``, accepting and discarding fields the model does not recognize."""
+    return model.model_validate(data, extra="ignore", context={_EXTRA_FIELDS_CONTEXT_KEY: "ignore"})
+
+
+def validate_list_ignoring_unknown_fields(
+    adapter: TypeAdapter[list[T_BaseModelResource]], data: list[Any]
+) -> list[T_BaseModelResource]:
+    """List equivalent of :func:`validate_ignoring_unknown_fields`."""
+    return adapter.validate_python(data, extra="ignore", context={_EXTRA_FIELDS_CONTEXT_KEY: "ignore"})
+
+
+def _extra_from_context(context: Any) -> ExtraValues | None:
+    if isinstance(context, dict):
+        return context.get(_EXTRA_FIELDS_CONTEXT_KEY)
+    return None

--- a/cognite_toolkit/_cdf_tk/yaml_classes/capabilities.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/capabilities.py
@@ -2,7 +2,7 @@ import sys
 from types import MappingProxyType, UnionType
 from typing import Any, ClassVar, Literal, cast, get_args
 
-from pydantic import ModelWrapValidatorHandler, field_validator, model_serializer, model_validator
+from pydantic import ModelWrapValidatorHandler, ValidationInfo, field_validator, model_serializer, model_validator
 from pydantic_core.core_schema import SerializerFunctionWrapHandler
 
 from cognite_toolkit._cdf_tk.utils.collection import humanize_collection
@@ -12,7 +12,7 @@ if sys.version_info < (3, 11):
 else:
     from typing import Self
 
-from .base import BaseModelResource
+from .base import BaseModelResource, validate_as
 
 
 class Scope(BaseModelResource):
@@ -20,7 +20,7 @@ class Scope(BaseModelResource):
 
     @model_validator(mode="wrap")
     @classmethod
-    def find_scope_cls(cls, data: Any, handler: ModelWrapValidatorHandler[Self]) -> Self:
+    def find_scope_cls(cls, data: Any, handler: ModelWrapValidatorHandler[Self], info: ValidationInfo) -> Self:
         if isinstance(data, Scope):
             return cast(Self, data)
         if not isinstance(data, dict):
@@ -34,7 +34,7 @@ class Scope(BaseModelResource):
                 f"invalid scope name '{name}'. Expected one of {humanize_collection(_SCOPE_CLASS_BY_NAME.keys(), bind_word='or')}"
             )
         cls_ = _SCOPE_CLASS_BY_NAME[name]
-        return cast(Self, cls_.model_validate(content))
+        return cast(Self, validate_as(cls_, content, info))
 
     @model_serializer(mode="wrap", when_used="always", return_type=dict)
     def include_scope_name(self, handler: SerializerFunctionWrapHandler) -> dict:
@@ -145,7 +145,7 @@ class Capability(BaseModelResource):
 
     @field_validator("scope", mode="before")
     @classmethod
-    def find_scope_cls(cls, data: Any) -> Scope:
+    def find_scope_cls(cls, data: Any, info: ValidationInfo) -> Scope:
         annotation = cls.model_fields["scope"].annotation
         if isinstance(annotation, UnionType):
             valid_types = {s._scope_name for s in get_args(annotation)}
@@ -160,11 +160,11 @@ class Capability(BaseModelResource):
                 f"invalid scope name '{name}'. Expected {humanize_collection(valid_types, bind_word='or')}"
             )
 
-        return Scope.model_validate(data)
+        return validate_as(Scope, data, info)
 
     @model_validator(mode="wrap")
     @classmethod
-    def find_capability_cls(cls, data: Any, handler: ModelWrapValidatorHandler[Self]) -> Self:
+    def find_capability_cls(cls, data: Any, handler: ModelWrapValidatorHandler[Self], info: ValidationInfo) -> Self:
         if cls is not Capability:
             return handler(data)
         if not isinstance(data, dict):
@@ -173,7 +173,7 @@ class Capability(BaseModelResource):
         if name not in _CAPABILITY_CLASS_BY_NAME:
             raise ValueError(f"Invalid capability name '{name}'. Expected one of {_CAPABILITY_CLASS_BY_NAME.keys()}")
         cls_ = _CAPABILITY_CLASS_BY_NAME[name]
-        return cast(Self, cls_.model_validate(content))
+        return cast(Self, validate_as(cls_, content, info))
 
     @model_serializer(mode="wrap", when_used="always", return_type=dict)
     def include_capability_name(self, handler: SerializerFunctionWrapHandler) -> dict:

--- a/cognite_toolkit/_cdf_tk/yaml_classes/container_field_definitions.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/container_field_definitions.py
@@ -2,7 +2,7 @@ import sys
 from types import MappingProxyType
 from typing import Any, ClassVar, Literal, cast
 
-from pydantic import Field, ModelWrapValidatorHandler, model_serializer, model_validator
+from pydantic import Field, ModelWrapValidatorHandler, ValidationInfo, model_serializer, model_validator
 from pydantic_core.core_schema import SerializationInfo, SerializerFunctionWrapHandler
 
 from cognite_toolkit._cdf_tk.client import identifiers
@@ -12,7 +12,7 @@ from cognite_toolkit._cdf_tk.constants import (
 )
 from cognite_toolkit._cdf_tk.utils.collection import humanize_collection
 
-from .base import BaseModelResource
+from .base import BaseModelResource, validate_as
 
 if sys.version_info < (3, 11):
     from typing_extensions import Self
@@ -45,7 +45,9 @@ class ConstraintDefinition(BaseModelResource):
 
     @model_validator(mode="wrap")
     @classmethod
-    def find_constraint_definition_cls(cls, data: Any, handler: ModelWrapValidatorHandler[Self]) -> Self:
+    def find_constraint_definition_cls(
+        cls, data: Any, handler: ModelWrapValidatorHandler[Self], info: ValidationInfo
+    ) -> Self:
         if isinstance(data, ConstraintDefinition):
             return cast(Self, data)
         if not isinstance(data, dict):
@@ -67,7 +69,7 @@ class ConstraintDefinition(BaseModelResource):
         data_copy = dict(data)
         data_copy.pop("constraintType")
 
-        return cast(Self, cls_.model_validate(data_copy))
+        return cast(Self, validate_as(cls_, data_copy, info))
 
     @model_serializer(mode="wrap", when_used="always", return_type=dict)
     def serialize_constrain_definition(self, handler: SerializerFunctionWrapHandler) -> dict:
@@ -98,7 +100,9 @@ class IndexDefinition(BaseModelResource):
 
     @model_validator(mode="wrap")
     @classmethod
-    def find_index_definition_cls(cls, data: Any, handler: ModelWrapValidatorHandler[Self]) -> Self:
+    def find_index_definition_cls(
+        cls, data: Any, handler: ModelWrapValidatorHandler[Self], info: ValidationInfo
+    ) -> Self:
         if isinstance(data, IndexDefinition):
             return cast(Self, data)
         if not isinstance(data, dict):
@@ -119,7 +123,7 @@ class IndexDefinition(BaseModelResource):
         cls_ = _INDEX_DEFINITION_CLASS_BY_TYPE[index_type]
         data_copy = dict(data)
         data_copy.pop("indexType")
-        return cast(Self, cls_.model_validate(data_copy))
+        return cast(Self, validate_as(cls_, data_copy, info))
 
     @model_serializer(mode="wrap", when_used="always", return_type=dict)
     def serialize_index(self, handler: SerializerFunctionWrapHandler) -> dict:
@@ -150,7 +154,7 @@ class PropertyTypeDefinition(BaseModelResource):
 
     @model_validator(mode="wrap")
     @classmethod
-    def find_property_type_cls(cls, data: Any, handler: ModelWrapValidatorHandler[Self]) -> Self:
+    def find_property_type_cls(cls, data: Any, handler: ModelWrapValidatorHandler[Self], info: ValidationInfo) -> Self:
         if isinstance(data, PropertyTypeDefinition):
             return cast(Self, data)
         if not isinstance(data, dict):
@@ -171,7 +175,7 @@ class PropertyTypeDefinition(BaseModelResource):
         cls_ = _PROPERTY_TYPE_CLASS_BY_TYPE[property_type]
         data_copy = dict(data)
         data_copy.pop("type")
-        return cast(Self, cls_.model_validate(data_copy))
+        return cast(Self, validate_as(cls_, data_copy, info))
 
     @model_serializer(mode="wrap", when_used="always", return_type=dict)
     def serialize_property_type(self, handler: SerializerFunctionWrapHandler) -> dict:

--- a/cognite_toolkit/_cdf_tk/yaml_classes/groups.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/groups.py
@@ -1,13 +1,13 @@
 import sys
 from typing import Any, Literal, cast
 
-from pydantic import ModelWrapValidatorHandler, model_serializer, model_validator
+from pydantic import ModelWrapValidatorHandler, ValidationInfo, model_serializer, model_validator
 from pydantic_core.core_schema import SerializationInfo, SerializerFunctionWrapHandler
 
 from cognite_toolkit._cdf_tk.client.identifiers import NameId
 from cognite_toolkit._cdf_tk.client.resource_classes.group import GroupAttributes
 
-from .base import ToolkitResource
+from .base import ToolkitResource, validate_as
 from .capabilities import Capability
 
 if sys.version_info < (3, 11):
@@ -27,13 +27,13 @@ class GroupYAML(ToolkitResource):
 
     @model_validator(mode="wrap")
     @classmethod
-    def select_group_type(cls, data: Any, handler: ModelWrapValidatorHandler[Self]) -> Self:
+    def select_group_type(cls, data: Any, handler: ModelWrapValidatorHandler[Self], info: ValidationInfo) -> Self:
         if cls is not GroupYAML:
             return handler(data)
         if "sourceId" in data:
-            return cast(Self, ExternalGroupYAML.model_validate(data))
+            return cast(Self, validate_as(ExternalGroupYAML, data, info))
         elif "members" in data:
-            return cast(Self, CDFGroupYAML.model_validate(data))
+            return cast(Self, validate_as(CDFGroupYAML, data, info))
         raise ValueError("Missing required field: Either 'sourceId' or 'members'")
 
     @model_serializer(mode="wrap")

--- a/cognite_toolkit/_cdf_tk/yaml_classes/hosted_extractor_job.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/hosted_extractor_job.py
@@ -3,7 +3,15 @@ from abc import ABC
 from types import MappingProxyType
 from typing import Any, ClassVar, Literal, cast
 
-from pydantic import Field, JsonValue, ModelWrapValidatorHandler, field_validator, model_serializer, model_validator
+from pydantic import (
+    Field,
+    JsonValue,
+    ModelWrapValidatorHandler,
+    ValidationInfo,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 from pydantic_core.core_schema import SerializationInfo, SerializerFunctionWrapHandler
 
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
@@ -11,7 +19,7 @@ from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 from cognite_toolkit._cdf_tk.utils import humanize_collection
 from cognite_toolkit._cdf_tk.utils._auxiliary import get_concrete_subclasses
 
-from .base import BaseModelResource, ToolkitResource
+from .base import BaseModelResource, ToolkitResource, validate_as
 
 if sys.version_info < (3, 11):
     from typing_extensions import Self
@@ -31,7 +39,9 @@ class JobFormat(BaseModelResource, ABC):
 
     @model_validator(mode="wrap")
     @classmethod
-    def find_format(cls, data: "dict[str, Any] | JobFormat", handler: ModelWrapValidatorHandler[Self]) -> Self:
+    def find_format(
+        cls, data: "dict[str, Any] | JobFormat", handler: ModelWrapValidatorHandler[Self], info: ValidationInfo
+    ) -> Self:
         if isinstance(data, JobFormat):
             return cast(Self, data)
         if not isinstance(data, dict):
@@ -49,7 +59,7 @@ class JobFormat(BaseModelResource, ABC):
                 f"invalid type '{type_}'. Expected one of {humanize_collection(_JOB_FORMAT_CLS_BY_TYPE.keys(), bind_word='or')}"
             )
         cls_ = _JOB_FORMAT_CLS_BY_TYPE[type_]
-        return cast(Self, cls_.model_validate({k: v for k, v in data.items() if k != "type"}))
+        return cast(Self, validate_as(cls_, {k: v for k, v in data.items() if k != "type"}, info))
 
     @model_serializer(mode="wrap", when_used="always", return_type=dict)
     def include_type(self, handler: SerializerFunctionWrapHandler) -> dict:
@@ -120,7 +130,7 @@ class IncrementalLoad(BaseModelResource, ABC):
     @model_validator(mode="wrap")
     @classmethod
     def find_incremental_load(
-        cls, data: "dict[str, Any] | IncrementalLoad", handler: ModelWrapValidatorHandler[Self]
+        cls, data: "dict[str, Any] | IncrementalLoad", handler: ModelWrapValidatorHandler[Self], info: ValidationInfo
     ) -> Self:
         if isinstance(data, IncrementalLoad):
             return cast(Self, data)
@@ -139,7 +149,7 @@ class IncrementalLoad(BaseModelResource, ABC):
                 f"invalid type '{type_}'. Expected one of {humanize_collection(_INCREMENTAL_LOAD_CLS_BY_TYPE.keys(), bind_word='or')}"
             )
         cls_ = _INCREMENTAL_LOAD_CLS_BY_TYPE[type_]
-        return cast(Self, cls_.model_validate({k: v for k, v in data.items() if k != "type"}))
+        return cast(Self, validate_as(cls_, {k: v for k, v in data.items() if k != "type"}, info))
 
     @model_serializer(mode="wrap", when_used="always", return_type=dict)
     def include_type(self, handler: SerializerFunctionWrapHandler) -> dict:

--- a/cognite_toolkit/_cdf_tk/yaml_classes/hosted_extractor_mapping.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/hosted_extractor_mapping.py
@@ -2,13 +2,13 @@ import sys
 from types import MappingProxyType
 from typing import Any, ClassVar, cast
 
-from pydantic import Field, ModelWrapValidatorHandler, model_serializer, model_validator
+from pydantic import Field, ModelWrapValidatorHandler, ValidationInfo, model_serializer, model_validator
 from pydantic_core.core_schema import SerializationInfo, SerializerFunctionWrapHandler
 
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.utils import humanize_collection
 
-from .base import BaseModelResource, ToolkitResource
+from .base import BaseModelResource, ToolkitResource, validate_as
 
 if sys.version_info < (3, 11):
     from typing_extensions import Self
@@ -27,7 +27,9 @@ class MappingInput(BaseModelResource):
 
     @model_validator(mode="wrap")
     @classmethod
-    def find_type(cls, data: "dict[str, Any] | MappingInput", handler: ModelWrapValidatorHandler[Self]) -> Self:
+    def find_type(
+        cls, data: "dict[str, Any] | MappingInput", handler: ModelWrapValidatorHandler[Self], info: ValidationInfo
+    ) -> Self:
         if isinstance(data, MappingInput):
             return cast(Self, data)
         if not isinstance(data, dict):
@@ -45,7 +47,7 @@ class MappingInput(BaseModelResource):
                 f"invalid type '{type_}'. Expected one of {humanize_collection(_MAPPING_INPUT_CLS_BY_TYPE.keys(), bind_word='or')}"
             )
         cls_ = _MAPPING_INPUT_CLS_BY_TYPE[type_]
-        return cast(Self, cls_.model_validate({k: v for k, v in data.items() if k != "type"}))
+        return cast(Self, validate_as(cls_, {k: v for k, v in data.items() if k != "type"}, info))
 
     @model_serializer(mode="wrap", when_used="always", return_type=dict)
     def include_type(self, handler: SerializerFunctionWrapHandler) -> dict:

--- a/cognite_toolkit/_cdf_tk/yaml_classes/hosted_extractor_source.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/hosted_extractor_source.py
@@ -7,6 +7,7 @@ from pydantic import (
     Field,
     ModelWrapValidatorHandler,
     SecretStr,
+    ValidationInfo,
     field_serializer,
     field_validator,
     model_serializer,
@@ -18,7 +19,7 @@ from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.utils import humanize_collection
 from cognite_toolkit._cdf_tk.utils._auxiliary import get_concrete_subclasses
 
-from .base import BaseModelResource, ToolkitResource
+from .base import BaseModelResource, ToolkitResource, validate_as
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -66,7 +67,7 @@ class Authentication(BaseModelResource):
     @model_validator(mode="wrap")
     @classmethod
     def find_source_type(
-        cls, data: "dict[str, Any] | Authentication", handler: ModelWrapValidatorHandler[Self]
+        cls, data: "dict[str, Any] | Authentication", handler: ModelWrapValidatorHandler[Self], info: ValidationInfo
     ) -> Self:
         if isinstance(data, Authentication):
             return cast(Self, data)
@@ -85,7 +86,7 @@ class Authentication(BaseModelResource):
                 f"invalid authentication type '{type_}'. Expected one of {humanize_collection(_AUTHENTICATION_CLS_BY_TYPE.keys(), bind_word='or')}"
             )
         cls_ = _AUTHENTICATION_CLS_BY_TYPE[type_]
-        return cast(Self, cls_.model_validate({k: v for k, v in data.items() if k != "type"}))
+        return cast(Self, validate_as(cls_, {k: v for k, v in data.items() if k != "type"}, info))
 
     @model_serializer(mode="wrap", when_used="always", return_type=dict)
     def include_type(self, handler: SerializerFunctionWrapHandler) -> dict:
@@ -191,7 +192,10 @@ class HostedExtractorSourceYAML(ToolkitResource):
     @model_validator(mode="wrap")
     @classmethod
     def find_source_type(
-        cls, data: "dict[str, Any] | HostedExtractorSourceYAML", handler: ModelWrapValidatorHandler[Self]
+        cls,
+        data: "dict[str, Any] | HostedExtractorSourceYAML",
+        handler: ModelWrapValidatorHandler[Self],
+        info: ValidationInfo,
     ) -> Self:
         if isinstance(data, HostedExtractorSourceYAML):
             return cast(Self, data)
@@ -210,7 +214,7 @@ class HostedExtractorSourceYAML(ToolkitResource):
                 f"Invalid hosted extractor source type='{type_}'. Expected one of {humanize_collection(_SOURCE_CLS_BY_TYPE.keys(), bind_word='or')}"
             )
         cls_ = _SOURCE_CLS_BY_TYPE[type_]
-        return cast(Self, cls_.model_validate({k: v for k, v in data.items() if k != "type"}))
+        return cast(Self, validate_as(cls_, {k: v for k, v in data.items() if k != "type"}, info))
 
     def as_id(self) -> ExternalId:
         return ExternalId(external_id=self.external_id)

--- a/cognite_toolkit/_cdf_tk/yaml_classes/signal_sink.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/signal_sink.py
@@ -2,13 +2,13 @@ import sys
 from types import MappingProxyType
 from typing import Any, ClassVar, cast
 
-from pydantic import Field, ModelWrapValidatorHandler, model_serializer, model_validator
+from pydantic import Field, ModelWrapValidatorHandler, ValidationInfo, model_serializer, model_validator
 from pydantic_core.core_schema import SerializerFunctionWrapHandler
 
 from cognite_toolkit._cdf_tk.client.identifiers import SignalSinkId
 from cognite_toolkit._cdf_tk.utils import humanize_collection
 
-from .base import ToolkitResource
+from .base import ToolkitResource, validate_as
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -26,7 +26,9 @@ class SignalSinkYAML(ToolkitResource):
 
     @model_validator(mode="wrap")
     @classmethod
-    def find_sink_type(cls, data: "dict[str, Any] | SignalSinkYAML", handler: ModelWrapValidatorHandler[Self]) -> Self:
+    def find_sink_type(
+        cls, data: "dict[str, Any] | SignalSinkYAML", handler: ModelWrapValidatorHandler[Self], info: ValidationInfo
+    ) -> Self:
         if isinstance(data, SignalSinkYAML):
             return cast(Self, data)
         if not isinstance(data, dict):
@@ -44,7 +46,7 @@ class SignalSinkYAML(ToolkitResource):
                 f"Expected one of {humanize_collection(_SINK_CLS_BY_TYPE.keys(), bind_word='or')}"
             )
         cls_ = _SINK_CLS_BY_TYPE[type_]
-        return cast(Self, cls_.model_validate({k: v for k, v in data.items() if k != "type"}))
+        return cast(Self, validate_as(cls_, {k: v for k, v in data.items() if k != "type"}, info))
 
     def as_id(self) -> SignalSinkId:
         return SignalSinkId(type=cast(Any, self.type), external_id=self.external_id)

--- a/cognite_toolkit/_cdf_tk/yaml_classes/transformation_destination.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/transformation_destination.py
@@ -2,13 +2,13 @@ import sys
 from types import MappingProxyType
 from typing import Any, ClassVar, Literal, cast
 
-from pydantic import Field, ModelWrapValidatorHandler, model_serializer, model_validator
+from pydantic import Field, ModelWrapValidatorHandler, ValidationInfo, model_serializer, model_validator
 from pydantic_core.core_schema import SerializerFunctionWrapHandler
 
 from cognite_toolkit._cdf_tk.constants import SPACE_FORMAT_PATTERN
 from cognite_toolkit._cdf_tk.utils.collection import humanize_collection
 
-from .base import BaseModelResource
+from .base import BaseModelResource, validate_as
 
 if sys.version_info < (3, 11):
     from typing_extensions import Self
@@ -73,7 +73,7 @@ class Destination(BaseModelResource):
 
     @model_validator(mode="wrap")
     @classmethod
-    def find_destination_cls(cls, data: Any, handler: ModelWrapValidatorHandler[Self]) -> Self:
+    def find_destination_cls(cls, data: Any, handler: ModelWrapValidatorHandler[Self], info: ValidationInfo) -> Self:
         if isinstance(data, Destination):
             return cast(Self, data)
         if not isinstance(data, dict):
@@ -90,7 +90,7 @@ class Destination(BaseModelResource):
                 f"invalid destination type '{dest_type}'. Expected one of {humanize_collection(_DESTINATION_CLASS_BY_TYPE.keys(), bind_word='or')}"
             )
         cls_ = _DESTINATION_CLASS_BY_TYPE[dest_type]
-        return cast(Self, cls_.model_validate(data))
+        return cast(Self, validate_as(cls_, data, info))
 
     @model_serializer(mode="wrap", when_used="always", return_type=dict)
     def serialize_destination(self, handler: SerializerFunctionWrapHandler) -> dict:

--- a/cognite_toolkit/_cdf_tk/yaml_classes/transformations.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/transformations.py
@@ -1,12 +1,12 @@
 from typing import Any, Literal
 
-from pydantic import Field, field_validator, model_serializer
+from pydantic import Field, ValidationInfo, field_validator, model_serializer
 from pydantic_core.core_schema import SerializationInfo, SerializerFunctionWrapHandler
 
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 
 from .authentication import AuthenticationClientIdSecret, OIDCCredential
-from .base import ToolkitResource
+from .base import ToolkitResource, validate_as
 from .transformation_destination import Destination
 
 
@@ -61,15 +61,17 @@ class TransformationYAML(ToolkitResource):
 
     @field_validator("authentication", mode="before")
     @classmethod
-    def validate_serialization(cls, value: Any) -> Any:
+    def validate_serialization(cls, value: Any, info: ValidationInfo) -> Any:
         if not isinstance(value, dict):
             return value
         if "read" in value or "write" in value:
-            return {k: cls._validate_auth_value(v) if isinstance(v, dict) else v for k, v in value.items()}
-        return cls._validate_auth_value(value)
+            return {k: cls._validate_auth_value(v, info) if isinstance(v, dict) else v for k, v in value.items()}
+        return cls._validate_auth_value(value, info)
 
     @classmethod
-    def _validate_auth_value(cls, value: dict[str, Any]) -> AuthenticationClientIdSecret | OIDCCredential:
+    def _validate_auth_value(
+        cls, value: dict[str, Any], info: ValidationInfo
+    ) -> AuthenticationClientIdSecret | OIDCCredential:
         if "scopes" in value or "tokenUri" in value or "cdfProjectName" in value or "audience" in value:
-            return OIDCCredential.model_validate(value)
-        return AuthenticationClientIdSecret.model_validate(value)
+            return validate_as(OIDCCredential, value, info)
+        return validate_as(AuthenticationClientIdSecret, value, info)

--- a/cognite_toolkit/_cdf_tk/yaml_classes/view_field_definitions.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/view_field_definitions.py
@@ -3,7 +3,7 @@ import sys
 from types import MappingProxyType
 from typing import Any, ClassVar, Literal, cast
 
-from pydantic import Field, ModelWrapValidatorHandler, model_serializer, model_validator
+from pydantic import Field, ModelWrapValidatorHandler, ValidationInfo, model_serializer, model_validator
 from pydantic_core.core_schema import SerializerFunctionWrapHandler
 
 from cognite_toolkit._cdf_tk.client import identifiers
@@ -15,7 +15,7 @@ from cognite_toolkit._cdf_tk.constants import (
 )
 from cognite_toolkit._cdf_tk.utils.collection import humanize_collection
 
-from .base import BaseModelResource
+from .base import BaseModelResource, validate_as
 from .container_field_definitions import ContainerReference
 
 if sys.version_info < (3, 11):
@@ -91,7 +91,7 @@ class ViewProperty(BaseModelResource):
 
     @model_validator(mode="wrap")
     @classmethod
-    def find_property_type_cls(cls, data: Any, handler: ModelWrapValidatorHandler[Self]) -> Self:
+    def find_property_type_cls(cls, data: Any, handler: ModelWrapValidatorHandler[Self], info: ValidationInfo) -> Self:
         if isinstance(data, ViewProperty):
             return cast(Self, data)
         if not isinstance(data, dict):
@@ -122,7 +122,7 @@ class ViewProperty(BaseModelResource):
 
         data_copy = dict(data)
         data_copy.pop("connectionType", None)
-        return cast(Self, cls_.model_validate(data_copy))
+        return cast(Self, validate_as(cls_, data_copy, info))
 
     @model_serializer(mode="wrap", when_used="always", return_type=dict)
     def serialize_property_type(self, handler: SerializerFunctionWrapHandler) -> dict:

--- a/cognite_toolkit/_cdf_tk/yaml_classes/workflow_trigger.py
+++ b/cognite_toolkit/_cdf_tk/yaml_classes/workflow_trigger.py
@@ -2,14 +2,14 @@ import sys
 from types import MappingProxyType
 from typing import Any, ClassVar, cast
 
-from pydantic import Field, JsonValue, ModelWrapValidatorHandler, model_serializer, model_validator
+from pydantic import Field, JsonValue, ModelWrapValidatorHandler, ValidationInfo, model_serializer, model_validator
 from pydantic_core.core_schema import SerializationInfo, SerializerFunctionWrapHandler
 
 from cognite_toolkit._cdf_tk.client.identifiers import ContainerId, ExternalId
 from cognite_toolkit._cdf_tk.utils import humanize_collection
 
 from .authentication import AuthenticationClientIdSecret
-from .base import BaseModelResource, ToolkitResource
+from .base import BaseModelResource, ToolkitResource, validate_as
 
 if sys.version_info < (3, 11):
     from typing_extensions import Self
@@ -23,7 +23,7 @@ class TriggerRuleYAML(BaseModelResource):
     @model_validator(mode="wrap")
     @classmethod
     def find_trigger_type(
-        cls, data: "dict[str, Any] | TriggerRuleYAML", handler: ModelWrapValidatorHandler[Self]
+        cls, data: "dict[str, Any] | TriggerRuleYAML", handler: ModelWrapValidatorHandler[Self], info: ValidationInfo
     ) -> Self:
         if isinstance(data, TriggerRuleYAML):
             return cast(Self, data)
@@ -42,7 +42,7 @@ class TriggerRuleYAML(BaseModelResource):
                 f"invalid trigger type '{trigger_type}'. Expected one of {humanize_collection(_TRIGGER_CLS_BY_NAME.keys(), bind_word='or')}"
             )
         cls_ = _TRIGGER_CLS_BY_NAME[trigger_type]
-        return cast(Self, cls_.model_validate({k: v for k, v in data.items() if k != "triggerType"}))
+        return cast(Self, validate_as(cls_, {k: v for k, v in data.items() if k != "triggerType"}, info))
 
     @model_serializer(mode="wrap", when_used="always", return_type=dict)
     def include_trigger_type(self, handler: SerializerFunctionWrapHandler) -> dict:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
@@ -608,7 +608,7 @@ def _read_resource_outcome(result: FailedReadYAMLFile | SuccessfulReadYAMLFile) 
         "outcome": "success",
         "code": None,
         "resource_count": len(result.resources),
-        "has_syntax_warning": result.syntax_warning is not None,
+        "has_syntax_warning": bool(result.syntax_warnings),
     }
 
 
@@ -708,8 +708,21 @@ class TestReadResourceFile:
         result = cmd._read_resource_file(resource_file, crud_class, [])
         assert isinstance(result, SuccessfulReadYAMLFile)
         assert len(result.resources) == expected_resource_count
-        assert has_syntax_error == (result.syntax_error is not None)
-        assert has_syntax_warning == (result.syntax_warning is not None)
+        assert has_syntax_error == bool(result.syntax_errors)
+        assert has_syntax_warning == bool(result.syntax_warnings)
+
+    def test_read_resource_file_creates_one_insight_per_finding(self, tmp_path: Path) -> None:
+        """Findings must stay separate insights instead of being concatenated into one message."""
+        resource_file = tmp_path / "resource.Space.yaml"
+        resource_file.write_text('space: ""\nextra_one: value\nextra_two: value\n')
+
+        result = BuildV2Command()._read_resource_file(resource_file, SpaceCRUD, [])
+
+        assert isinstance(result, SuccessfulReadYAMLFile)
+        assert [error.message for error in result.syntax_errors] == [
+            "Invalid value for space: String should have at least 1 character"
+        ]
+        assert [warning.message for warning in result.syntax_warnings] == ["Unknown fields: 'extra_one' and 'extra_two'"]
 
 
 class TestFindUnresolvedVariables:

--- a/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_buildv2/test_command.py
@@ -562,7 +562,7 @@ class TestDisplayInsightsOutput:
             [
                 ModelSyntaxWarning(
                     code="MODEL-SYNTAX-WARNING",
-                    message="Unknown field: 'Name'",
+                    message="Unrecognized field: 'Name'",
                     fix="Make sure the resource YAML content is valid and follows the expected structure.",
                     source_file="modules/my_module/data_modeling/my_space.Space.yaml",
                 )
@@ -573,7 +573,7 @@ class TestDisplayInsightsOutput:
 
         rendered = output.getvalue()
         assert "Model syntax warning in modules/my_module/data_modeling/my_space.Space.yaml" in rendered
-        assert "Unknown field: 'Name'" in rendered
+        assert "Unrecognized field: 'Name'" in rendered
 
     def test_displays_regex_pattern_without_rich_markup_corruption(self, tmp_path: Path) -> None:
         console, output = self._console()
@@ -722,7 +722,9 @@ class TestReadResourceFile:
         assert [error.message for error in result.syntax_errors] == [
             "Invalid value for space: String should have at least 1 character"
         ]
-        assert [warning.message for warning in result.syntax_warnings] == ["Unknown fields: 'extra_one' and 'extra_two'"]
+        assert [warning.message for warning in result.syntax_warnings] == [
+            "Unrecognized fields: 'extra_one' and 'extra_two'"
+        ]
 
 
 class TestFindUnresolvedVariables:

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_agents.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_agents.py
@@ -148,7 +148,7 @@ def invalid_test_cases() -> Iterable:
             "Hint: Use double quotes to force string.",
             "Invalid value for tools: Input should be a valid list. Got 'not_a_list'.",
             "Missing required field: 'externalId'",
-            "Unknown field: 'external_id'",
+            "Unrecognized field: 'external_id'",
         },
         id="type-validation-errors",
     )

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_asset.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_asset.py
@@ -15,8 +15,8 @@ def invalid_asset_test_cases() -> Iterable:
     )
     yield pytest.param(
         {"externalId": "asset_1", "name": "Asset 1", "parentId": 123},
-        {"Unknown field: 'parentId'"},
-        id="Unknown field: parentId",
+        {"Unrecognized field: 'parentId'"},
+        id="Unrecognized field: parentId",
     )
 
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_data_model.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_data_model.py
@@ -171,7 +171,7 @@ class TestDataModelYAML:
                     "version": "v1",
                     "unknown_field": "some_value",
                 },
-                ["Unknown field: 'unknown_field'"],
+                ["Unrecognized field: 'unknown_field'"],
                 id="single-unknown-field",
             ),
         ],

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline.py
@@ -39,7 +39,7 @@ def invalid_extraction_pipeline_test_cases() -> Iterable:
     # All required fields present but with extra unknown field
     yield pytest.param(
         {"externalId": "pipeline5", "name": "Pipeline 5", "dataSetExternalId": "ds5", "unknownField": "value"},
-        {"Unknown field: 'unknownField'"},
+        {"Unrecognized field: 'unknownField'"},
         id="Unknown field present",
     )
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline.py
@@ -12,7 +12,7 @@ from tests.test_unit.utils import find_resources
 def invalid_extraction_pipeline_test_cases() -> Iterable:
     yield pytest.param(
         {"externalId": "myPipeline"},
-        {"Missing required field: 'name'", "Missing required field: 'dataSetExternalId'"},
+        {"Missing required fields: 'dataSetExternalId' and 'name'"},
         id="Missing required fields",
     )
     # Missing externalId

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_extraction_pipeline_config.py
@@ -37,7 +37,7 @@ def invalid_extraction_pipeline_config_test_cases() -> Iterable:
     # Unknown field present
     yield pytest.param(
         {"externalId": "myConfig", "config": {"key": "value"}, "unknownField": 1},
-        {"Unknown field: 'unknownField'"},
+        {"Unrecognized field: 'unknownField'"},
         id="Unknown field present",
     )
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_groups.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_groups.py
@@ -7,6 +7,8 @@ from cognite_toolkit._cdf_tk.tk_warnings.fileread import ResourceFormatWarning
 from cognite_toolkit._cdf_tk.utils import read_yaml_content
 from cognite_toolkit._cdf_tk.validation import validate_resource_yaml_pydantic
 from cognite_toolkit._cdf_tk.yaml_classes import GroupYAML
+from cognite_toolkit._cdf_tk.yaml_classes.base import validate_ignoring_unknown_fields
+from cognite_toolkit._cdf_tk.yaml_classes.groups import CDFGroupYAML
 from tests.test_unit.utils import find_resources
 
 
@@ -82,6 +84,21 @@ class TestTimeSeriesTK:
         loaded = GroupYAML.model_validate(data)
 
         assert loaded.model_dump(exclude_unset=True, by_alias=True) == data
+
+    def test_unknown_field_in_capability_scope_is_ignored(self) -> None:
+        """The unknown field sits in a capability scope, two class selections below the group itself."""
+        data = {
+            "name": "my-group",
+            "members": ["my-user"],
+            "capabilities": [
+                {"timeSeriesAcl": {"actions": ["READ"], "scope": {"datasetScope": {"ids": ["1"], "unknown": "x"}}}}
+            ],
+        }
+
+        loaded = validate_ignoring_unknown_fields(GroupYAML, data)
+
+        assert isinstance(loaded, CDFGroupYAML)
+        assert loaded.as_id().name == "my-group"
 
     @pytest.mark.parametrize("content, expected_errors", list(invalid_group_test_cases()))
     def test_invalid_group_error_messages(self, content: str, expected_errors: set[str]) -> None:

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_hosted_extractor_destination.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_hosted_extractor_destination.py
@@ -13,13 +13,13 @@ from tests.test_unit.utils import find_resources
 def invalid_hosted_extractor_destination_test_cases() -> Iterable:
     yield pytest.param(
         {"name": "Pump"},
-        {"Missing required field: 'externalId'", "Unknown field: 'name'"},
+        {"Missing required field: 'externalId'", "Unrecognized field: 'name'"},
         id="Missing required field: externalId",
     )
     yield pytest.param(
         {"externalId": "myDestination", "dataSetId": 123},
-        {"Unknown field: 'dataSetId'"},
-        id="Unknown field: dataSetId",
+        {"Unrecognized field: 'dataSetId'"},
+        id="Unrecognized field: dataSetId",
     )
 
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_hosted_extractor_jobs.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_hosted_extractor_jobs.py
@@ -206,10 +206,10 @@ def invalid_hosted_extractor_job_test_cases() -> Iterable:
         {
             "Missing required field in config.KafkaConfig: 'topic'",
             "Unrecognized fields in config.KafkaConfig: 'incrementalLoad', 'interval', 'method', "
-            "'pagination' and 'path'.",
+            "'pagination' and 'path'",
             "Missing required field in config.MQTTConfig: 'topicFilter'",
             "Unrecognized fields in config.MQTTConfig: 'incrementalLoad', 'interval', 'method', "
-            "'pagination' and 'path'.",
+            "'pagination' and 'path'",
             "Invalid value at config.RestConfig.incrementalLoad: Invalid type 'nextUrl'. Expected one of "
             "body, headerValue and queryParameter",
         },

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_hosted_extractor_jobs.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_hosted_extractor_jobs.py
@@ -28,11 +28,7 @@ def invalid_hosted_extractor_job_test_cases() -> Iterable:
         {
             "externalId": "myJob",
         },
-        {
-            "Missing required field: 'destinationId'",
-            "Missing required field: 'sourceId'",
-            "Missing required field: 'format'",
-        },
+        {"Missing required fields: 'destinationId', 'format' and 'sourceId'"},
         id="Missing required fields",
     )
 
@@ -210,10 +206,10 @@ def invalid_hosted_extractor_job_test_cases() -> Iterable:
         {
             "Missing required field in config.KafkaConfig: 'topic'",
             "Unrecognized fields in config.KafkaConfig: 'incrementalLoad', 'interval', 'method', "
-            "'pagination' and 'path'. ",
+            "'pagination' and 'path'.",
             "Missing required field in config.MQTTConfig: 'topicFilter'",
             "Unrecognized fields in config.MQTTConfig: 'incrementalLoad', 'interval', 'method', "
-            "'pagination' and 'path'. ",
+            "'pagination' and 'path'.",
             "Invalid value at config.RestConfig.incrementalLoad: Invalid type 'nextUrl'. Expected one of "
             "body, headerValue and queryParameter",
         },

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_hosted_extractor_source.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_hosted_extractor_source.py
@@ -119,7 +119,7 @@ def invalid_hosted_extractor_source_test_cases() -> Iterable:
         },
         {
             "Missing required fields in authentication: 'clientId', 'clientSecret' and 'tokenUrl'",
-            "Unrecognized fields in authentication: 'client_id' and 'token_url'.",
+            "Unrecognized fields in authentication: 'client_id' and 'token_url'",
         },
         id="RESTSource ClientCredentials missing client_secret",
     )

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_hosted_extractor_source.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_hosted_extractor_source.py
@@ -119,7 +119,7 @@ def invalid_hosted_extractor_source_test_cases() -> Iterable:
         },
         {
             "Missing required fields in authentication: 'clientId', 'clientSecret' and 'tokenUrl'",
-            "Unrecognized fields in authentication: 'client_id' and 'token_url'. ",
+            "Unrecognized fields in authentication: 'client_id' and 'token_url'.",
         },
         id="RESTSource ClientCredentials missing client_secret",
     )

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
@@ -28,7 +28,10 @@ def invalid_test_cases() -> Iterable:
                 "invalidToggle": "bad_value",
             },
         },
-        {"Unrecognized field in featureToggles: 'invalidToggle'.", "Unknown fields: 'anotherUnknownField' and 'unknownField'"},
+        {
+            "Unrecognized field in featureToggles: 'invalidToggle'",
+            "Unrecognized fields: 'anotherUnknownField' and 'unknownField'",
+        },
         id="Multiple extra fields at different levels",
     )
     yield pytest.param(
@@ -87,7 +90,7 @@ def invalid_test_cases() -> Iterable:
                 "unknownField": "bad_value",
             },
         },
-        {"Unrecognized field in dataExplorationConfig: 'unknownField'."},
+        {"Unrecognized field in dataExplorationConfig: 'unknownField'"},
         id="Unknown field in dataExplorationConfig",
     )
     yield pytest.param(
@@ -119,7 +122,7 @@ def invalid_test_cases() -> Iterable:
                 },
             },
         },
-        {"Unrecognized field in dataExplorationConfig.assetPropertiesCardConfig.name: 'unknownField'."},
+        {"Unrecognized field in dataExplorationConfig.assetPropertiesCardConfig.name: 'unknownField'"},
         id="Unknown field in dataExplorationConfig.assetPropertiesCardConfig entry",
     )
     yield pytest.param(
@@ -171,7 +174,7 @@ def invalid_test_cases() -> Iterable:
         },
         {
             "Missing required field in viewMappings.observation[1]: 'view'",
-            "Unrecognized fields in viewMappings.observation[1]: 'externalId', 'space' and 'version'.",
+            "Unrecognized fields in viewMappings.observation[1]: 'externalId', 'space' and 'version'",
         },
         id="Flat legacy ViewMapping shape in viewMappings.observation",
     )
@@ -193,7 +196,7 @@ def invalid_test_cases() -> Iterable:
         {
             "Empty field in viewMappings.observation[1]: 'view'. "
             "Hint: Check that its properties are properly indented underneath it.",
-            "Unrecognized fields in viewMappings.observation[1]: 'externalId', 'space' and 'version'.",
+            "Unrecognized fields in viewMappings.observation[1]: 'externalId', 'space' and 'version'",
         },
         id="Empty view (under-indented siblings) in viewMappings.observation",
     )
@@ -249,7 +252,7 @@ def invalid_test_cases() -> Iterable:
                 ],
             },
         },
-        {"Unrecognized field in viewMappings.observation[1]: 'unknownField'."},
+        {"Unrecognized field in viewMappings.observation[1]: 'unknownField'"},
         id="Unknown field in viewMappings.observation",
     )
     yield pytest.param(
@@ -272,7 +275,7 @@ def invalid_test_cases() -> Iterable:
                 ],
             },
         },
-        {"Unrecognized field in viewMappings.observation[1].writeBack: 'unknownField'."},
+        {"Unrecognized field in viewMappings.observation[1].writeBack: 'unknownField'"},
         id="Unknown field in viewMappings.observation.writeBack",
     )
     yield pytest.param(
@@ -342,7 +345,7 @@ def invalid_test_cases() -> Iterable:
                 ],
             },
         },
-        {"Unrecognized field in viewMappings.observation[1].fieldsConfig.assets: 'unknownField'."},
+        {"Unrecognized field in viewMappings.observation[1].fieldsConfig.assets: 'unknownField'"},
         id="Unknown field in viewMappings.observation.fieldsConfig entry",
     )
     yield pytest.param(
@@ -358,7 +361,7 @@ def invalid_test_cases() -> Iterable:
                 },
             },
         },
-        {"Unrecognized field in dataExplorationConfig.assetActivitiesCardView: 'unknownNested'."},
+        {"Unrecognized field in dataExplorationConfig.assetActivitiesCardView: 'unknownNested'"},
         id="Unknown field in dataExplorationConfig.assetActivitiesCardView",
     )
     yield pytest.param(
@@ -388,7 +391,7 @@ def invalid_test_cases() -> Iterable:
                 },
             },
         },
-        {"Unrecognized field in dataExplorationConfig.assetNotificationsCardView: 'extraProp'."},
+        {"Unrecognized field in dataExplorationConfig.assetNotificationsCardView: 'extraProp'"},
         id="Unknown field in dataExplorationConfig.assetNotificationsCardView",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_cdm_location_config.py
@@ -14,7 +14,7 @@ from tests.test_unit.utils import find_resources
 def invalid_test_cases() -> Iterable:
     yield pytest.param(
         {"name": "MyLocationConfig"},
-        {"Missing required field: 'externalId'", "Missing required field: 'space'"},
+        {"Missing required fields: 'externalId' and 'space'"},
         id="Missing required fields: externalId and space",
     )
     yield pytest.param(
@@ -28,11 +28,7 @@ def invalid_test_cases() -> Iterable:
                 "invalidToggle": "bad_value",
             },
         },
-        {
-            "Unrecognized field in featureToggles: 'invalidToggle'. ",
-            "Unknown field: 'anotherUnknownField'",
-            "Unknown field: 'unknownField'",
-        },
+        {"Unrecognized field in featureToggles: 'invalidToggle'.", "Unknown fields: 'anotherUnknownField' and 'unknownField'"},
         id="Multiple extra fields at different levels",
     )
     yield pytest.param(
@@ -91,7 +87,7 @@ def invalid_test_cases() -> Iterable:
                 "unknownField": "bad_value",
             },
         },
-        {"Unrecognized field in dataExplorationConfig: 'unknownField'. "},
+        {"Unrecognized field in dataExplorationConfig: 'unknownField'."},
         id="Unknown field in dataExplorationConfig",
     )
     yield pytest.param(
@@ -123,7 +119,7 @@ def invalid_test_cases() -> Iterable:
                 },
             },
         },
-        {"Unrecognized field in dataExplorationConfig.assetPropertiesCardConfig.name: 'unknownField'. "},
+        {"Unrecognized field in dataExplorationConfig.assetPropertiesCardConfig.name: 'unknownField'."},
         id="Unknown field in dataExplorationConfig.assetPropertiesCardConfig entry",
     )
     yield pytest.param(
@@ -175,7 +171,7 @@ def invalid_test_cases() -> Iterable:
         },
         {
             "Missing required field in viewMappings.observation[1]: 'view'",
-            "Unrecognized fields in viewMappings.observation[1]: 'externalId', 'space' and 'version'. ",
+            "Unrecognized fields in viewMappings.observation[1]: 'externalId', 'space' and 'version'.",
         },
         id="Flat legacy ViewMapping shape in viewMappings.observation",
     )
@@ -197,7 +193,7 @@ def invalid_test_cases() -> Iterable:
         {
             "Empty field in viewMappings.observation[1]: 'view'. "
             "Hint: Check that its properties are properly indented underneath it.",
-            "Unrecognized fields in viewMappings.observation[1]: 'externalId', 'space' and 'version'. ",
+            "Unrecognized fields in viewMappings.observation[1]: 'externalId', 'space' and 'version'.",
         },
         id="Empty view (under-indented siblings) in viewMappings.observation",
     )
@@ -253,7 +249,7 @@ def invalid_test_cases() -> Iterable:
                 ],
             },
         },
-        {"Unrecognized field in viewMappings.observation[1]: 'unknownField'. "},
+        {"Unrecognized field in viewMappings.observation[1]: 'unknownField'."},
         id="Unknown field in viewMappings.observation",
     )
     yield pytest.param(
@@ -276,7 +272,7 @@ def invalid_test_cases() -> Iterable:
                 ],
             },
         },
-        {"Unrecognized field in viewMappings.observation[1].writeBack: 'unknownField'. "},
+        {"Unrecognized field in viewMappings.observation[1].writeBack: 'unknownField'."},
         id="Unknown field in viewMappings.observation.writeBack",
     )
     yield pytest.param(
@@ -346,7 +342,7 @@ def invalid_test_cases() -> Iterable:
                 ],
             },
         },
-        {"Unrecognized field in viewMappings.observation[1].fieldsConfig.assets: 'unknownField'. "},
+        {"Unrecognized field in viewMappings.observation[1].fieldsConfig.assets: 'unknownField'."},
         id="Unknown field in viewMappings.observation.fieldsConfig entry",
     )
     yield pytest.param(
@@ -362,7 +358,7 @@ def invalid_test_cases() -> Iterable:
                 },
             },
         },
-        {"Unrecognized field in dataExplorationConfig.assetActivitiesCardView: 'unknownNested'. "},
+        {"Unrecognized field in dataExplorationConfig.assetActivitiesCardView: 'unknownNested'."},
         id="Unknown field in dataExplorationConfig.assetActivitiesCardView",
     )
     yield pytest.param(
@@ -392,7 +388,7 @@ def invalid_test_cases() -> Iterable:
                 },
             },
         },
-        {"Unrecognized field in dataExplorationConfig.assetNotificationsCardView: 'extraProp'. "},
+        {"Unrecognized field in dataExplorationConfig.assetNotificationsCardView: 'extraProp'."},
         id="Unknown field in dataExplorationConfig.assetNotificationsCardView",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_location_config.py
@@ -28,11 +28,7 @@ def invalid_test_cases() -> Iterable:
                 "invalidToggle": "bad_value",
             },
         },
-        {
-            "Unrecognized field in featureToggles: 'invalidToggle'. ",
-            "Unknown field: 'anotherUnknownField'",
-            "Unknown field: 'unknownField'",
-        },
+        {"Unrecognized field in featureToggles: 'invalidToggle'.", "Unknown fields: 'anotherUnknownField' and 'unknownField'"},
         id="Multiple extra fields at different levels",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_location_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_location_config.py
@@ -28,7 +28,10 @@ def invalid_test_cases() -> Iterable:
                 "invalidToggle": "bad_value",
             },
         },
-        {"Unrecognized field in featureToggles: 'invalidToggle'.", "Unknown fields: 'anotherUnknownField' and 'unknownField'"},
+        {
+            "Unrecognized field in featureToggles: 'invalidToggle'",
+            "Unrecognized fields: 'anotherUnknownField' and 'unknownField'",
+        },
         id="Multiple extra fields at different levels",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_v1.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_infield_v1.py
@@ -28,7 +28,7 @@ def invalid_test_cases() -> Iterable:
             "Invalid value for externalId: Input should be a valid string. Got 123 of type int. Hint: Use double quotes to force string.",
             "Invalid value for name: Input should be a valid string. Got 456 of type int. Hint: Use double quotes to force string.",
             "Invalid value for appDataSpaceVersion: Input should be a valid string. Got [] of type list. Hint: Use double quotes to force string.",
-            "Unknown field: 'dataSetId'",
+            "Unrecognized field: 'dataSetId'",
         },
         id="Multiple type validation errors",
     )

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_instance.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_instance.py
@@ -39,7 +39,7 @@ def invalid_edge_test_cases() -> Iterable:
             **_EDGE_TEST_DATA,
             "unknownField": "value",
         },
-        {"Unknown field: 'unknownField'"},
+        {"Unrecognized field: 'unknownField'"},
         id="unknown-field-present",
     )
     yield pytest.param(
@@ -83,7 +83,7 @@ def invalid_edge_test_cases() -> Iterable:
                 "unknownField": "value",
             },
         },
-        {"Unrecognized field in type: 'unknownField'."},
+        {"Unrecognized field in type: 'unknownField'"},
         id="unknown-field-node-type",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_instance.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_instance.py
@@ -23,13 +23,7 @@ def invalid_edge_test_cases() -> Iterable:
         {
             "existingVersion": 1,
         },
-        {
-            "Missing required field: 'externalId'",
-            "Missing required field: 'space'",
-            "Missing required field: 'type'",
-            "Missing required field: 'startNode'",
-            "Missing required field: 'endNode'",
-        },
+        {"Missing required fields: 'endNode', 'externalId', 'space', 'startNode' and 'type'"},
         id="missing-required-fields",
     )
     yield pytest.param(
@@ -89,7 +83,7 @@ def invalid_edge_test_cases() -> Iterable:
                 "unknownField": "value",
             },
         },
-        {"Unrecognized field in type: 'unknownField'. "},
+        {"Unrecognized field in type: 'unknownField'."},
         id="unknown-field-node-type",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_labels.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_labels.py
@@ -15,8 +15,8 @@ def invalid_label_test_cases() -> Iterable:
     )
     yield pytest.param(
         {"externalId": "equipment:pump", "dataSetId": 123},
-        {"Unknown field: 'dataSetId'", "Missing required field: 'name'"},
-        id="Unknown field: dataSetId and missing name",
+        {"Unrecognized field: 'dataSetId'", "Missing required field: 'name'"},
+        id="Unrecognized field: dataSetId and missing name",
     )
 
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_migration.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_migration.py
@@ -11,11 +11,7 @@ from cognite_toolkit._cdf_tk.yaml_classes.migration import ResourceViewMappingYA
 def invalid_mapping_test_cases() -> Iterable:
     yield pytest.param(
         {"viewId": {"space": "cdf_cdm", "externalId": "CogniteAsset", "version": "v1"}},
-        {
-            "Missing required field: 'propertyMapping'",
-            "Missing required field: 'resourceType'",
-            "Missing required field: 'externalId'",
-        },
+        {"Missing required fields: 'externalId', 'propertyMapping' and 'resourceType'"},
         id="Missing required field: externalId",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_migration.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_migration.py
@@ -32,7 +32,7 @@ def invalid_mapping_test_cases() -> Iterable:
             "Invalid value at viewId.version: Input should be a valid string. Got 123 of type int. Hint: "
             "Use double quotes to force string.",
         },
-        id="Unknown field: dataSetId and missing name",
+        id="Unrecognized field: dataSetId and missing name",
     )
 
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_raw_database_table.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_raw_database_table.py
@@ -12,7 +12,7 @@ from tests.test_unit.utils import find_resources
 def invalid_database_test_cases() -> Iterable:
     yield pytest.param(
         {"name": "Asset 1"},
-        {"Unknown field: 'name'", "Missing required field: 'dbName'"},
+        {"Unrecognized field: 'name'", "Missing required field: 'dbName'"},
         id="Missing required field: dbName",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_relationships.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_relationships.py
@@ -13,18 +13,12 @@ from tests.test_unit.utils import find_resources
 def invalid_relationship_test_cases() -> Iterable:
     yield pytest.param(
         {"externalId": "myRelationship", "targetExternalId": "target", "sourceExternalId": "source"},
-        {"Missing required field: 'sourceType'", "Missing required field: 'targetType'"},
+        {"Missing required fields: 'sourceType' and 'targetType'"},
         id="Missing required fields",
     )
     yield pytest.param(
         {"externalId": "equipment:pump", "dataSetId": 123},
-        {
-            "Missing required field: 'sourceExternalId'",
-            "Missing required field: 'sourceType'",
-            "Missing required field: 'targetExternalId'",
-            "Missing required field: 'targetType'",
-            "Unknown field: 'dataSetId'",
-        },
+        {"Missing required fields: 'sourceExternalId', 'sourceType', 'targetExternalId' and 'targetType'", "Unknown field: 'dataSetId'"},
         id="Unknown field: dataSetId and missing name",
     )
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_relationships.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_relationships.py
@@ -18,8 +18,11 @@ def invalid_relationship_test_cases() -> Iterable:
     )
     yield pytest.param(
         {"externalId": "equipment:pump", "dataSetId": 123},
-        {"Missing required fields: 'sourceExternalId', 'sourceType', 'targetExternalId' and 'targetType'", "Unknown field: 'dataSetId'"},
-        id="Unknown field: dataSetId and missing name",
+        {
+            "Missing required fields: 'sourceExternalId', 'sourceType', 'targetExternalId' and 'targetType'",
+            "Unrecognized field: 'dataSetId'",
+        },
+        id="Unrecognized field: dataSetId and missing name",
     )
 
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_robotics/test_capability.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_robotics/test_capability.py
@@ -59,7 +59,7 @@ class TestRobotCapabilityYAML:
             ),
             pytest.param(
                 {"externalId": "cap_001", "name": "Test Capability", "method": "test_method", "unknownField": "value"},
-                {"Unknown field: 'unknownField'"},
+                {"Unrecognized field: 'unknownField'"},
                 id="unknown-field-present",
             ),
         ],

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_robotics/test_data_postprocessing.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_robotics/test_data_postprocessing.py
@@ -53,7 +53,7 @@ def invalid_robot_data_postprocessing_cases() -> Iterable:
     )
     yield pytest.param(
         {"name": "Test PostProcessing", "externalId": "postproc_001", "method": "test_method", "unknownField": "value"},
-        {"Unknown field: 'unknownField'"},
+        {"Unrecognized field: 'unknownField'"},
         id="unknown-field-present",
     )
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_robotics/test_frame.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_robotics/test_frame.py
@@ -43,7 +43,7 @@ def invalid_robot_frame_cases() -> Iterable:
             "externalId": "frame_001",
             "unknownField": "value",
         },
-        {"Unknown field: 'unknownField'"},
+        {"Unrecognized field: 'unknownField'"},
         id="unknown-field-present",
     )
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_robotics/test_location.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_robotics/test_location.py
@@ -39,7 +39,7 @@ def invalid_robot_location_cases() -> Iterable:
             "externalId": "loc_001",
             "unknownField": "value",
         },
-        {"Unknown field: 'unknownField'"},
+        {"Unrecognized field: 'unknownField'"},
         id="unknown-field-present",
     )
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_search_config.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_search_config.py
@@ -31,7 +31,7 @@ def invalid_search_config_test_cases() -> Iterable:
             "view": {"space": "my_space", "externalId": "my_view"},
             "unknown_field": "value",
         },
-        {"Unknown field: 'unknown_field'"},
+        {"Unrecognized field: 'unknown_field'"},
         id="Unknown field",
     )
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_securitycategories.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_securitycategories.py
@@ -12,7 +12,7 @@ from tests.test_unit.utils import find_resources
 def invalid_security_category_test_cases() -> Iterable:
     yield pytest.param(
         {"externalId": "MyCategory"},
-        {"Missing required field: 'name'", "Unknown field: 'externalId'"},
+        {"Missing required field: 'name'", "Unrecognized field: 'externalId'"},
         id="Missing required field: name",
     )
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_sequence.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_sequence.py
@@ -47,7 +47,7 @@ def invalid_sequence_test_cases() -> Iterable:
     )
     yield pytest.param(
         {"externalId": "seq_1", "columns": [{"externalId": "col_1"}], "unknownField": "value"},
-        {"Unknown field: 'unknownField'"},
+        {"Unrecognized field: 'unknownField'"},
         id="unknown-field-present",
     )
 
@@ -205,7 +205,7 @@ def invalid_sequence_row_test_cases() -> Iterable:
             "rows": [{"rowNumber": 0, "values": [1]}],
             "unknownField": "value",
         },
-        {"Unknown field: 'unknownField'"},
+        {"Unrecognized field: 'unknownField'"},
         id="unknown-field-present",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_sequence.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_sequence.py
@@ -12,7 +12,7 @@ from tests.test_unit.utils import find_resources
 def invalid_sequence_test_cases() -> Iterable:
     yield pytest.param(
         {"name": "Sequence 1"},
-        {"Missing required field: 'externalId'", "Missing required field: 'columns'"},
+        {"Missing required fields: 'columns' and 'externalId'"},
         id="missing-required-fields",
     )
     yield pytest.param(
@@ -138,7 +138,7 @@ class TestSequenceYAML:
 def invalid_sequence_row_test_cases() -> Iterable:
     yield pytest.param(
         {"externalId": "seq_row_1"},
-        {"Missing required field: 'columns'", "Missing required field: 'rows'"},
+        {"Missing required fields: 'columns' and 'rows'"},
         id="missing-required-fields",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_signal_sink.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_signal_sink.py
@@ -24,7 +24,7 @@ def invalid_test_cases() -> Iterable:
     )
     yield pytest.param(
         {"type": "email", "externalId": "my-sink", "emailAddress": "a@b.com", "unknownField": "x"},
-        {"Unknown field: 'unknownField'"},
+        {"Unrecognized field: 'unknownField'"},
         id="unknown-field",
     )
     yield pytest.param(
@@ -34,7 +34,7 @@ def invalid_test_cases() -> Iterable:
     )
     yield pytest.param(
         {"type": "user", "externalId": "my-sink", "emailAddress": "a@b.com"},
-        {"Unknown field: 'emailAddress'"},
+        {"Unrecognized field: 'emailAddress'"},
         id="user-type-rejects-email-address",
     )
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_signal_subscription.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_signal_subscription.py
@@ -95,7 +95,7 @@ def invalid_test_cases() -> Iterable:
             "filter": {"topic": "cognite_integrations"},
             "unknownField": "x",
         },
-        {"Unknown field: 'unknownField'"},
+        {"Unrecognized field: 'unknownField'"},
         id="unknown-field",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_simulator_model.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_simulator_model.py
@@ -12,12 +12,7 @@ from tests.test_unit.utils import find_resources
 def invalid_simulator_model_test_cases() -> Iterable:
     yield pytest.param(
         {"name": "Model 1"},
-        {
-            "Missing required field: 'externalId'",
-            "Missing required field: 'simulatorExternalId'",
-            "Missing required field: 'dataSetExternalId'",
-            "Missing required field: 'type'",
-        },
+        {"Missing required fields: 'dataSetExternalId', 'externalId', 'simulatorExternalId' and 'type'"},
         id="Missing required fields",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_simulator_model.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_simulator_model.py
@@ -34,8 +34,8 @@ def invalid_simulator_model_test_cases() -> Iterable:
             "type": "steady_state",
             "id": 123,
         },
-        {"Unknown field: 'id'"},
-        id="Unknown field: id",
+        {"Unrecognized field: 'id'"},
+        id="Unrecognized field: id",
     )
     yield pytest.param(
         {
@@ -46,8 +46,8 @@ def invalid_simulator_model_test_cases() -> Iterable:
             "type": "steady_state",
             "dataSetId": 123,
         },
-        {"Unknown field: 'dataSetId'"},
-        id="Unknown field: dataSetId (should use dataSetExternalId)",
+        {"Unrecognized field: 'dataSetId'"},
+        id="Unrecognized field: dataSetId (should use dataSetExternalId)",
     )
 
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_skill.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_skill.py
@@ -18,11 +18,7 @@ def invalid_test_cases() -> Iterable:
             "name": "toolkit-demo-skill",
             "description": "Skill without external id",
         },
-        [
-            "Missing required field: 'externalId'",
-            "Unknown field: 'name'",
-            "Unknown field: 'description'",
-        ],
+        ["Missing required field: 'externalId'", "Unknown fields: 'description' and 'name'"],
         id="missing-external-id",
     )
     yield pytest.param(
@@ -32,11 +28,7 @@ def invalid_test_cases() -> Iterable:
             "description": "Skill with invalid name pattern",
             "content": "not markdown frontmatter format",
         },
-        [
-            "Unknown field: 'name'",
-            "Unknown field: 'description'",
-            "Invalid value for content: String should match pattern",
-        ],
+        ["Unknown fields: 'description' and 'name'", "Invalid value for content: String should match pattern"],
         id="schema-allows-content-but-rejects-invalid-markdown-format",
     )
     yield pytest.param(
@@ -45,11 +37,7 @@ def invalid_test_cases() -> Iterable:
             "name": "",
             "description": "",
         },
-        [
-            "Invalid value for externalId: String should have at least 1 character",
-            "Unknown field: 'name'",
-            "Unknown field: 'description'",
-        ],
+        ["Invalid value for externalId: String should have at least 1 character", "Unknown fields: 'description' and 'name'"],
         id="empty-strings",
     )
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_skill.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_skill.py
@@ -18,7 +18,7 @@ def invalid_test_cases() -> Iterable:
             "name": "toolkit-demo-skill",
             "description": "Skill without external id",
         },
-        ["Missing required field: 'externalId'", "Unknown fields: 'description' and 'name'"],
+        ["Missing required field: 'externalId'", "Unrecognized fields: 'description' and 'name'"],
         id="missing-external-id",
     )
     yield pytest.param(
@@ -28,7 +28,7 @@ def invalid_test_cases() -> Iterable:
             "description": "Skill with invalid name pattern",
             "content": "not markdown frontmatter format",
         },
-        ["Unknown fields: 'description' and 'name'", "Invalid value for content: String should match pattern"],
+        ["Unrecognized fields: 'description' and 'name'", "Invalid value for content: String should match pattern"],
         id="schema-allows-content-but-rejects-invalid-markdown-format",
     )
     yield pytest.param(
@@ -37,7 +37,10 @@ def invalid_test_cases() -> Iterable:
             "name": "",
             "description": "",
         },
-        ["Invalid value for externalId: String should have at least 1 character", "Unknown fields: 'description' and 'name'"],
+        [
+            "Invalid value for externalId: String should have at least 1 character",
+            "Unrecognized fields: 'description' and 'name'",
+        ],
         id="empty-strings",
     )
 

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_space.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_space.py
@@ -12,7 +12,7 @@ from tests.test_unit.utils import find_resources
 def invalid_space_test_cases() -> Iterable:
     yield pytest.param(
         {"externalId": "mySpace"},
-        {"Unknown field: 'externalId'", "Missing required field: 'space'"},
+        {"Unrecognized field: 'externalId'", "Missing required field: 'space'"},
         id="Missing required field: space",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_streamlit.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_streamlit.py
@@ -19,7 +19,7 @@ def invalid_streamlit_test_cases() -> Iterable:
         {"externalId": "MyApp", "creator": "doctrino", "name": "MyApp", "published": "yes", "draft": "no"},
         {
             "Invalid value for published: Input should be a valid boolean. Got 'yes' of type str.",
-            "Unknown field: 'draft'",
+            "Unrecognized field: 'draft'",
         },
         id="Invalid boolean and unknown field",
     )

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_streams.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_streams.py
@@ -35,7 +35,7 @@ def invalid_stream_test_cases() -> Iterable:
             "settings": {"template": {"name": "ImmutableTestStream"}},
             "unknownField": "value",
         },
-        {"Unknown field: 'unknownField'"},
+        {"Unrecognized field: 'unknownField'"},
         id="Unknown field",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_threedmodels.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_threedmodels.py
@@ -12,13 +12,13 @@ from tests.test_unit.utils import find_resources
 def invalid_3D_test_cases() -> Iterable:
     yield pytest.param(
         {"externalId": "MyModel"},
-        {"Missing required field: 'name'", "Unknown field: 'externalId'"},
+        {"Missing required field: 'name'", "Unrecognized field: 'externalId'"},
         id="Missing required field: externalId",
     )
     yield pytest.param(
         {"name": "MyModel", "dataSetId": 123},
-        {"Unknown field: 'dataSetId'"},
-        id="Unknown field: dataSetId",
+        {"Unrecognized field: 'dataSetId'"},
+        id="Unrecognized field: dataSetId",
     )
     yield pytest.param(
         {"name": "MyModel", "metadata": {f"key{i}": f"value{i}" for i in range(17)}},

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_transformation_notification.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_transformation_notification.py
@@ -37,7 +37,7 @@ class TestTransformationNotificationYAML:
                     "transformationId": 123,
                     "transformationExternalId": "ext-123",
                 },
-                {"Unknown field: 'transformationId'"},
+                {"Unrecognized field: 'transformationId'"},
                 id="Specifying transformationId",
             ),
         ],

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_transformations.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_transformations.py
@@ -151,7 +151,7 @@ def invalid_transformation_test_cases() -> Iterable:
                 "tokenUri": "https://api.cognitedata.com/api/v1/oauth/token",
             },
         },
-        {"Unknown field: 'authentication.read'", "Unknown field: 'authentication.write'"},
+        {"Unknown fields: 'authentication.read' and 'authentication.write'"},
         id="Invalid authentication - base on real use case",
     )
     yield pytest.param(
@@ -194,7 +194,7 @@ def invalid_transformation_test_cases() -> Iterable:
         },
         {
             "Missing required fields in authentication: 'clientId' and 'clientSecret'",
-            "Unrecognized field in authentication: 'invalid_key'. ",
+            "Unrecognized field in authentication: 'invalid_key'.",
         },
         id="Invalid authentication type",
     )

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_transformations.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_transformations.py
@@ -151,7 +151,7 @@ def invalid_transformation_test_cases() -> Iterable:
                 "tokenUri": "https://api.cognitedata.com/api/v1/oauth/token",
             },
         },
-        {"Unknown fields: 'authentication.read' and 'authentication.write'"},
+        {"Unrecognized fields: 'authentication.read' and 'authentication.write'"},
         id="Invalid authentication - base on real use case",
     )
     yield pytest.param(
@@ -194,7 +194,7 @@ def invalid_transformation_test_cases() -> Iterable:
         },
         {
             "Missing required fields in authentication: 'clientId' and 'clientSecret'",
-            "Unrecognized field in authentication: 'invalid_key'.",
+            "Unrecognized field in authentication: 'invalid_key'",
         },
         id="Invalid authentication type",
     )

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_workflow.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_workflow.py
@@ -12,7 +12,7 @@ from tests.test_unit.utils import find_resources
 def invalid_workflow_test_cases() -> Iterable:
     yield pytest.param(
         {"name": "MyWorkflow"},
-        {"Missing required field: 'externalId'", "Unknown field: 'name'"},
+        {"Missing required field: 'externalId'", "Unrecognized field: 'name'"},
         id="Missing required field: externalId",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_workflow_triggers.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_workflow_triggers.py
@@ -14,7 +14,10 @@ def invalid_workflow_trigger_test_cases() -> Iterable:
     # Missing required field: externalId, extra field 'name'
     yield pytest.param(
         {"name": "MyWorkflowTrigger"},
-        {"Missing required fields: 'authentication', 'externalId', 'triggerRule', 'workflowExternalId' and 'workflowVersion'", "Unknown field: 'name'"},
+        {
+            "Missing required fields: 'authentication', 'externalId', 'triggerRule', 'workflowExternalId' and 'workflowVersion'",
+            "Unrecognized field: 'name'",
+        },
         id="Missing required fields ",
     )
     # Extra/unknown field
@@ -30,7 +33,7 @@ def invalid_workflow_trigger_test_cases() -> Iterable:
         {
             "Missing required fields in authentication: 'clientId' and 'clientSecret'",
             "Invalid value for triggerRule: Invalid trigger rule data missing 'triggerType' key",
-            "Unknown field: 'foo'",
+            "Unrecognized field: 'foo'",
         },
         id="Extra field and missing triggerType in triggerRule",
     )

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_workflow_triggers.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_workflow_triggers.py
@@ -14,14 +14,7 @@ def invalid_workflow_trigger_test_cases() -> Iterable:
     # Missing required field: externalId, extra field 'name'
     yield pytest.param(
         {"name": "MyWorkflowTrigger"},
-        {
-            "Missing required field: 'authentication'",
-            "Missing required field: 'externalId'",
-            "Missing required field: 'triggerRule'",
-            "Missing required field: 'workflowExternalId'",
-            "Missing required field: 'workflowVersion'",
-            "Unknown field: 'name'",
-        },
+        {"Missing required fields: 'authentication', 'externalId', 'triggerRule', 'workflowExternalId' and 'workflowVersion'", "Unknown field: 'name'"},
         id="Missing required fields ",
     )
     # Extra/unknown field

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_workflow_version.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_workflow_version.py
@@ -27,11 +27,7 @@ def enable_data_products(monkeypatch: pytest.MonkeyPatch) -> None:
 def invalid_workflow_version_test_cases() -> Iterable:
     yield pytest.param(
         {},
-        {
-            "Missing required field: 'workflowExternalId'",
-            "Missing required field: 'version'",
-            "Missing required field: 'workflowDefinition'",
-        },
+        {"Missing required fields: 'version', 'workflowDefinition' and 'workflowExternalId'"},
         id="Missing all required top-level fields",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_resource_classes/test_workflow_version.py
+++ b/tests/test_unit/test_cdf_tk/test_resource_classes/test_workflow_version.py
@@ -37,7 +37,7 @@ def invalid_workflow_version_test_cases() -> Iterable:
             "workflowDefinition": {"description": "desc", "tasks": []},
             "foo": 123,
         },
-        {"Unknown field: 'foo'"},
+        {"Unrecognized field: 'foo'"},
         id="Extra field at top level",
     )
     yield pytest.param(

--- a/tests/test_unit/test_cdf_tk/test_validation/test_validate_resource_pydantic.py
+++ b/tests/test_unit/test_cdf_tk/test_validation/test_validate_resource_pydantic.py
@@ -19,14 +19,14 @@ def timeseries_yaml_test_cases() -> Iterable:
     yield pytest.param(
         {"externalId": "my_timeseries", "type": "numeric"},
         [
-            "Unknown field: 'type'",
+            "Unrecognized field: 'type'",
         ],
         id="Unknown field type",
     )
     yield pytest.param(
         {"externalId": "my_timeseries", "type": "numeric", "assetId": 123},
         [
-            "Unknown fields: 'assetId' and 'type'",
+            "Unrecognized fields: 'assetId' and 'type'",
         ],
         id="Multiple top level unknown fields are grouped into one message",
     )
@@ -48,9 +48,9 @@ def timeseries_yaml_test_cases() -> Iterable:
             {"name": "my_timeseries_2", "type": "numeric"},
         ],
         [
-            "Unrecognized field in item [1]: 'nam'.",
+            "Unrecognized field in item [1]: 'nam'",
             "Missing required field in item [2]: 'externalId'",
-            "Unrecognized field in item [2]: 'type'.",
+            "Unrecognized field in item [2]: 'type'",
         ],
         id="Multiple issues in a list of timeseries",
     )

--- a/tests/test_unit/test_cdf_tk/test_validation/test_validate_resource_pydantic.py
+++ b/tests/test_unit/test_cdf_tk/test_validation/test_validate_resource_pydantic.py
@@ -23,6 +23,13 @@ def timeseries_yaml_test_cases() -> Iterable:
         ],
         id="Unknown field type",
     )
+    yield pytest.param(
+        {"externalId": "my_timeseries", "type": "numeric", "assetId": 123},
+        [
+            "Unknown fields: 'assetId' and 'type'",
+        ],
+        id="Multiple top level unknown fields are grouped into one message",
+    )
 
     yield pytest.param(
         [
@@ -41,9 +48,9 @@ def timeseries_yaml_test_cases() -> Iterable:
             {"name": "my_timeseries_2", "type": "numeric"},
         ],
         [
-            "Unrecognized field in item [1]: 'nam'. ",
+            "Unrecognized field in item [1]: 'nam'.",
             "Missing required field in item [2]: 'externalId'",
-            "Unrecognized field in item [2]: 'type'. ",
+            "Unrecognized field in item [2]: 'type'.",
         ],
         id="Multiple issues in a list of timeseries",
     )

--- a/tests/test_unit/test_cli/test_behavior.py
+++ b/tests/test_unit/test_cli/test_behavior.py
@@ -54,7 +54,11 @@ from cognite_toolkit._cdf_tk.commands import (
     DumpResourceCommand,
     PullV2Command,
 )
-from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import BuildParameters, ConsistencyError
+from cognite_toolkit._cdf_tk.commands.build_v2.data_classes import (
+    BuildParameters,
+    ConsistencyError,
+    ModelSyntaxWarning,
+)
 from cognite_toolkit._cdf_tk.commands.dump_resource import DataModelFinder, WorkflowFinder
 from cognite_toolkit._cdf_tk.constants import MODULES
 from cognite_toolkit._cdf_tk.exceptions import ToolkitValueError
@@ -1059,3 +1063,51 @@ capabilities:
     assert isinstance(insight, ConsistencyError)
     assert insight.message == "Unknown reference to spaces with id 'my_non_existent_space'"
     assert insight.source_file == "modules/my_module/auth/scoped_group.Group.yaml"
+
+
+def test_unknown_field_does_not_hide_missing_dependency(
+    default_config_dev_yaml: str,
+    toolkit_client_approval: ApprovalToolkitClient,
+    env_vars_with_client: EnvironmentVariables,
+    tmp_path: Path,
+) -> None:
+    """An unrecognized field is only a warning, so it must not disable the dependency validation
+    of the rest of the resource."""
+    group_yaml = """name: scoped_group
+sourceId: '1234567890123456789'
+sourceIdd: '1234567890123456789'
+metadata:
+  origin: cognite-toolkit
+capabilities:
+- dataModelsAcl:
+    actions:
+    - READ
+    scope:
+      spaceIdScope:
+        spaceIds:
+        - my_non_existent_space
+"""
+
+    my_org = tmp_path / "my_org"
+    yaml_filepath = my_org / "modules" / "my_module" / "auth" / "scoped_group.Group.yaml"
+    yaml_filepath.parent.mkdir(parents=True, exist_ok=True)
+    yaml_filepath.write_text(group_yaml, encoding="utf-8")
+
+    (my_org / "config.dev.yaml").write_text(default_config_dev_yaml, encoding="utf-8")
+
+    folder = BuildV2Command(silent=True, skip_tracking=True).build(
+        client=env_vars_with_client.get_client(),
+        parameters=BuildParameters(
+            organization_dir=my_org,
+            build_dir=tmp_path / "build",
+            config_yaml=my_org / "config.dev.yaml",
+        ),
+    )
+    syntax_warnings = [insight for insight in folder.all_insights if isinstance(insight, ModelSyntaxWarning)]
+    assert len(syntax_warnings) == 1
+    assert syntax_warnings[0].message == "Unknown field: 'sourceIdd'"
+
+    dependency_insights = [insight for insight in folder.all_insights if insight.code == "UNKNOWN-REFERENCE"]
+    assert len(dependency_insights) == 1
+    assert isinstance(dependency_insights[0], ConsistencyError)
+    assert dependency_insights[0].message == "Unknown reference to spaces with id 'my_non_existent_space'"

--- a/tests/test_unit/test_cli/test_behavior.py
+++ b/tests/test_unit/test_cli/test_behavior.py
@@ -1105,7 +1105,7 @@ capabilities:
     )
     syntax_warnings = [insight for insight in folder.all_insights if isinstance(insight, ModelSyntaxWarning)]
     assert len(syntax_warnings) == 1
-    assert syntax_warnings[0].message == "Unknown field: 'sourceIdd'"
+    assert syntax_warnings[0].message == "Unrecognized field: 'sourceIdd'"
 
     dependency_insights = [insight for insight in folder.all_insights if insight.code == "UNKNOWN-REFERENCE"]
     assert len(dependency_insights) == 1

--- a/tests/test_unit/test_toolkit_package.py
+++ b/tests/test_unit/test_toolkit_package.py
@@ -15,6 +15,10 @@ else:
     import tomli as tomllib
 
 CDF_TK_PATH = REPO_ROOT / "cognite_toolkit" / "_cdf_tk"
+YAML_CLASSES_PATH = CDF_TK_PATH / "yaml_classes"
+
+# Methods that start a new validation, which does not inherit the settings of an ongoing one.
+_VALIDATION_METHODS: frozenset[str] = frozenset({"model_validate", "validate_python"})
 
 # Mapping from PyPI package names to Python import names
 # Only needed when they differ
@@ -32,7 +36,7 @@ _PACKAGE_TO_IMPORT_NAME: dict[str, str] = {
 _EXCEPTION_MODULES: frozenset[str] = frozenset({"cognite.neat"})
 
 
-def _assert_import_violations(
+def _assert_violations(
     extract_fn: Callable[[Path], list[tuple[str, int, str]]],
     description: str,
     expected_total: int | None = None,
@@ -79,7 +83,7 @@ def test_no_private_third_party_imports() -> None:
     # We are not copying over protobuf files, so private imports from cognite.client._proto are currently acceptable.
     # We also need to look up the version of CogniteSDK as we dynamically create requirement.txt files for
     # Streamlit apps
-    _assert_import_violations(
+    _assert_violations(
         _extract_private_imports,
         "private imports from third-party packages",
         exceptions={"cognite.client._proto", "cognite.client._version"},
@@ -94,7 +98,19 @@ def test_no_cognite_sdk_imports() -> None:
     The goal is to fully remove the cognite-sdk dependency from the toolkit (with the exception of Auth and protobuf files).
     This test tracks progress toward that goal.
     """
-    _assert_import_violations(_extract_cognite_sdk_imports, "cognite.client imports", 90)
+    _assert_violations(_extract_cognite_sdk_imports, "cognite.client imports", 90)
+
+
+def test_resource_classes_revalidate_through_validate_as() -> None:
+    """
+    Test that resource classes picking a class based on the file content go through validate_as.
+
+    model_validate starts a fresh validation that does not inherit the extra argument of the ongoing one, so
+    calling it directly makes unrecognized fields an error again for that resource and everything below it.
+    An unrecognized field is only a warning, and must not stop the resource from being validated, as that
+    silently skips all downstream validation of it (dependencies, data modeling, agents, ...).
+    """
+    _assert_violations(_extract_direct_validation_calls, "resource classes validating directly")
 
 
 def _parse_package_name(dependency: str) -> str:
@@ -257,3 +273,33 @@ def _extract_cognite_sdk_imports(file_path: Path) -> list[tuple[str, int, str]]:
                     cognite_imports.append((alias.name, node.lineno, reason))
 
     return cognite_imports
+
+
+def _extract_direct_validation_calls(file_path: Path) -> list[tuple[str, int, str]]:
+    """
+    Extract resource class validation calls that do not go through validate_as.
+
+    Returns a list of tuples: (file_name, line_number, reason)
+    """
+    if not file_path.is_relative_to(YAML_CLASSES_PATH) or file_path.name == "base.py":
+        # base.py implements validate_as and the lenient entry points.
+        return []
+
+    direct_calls: list[tuple[str, int, str]] = []
+
+    try:
+        source = file_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+    except (SyntaxError, UnicodeDecodeError):
+        return direct_calls
+
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in _VALIDATION_METHODS
+        ):
+            reason = f"calls {node.func.attr}() directly, use validate_as from yaml_classes.base instead"
+            direct_calls.append((file_path.name, node.lineno, reason))
+
+    return direct_calls


### PR DESCRIPTION
# Description

An unrecognized field in a YAML file made `crud_class.yaml_cls.model_validate` fail, leaving `ReadResource.validated` as `None`. That set `has_syntax_error=True`, which emptied `BuiltResource.dependencies` and made every `can_verify`-gated rule set (`_dependencies`, `_data_modeling`, `_neat`, `_agents`, `_functions`, `_infield`) skip the resource — so a warning-severity finding silently discarded all error-severity findings for that file, and flipped the build summary from red to amber. `_read_resource_file` now retries validation with the reported `extra_forbidden` fields stripped when no error-severity findings are present, so downstream validation still runs. Stripping the fields up front rather than only passing `extra="ignore"` is needed because classes like `GroupYAML` re-enter `model_validate` on a subclass, which drops the runtime override.

Additionally, this PR introduces some slight UX improvement, `_create_syntax_insights` will now emit one insight per finding instead of joining every message for a file with newlines into a single insight, which under-reported insight counts and added confusing newlines in `insights.csv`. Finally, `humanize_validation_error_categorized` now groups top-level missing and unknown fields in YAML files the same way it already grouped nested ones, and slightly modified some warnings to be more standardized across the board (see modified test expecations).

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Fixed

- When running `cdf build`, an unrecognized field in a resource file will no longer silently hide other problems in the same file.