### PR TITLE
[CDF-28572, CDF-28573] 🚄  Speed up tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run pytest
         env:
           IS_GITHUB_ACTIONS: "true"
-        run: uv run pytest tests/test_unit -n8
+        run: uv run pytest tests/test_unit -n auto --durations=20
 
   test:
     name: Run tests
@@ -76,7 +76,7 @@ jobs:
       - name: Run pytest
         env:
           IS_GITHUB_ACTIONS: "true"
-        run: uv run pytest tests/test_unit -n8
+        run: uv run pytest tests/test_unit -n auto --durations=20
   coverage:
     name: Create coverage report
     runs-on: ubuntu-latest
@@ -98,7 +98,7 @@ jobs:
       - name: Create test coverage report
         env:
           IS_GITHUB_ACTIONS: "true"
-        run: uv run pytest --cov=cognite_toolkit/ --cov-config=pyproject.toml --cov-report=xml:coverage.xml tests/   -n8
+        run: uv run pytest --cov=cognite_toolkit/ --cov-config=pyproject.toml --cov-report=xml:coverage.xml tests/ -n auto --durations=20
       - name: Push coverage report to PR
         uses: orgoro/coverage@71cf993a407154ad9d8dd027c88a374b0ed002a9 # v3.3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         run: uv run pytest tests/test_unit -n auto --durations=20
 
   test:
-    name: Run tests
+    name: Run tests passed Python versions
     runs-on: ubuntu-latest
     env:
       CDF_CLUSTER: ${{ vars.CDF_CLUSTER }}
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: 3.11
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           pip install uv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  PYTHON_VERSION: '3.10'
+  PYTHON_VERSION: '3.14'
 
 
 jobs:
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           pip install uv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,8 @@ jobs:
         run: uv run pytest tests/test_unit -n auto --durations=20
 
   test:
-    name: Run tests passed Python versions
+    # Running on past pytest versions
+    name: Run tests
     runs-on: ubuntu-latest
     env:
       CDF_CLUSTER: ${{ vars.CDF_CLUSTER }}

--- a/cognite_toolkit/_cdf_tk/utils/fileio/_writers.py
+++ b/cognite_toolkit/_cdf_tk/utils/fileio/_writers.py
@@ -265,7 +265,7 @@ class CSVWriter(TableWriter[TextIOWrapper]):
         return csv_writer
 
 
-class ParquetWriter(TableWriter["pq.ParquetWriter"]):
+class ParquetWriter(TableWriter["pq.ParquetWriter"]):  # type: ignore[type-var]
     FORMAT = ".parquet"
 
     def __init__(

--- a/cognite_toolkit/_cdf_tk/utils/fileio/_writers.py
+++ b/cognite_toolkit/_cdf_tk/utils/fileio/_writers.py
@@ -265,7 +265,7 @@ class CSVWriter(TableWriter[TextIOWrapper]):
         return csv_writer
 
 
-class ParquetWriter(TableWriter["pq.ParquetWriter"]):  # type: ignore[type-var]
+class ParquetWriter(TableWriter["pq.ParquetWriter"]):
     FORMAT = ".parquet"
 
     def __init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev = [
     "responses>=0.25.7",
     "respx>=0.22.0",
     "pytest-json-report>=1.5.0", # For generating JSON reports from tests, this is used in the smoke tests
+    "pytest-durations>=1.9.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ dev = [
     "types-toml >=0.10.8.20240310",
     "twine >=6.0.0",
     "toml >=0.10.2; python_version >= '3.11'",
-    "pytest-freezegun >=0.4.2",
     "pytest-cov >=6.0.0",
     "setuptools >=75.0.0",
     "fastparquet >=2024.5.0",

--- a/tests/test_unit/conftest.py
+++ b/tests/test_unit/conftest.py
@@ -5,6 +5,7 @@ import shutil
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 import yaml
@@ -12,6 +13,7 @@ from cognite.client import global_config
 from cognite.client.credentials import Token
 from cognite.client.data_classes import CreatedSession
 from pytest import MonkeyPatch
+from rich.console import Console
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
 from cognite_toolkit._cdf_tk.client.resource_classes.canvas import (
@@ -64,6 +66,14 @@ def toolkit_client_approval() -> Iterator[ApprovalToolkitClient]:
         approval_client.mock_client.__class__ = type("ToolkitClientMock", (original_class, ToolkitClient), {})
 
         yield approval_client
+
+
+@pytest.fixture(scope="session")
+def toolkit_client_cheap() -> ToolkitClient:
+    """A bare minimum fast to initialize client. For tests that don't need to make any calls to the CDF API."""
+    mock_client = MagicMock(spec=ToolkitClient)
+    mock_client.console = MagicMock(spec=Console)
+    return mock_client
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_unit/test_cdf_tk/test_commands/test_run.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_run.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Iterator
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -54,6 +55,12 @@ def function_build_folder() -> BuildLineage:
     )
 
 
+@pytest.fixture
+def mock_function_venv() -> Iterator[MagicMock]:
+    with patch("cognite_toolkit._cdf_tk.commands._virtual_env.FunctionVirtualEnvironment") as mock_cls:
+        yield mock_cls.return_value
+
+
 class TestRunFunction:
     def test_run_function_live(
         self, toolkit_client_approval: ApprovalToolkitClient, env_vars_with_client: EnvironmentVariables
@@ -96,7 +103,9 @@ class TestRunFunction:
             "IDP_FUN_CLIENT_SECRET": "dummy",
         },
     )
-    def test_run_local_function(self, env_vars_with_client: EnvironmentVariables) -> None:
+    def test_run_local_function(
+        self, env_vars_with_client: EnvironmentVariables, mock_function_venv: MagicMock
+    ) -> None:
         cmd = RunFunctionCommand()
 
         cmd.run_local(
@@ -109,6 +118,9 @@ class TestRunFunction:
             virtual_env_folder_name="function_local_venvs_test_run_local_function",
         )
 
+        mock_function_venv.create.assert_called_once()
+        assert mock_function_venv.execute.call_count == 2
+
     @patch.dict(
         os.environ,
         {
@@ -116,7 +128,9 @@ class TestRunFunction:
             "IDP_WF_CLIENT_SECRET": "dummy",
         },
     )
-    def test_run_local_function_with_workflow(self, env_vars_with_client: EnvironmentVariables) -> None:
+    def test_run_local_function_with_workflow(
+        self, env_vars_with_client: EnvironmentVariables, mock_function_venv: MagicMock
+    ) -> None:
         cmd = RunFunctionCommand()
 
         cmd.run_local(
@@ -128,6 +142,9 @@ class TestRunFunction:
             rebuild_env=False,
             virtual_env_folder_name="function_local_venvs_test_run_local_function_workflow",
         )
+
+        mock_function_venv.create.assert_called_once()
+        assert mock_function_venv.execute.call_count == 2
 
     @pytest.mark.parametrize(
         "data_source, expected",

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_base.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_base.py
@@ -15,7 +15,6 @@ from cognite.client.data_classes import (
 from cognite.client.data_classes.data_modeling import Edge, Node
 from cognite.client.data_classes.hosted_extractors import Destination
 from pytest import MonkeyPatch
-from rich.console import Console
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.resource_classes.app_version import AppVersionResponse
@@ -54,11 +53,11 @@ SNAPSHOTS_DIR = SNAPSHOTS_DIR_ALL / "load_data_snapshots"
 class TestFormatConsistency:
     @pytest.mark.parametrize("Loader", RESOURCE_CRUD_LIST)
     def test_fake_resource_generator(
-        self, Loader: type[ResourceIO], env_vars_with_client: EnvironmentVariables, monkeypatch: MonkeyPatch
+        self, Loader: type[ResourceIO], toolkit_client_cheap: ToolkitClient, monkeypatch: MonkeyPatch
     ):
         fakegenerator = FakeCogniteResourceGenerator(seed=1337)
 
-        loader = Loader.create_loader(env_vars_with_client.get_client())
+        loader = Loader.create_loader(toolkit_client_cheap)
         instance = fakegenerator.create_instance(loader.resource_write_cls)
 
         if get_origin(loader.resource_write_cls) is typing.Annotated:
@@ -166,10 +165,8 @@ class TestFormatConsistency:
     @pytest.mark.parametrize(
         "Loader", [loader for loader in CRUD_LIST if loader.folder_name != "robotics"]
     )  # Robotics does not have a public doc_url
-    def test_loader_has_doc_url(self, Loader: type[Loader]):
-        mock_client = MagicMock(spec=ToolkitClient)
-        mock_client.console = MagicMock(spec=Console)
-        loader = Loader.create_loader(mock_client)
+    def test_loader_has_doc_url(self, Loader: type[Loader], toolkit_client_cheap: ToolkitClient):
+        loader = Loader.create_loader(toolkit_client_cheap)
         assert loader.doc_url() != loader._doc_base_url, f"{Loader.folder_name} is missing doc_url deep link"
 
 

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_base.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_base.py
@@ -71,11 +71,11 @@ class TestFormatConsistency:
     def test_loader_takes_dict(
         self,
         Loader: type[ResourceIO],
-        env_vars_with_client: EnvironmentVariables,
+        toolkit_client_cheap: ToolkitClient,
         monkeypatch: MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        loader = Loader.create_loader(env_vars_with_client.get_client(), tmp_path)
+        loader = Loader.create_loader(toolkit_client_cheap, tmp_path)
 
         if loader.resource_cls in [
             TransformationResponse,
@@ -108,7 +108,7 @@ class TestFormatConsistency:
         file.name = "dict.yaml"
         file.parent.name = loader.folder_name
 
-        loaded = loader.load_resource_file(filepath=file, environment_variables=env_vars_with_client.dump())
+        loaded = loader.load_resource_file(filepath=file, environment_variables={})
         assert isinstance(loaded, list)
         assert len(loaded) == 1
 
@@ -116,11 +116,11 @@ class TestFormatConsistency:
     def test_loader_takes_list(
         self,
         Loader: type[ResourceIO],
-        env_vars_with_client: EnvironmentVariables,
+        toolkit_client_cheap: ToolkitClient,
         monkeypatch: MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        loader = Loader.create_loader(env_vars_with_client.get_client(), tmp_path)
+        loader = Loader.create_loader(toolkit_client_cheap, tmp_path)
 
         if loader.resource_cls in [
             TransformationResponse,
@@ -159,7 +159,7 @@ class TestFormatConsistency:
         file.name = "dict.yaml"
         file.parent.name = loader.folder_name
 
-        loaded = loader.load_resource_file(filepath=file, environment_variables=env_vars_with_client.dump())
+        loaded = loader.load_resource_file(filepath=file, environment_variables={})
         assert isinstance(loaded, list)
 
     @pytest.mark.parametrize(

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_base.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_base.py
@@ -15,7 +15,9 @@ from cognite.client.data_classes import (
 from cognite.client.data_classes.data_modeling import Edge, Node
 from cognite.client.data_classes.hosted_extractors import Destination
 from pytest import MonkeyPatch
+from rich.console import Console
 
+from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.client.resource_classes.app_version import AppVersionResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.cognite_file import CogniteFileResponse
 from cognite_toolkit._cdf_tk.client.resource_classes.filemetadata import FileMetadataResponse
@@ -164,10 +166,10 @@ class TestFormatConsistency:
     @pytest.mark.parametrize(
         "Loader", [loader for loader in CRUD_LIST if loader.folder_name != "robotics"]
     )  # Robotics does not have a public doc_url
-    def test_loader_has_doc_url(
-        self, Loader: type[Loader], env_vars_with_client: EnvironmentVariables, monkeypatch: MonkeyPatch
-    ):
-        loader = Loader.create_loader(env_vars_with_client.get_client())
+    def test_loader_has_doc_url(self, Loader: type[Loader]):
+        mock_client = MagicMock(spec=ToolkitClient)
+        mock_client.console = MagicMock(spec=Console)
+        loader = Loader.create_loader(mock_client)
         assert loader.doc_url() != loader._doc_base_url, f"{Loader.folder_name} is missing doc_url deep link"
 
 

--- a/tests/test_unit/utils.py
+++ b/tests/test_unit/utils.py
@@ -199,6 +199,15 @@ class FakeCogniteResourceGenerator:
         )
 
     def create_instance(self, resource_cls: type[T_Object], skip_defaulted_args: bool = False) -> T_Object:
+        try:
+            # All the subsequent inspection calls (get_origin, get_args, etc.) are very expensive, so we
+            # first check if the class is a subclass of BaseModel, which is a common case and can be handled more efficiently.
+            # If `issubclass` raises a TypeError, we ignore it and continue with the other checks.
+            if issubclass(resource_cls, BaseModel):
+                return self.create_pydantic_instance(resource_cls, skip_defaulted_args)  # type: ignore[return-value]
+        except TypeError:
+            ...
+
         if get_origin(resource_cls) is typing.Annotated:
             resource_cls = get_args(resource_cls)[0]
 
@@ -206,9 +215,6 @@ class FakeCogniteResourceGenerator:
             args = get_args(resource_cls)
             first_not_none = next(arg for arg in args if arg is not type(None))
             return self.create_instance(first_not_none, skip_defaulted_args)
-
-        if issubclass(resource_cls, BaseModel):
-            return self.create_pydantic_instance(resource_cls, skip_defaulted_args)  # type: ignore[return-value]
 
         is_abstract = any(base is abc.ABC for base in resource_cls.__bases__)
         if is_abstract:

--- a/tests/test_unit/utils.py
+++ b/tests/test_unit/utils.py
@@ -18,7 +18,6 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from cognite.client import CogniteClient
 from cognite.client._constants import MAX_VALID_INTERNAL_ID
 from cognite.client.data_classes import (
     Datapoints,
@@ -53,7 +52,6 @@ from cognite.client.data_classes.workflows import (
     WorkflowTaskParameters,
     WorkflowTriggerDataModelingQuery,
 )
-from cognite.client.testing import CogniteClientMock
 from cognite.client.utils.useful_types import SequenceNotStr
 from pydantic import BaseModel, JsonValue
 from questionary import Choice
@@ -180,14 +178,12 @@ class FakeCogniteResourceGenerator:
     def __init__(
         self,
         seed: int | None = None,
-        cognite_client: CogniteClientMock | CogniteClient | None = None,
         max_list_dict_items: int = 3,
         sample_from_string: str | None = None,
         min_string_length: int = 1,
         max_string_length: int = 100,
     ) -> None:
         self._random = random.Random(seed)
-        self._cognite_client = cognite_client or CogniteClientMock()
         self._max_list_dict_items = max_list_dict_items
         self._sample_from_string = sample_from_string
         self._min_string_length = min_string_length
@@ -445,8 +441,8 @@ class FakeCogniteResourceGenerator:
             return date.fromtimestamp(self._random.randint(1, 1704067200))
         elif type_ is dict:
             return {self._random_string(10): self._random_string(10) for _ in range(self._random.randint(1, 3))}
-        elif type_ is CogniteClient:
-            return self._cognite_client
+        # elif type_ is CogniteClient:
+        #     return self._cognite_client
         elif inspect.isclass(type_) and any(base is abc.ABC for base in type_.__bases__):
             implementations = all_concrete_subclasses(type_)
             if type_ is Filter:

--- a/tests_smoke/test_commands/test_run.py
+++ b/tests_smoke/test_commands/test_run.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+from cognite_toolkit._cdf_tk.client import ToolkitClient
+from cognite_toolkit._cdf_tk.commands import RunFunctionCommand
+from cognite_toolkit._cdf_tk.constants import MODULES
+from cognite_toolkit._cdf_tk.exceptions import ToolkitError
+from cognite_toolkit._cdf_tk.utils.auth import EnvironmentVariables
+
+
+class TestRunFunctionLocal:
+    FUNCTION_CODE = """from cognite.client import CogniteClient
+
+
+def handle(data: dict, client: CogniteClient, secrets: dict, function_call_info: dict) -> dict:
+    print("Function called with data:", data)
+    return {
+        "data": data,
+        "secrets": mask_secrets(secrets),
+        "functionInfo": function_call_info,
+    }
+
+
+def mask_secrets(secrets: dict) -> dict:
+    return {k: "***" for k in secrets}
+
+"""
+    REQUIREMENT_TXT = "cognite-sdk>=7.85.0"
+
+    def test_run_local_function(self, toolkit_client: ToolkitClient, tmp_path: Path) -> None:
+        functions_dir = tmp_path / MODULES / "fun_module" / "functions"
+        functions_dir.mkdir(parents=True)
+        external_id = "smoke_test_run_local_function"
+        schedule_name = "smoke-daily"
+
+        (functions_dir / "first.function.yaml").write_text(
+            f"""name: Smoke test run local function
+externalId: {external_id}
+owner: toolkit-smoke
+description: This function is executed locally
+metadata:
+  version: v1
+runtime: py312
+functionPath: ./handler.py
+secrets:
+  mysecret: smoke-secret
+"""
+        )
+        (functions_dir / "first.schedule.yaml").write_text(
+            f"""name: {schedule_name}
+functionExternalId: {external_id}
+description: Schedule used as the local run data source
+cronExpression: "0 8 * * *"
+data:
+  breakfast: egg and bacon
+  lunch: a chicken
+"""
+        )
+        code_dir = functions_dir / external_id
+        code_dir.mkdir()
+        (code_dir / "handler.py").write_text(self.FUNCTION_CODE)
+        (code_dir / "requirements.txt").write_text(self.REQUIREMENT_TXT)
+
+        env_vars = EnvironmentVariables.create_from_environment()
+        env_vars._client = toolkit_client
+
+        try:
+            RunFunctionCommand(skip_tracking=True, silent=True).run_local(
+                env_vars=env_vars,
+                organization_dir=tmp_path,
+                build_env_name=None,
+                external_id=external_id,
+                data_source=schedule_name,
+                rebuild_env=True,
+            )
+        except ToolkitError as e:
+            raise AssertionError(
+                f"Running function {external_id!r} locally failed. "
+                "Toolkit could not set up the virtual environment, install requirements, "
+                f"or execute the handler. Details: {e}"
+            ) from e

--- a/uv.lock
+++ b/uv.lock
@@ -413,6 +413,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-durations" },
     { name = "pytest-icdiff" },
     { name = "pytest-json-report" },
     { name = "pytest-regressions" },
@@ -463,6 +464,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-durations", specifier = ">=1.9.0" },
     { name = "pytest-icdiff" },
     { name = "pytest-json-report", specifier = ">=1.5.0" },
     { name = "pytest-regressions", specifier = ">=2.4.2" },
@@ -1956,6 +1958,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b4/46/db060b291999ca048edd06d6fa9ee95945d088edc38b1172c59eeb46ec45/pytest_datadir-1.8.0.tar.gz", hash = "sha256:7a15faed76cebe87cc91941dd1920a9a38eba56a09c11e9ddf1434d28a0f78eb", size = 11848, upload-time = "2025-07-30T13:52:12.518Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/7a/33895863aec26ac3bb5068a73583f935680d6ab6af2a9567d409430c3ee1/pytest_datadir-1.8.0-py3-none-any.whl", hash = "sha256:5c677bc097d907ac71ca418109adc3abe34cf0bddfe6cf78aecfbabd96a15cf0", size = 6512, upload-time = "2025-07-30T13:52:11.525Z" },
+]
+
+[[package]]
+name = "pytest-durations"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/7c/e8c05c44a0322f1580a2fca4de67fa521b6eae02746331fd33bd4f95ed41/pytest_durations-1.9.0.tar.gz", hash = "sha256:248ac89d9f926fc119508f20ce54c14a0622dbe496d128e18548db948edcdf93", size = 18251, upload-time = "2026-08-14T07:27:48.183Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/de/393d09e6038aaf96a17e14a01aca469e0395367a79b6608734c34be4ffc2/pytest_durations-1.9.0-py3-none-any.whl", hash = "sha256:9ec7c373635abf9747ab84872dd11795e05e7aa0e050e68c01166fc5b9afa0d1", size = 19425, upload-time = "2026-08-14T07:27:46.728Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -413,7 +413,6 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-freezegun" },
     { name = "pytest-icdiff" },
     { name = "pytest-json-report" },
     { name = "pytest-regressions" },
@@ -464,7 +463,6 @@ dev = [
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
-    { name = "pytest-freezegun", specifier = ">=0.4.2" },
     { name = "pytest-icdiff" },
     { name = "pytest-json-report", specifier = ">=1.5.0" },
     { name = "pytest-regressions", specifier = ">=2.4.2" },
@@ -903,18 +901,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
-]
-
-[[package]]
-name = "freezegun"
-version = "1.5.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dateutil" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
 ]
 
 [[package]]
@@ -1970,19 +1956,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b4/46/db060b291999ca048edd06d6fa9ee95945d088edc38b1172c59eeb46ec45/pytest_datadir-1.8.0.tar.gz", hash = "sha256:7a15faed76cebe87cc91941dd1920a9a38eba56a09c11e9ddf1434d28a0f78eb", size = 11848, upload-time = "2025-07-30T13:52:12.518Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/7a/33895863aec26ac3bb5068a73583f935680d6ab6af2a9567d409430c3ee1/pytest_datadir-1.8.0-py3-none-any.whl", hash = "sha256:5c677bc097d907ac71ca418109adc3abe34cf0bddfe6cf78aecfbabd96a15cf0", size = 6512, upload-time = "2025-07-30T13:52:11.525Z" },
-]
-
-[[package]]
-name = "pytest-freezegun"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "freezegun" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/e3/c39d7c3d3afef5652f19323f3483267d7e6b0d9911c3867e10d6e2d3c9ae/pytest-freezegun-0.4.2.zip", hash = "sha256:19c82d5633751bf3ec92caa481fb5cffaac1787bd485f0df6436fd6242176949", size = 9059, upload-time = "2020-07-19T17:50:03.678Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/09/0bdd7d24b9d21453ad3364ae1efbd65082045bb6081b5fd5eade91a9b644/pytest_freezegun-0.4.2-py2.py3-none-any.whl", hash = "sha256:5318a6bfb8ba4b709c8471c94d0033113877b3ee02da5bfcd917c1889cde99a7", size = 4590, upload-time = "2020-07-19T17:50:02.191Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Speeding up tests round 1. 

- Unit test were runing around 5-6 minutes. Now 2.5 minutes. 
- Coverage tests were running at 7-8 minutes. Now 4.5 minutes. 

In total, shaving off 3 - 3.5 minutes on current runtimes, almost 50% improvement.

Will do a second round on it.

FYI: Locally I am able to run all unit test in 45 sec.

## Bump

- [ ] Patch
- [x] Skip

