### PR TITLE
[CDF-28586] 🔄 Replace httpx with httpx2

### DIFF
--- a/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
+++ b/cognite_toolkit/_cdf_tk/client/api/filemetadata.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
 from typing import IO, Any, Literal
 
-import httpx
+import httpx2
 
 from cognite_toolkit._cdf_tk.client.cdf_client import CDFResourceAPI, PagedResponse, ResponseItems
 from cognite_toolkit._cdf_tk.client.cdf_client.api import Endpoint
@@ -30,9 +30,9 @@ from cognite_toolkit._cdf_tk.utils.collection import chunker_sequence
 class _LimitedFileReader(Iterable[bytes]):
     """A file-like wrapper that limits the number of bytes read from a file stream.
 
-    This allows httpx to stream content directly from disk in smaller chunks,
+    This allows httpx2 to stream content directly from disk in smaller chunks,
     without loading the entire part into memory at once. Implements Iterable[bytes]
-    for compatibility with httpx's content parameter.
+    for compatibility with httpx2's content parameter.
     """
 
     _CHUNK_SIZE = 64 * 1024  # 64 KB chunks
@@ -369,7 +369,7 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
                     current_part_size = part_size
 
                 # Use a stream wrapper that limits reads to the part size,
-                # allowing httpx to stream directly from disk without loading the entire chunk into memory.
+                # allowing httpx2 to stream directly from disk without loading the entire chunk into memory.
                 chunk_stream = _LimitedFileReader(file_stream, current_part_size)
 
                 # Build headers with explicit Content-Length to avoid chunked transfer encoding.
@@ -474,7 +474,7 @@ class FileMetadataAPI(CDFResourceAPI[FileMetadataResponse]):
             download_url: The URL to download the file from.
             destination: The local path to save the downloaded file to.
         """
-        with httpx.stream("GET", download_url) as response:
+        with httpx2.stream("GET", download_url) as response:
             if response.status_code != 200:
                 raise ToolkitAPIError(
                     message=f"Download failed with status code {response.status_code}: {response.text}",

--- a/cognite_toolkit/_cdf_tk/client/http_client/_client.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_client.py
@@ -6,7 +6,7 @@ from collections import deque
 from collections.abc import Iterable, MutableMapping, Sequence, Set
 from typing import Literal, TypeVar
 
-import httpx
+import httpx2
 from cognite.client import global_config
 from rich.console import Console
 
@@ -92,9 +92,9 @@ class HTTPClient:
         self.session.close()
         return False  # Do not suppress exceptions
 
-    def _create_thread_safe_session(self) -> httpx.Client:
-        return httpx.Client(
-            limits=httpx.Limits(
+    def _create_thread_safe_session(self) -> httpx2.Client:
+        return httpx2.Client(
+            limits=httpx2.Limits(
                 max_connections=self._pool_maxsize,
                 max_keepalive_connections=self._pool_connections,
             ),
@@ -110,7 +110,7 @@ class HTTPClient:
         disable_gzip: bool = False,
     ) -> MutableMapping[str, str]:
         headers: MutableMapping[str, str] = {}
-        headers["User-Agent"] = f"httpx/{httpx.__version__} {get_user_agent()}"
+        headers["User-Agent"] = f"httpx2/{httpx2.__version__} {get_user_agent()}"
         auth_name, auth_value = self.config.credentials.authorization_header()
         headers[auth_name] = auth_value
         headers["Content-Type"] = content_type
@@ -125,7 +125,7 @@ class HTTPClient:
         return headers
 
     @staticmethod
-    def _get_retry_after_in_header(response: httpx.Response) -> float | None:
+    def _get_retry_after_in_header(response: httpx2.Response) -> float | None:
         if "Retry-After" not in response.headers:
             return None
         try:
@@ -180,7 +180,7 @@ class HTTPClient:
             else:
                 raise TypeError(f"Unexpected result type: {type(result)}")
 
-    def _make_request(self, message: BaseRequestMessage) -> httpx.Response:
+    def _make_request(self, message: BaseRequestMessage) -> httpx2.Response:
         headers = self._create_headers(
             message.api_version,
             message.content_type,
@@ -198,7 +198,9 @@ class HTTPClient:
             follow_redirects=False,
         )
 
-    def _handle_response_single(self, response: httpx.Response, request: RequestMessage) -> RequestMessage | HTTPResult:
+    def _handle_response_single(
+        self, response: httpx2.Response, request: RequestMessage
+    ) -> RequestMessage | HTTPResult:
         if 200 <= response.status_code < 300:
             return SuccessResponse(
                 status_code=response.status_code,
@@ -217,7 +219,7 @@ class HTTPClient:
             )
 
     def _retry_request(
-        self, response: httpx.Response, request: _T_Request_Message, error_details: ErrorDetails
+        self, response: httpx2.Response, request: _T_Request_Message, error_details: ErrorDetails
     ) -> _T_Request_Message | None:
         retry_after = self._get_retry_after_in_header(response)
         if retry_after is not None and response.status_code == 429 and request.status_attempt < self._max_retries:
@@ -241,11 +243,11 @@ class HTTPClient:
         return None
 
     def _handle_error_single(self, e: Exception, request: RequestMessage) -> RequestMessage | HTTPResult:
-        if isinstance(e, httpx.ReadTimeout | httpx.TimeoutException):
+        if isinstance(e, httpx2.ReadTimeout | httpx2.TimeoutException):
             error_type = "read"
             request.read_attempt += 1
             attempts = request.read_attempt
-        elif isinstance(e, ConnectionError | httpx.ConnectError | httpx.ConnectTimeout):
+        elif isinstance(e, ConnectionError | httpx2.ConnectError | httpx2.ConnectTimeout):
             error_type = "connect"
             request.connect_attempt += 1
             attempts = request.connect_attempt
@@ -304,11 +306,11 @@ class HTTPClient:
                     error=ErrorDetails.from_response(response),
                 )
             except (
-                httpx.ReadTimeout,
-                httpx.TimeoutException,
+                httpx2.ReadTimeout,
+                httpx2.TimeoutException,
                 ConnectionError,
-                httpx.ConnectError,
-                httpx.ConnectTimeout,
+                httpx2.ConnectError,
+                httpx2.ConnectTimeout,
             ) as e:
                 attempt += 1
                 if attempt <= max_retries:
@@ -355,14 +357,14 @@ class HTTPClient:
     ) -> SuccessResponse | FailedResponse:
         """POST multipart/form-data to a CDF endpoint with auth headers and retry logic.
 
-        Uses httpx's native multipart encoder — Content-Type (with boundary) and
+        Uses httpx2's native multipart encoder — Content-Type (with boundary) and
         Content-Length are set automatically. Unlike request_raw_retries, CDF auth
         headers are included because this method targets CDF endpoints, not signed URLs.
         """
         auth_name, auth_value = self.config.credentials.authorization_header()
-        # Content-Type is intentionally absent — httpx sets it from the multipart body (including boundary).
+        # Content-Type is intentionally absent — httpx2 sets it from the multipart body (including boundary).
         headers: dict[str, str] = {
-            "User-Agent": f"httpx/{httpx.__version__} {get_user_agent()}",
+            "User-Agent": f"httpx2/{httpx2.__version__} {get_user_agent()}",
             auth_name: auth_value,
             "accept": "application/json",
             "x-cdp-sdk": f"CogniteToolkit:{get_current_toolkit_version()}",
@@ -431,7 +433,7 @@ class HTTPClient:
         return final_responses
 
     def _handle_items_response(
-        self, response: httpx.Response, request: ItemsRequest
+        self, response: httpx2.Response, request: ItemsRequest
     ) -> Sequence[ItemsRequest | ItemsResultMessage]:
         if 200 <= response.status_code < 300:
             return [
@@ -476,11 +478,11 @@ class HTTPClient:
             ]
 
     def _handle_items_error(self, e: Exception, request: ItemsRequest) -> Sequence[ItemsRequest | ItemsResultMessage]:
-        if isinstance(e, httpx.ReadTimeout | httpx.TimeoutException):
+        if isinstance(e, httpx2.ReadTimeout | httpx2.TimeoutException):
             error_type = "read"
             request.read_attempt += 1
             attempts = request.read_attempt
-        elif isinstance(e, ConnectionError | httpx.ConnectError | httpx.ConnectTimeout):
+        elif isinstance(e, ConnectionError | httpx2.ConnectError | httpx2.ConnectTimeout):
             error_type = "connect"
             request.connect_attempt += 1
             attempts = request.connect_attempt

--- a/cognite_toolkit/_cdf_tk/client/http_client/_data_classes.py
+++ b/cognite_toolkit/_cdf_tk/client/http_client/_data_classes.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Set
 from typing import TYPE_CHECKING, Any, Literal
 
-import httpx
+import httpx2
 from cognite.client import global_config
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, TypeAdapter, model_validator
 from pydantic.alias_generators import to_camel
@@ -108,8 +108,8 @@ class ErrorDetails(HTTPBaseModel):
         return " | ".join(parts)
 
     @classmethod
-    def from_response(cls, response: httpx.Response) -> "ErrorDetails":
-        """Populate the error details from a httpx response."""
+    def from_response(cls, response: httpx2.Response) -> "ErrorDetails":
+        """Populate the error details from a httpx2 response."""
         x_request_id = response.headers.get("x-request-id")
         try:
             res = TypeAdapter(dict[Literal["error"], ErrorDetails]).validate_json(response.text)

--- a/cognite_toolkit/_cdf_tk/dataio/_file_content.py
+++ b/cognite_toolkit/_cdf_tk/dataio/_file_content.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, cast
 
-import httpx
+import httpx2
 from cognite.client import data_modeling as dm
 from pydantic import JsonValue
 
@@ -115,7 +115,7 @@ class FileContentIO(UploadableDataIO[FileContentSelector, MetadataWithFilePath, 
                 if download_url is None:
                     continue
                 filepath.parent.mkdir(parents=True, exist_ok=True)
-                with httpx.stream("GET", download_url) as response:
+                with httpx2.stream("GET", download_url) as response:
                     if response.status_code != 200:
                         continue
                     with filepath.open(mode="wb") as file_stream:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
     "python-dotenv >=1.0.0",
     "cognite-sdk>=8.6.0,<9.0.0",
-    "httpx>=0.28.1",
+    "httpx2>=2.12.0",
     "pyyaml >=6.0.1",
     "typer >=0.12.0, <1.0.0",
     "rich >=13.9.4",
@@ -119,6 +119,12 @@ testpaths = [
     "tests",
     # In the case of doctests.
     "cognite_toolkit",
+]
+
+addopts = [
+    # Must load before the respx plugin so import httpx resolves to httpx2.
+    "-p",
+    "tests.httpx2_alias_plugin",
 ]
 
 markers = [

--- a/tests/httpx2_alias_plugin.py
+++ b/tests/httpx2_alias_plugin.py
@@ -1,0 +1,10 @@
+"""Alias ``httpx`` to ``httpx2`` before pytest loads the respx plugin.
+
+respx type-checks mock responses as ``httpx.Response``. Toolkit talks HTTP through
+``httpx2``, so without this alias those objects are distinct classes and mocks fail.
+Must run before anything imports ``httpx`` or ``httpcore``.
+"""
+
+import httpx2
+
+httpx2.alias_httpx()

--- a/tests/test_unit/test_cdf_tk/test_client/test_cdf_apis.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_cdf_apis.py
@@ -3,7 +3,7 @@ import json
 from typing import Any
 from unittest.mock import MagicMock
 
-import httpx
+import httpx2
 import pytest
 import respx
 from pydantic import JsonValue
@@ -116,7 +116,7 @@ class TestCDFResourceAPI:
                 # Path-parameter retrieve (e.g. GET /dataproducts/{externalId}) returns a single object.
                 resolved_path = retrieve_endpoint.path.format_map(resource.resource_id.dump())
                 respx_mock.request(retrieve_endpoint.method, api._make_url(resolved_path)).mock(
-                    return_value=httpx.Response(status_code=200, json=resource.example_data)
+                    return_value=httpx2.Response(status_code=200, json=resource.example_data)
                 )
             elif retrieve_endpoint:
                 self._mock_endpoint(api, "retrieve", {"items": [resource.example_data]}, respx_mock)
@@ -175,7 +175,7 @@ class TestCDFResourceAPI:
         endpoint = api._method_endpoint_map[api_method]
         url = api._make_url(endpoint.path)
 
-        respx_mock.request(endpoint.method, url).mock(return_value=httpx.Response(status_code=200, json=json))
+        respx_mock.request(endpoint.method, url).mock(return_value=httpx2.Response(status_code=200, json=json))
 
     #### These are tests for APIs that cannot use the generic test above
     # This is typically due to custom endpoints or request object cannot be made from response object
@@ -190,7 +190,7 @@ class TestCDFResourceAPI:
 
         # Test create
         respx_mock.post(config.create_api_url("/dataproducts")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         created = api.create([request])
         assert len(created) == 1
@@ -198,7 +198,7 @@ class TestCDFResourceAPI:
 
         # Test retrieve
         respx_mock.get(config.create_api_url(f"/dataproducts/{instance.external_id}")).mock(
-            return_value=httpx.Response(status_code=200, json=resource)
+            return_value=httpx2.Response(status_code=200, json=resource)
         )
         retrieved = api.retrieve([request.as_id()])
         assert len(retrieved) == 1
@@ -206,7 +206,7 @@ class TestCDFResourceAPI:
 
         # Test update
         respx_mock.post(config.create_api_url("/dataproducts/update")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         updated = api.update([request])
         assert len(updated) == 1
@@ -214,14 +214,14 @@ class TestCDFResourceAPI:
 
         # Test delete
         respx_mock.post(config.create_api_url("/dataproducts/delete")).mock(
-            return_value=httpx.Response(status_code=200)
+            return_value=httpx2.Response(status_code=200)
         )
         api.delete([request.as_id()])
         assert len(respx_mock.calls) >= 1
 
         # Test list/paginate/iterate
         respx_mock.get(config.create_api_url("/dataproducts")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         listed = api.list(limit=10)
         assert len(listed) == 1
@@ -250,7 +250,7 @@ class TestCDFResourceAPI:
 
         # Test create
         respx_mock.post(config.create_api_url(f"/raw/dbs/{instance.db_name}/tables")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         created = api.create([request])
         assert len(created) == 1
@@ -258,13 +258,13 @@ class TestCDFResourceAPI:
 
         # Test delete
         respx_mock.post(config.create_api_url(f"/raw/dbs/{instance.db_name}/tables/delete")).mock(
-            return_value=httpx.Response(status_code=200)
+            return_value=httpx2.Response(status_code=200)
         )
         api.delete([request.as_id()])
 
         # Test retrieve list
         respx_mock.get(config.create_api_url(f"/raw/dbs/{instance.db_name}/tables")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         listed = api.list(db_name=instance.db_name, limit=10)
         assert len(listed) == 1
@@ -272,7 +272,7 @@ class TestCDFResourceAPI:
 
         # Test iterate
         respx_mock.get(config.create_api_url(f"/raw/dbs/{instance.db_name}/tables")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         page = api.paginate(db_name=instance.db_name, limit=10)
         assert len(page.items) == 1
@@ -287,7 +287,7 @@ class TestCDFResourceAPI:
 
         # Test create
         respx_mock.post(config.create_api_url("/files")).mock(
-            return_value=httpx.Response(status_code=200, json=resource)
+            return_value=httpx2.Response(status_code=200, json=resource)
         )
         created = api.create([request_item], overwrite=False)
         assert len(created) == 1
@@ -295,7 +295,7 @@ class TestCDFResourceAPI:
 
         # Test retrieve
         respx_mock.post(config.create_api_url("/files/byids")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         retrieved = api.retrieve([instance.as_id()])
         assert len(retrieved) == 1
@@ -303,20 +303,20 @@ class TestCDFResourceAPI:
 
         # Test update
         respx_mock.post(config.create_api_url("/files/update")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         updated = api.update([request_item])
         assert len(updated) == 1
         assert updated[0].dump() == resource
 
         # Test delete
-        respx_mock.post(config.create_api_url("/files/delete")).mock(return_value=httpx.Response(status_code=200))
+        respx_mock.post(config.create_api_url("/files/delete")).mock(return_value=httpx2.Response(status_code=200))
         api.delete([instance.as_id()])
         assert len(respx_mock.calls) >= 1  # At least one call should have
 
         # Test iterate/list/paginate
         respx_mock.post(config.create_api_url("/files/list")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
 
         listed = api.list(limit=10)
@@ -345,25 +345,25 @@ class TestCDFResourceAPI:
         aggregate_url = config.create_api_url(endpoints["aggregate"].path)
 
         respx_mock.post(list_url).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [doc_json], "nextCursor": None})
+            return_value=httpx2.Response(status_code=200, json={"items": [doc_json], "nextCursor": None})
         )
         respx_mock.post(search_url).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={"items": [{"item": doc_json, "highlight": None}], "nextCursor": None},
             )
         )
 
-        def aggregate_response(request: httpx.Request) -> httpx.Response:
+        def aggregate_response(request: httpx2.Request) -> httpx2.Response:
             raw = request.content
             if len(raw) >= 2 and raw[:2] == b"\x1f\x8b":
                 raw = gzip.decompress(raw)
             payload = json.loads(raw)
             agg = payload["aggregate"]
             if agg in ("count", "cardinalityValues", "cardinalityProperties"):
-                return httpx.Response(status_code=200, json={"items": [{"count": 11}]})
+                return httpx2.Response(status_code=200, json={"items": [{"count": 11}]})
             if agg in ("uniqueValues", "uniqueProperties"):
-                return httpx.Response(status_code=200, json={"items": [{"count": 2, "values": ["a"]}]})
+                return httpx2.Response(status_code=200, json={"items": [{"count": 2, "values": ["a"]}]})
             raise AssertionError(f"unexpected aggregate {agg!r}")
 
         respx_mock.post(aggregate_url).mock(side_effect=aggregate_response)
@@ -422,7 +422,7 @@ class TestCDFResourceAPI:
 
         # Test create/update (same endpoint)
         respx_mock.post(config.create_api_url("/workflows")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         created = api.create([request_item])
         assert len(created) == 1
@@ -434,20 +434,20 @@ class TestCDFResourceAPI:
 
         # Test retrieve
         respx_mock.get(config.create_api_url(f"/workflows/{instance.external_id}")).mock(
-            return_value=httpx.Response(status_code=200, json=resource)
+            return_value=httpx2.Response(status_code=200, json=resource)
         )
         retrieved = api.retrieve([instance.as_id()])
         assert len(retrieved) == 1
         assert retrieved[0].dump() == resource
 
         # Test delete
-        respx_mock.post(config.create_api_url("/workflows/delete")).mock(return_value=httpx.Response(status_code=200))
+        respx_mock.post(config.create_api_url("/workflows/delete")).mock(return_value=httpx2.Response(status_code=200))
         api.delete([instance.as_id()])
         assert len(respx_mock.calls) >= 1  # At least one call should have been made
 
         # Test iterate/list
         respx_mock.get(config.create_api_url("/workflows")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         listed = api.list(limit=10)
         assert len(listed) == 1
@@ -468,7 +468,7 @@ class TestCDFResourceAPI:
 
         # Test create/update (same endpoint)
         respx_mock.post(config.create_api_url("/workflows/versions")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         created = api.create([request_item])
         assert len(created) == 1
@@ -481,21 +481,21 @@ class TestCDFResourceAPI:
         # Test retrieve
         respx_mock.get(
             config.create_api_url(f"/workflows/{instance.workflow_external_id}/versions/{instance.version}")
-        ).mock(return_value=httpx.Response(status_code=200, json=resource))
+        ).mock(return_value=httpx2.Response(status_code=200, json=resource))
         retrieved = api.retrieve([instance.as_id()])
         assert len(retrieved) == 1
         assert retrieved[0].dump() == resource
 
         # Test delete
         respx_mock.post(config.create_api_url("/workflows/versions/delete")).mock(
-            return_value=httpx.Response(status_code=200)
+            return_value=httpx2.Response(status_code=200)
         )
         api.delete([instance.as_id()])
         assert len(respx_mock.calls) >= 1  # At least one call should have been made
 
         # Test iterate/list
         respx_mock.post(config.create_api_url("/workflows/versions/list")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         listed = api.list(limit=10)
         assert len(listed) == 1
@@ -518,7 +518,7 @@ class TestCDFResourceAPI:
 
         # Test create/update (same endpoint)
         respx_mock.post(config.create_api_url("/workflows/triggers")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         created = api.create([request_item])
         assert len(created) == 1
@@ -530,14 +530,14 @@ class TestCDFResourceAPI:
 
         # Test delete
         respx_mock.post(config.create_api_url("/workflows/triggers/delete")).mock(
-            return_value=httpx.Response(status_code=200)
+            return_value=httpx2.Response(status_code=200)
         )
         api.delete([instance.as_id()])
         assert len(respx_mock.calls) >= 1  # At least one call should have been made
 
         # Test iterate/list
         respx_mock.get(config.create_api_url("/workflows/triggers")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         listed = api.list(limit=10)
         assert len(listed) == 1
@@ -559,7 +559,7 @@ class TestCDFResourceAPI:
         )
         # Test create
         respx_mock.post(config.create_api_url("/functions/schedules")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         created = api.create([request_item])
         assert len(created) == 1
@@ -567,7 +567,7 @@ class TestCDFResourceAPI:
 
         # Test retrieve
         respx_mock.post(config.create_api_url("/functions/schedules/byids")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         retrieved = api.retrieve([request_item.as_id()])
         assert len(retrieved) == 1
@@ -575,14 +575,14 @@ class TestCDFResourceAPI:
 
         # Test delete
         respx_mock.post(config.create_api_url("/functions/schedules/delete")).mock(
-            return_value=httpx.Response(status_code=200)
+            return_value=httpx2.Response(status_code=200)
         )
         api.delete([request_item.as_id()])
         assert len(respx_mock.calls) >= 1  # At least one call should have been made
 
         # Test iterate/list/paginate
         respx_mock.post(config.create_api_url("/functions/schedules/list")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         listed = api.list(limit=10)
         assert len(listed) == 1
@@ -610,7 +610,7 @@ class TestCDFResourceAPI:
 
         # Test create
         respx_mock.post(config.create_api_url("/annotations")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         created = api.create([request_item])
         assert len(created) == 1
@@ -618,7 +618,7 @@ class TestCDFResourceAPI:
 
         # Test retrieve
         respx_mock.post(config.create_api_url("/annotations/byids")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         retrieved = api.retrieve([instance.as_id()])
         assert len(retrieved) == 1
@@ -626,20 +626,22 @@ class TestCDFResourceAPI:
 
         # Test update
         respx_mock.post(config.create_api_url("/annotations/update")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         updated = api.update([request_item], mode="replace")
         assert len(updated) == 1
         assert updated[0].dump() == resource
 
         # Test delete
-        respx_mock.post(config.create_api_url("/annotations/delete")).mock(return_value=httpx.Response(status_code=200))
+        respx_mock.post(config.create_api_url("/annotations/delete")).mock(
+            return_value=httpx2.Response(status_code=200)
+        )
         api.delete([instance.as_id()])
         assert len(respx_mock.calls) >= 1  # At least one call should have been made
 
         # Test iterate/list/paginate
         respx_mock.post(config.create_api_url("/annotations/list")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         listed = api.list(limit=10, filter=filter)
         assert len(listed) == 1
@@ -664,7 +666,7 @@ class TestCDFResourceAPI:
 
         # Test create
         respx_mock.post(config.create_api_url("/streams")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         created = api.create([request_item])
         assert len(created) == 1
@@ -672,20 +674,20 @@ class TestCDFResourceAPI:
 
         # Test retrieve
         respx_mock.get(config.create_api_url(f"/streams/{instance.external_id}")).mock(
-            return_value=httpx.Response(status_code=200, json=resource)
+            return_value=httpx2.Response(status_code=200, json=resource)
         )
         retrieved = api.retrieve([request_item.as_id()])
         assert len(retrieved) == 1
         assert retrieved[0].dump() == resource
 
         # Test delete
-        respx_mock.post(config.create_api_url("/streams/delete")).mock(return_value=httpx.Response(status_code=200))
+        respx_mock.post(config.create_api_url("/streams/delete")).mock(return_value=httpx2.Response(status_code=200))
         api.delete([request_item.as_id()])
         assert len(respx_mock.calls) >= 1  # At least one call should have been made
 
         # Test list
         respx_mock.get(config.create_api_url("/streams")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         listed = api.list()
         assert len(listed) == 1
@@ -702,7 +704,7 @@ class TestCDFResourceAPI:
 
         # Test create/update (same endpoint)
         respx_mock.post(config.create_api_url("/dml/graphql")).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200, json={"data": {"upsertGraphQlDmlVersion": {"result": resource}}}
             )
         )
@@ -712,7 +714,7 @@ class TestCDFResourceAPI:
 
         # Test retrieve
         respx_mock.post(config.create_api_url("/models/datamodels/byids")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         retrieved = api.retrieve([request_item.as_id()], inline_views=False)
         assert len(retrieved) == 1
@@ -720,14 +722,14 @@ class TestCDFResourceAPI:
 
         # Test delete
         respx_mock.post(config.create_api_url("/models/datamodels/delete")).mock(
-            return_value=httpx.Response(status_code=200)
+            return_value=httpx2.Response(status_code=200)
         )
         api.delete([request_item.as_id()])
         assert len(respx_mock.calls) >= 1  # At least one call should have been made
 
         # Test iterate/list/paginate
         respx_mock.get(config.create_api_url("/models/datamodels")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         listed = api.list(limit=10)
         assert len(listed) == 1
@@ -752,7 +754,7 @@ class TestCDFResourceAPI:
 
         # Test create/update
         respx_mock.post(config.create_app_url("/storage/config/apps/search/views/upsert")).mock(
-            return_value=httpx.Response(status_code=200, json=resource)
+            return_value=httpx2.Response(status_code=200, json=resource)
         )
         created = api.create([request_item])
         assert len(created) == 1
@@ -764,7 +766,7 @@ class TestCDFResourceAPI:
 
         # Test iterate/list/paginate
         respx_mock.post(config.create_app_url("/storage/config/apps/search/views/list")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         listed = api.list()
         assert len(listed) == 1
@@ -789,7 +791,7 @@ class TestCDFResourceAPI:
 
         # Test create
         respx_mock.post(config.create_app_url("/storage/config/locationfilters")).mock(
-            return_value=httpx.Response(status_code=200, json=resource)
+            return_value=httpx2.Response(status_code=200, json=resource)
         )
         created = api.create([request_item])
         assert len(created) == 1
@@ -797,7 +799,7 @@ class TestCDFResourceAPI:
 
         # Test retrieve
         respx_mock.post(config.create_app_url("/storage/config/locationfilters/byids")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         retrieved = api.retrieve([request_item.as_id()])
         assert len(retrieved) == 1
@@ -805,7 +807,7 @@ class TestCDFResourceAPI:
 
         # Test update
         respx_mock.put(config.create_app_url(f"/storage/config/locationfilters/{instance.id}")).mock(
-            return_value=httpx.Response(status_code=200, json=resource)
+            return_value=httpx2.Response(status_code=200, json=resource)
         )
         updated = api.update([request_item])
         assert len(updated) == 1
@@ -813,7 +815,7 @@ class TestCDFResourceAPI:
 
         # Test delete
         respx_mock.delete(config.create_app_url(f"/storage/config/locationfilters/{instance.id}")).mock(
-            return_value=httpx.Response(status_code=200, json=resource)
+            return_value=httpx2.Response(status_code=200, json=resource)
         )
         deleted = api.delete([request_item.as_id()])
         assert len(respx_mock.calls) >= 1  # At least one call should have been made
@@ -822,7 +824,7 @@ class TestCDFResourceAPI:
 
         # Test iterate/list/paginate
         respx_mock.post(config.create_app_url("/storage/config/locationfilters/list")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         listed = api.list()
         assert len(listed) == 1
@@ -847,7 +849,7 @@ class TestCDFResourceAPI:
 
         # Test create
         respx_mock.post(config.create_api_url("/3d/models")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         created = api.create([request])
         assert len(created) == 1
@@ -855,22 +857,22 @@ class TestCDFResourceAPI:
 
         # Test retrieve
         respx_mock.post(config.create_api_url(f"/3d/models/{instance.id}")).mock(
-            return_value=httpx.Response(status_code=200, json=resource)
+            return_value=httpx2.Response(status_code=200, json=resource)
         )
         # Test update
         respx_mock.post(config.create_api_url("/3d/models/update")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         updated = api.update([request])
         assert len(updated) == 1
 
         # Test delete
-        respx_mock.post(config.create_api_url("/3d/models/delete")).mock(return_value=httpx.Response(status_code=200))
+        respx_mock.post(config.create_api_url("/3d/models/delete")).mock(return_value=httpx2.Response(status_code=200))
         api.delete([request.as_id()])
 
         # Test iterate/list/paginate
         respx_mock.get(config.create_api_url("/3d/models")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         listed = api.list()
         assert len(listed) == 1
@@ -898,7 +900,7 @@ class TestCDFResourceAPI:
 
         # Test me (service account)
         respx_mock.get(config.create_auth_url("/principals/me")).mock(
-            return_value=httpx.Response(status_code=200, json=sa_resource)
+            return_value=httpx2.Response(status_code=200, json=sa_resource)
         )
         me = api.me()
         assert isinstance(me, ServiceAccountPrincipal)
@@ -906,7 +908,7 @@ class TestCDFResourceAPI:
 
         # Test me (user principal)
         respx_mock.get(config.create_auth_url("/principals/me")).mock(
-            return_value=httpx.Response(status_code=200, json=user_resource)
+            return_value=httpx2.Response(status_code=200, json=user_resource)
         )
         me_user = api.me()
         assert isinstance(me_user, UserPrincipal)
@@ -914,7 +916,7 @@ class TestCDFResourceAPI:
 
         # Test retrieve
         respx_mock.post(config.create_auth_url(f"/orgs/{org_id}/principals/byids")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [sa_resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [sa_resource]})
         )
         retrieved = api.retrieve([PrincipalId(id=sa_resource["id"])])
         assert len(retrieved) == 1
@@ -922,7 +924,7 @@ class TestCDFResourceAPI:
 
         # Test list
         respx_mock.get(config.create_auth_url(f"/orgs/{org_id}/principals")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [sa_resource, user_resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [sa_resource, user_resource]})
         )
         listed = api.list(limit=10)
         assert len(listed) == 2
@@ -950,7 +952,7 @@ class TestCDFResourceAPI:
         api = PrincipalsAPI(client, project_api)
 
         respx_mock.get(config.create_auth_url(f"/orgs/{org_id}/principals")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [sa_resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [sa_resource]})
         )
         listed = api.list(types=["SERVICE_ACCOUNT"], limit=10)
         assert len(listed) == 1
@@ -971,7 +973,7 @@ class TestCDFResourceAPI:
 
         # Test list
         respx_mock.get(sessions_url).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [session_resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [session_resource]})
         )
         listed = api.list(principal_id=principal_id, limit=10)
         assert len(listed) == 1
@@ -1006,14 +1008,14 @@ class TestCDFResourceAPI:
 
         # Test create
         respx_mock.post(config.create_api_url("/models/instances")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [{**example, "wasModified": False}]})
+            return_value=httpx2.Response(status_code=200, json={"items": [{**example, "wasModified": False}]})
         )
         created = api.create([request])
         assert len(created) == 1
 
         # Test retrieve
         respx_mock.post(config.create_api_url("/models/instances/byids")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [example]})
+            return_value=httpx2.Response(status_code=200, json={"items": [example]})
         )
         retrieved = api.retrieve([request.as_id()])
         assert len(retrieved) == 1
@@ -1021,7 +1023,7 @@ class TestCDFResourceAPI:
 
         # Test delete
         respx_mock.post(config.create_api_url("/models/instances/delete")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [request.as_id().dump()]})
+            return_value=httpx2.Response(status_code=200, json={"items": [request.as_id().dump()]})
         )
         deleted = api.delete([request.as_id()])
         assert len(respx_mock.calls) >= 1  # At least one call should have been made
@@ -1030,7 +1032,7 @@ class TestCDFResourceAPI:
         # Test list/paginate/iterate (via POST /models/instances/query)
         query_url = config.create_api_url("/models/instances/query")
         query_page = {"items": {"root": [example]}, "nextCursor": {"root": None}}
-        respx_mock.post(query_url).mock(return_value=httpx.Response(status_code=200, json=query_page))
+        respx_mock.post(query_url).mock(return_value=httpx2.Response(status_code=200, json=query_page))
         listed = api.list(limit=10)
         assert len(listed) == 1
         assert listed[0].dump() == example
@@ -1056,7 +1058,7 @@ class TestCDFResourceAPI:
 
         # Test retrieve
         respx_mock.post(config.create_api_url("/streams/my_stream/records/filter")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [record]})
+            return_value=httpx2.Response(status_code=200, json={"items": [record]})
         )
         retrieved = api.retrieve("my_stream", [RecordId(space="my_space", external_id="rec_1")])
         assert len(retrieved) == 1
@@ -1064,7 +1066,9 @@ class TestCDFResourceAPI:
 
         # Test sync
         respx_mock.post(config.create_api_url("/streams/my_stream/records/sync")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [record], "nextCursor": "abc", "hasNext": True})
+            return_value=httpx2.Response(
+                status_code=200, json={"items": [record], "nextCursor": "abc", "hasNext": True}
+            )
         )
         sources = [
             {"source": {"type": "container", "space": "my_space", "externalId": "my_container"}, "properties": ["*"]}
@@ -1085,7 +1089,7 @@ class TestCDFResourceAPI:
 
         # Test create
         respx_mock.post(config.create_api_url("/monitoringtasks")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         created = api.create([request_item])
         assert len(created) == 1
@@ -1093,7 +1097,7 @@ class TestCDFResourceAPI:
 
         # Test retrieve
         respx_mock.post(config.create_api_url("/monitoringtasks/byids")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         retrieved = api.retrieve([instance.as_id()])
         assert len(retrieved) == 1
@@ -1101,7 +1105,7 @@ class TestCDFResourceAPI:
 
         # Test update
         respx_mock.post(config.create_api_url("/monitoringtasks/update")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         updated = api.update([request_item])
         assert len(updated) == 1
@@ -1109,7 +1113,7 @@ class TestCDFResourceAPI:
 
         # Test upsert
         respx_mock.post(config.create_api_url("/monitoringtasks/upsert")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         upserted = api.upsert([request_item])
         assert len(upserted) == 1
@@ -1117,14 +1121,14 @@ class TestCDFResourceAPI:
 
         # Test delete
         respx_mock.post(config.create_api_url("/monitoringtasks/delete")).mock(
-            return_value=httpx.Response(status_code=200)
+            return_value=httpx2.Response(status_code=200)
         )
         api.delete([instance.as_id()])
         assert len(respx_mock.calls) >= 1
 
         # Test list
         respx_mock.post(config.create_api_url("/monitoringtasks/list")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         listed = api.list(limit=10)
         assert len(listed) == 1
@@ -1146,7 +1150,7 @@ class TestCDFResourceAPI:
 
         # Test create
         respx_mock.post(config.create_api_url("/calculations/schedules")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         created = api.create([request_item])
         assert len(created) == 1
@@ -1154,7 +1158,7 @@ class TestCDFResourceAPI:
 
         # Test retrieve
         respx_mock.post(config.create_api_url("/calculations/schedules/byids")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         retrieved = api.retrieve([instance.as_id()])
         assert len(retrieved) == 1
@@ -1162,7 +1166,7 @@ class TestCDFResourceAPI:
 
         # Test update
         respx_mock.post(config.create_api_url("/calculations/schedules/update")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         updated = api.update([request_item])
         assert len(updated) == 1
@@ -1170,14 +1174,14 @@ class TestCDFResourceAPI:
 
         # Test delete
         respx_mock.post(config.create_api_url("/calculations/schedules/delete")).mock(
-            return_value=httpx.Response(status_code=200)
+            return_value=httpx2.Response(status_code=200)
         )
         api.delete([instance.as_id()])
         assert len(respx_mock.calls) >= 1
 
         # Test list
         respx_mock.get(config.create_api_url("/calculations/schedules")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [list_item]})
+            return_value=httpx2.Response(status_code=200, json={"items": [list_item]})
         )
         listed = api.list()
         assert len(listed) == 1
@@ -1194,7 +1198,7 @@ class TestCDFResourceAPI:
         api = ChartScheduledCalculationsAPI(HTTPClient(config))
 
         respx_mock.post(config.create_api_url("/calculations/schedules/byids")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         retrieved = api.retrieve([ExternalId(external_id=resource["externalId"])])
         assert len(retrieved) == 1
@@ -1211,7 +1215,7 @@ class TestCDFResourceAPI:
 
         # Test list
         respx_mock.post(config.create_api_url("/alerts/channels/list")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [resource]})
+            return_value=httpx2.Response(status_code=200, json={"items": [resource]})
         )
         listed = api.list()
         assert len(listed) == 1
@@ -1224,7 +1228,7 @@ class TestCDFResourceAPI:
         config = toolkit_config
         api = AppsAPI(HTTPClient(config))
         respx_mock.get(config.create_api_url("/apphosting/apps/missing-app")).mock(
-            return_value=httpx.Response(status_code=400)
+            return_value=httpx2.Response(status_code=400)
         )
         assert api.retrieve([ExternalId(external_id="missing-app")], ignore_unknown_ids=True) == []
 
@@ -1232,7 +1236,7 @@ class TestCDFResourceAPI:
         config = toolkit_config
         api = AppVersionsAPI(HTTPClient(config))
         respx_mock.post(config.create_api_url("/apphosting/apps/my-app/versions")).mock(
-            return_value=httpx.Response(status_code=201)
+            return_value=httpx2.Response(status_code=201)
         )
         api.upload("my-app", "1.0.0", "index.html", b"fake-zip")
 
@@ -1240,7 +1244,7 @@ class TestCDFResourceAPI:
         config = toolkit_config
         api = AppVersionsAPI(HTTPClient(config))
         respx_mock.post(config.create_api_url("/apphosting/apps/my-app/versions/update")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": []})
+            return_value=httpx2.Response(status_code=200, json={"items": []})
         )
         api.update("my-app", "1.0.0", {"lifecycleState": {"set": "PUBLISHED"}})
 
@@ -1254,7 +1258,7 @@ class TestCDFResourceAPI:
             "entrypoint": "index.html",
         }
         respx_mock.get(config.create_api_url("/apphosting/apps/my-app/versions/1.0.0")).mock(
-            return_value=httpx.Response(status_code=200, json=version_json)
+            return_value=httpx2.Response(status_code=200, json=version_json)
         )
         retrieved = api.retrieve([AppVersionId(app_external_id="my-app", version="1.0.0")])
 
@@ -1270,7 +1274,7 @@ class TestCDFResourceAPI:
         config = toolkit_config
         api = AppVersionsAPI(HTTPClient(config))
         respx_mock.get(config.create_api_url("/apphosting/apps/my-app/versions/1.0.0")).mock(
-            return_value=httpx.Response(status_code=400)
+            return_value=httpx2.Response(status_code=400)
         )
         assert api.retrieve([AppVersionId(app_external_id="my-app", version="1.0.0")], ignore_unknown_ids=True) == []
 
@@ -1284,7 +1288,7 @@ class TestCDFResourceAPI:
             "entrypoint": "index.html",
         }
         respx_mock.post(config.create_api_url("/apphosting/versions/list")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [version_json]})
+            return_value=httpx2.Response(status_code=200, json={"items": [version_json]})
         )
         batches = list(api.iterate(limit=10))
 
@@ -1295,7 +1299,7 @@ class TestCDFResourceAPI:
         config = toolkit_config
         api = AppVersionsAPI(HTTPClient(config))
         respx_mock.post(config.create_api_url("/apphosting/apps/my-app/versions/delete")).mock(
-            return_value=httpx.Response(status_code=200)
+            return_value=httpx2.Response(status_code=200)
         )
         api.delete([AppVersionId(app_external_id="my-app", version="1.0.0")])
 
@@ -1319,9 +1323,9 @@ description: Smoke test skill
         )
         upload_route = respx_mock.post(
             config.create_api_url("/ai/skills/upload?externalId=smoke-test-skill&overwrite=true")
-        ).mock(return_value=httpx.Response(status_code=200, json={}))
+        ).mock(return_value=httpx2.Response(status_code=200, json={}))
         retrieve_route = respx_mock.post(config.create_api_url("/ai/skills/byids")).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={
                     "items": [

--- a/tests/test_unit/test_cdf_tk/test_client/test_charts.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_charts.py
@@ -1,7 +1,7 @@
 import json
 from collections.abc import Iterator
 
-import httpx
+import httpx2
 import pytest
 import respx
 import yaml
@@ -91,11 +91,11 @@ class TestChartAPI:
 
         respx_mock.post(url).mock(
             side_effect=[
-                httpx.Response(
+                httpx2.Response(
                     status_code=200,
                     json={"items": [page_one.dump()], "nextCursor": "cursor_1"},
                 ),
-                httpx.Response(
+                httpx2.Response(
                     status_code=200,
                     json={"items": [page_two.dump()], "nextCursor": None},
                 ),

--- a/tests/test_unit/test_cdf_tk/test_client/test_extended_filemetadata.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_extended_filemetadata.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 
 import pytest
 import respx
-from httpx import Response
+from httpx2 import Response
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, InternalId, InternalOrExternalId, NodeId

--- a/tests/test_unit/test_cdf_tk/test_client/test_extended_timeseries.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_extended_timeseries.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 
 import pytest
 import respx
-from httpx import Response
+from httpx2 import Response
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId, InternalId, InternalOrExternalId, NodeId

--- a/tests/test_unit/test_cdf_tk/test_client/test_functions.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_functions.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import respx
 from cognite.client import global_config
-from httpx import Response
+from httpx2 import Response
 from rich.console import Console
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig

--- a/tests/test_unit/test_cdf_tk/test_client/test_lookup.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_lookup.py
@@ -1,7 +1,7 @@
 import json
 from collections.abc import Iterator, Sequence
 
-import httpx
+import httpx2
 import pytest
 import respx
 from _pytest.mark import ParameterSet
@@ -148,7 +148,7 @@ class TestLookup:
         resource_by_id = {resource.id: resource for resource in resources}
         resource_by_external_id = {resource.external_id: resource for resource in resources}
 
-        def retrieve_multiple_callback(request: httpx.Request) -> httpx.Response:
+        def retrieve_multiple_callback(request: httpx2.Request) -> httpx2.Response:
             items = json.loads(request.content)["items"]
             response_items = []
             for item in items:
@@ -156,7 +156,7 @@ class TestLookup:
                     response_items.append(resource.dump(camel_case=True))
                 elif "externalId" in item and (resource := resource_by_external_id.get(item["externalId"])) is not None:
                     response_items.append(resource.dump(camel_case=True))
-            return httpx.Response(200, json={"items": response_items})
+            return httpx2.Response(200, json={"items": response_items})
 
         rsps.post(config.create_api_url(f"{endpoint}/byids")).mock(side_effect=retrieve_multiple_callback)
         client = ToolkitClient(config)

--- a/tests/test_unit/test_cdf_tk/test_client/test_migration.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_migration.py
@@ -1,6 +1,6 @@
 from typing import Any, ClassVar
 
-import httpx
+import httpx2
 import pytest
 import respx
 
@@ -16,7 +16,7 @@ def lookup_client(
 ) -> tuple[ToolkitClient, respx.MockRouter]:
     config = toolkit_config
     respx_mock.post(config.create_api_url("/models/instances/query")).mock(
-        return_value=httpx.Response(status_code=200, json=TestMigrationLookup.QUERY_RESPONSE),
+        return_value=httpx2.Response(status_code=200, json=TestMigrationLookup.QUERY_RESPONSE),
     )
     return ToolkitClient(config=config), respx_mock
 

--- a/tests/test_unit/test_cdf_tk/test_client/test_three_d.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_three_d.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any
 
-import httpx
+import httpx2
 import pytest
 import respx
 
@@ -158,13 +158,13 @@ class TestAssetsMappingsDM:
         url_model_37 = config.create_api_url("/3d/models/37/revisions/42/mappings")
         url_model_38 = config.create_api_url("/3d/models/38/revisions/42/mappings")
 
-        def callback(request: httpx.Request) -> httpx.Response:
+        def callback(request: httpx2.Request) -> httpx2.Response:
             payload = json.loads(request.content.decode("utf-8"))
             items = payload.get("items", [])
             for item in items:
                 item["treeIndex"] = 1
                 item["subtreeSize"] = 10
-            return httpx.Response(status_code=200, json={"items": items})
+            return httpx2.Response(status_code=200, json={"items": items})
 
         respx_mock.post(url_model_37).mock(side_effect=callback)
         respx_mock.post(url_model_38).mock(side_effect=callback)

--- a/tests/test_unit/test_cdf_tk/test_client/test_transformation_externaldata.py
+++ b/tests/test_unit/test_cdf_tk/test_client/test_transformation_externaldata.py
@@ -1,4 +1,4 @@
-import httpx
+import httpx2
 import respx
 
 from cognite_toolkit._cdf_tk.client import ToolkitClientConfig
@@ -54,7 +54,7 @@ class TestTransformationExternalDataSourcesAPI:
 
         create_url = toolkit_config.create_api_url("/transformations/externaldata")
         respx_mock.post(create_url).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [_EXAMPLE_RESPONSE]})
+            return_value=httpx2.Response(status_code=200, json={"items": [_EXAMPLE_RESPONSE]})
         )
         created = api.create([request])
         assert len(created) == 1
@@ -62,14 +62,16 @@ class TestTransformationExternalDataSourcesAPI:
         assert respx_mock.calls[-1].request.headers["cdf-version"] == "beta"
 
         list_url = toolkit_config.create_api_url("/transformations/externaldata")
-        respx_mock.get(list_url).mock(return_value=httpx.Response(status_code=200, json={"items": [_EXAMPLE_RESPONSE]}))
+        respx_mock.get(list_url).mock(
+            return_value=httpx2.Response(status_code=200, json={"items": [_EXAMPLE_RESPONSE]})
+        )
         listed = api.list(limit=10)
         assert len(listed) == 1
         batches = list(api.iterate(limit=10))
         assert batches[0][0].external_id == "fabric-lakehouse-prod"
 
         delete_url = toolkit_config.create_api_url("/transformations/externaldata/delete")
-        respx_mock.post(delete_url).mock(return_value=httpx.Response(status_code=200, json={}))
+        respx_mock.post(delete_url).mock(return_value=httpx2.Response(status_code=200, json={}))
         api.delete([ExternalId(external_id="fabric-lakehouse-prod")])
         assert respx_mock.calls[-1].request.url.path.endswith("/transformations/externaldata/delete")
 
@@ -78,7 +80,7 @@ class TestTransformationExternalDataSourcesAPI:
         api = TransformationExternalDataSourcesAPI(client)
         usability_url = toolkit_config.create_api_url("/transformations/externaldata/usability")
         respx_mock.post(usability_url).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={"externalId": "fabric-lakehouse-prod", "usableVersion": "00000000-0000-0000-0000-000000000001"},
             )

--- a/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_deployv2/test_command.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import httpx
+import httpx2
 import pytest
 import respx
 
@@ -583,7 +583,7 @@ class TestDeployResourcesValidationError:
 
         with respx.mock() as mock_router:
             mock_router.post(spaces_url).mock(
-                return_value=httpx.Response(
+                return_value=httpx2.Response(
                     status_code=200,
                     # Missing space
                     json={"items": [{"createdTime": 0, "lastUpdatedTime": 1, "isGlobal": False}]},

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_command.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Literal
 from unittest.mock import MagicMock, patch
 
-import httpx
+import httpx2
 import pytest
 import respx
 from cognite.client import data_modeling as dm
@@ -318,7 +318,7 @@ class TestMigrationCommand:
         respx.post(
             config.create_api_url("/models/spaces/byids"),
         ).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={
                     "items": [SpaceResponse(space=space, created_time=1, last_updated_time=1, is_global=False).dump()]
@@ -330,7 +330,7 @@ class TestMigrationCommand:
         respx.post(
             config.create_api_url("/assets/byids"),
         ).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={"items": [asset.dump() for asset in assets]},
             )
@@ -340,7 +340,7 @@ class TestMigrationCommand:
         respx.post(
             config.create_api_url("/models/instances"),
         ).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={
                     "items": [
@@ -452,7 +452,7 @@ class TestMigrationCommand:
         respx.post(
             config.create_api_url("/models/spaces/byids"),
         ).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={
                     "items": [SpaceResponse(space=space, created_time=1, last_updated_time=1, is_global=False).dump()]
@@ -464,7 +464,7 @@ class TestMigrationCommand:
         respx.post(
             config.create_api_url("/assets/byids"),
         ).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={"items": [asset.dump() for asset in assets]},
             )
@@ -474,7 +474,7 @@ class TestMigrationCommand:
         respx_mock.post(
             config.create_api_url("/models/instances"),
         ).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={
                     "items": [
@@ -590,9 +590,9 @@ class TestMigrationCommand:
                 f"{2001},{space},annotation_{2001},{FILE_ANNOTATIONS_ID}",
             )
         )
-        # Annotation retrieve ids (toolkit API uses httpx)
+        # Annotation retrieve ids (toolkit API uses httpx2)
         respx_mock.post(config.create_api_url("/annotations/byids")).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={"items": [annotation.dump() for annotation in annotations]},
             )
@@ -600,7 +600,7 @@ class TestMigrationCommand:
         # None of the referenced files carry a native instanceId, so resolution falls back to the
         # InstanceSource lookup below.
         respx_mock.post(config.create_api_url("/files/byids")).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={
                     "items": [
@@ -623,7 +623,7 @@ class TestMigrationCommand:
             [("file", 5000), ("file", 3000), ("file", 3001)],
         ]:
             query_responses.append(
-                httpx.Response(
+                httpx2.Response(
                     status_code=200,
                     json={
                         "items": {
@@ -659,7 +659,7 @@ class TestMigrationCommand:
         respx.post(
             config.create_api_url("/models/instances"),
         ).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={
                     "items": [
@@ -851,9 +851,9 @@ class TestMigrationCommand:
                 "nextCursor": None,
             },
         )
-        # TimeSeries Instance ID lookup (uses toolkit InstancesAPI → httpx)
+        # TimeSeries Instance ID lookup (uses toolkit InstancesAPI → httpx2)
         respx_mock.post(config.create_api_url("/models/instances/query")).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={
                     "items": {
@@ -895,7 +895,7 @@ class TestMigrationCommand:
         # Chart update (existing chart goes through per-chart update endpoint)
         respx.put(
             config.create_app_url("/storage/charts/charts/my_chart"),
-        ).mock(return_value=httpx.Response(status_code=200, json={"items": [charts[0].dump()]}))
+        ).mock(return_value=httpx2.Response(status_code=200, json={"items": [charts[0].dump()]}))
 
         client = ToolkitClient(config)
         command = MigrationCommand(silent=True)
@@ -1078,12 +1078,12 @@ class TestMigrationCommand:
         empty_query_data = {"items": {"canvas": []}, "nextCursor": {}}
         canvas_query_done = False
 
-        def _query_side_effect(request: httpx.Request) -> httpx.Response:
+        def _query_side_effect(request: httpx2.Request) -> httpx2.Response:
             nonlocal canvas_query_done
             body = json.loads(request.content)
             with_keys = set(body.get("with", {}).keys())
             if "instanceSource" in with_keys:
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=200,
                     json={
                         "items": {
@@ -1107,14 +1107,14 @@ class TestMigrationCommand:
                 )
             if not canvas_query_done:
                 canvas_query_done = True
-                return httpx.Response(status_code=200, json=canvas_query_data)
-            return httpx.Response(status_code=200, json=empty_query_data)
+                return httpx2.Response(status_code=200, json=canvas_query_data)
+            return httpx2.Response(status_code=200, json=empty_query_data)
 
         respx_mock.post(config.create_api_url("/models/instances/query")).mock(
             side_effect=_query_side_effect,
         )
 
-        def _echo_upsert_items(request: httpx.Request) -> httpx.Response:
+        def _echo_upsert_items(request: httpx2.Request) -> httpx2.Response:
             body = json.loads(request.content)
             items = [
                 {
@@ -1128,7 +1128,7 @@ class TestMigrationCommand:
                 }
                 for item in body.get("items", [])
             ]
-            return httpx.Response(status_code=200, json={"items": items})
+            return httpx2.Response(status_code=200, json={"items": items})
 
         respx_mock.post(config.create_api_url("/models/instances")).mock(
             side_effect=_echo_upsert_items,
@@ -1408,7 +1408,7 @@ class TestMigrationCommand:
 
         # Space validation
         respx_mock.post(config.create_api_url("/models/spaces/byids")).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={
                     "items": [SpaceResponse(space=space, created_time=1, last_updated_time=1, is_global=False).dump()]
@@ -1424,7 +1424,7 @@ class TestMigrationCommand:
         )
         # Event retrieve
         respx_mock.post(config.create_api_url("/events/byids")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [e.dump() for e in events]})
+            return_value=httpx2.Response(status_code=200, json={"items": [e.dump() for e in events]})
         )
         # Container retrieve for mapper.prepare()
         container = ContainerResponse(
@@ -1441,12 +1441,12 @@ class TestMigrationCommand:
             is_global=False,
         )
         respx_mock.post(config.create_api_url("/models/containers/byids")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [container.dump()]})
+            return_value=httpx2.Response(status_code=200, json={"items": [container.dump()]})
         )
         # Records upload — capture the request. Endpoint depends on stream mutability.
         ingest_records = respx_mock.post(
             config.create_api_url(expected_endpoint.format(stream=stream_external_id))
-        ).mock(return_value=httpx.Response(status_code=200, json={}))
+        ).mock(return_value=httpx2.Response(status_code=200, json={}))
 
         csv_file = tmp_path / "events.csv"
         csv_file.write_text(

--- a/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_migration_io.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_migration_cmd/test_migration_io.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import httpx
+import httpx2
 import pytest
 import respx
-from httpx import Response
+from httpx2 import Response
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient, ToolkitClientConfig
 from cognite_toolkit._cdf_tk.client.http_client import HTTPClient
@@ -59,7 +59,7 @@ class TestAssetCentricMigrationIOAdapter:
         respx.post(
             config.create_api_url("/models/spaces/byids"),
         ).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={
                     "items": [

--- a/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
+++ b/tests/test_unit/test_cdf_tk/test_commands/test_purge.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
-import httpx
+import httpx2
 import pytest
 import respx
 from cognite.client import data_modeling as dm
@@ -225,47 +225,47 @@ class TestPurgeInstances:
         )
         instance_dumps = [instance.dump() for instance in instances]
         respx_mock.post(config.create_api_url("/models/instances/query")).side_effect = [
-            httpx.Response(
+            httpx2.Response(
                 status_code=200,
                 json={"items": {"root": instance_dumps[:1000]}, "nextCursor": {"root": "next"}},
             ),
-            httpx.Response(
+            httpx2.Response(
                 status_code=200,
                 json={"items": {"root": instance_dumps[1000:]}, "nextCursor": {"root": None}},
             ),
         ]
         if unlink:
 
-            def ts_byids_callback(request: httpx.Request) -> httpx.Response:
+            def ts_byids_callback(request: httpx2.Request) -> httpx2.Response:
                 body = json.loads(request.content.decode("utf-8"))
                 requested_ids = {
                     dm.NodeId(space=item["instanceId"]["space"], external_id=item["instanceId"]["externalId"])
                     for item in body.get("items", [])
                 }
                 filtered = [v for k, v in timeseries_by_node_id.items() if k in requested_ids]
-                return httpx.Response(status_code=200, json={"items": filtered})
+                return httpx2.Response(status_code=200, json={"items": filtered})
 
-            def files_byids_callback(request: httpx.Request) -> httpx.Response:
+            def files_byids_callback(request: httpx2.Request) -> httpx2.Response:
                 body = json.loads(request.content.decode("utf-8"))
                 requested_ids = {
                     dm.NodeId(space=item["instanceId"]["space"], external_id=item["instanceId"]["externalId"])
                     for item in body.get("items", [])
                 }
                 filtered = [v for k, v in files_by_node_id.items() if k in requested_ids]
-                return httpx.Response(status_code=200, json={"items": filtered})
+                return httpx2.Response(status_code=200, json={"items": filtered})
 
             respx_mock.post(config.create_api_url("/timeseries/byids")).mock(side_effect=ts_byids_callback)
             respx_mock.post(config.create_api_url("/files/byids")).mock(side_effect=files_byids_callback)
         if unlink and not dry_run and instance_type == "timeseries":
             respx_mock.post(config.create_api_url("/timeseries/unlink-instance-ids")).mock(
-                return_value=httpx.Response(
+                return_value=httpx2.Response(
                     status_code=200,
                     json={"items": list(timeseries_by_node_id.values())},
                 )
             )
         if unlink and not dry_run and instance_type == "files":
             respx_mock.post(config.create_api_url("/files/unlink-instance-ids")).mock(
-                return_value=httpx.Response(
+                return_value=httpx2.Response(
                     status_code=200,
                     json={"items": list(files_by_node_id.values())},
                 )
@@ -274,7 +274,7 @@ class TestPurgeInstances:
             respx_mock.post(
                 config.create_api_url("/models/instances/delete"),
             ).mock(
-                return_value=httpx.Response(
+                return_value=httpx2.Response(
                     status_code=200,
                     json={"items": [instance.as_id().dump() for instance in instances]},
                 )
@@ -361,8 +361,8 @@ class TestPurgeSpace:
                 json=project_statistics_response,
             )
 
-        def delete_callback(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, content=request.content)
+        def delete_callback(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(200, content=request.content)
 
         gen = FakeCogniteResourceGenerator(seed=42)
         # The cross-reference safety check runs in both dry-run and real mode and lists/inspects all
@@ -413,11 +413,11 @@ class TestPurgeSpace:
             edge_items = [gen.create_instance(EdgeResponse) for _ in range(edge_count)]
             node_items = [gen.create_instance(NodeResponse) for _ in range(node_count)]
 
-            def list_instances_query_callback(request: httpx.Request) -> httpx.Response:
+            def list_instances_query_callback(request: httpx2.Request) -> httpx2.Response:
                 body = json.loads(request.content.decode("utf-8"))
                 root_expr = body.get("with", {}).get("root", {})
                 items = edge_items if "edges" in root_expr else node_items
-                return httpx.Response(
+                return httpx2.Response(
                     200,
                     json={"items": {"root": [item.dump() for item in items]}, "nextCursor": {"root": None}},
                 )

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_ruleset.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_ruleset.py
@@ -5,7 +5,7 @@ import json
 import tempfile
 from pathlib import Path
 
-import httpx
+import httpx2
 import pytest
 import respx
 import yaml
@@ -205,7 +205,7 @@ class TestRuleSetsAPIRetrieve:
         api = RuleSetsAPI(HTTPClient(toolkit_config))
         rule_set = {"externalId": "my_rules", "name": "My Rules", "createdTime": 1000}
         respx_mock.post(toolkit_config.create_api_url("/rulesets/byids")).mock(
-            return_value=httpx.Response(status_code=200, json={"items": [rule_set]})
+            return_value=httpx2.Response(status_code=200, json={"items": [rule_set]})
         )
 
         api.retrieve([ExternalId(external_id="my_rules")])
@@ -227,12 +227,12 @@ class TestRuleSetsAPIRetrieve:
         rule_set = {"externalId": "exists", "name": "Exists", "createdTime": 1000}
         error_body = {"error": {"code": 400, "message": "IDs not found"}}
 
-        def side_effect(request: httpx.Request) -> httpx.Response:
+        def side_effect(request: httpx2.Request) -> httpx2.Response:
             body = json.loads(gzip.decompress(request.content))
             items = body.get("items", [])
             if any(i.get("externalId") == "missing_one" for i in items):
-                return httpx.Response(status_code=400, json=error_body)
-            return httpx.Response(status_code=200, json={"items": [rule_set]})
+                return httpx2.Response(status_code=400, json=error_body)
+            return httpx2.Response(status_code=200, json={"items": [rule_set]})
 
         respx_mock.post(toolkit_config.create_api_url("/rulesets/byids")).mock(side_effect=side_effect)
 

--- a/tests/test_unit/test_cdf_tk/test_cruds/test_view.py
+++ b/tests/test_unit/test_cdf_tk/test_cruds/test_view.py
@@ -1,6 +1,6 @@
 from collections.abc import Hashable
 
-import httpx
+import httpx2
 import pytest
 import respx
 
@@ -432,7 +432,7 @@ class TestRecordViewSupport:
         )
         upsert_url = toolkit_config.create_api_url("/models/views")
         respx_mock.post(upsert_url).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={
                     "items": [
@@ -471,7 +471,7 @@ class TestRecordViewSupport:
         )
         upsert_url = toolkit_config.create_api_url("/models/datamodels")
         respx_mock.post(upsert_url).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 status_code=200,
                 json={
                     "items": [

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_annotations.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_annotations.py
@@ -1,4 +1,4 @@
-import httpx
+import httpx2
 import pytest
 import respx
 
@@ -13,7 +13,7 @@ class TestAnnotationIO:
         config = toolkit_config
         client = ToolkitClient(config)
         respx_mock.post(config.create_api_url("/files/list")).mock(
-            return_value=httpx.Response(
+            return_value=httpx2.Response(
                 200,
                 json={
                     "items": [
@@ -101,8 +101,8 @@ class TestAnnotationIO:
         }
         respx_mock.post(config.create_api_url("/annotations/list")).mock(
             side_effect=[
-                httpx.Response(200, json={"items": [file_link_annotation]}),
-                httpx.Response(200, json={"items": [asset_link_annotation]}),
+                httpx2.Response(200, json={"items": [file_link_annotation]}),
+                httpx2.Response(200, json={"items": [asset_link_annotation]}),
             ]
         )
 

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_asset_centric.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_asset_centric.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import httpx
+import httpx2
 import pytest
 import respx
 from cognite.client.data_classes import (
@@ -276,12 +276,12 @@ class TestAssetCentricIO:
             resource.external_id: resource for resource in resources if resource.external_id is not None
         }
 
-        def create_callback(request: httpx.Request) -> httpx.Response:
+        def create_callback(request: httpx2.Request) -> httpx2.Response:
             payload = json.loads(request.content)
             assert "items" in payload
             items = payload["items"]
             assert isinstance(items, list)
-            return httpx.Response(
+            return httpx2.Response(
                 status_code=200,
                 json={
                     "items": [
@@ -320,14 +320,14 @@ class TestAssetIO:
         monkeypatch.setenv("CDF_CLUSTER", config.cdf_cluster)
         monkeypatch.setenv("CDF_PROJECT", config.project)
 
-        def asset_create_callback(request: httpx.Request) -> httpx.Response:
+        def asset_create_callback(request: httpx2.Request) -> httpx2.Response:
             payload = json.loads(request.content)
             assert "items" in payload
             items = payload["items"]
             assert isinstance(items, list)
             assert len(items) == len(some_asset_data)
             assert {item["externalId"] for item in items} == {asset.external_id for asset in some_asset_data}
-            return httpx.Response(status_code=200, json={"items": [asset.dump() for asset in some_asset_data]})
+            return httpx2.Response(status_code=200, json={"items": [asset.dump() for asset in some_asset_data]})
 
         respx_mock.post(config.create_api_url("/assets")).mock(side_effect=asset_create_callback)
 

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_filecontent.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-import httpx
+import httpx2
 import pytest
 import respx
 
@@ -37,19 +37,19 @@ class TestFileContent:
         client = ToolkitClient(config)
         file_upload_url = "https://upload.url/for/testing/{externalId}"
 
-        def create_callback(request: httpx.Request) -> httpx.Response:
+        def create_callback(request: httpx2.Request) -> httpx2.Response:
             payload = json.loads(request.content)
             assert "name" in payload
             assert "externalId" in payload
             payload["uploadUrl"] = file_upload_url.format(externalId=payload["externalId"])
-            return httpx.Response(status_code=200, json=payload, headers={})
+            return httpx2.Response(status_code=200, json=payload, headers={})
 
         respx_mock.post(config.create_api_url("/files")).mock(side_effect=create_callback)
         upload_endpoints: list[str] = []
         for filepath in file_folder.iterdir():
             if filepath.is_file():
                 upload_endpoint = file_upload_url.format(externalId=f"my_file_{filepath.name}")
-                respx_mock.put(upload_endpoint).mock(return_value=httpx.Response(status_code=200))
+                respx_mock.put(upload_endpoint).mock(return_value=httpx2.Response(status_code=200))
                 upload_endpoints.append(upload_endpoint)
 
         selector = FileMetadataTemplateSelector(
@@ -85,13 +85,13 @@ class TestFileContent:
         file_dir.mkdir()
         (file_dir / "my_report.json").write_text('{"data": "test"}', encoding="utf-8")
 
-        not_found = httpx.Response(400, json={"error": {"code": 400, "message": "not found", "missing": [{}]}})
-        upload_url = httpx.Response(200, json={"items": [{"uploadUrl": "https://upload.test/file"}]})
+        not_found = httpx2.Response(400, json={"error": {"code": 400, "message": "not found", "missing": [{}]}})
+        upload_url = httpx2.Response(200, json={"items": [{"uploadUrl": "https://upload.test/file"}]})
         respx_mock.post(config.create_api_url("/files/uploadlink")).mock(side_effect=[not_found, upload_url])
         respx_mock.post(config.create_api_url("/models/instances")).mock(
-            return_value=httpx.Response(200, json={"items": []})
+            return_value=httpx2.Response(200, json={"items": []})
         )
-        respx_mock.put("https://upload.test/file").mock(return_value=httpx.Response(200))
+        respx_mock.put("https://upload.test/file").mock(return_value=httpx2.Response(200))
         view_id = SelectedView(space="my_custom_space", external_id="MyFileView", version="v2")
         selector = FileDataModelingTemplateSelector(
             file_directory=file_dir,

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_instance_io.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_instance_io.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-import httpx
+import httpx2
 import pytest
 import respx
 from cognite.client.data_classes.data_modeling import EdgeApply, NodeApply
@@ -65,21 +65,21 @@ class TestInstanceIO:
 
         respx_mock.post(url).mock(
             side_effect=[
-                httpx.Response(
+                httpx2.Response(
                     status_code=200,
                     json={
                         "items": {"root": [_node_dict(i) for i in range(1000)]},
                         "nextCursor": {"root": "cursor_1"},
                     },
                 ),
-                httpx.Response(
+                httpx2.Response(
                     status_code=200,
                     json={
                         "items": {"root": [_node_dict(i) for i in range(1000, 2000)]},
                         "nextCursor": {"root": "cursor_2"},
                     },
                 ),
-                httpx.Response(
+                httpx2.Response(
                     status_code=200,
                     json={
                         "items": {"root": [_node_dict(i) for i in range(2000, N)]},
@@ -122,11 +122,11 @@ class TestInstanceIO:
                 items=[DataItem(tracking_id=instance.external_id, item=instance) for instance in instances],
             )
 
-            def hate_edges(request: httpx.Request) -> httpx.Response:
+            def hate_edges(request: httpx2.Request) -> httpx2.Response:
                 # Check request body content
                 body_content = request.content.decode() if request.content else ""
                 if "edge" in body_content:
-                    return httpx.Response(
+                    return httpx2.Response(
                         400, json={"error": {"code": "InvalidArgument", "message": "I do not like edges!"}}
                     )
                 else:
@@ -144,7 +144,7 @@ class TestInstanceIO:
                             for item in items
                         ]
                     }
-                    return httpx.Response(200, json=response_data)
+                    return httpx2.Response(200, json=response_data)
 
             url = toolkit_config.create_api_url("/models/instances")
 
@@ -185,14 +185,14 @@ class TestInstanceIO:
             for i in range(100)
         ]
 
-        def instance_create_callback(request: httpx.Request) -> httpx.Response:
+        def instance_create_callback(request: httpx2.Request) -> httpx2.Response:
             payload = json.loads(request.content)
             assert "items" in payload
             items = payload["items"]
             assert isinstance(items, list)
             assert len(items) == len(some_instance_data)
             assert {item["externalId"] for item in items} == {inst.external_id for inst in some_instance_data}
-            return httpx.Response(status_code=200, json={"items": [inst.dump() for inst in some_instance_data]})
+            return httpx2.Response(status_code=200, json={"items": [inst.dump() for inst in some_instance_data]})
 
         # Download count
         respx_mock.post(config.create_api_url("/models/instances/aggregate")).respond(
@@ -438,7 +438,7 @@ class TestInstanceIO:
         respx_mock.post(query_url).mock(
             side_effect=[
                 # Call 1: first node batch + first edge batch (edge cursor present)
-                httpx.Response(
+                httpx2.Response(
                     status_code=200,
                     json={
                         "items": {
@@ -451,7 +451,7 @@ class TestInstanceIO:
                     },
                 ),
                 # Call 2: second edge batch (no more edge cursor → exhausts edges for first node batch)
-                httpx.Response(
+                httpx2.Response(
                     status_code=200,
                     json={
                         "items": {
@@ -462,7 +462,7 @@ class TestInstanceIO:
                     },
                 ),
                 # Call 3: second node batch (no more cursors → done)
-                httpx.Response(
+                httpx2.Response(
                     status_code=200,
                     json={
                         "items": {
@@ -524,7 +524,7 @@ class TestInstanceIO:
         respx_mock.post(query_url).mock(
             side_effect=[
                 # Call 1: image360 has a cursor, so pagination continues even though image360station doesn't.
-                httpx.Response(
+                httpx2.Response(
                     status_code=200,
                     json={
                         "items": {
@@ -535,7 +535,7 @@ class TestInstanceIO:
                     },
                 ),
                 # Call 2: no more cursors → done.
-                httpx.Response(
+                httpx2.Response(
                     status_code=200,
                     json={
                         "items": {

--- a/tests/test_unit/test_cdf_tk/test_storageio/test_record_io.py
+++ b/tests/test_unit/test_cdf_tk/test_storageio/test_record_io.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-import httpx
+import httpx2
 import pytest
 import respx
 
@@ -69,17 +69,17 @@ class TestRecordIO:
         expected_url = toolkit_config.create_api_url("/streams/my_stream/records/upsert")
         stream_url = toolkit_config.create_api_url("/streams/my_stream")
 
-        def record_callback(request: httpx.Request) -> httpx.Response:
+        def record_callback(request: httpx2.Request) -> httpx2.Response:
             payload = json.loads(request.content)
             assert "items" in payload
             items = payload["items"]
             assert len(items) == record_count
-            return httpx.Response(status_code=200, json={"items": items})
+            return httpx2.Response(status_code=200, json={"items": items})
 
         with HTTPClient(toolkit_config) as http_client:
             with respx.mock() as mock_router:
                 mock_router.get(stream_url).mock(
-                    return_value=httpx.Response(
+                    return_value=httpx2.Response(
                         status_code=200,
                         json={
                             "externalId": "my_stream",
@@ -105,11 +105,11 @@ class TestRecordIO:
         with respx.mock() as mock_router:
             route = mock_router.post(sync_url)
             route.side_effect = [
-                httpx.Response(
+                httpx2.Response(
                     status_code=200,
                     json=_make_sync_response(3, has_next=True, next_cursor="cursor_page2", start_index=0),
                 ),
-                httpx.Response(
+                httpx2.Response(
                     status_code=200,
                     json=_make_sync_response(2, has_next=False, next_cursor="cursor_page3", start_index=3),
                 ),
@@ -142,7 +142,7 @@ class TestRecordIO:
 
         with respx.mock() as mock_router:
             mock_router.post(sync_url).mock(
-                return_value=httpx.Response(status_code=200, json=_make_sync_response(0, has_next=False))
+                return_value=httpx2.Response(status_code=200, json=_make_sync_response(0, has_next=False))
             )
             io = RecordIO(client)
             pages = list(io.stream_data(selector, limit=100))
@@ -160,7 +160,7 @@ class TestRecordIO:
         )
         sync_url = toolkit_config.create_api_url("/streams/my_stream/records/sync")
 
-        def sync_callback(request: httpx.Request) -> httpx.Response:
+        def sync_callback(request: httpx2.Request) -> httpx2.Response:
             payload = json.loads(request.content)
             record_filter = payload["filter"]
             assert "and" in record_filter
@@ -170,7 +170,7 @@ class TestRecordIO:
                 "in" in part and part["in"]["property"] == ["space"] and part["in"]["values"] == ["filtered_space"]
                 for part in filter_parts
             )
-            return httpx.Response(status_code=200, json=_make_sync_response(1, has_next=False))
+            return httpx2.Response(status_code=200, json=_make_sync_response(1, has_next=False))
 
         with respx.mock() as mock_router:
             mock_router.post(sync_url).mock(side_effect=sync_callback)
@@ -192,7 +192,7 @@ class TestRecordIO:
         with respx.mock() as mock_router:
             route = mock_router.post(sync_url)
             route.side_effect = [
-                httpx.Response(status_code=200, json=_make_sync_response(5, has_next=True)),
+                httpx2.Response(status_code=200, json=_make_sync_response(5, has_next=True)),
             ]
             pages = list(io.stream_data(selector, limit=None))
 
@@ -219,14 +219,14 @@ class TestRecordIO:
         record_count = 10
         sync_response_data = _make_sync_response(record_count, has_next=False)
 
-        def record_upload_callback(request: httpx.Request) -> httpx.Response:
+        def record_upload_callback(request: httpx2.Request) -> httpx2.Response:
             payload = json.loads(request.content)
             assert "items" in payload
             items = payload["items"]
             assert isinstance(items, list)
             assert len(items) == record_count
             assert {item["externalId"] for item in items} == {f"record_{i}" for i in range(record_count)}
-            return httpx.Response(status_code=200, json={"items": items})
+            return httpx2.Response(status_code=200, json={"items": items})
 
         stream_url = config.create_api_url("/streams/my_stream")
         aggregate_url = config.create_api_url("/streams/my_stream/records/aggregate")

--- a/tests/test_unit/test_cdf_tk/test_utils/test_http_client.py
+++ b/tests/test_unit/test_cdf_tk/test_utils/test_http_client.py
@@ -3,7 +3,7 @@ from collections import Counter
 from collections.abc import Iterator
 from unittest.mock import patch
 
-import httpx
+import httpx2
 import pytest
 import respx
 
@@ -108,8 +108,8 @@ class TestHTTPClient2:
         url = "https://example.com/api/resource"
         rsps.get(url).mock(
             side_effect=[
-                httpx.Response(409, json={"error": {"message": "conflict", "code": 409, "isAutoRetryable": True}}),
-                httpx.Response(200, json={"key": "value"}),
+                httpx2.Response(409, json={"error": {"message": "conflict", "code": 409, "isAutoRetryable": True}}),
+                httpx2.Response(200, json={"key": "value"}),
             ]
         )
         with patch("time.sleep"):
@@ -131,7 +131,7 @@ class TestHTTPClient2:
     def test_connection_error(self, http_client_one_retry: HTTPClient, rsps: respx.MockRouter) -> None:
         http_client = http_client_one_retry
         rsps.get("http://nonexistent.domain/api/resource").mock(
-            side_effect=httpx.ConnectError("Simulated connection error")
+            side_effect=httpx2.ConnectError("Simulated connection error")
         )
         with patch(f"{HTTPClient.__module__}.time"):
             # Patch time to avoid actual sleep
@@ -143,7 +143,7 @@ class TestHTTPClient2:
 
     def test_read_timeout_error(self, http_client_one_retry: HTTPClient, rsps: respx.MockRouter) -> None:
         http_client = http_client_one_retry
-        rsps.get("https://example.com/api/resource").mock(side_effect=httpx.ReadTimeout("Simulated read timeout"))
+        rsps.get("https://example.com/api/resource").mock(side_effect=httpx2.ReadTimeout("Simulated read timeout"))
         with patch(f"{HTTPClient.__module__}.time"):
             # Patch time to avoid actual sleep
             response = http_client.request_single_retries(
@@ -237,15 +237,15 @@ class TestHTTPClientItemRequests2:
             {"externalId": "success", "data": 123},
         ]
 
-        def server_callback(request: httpx.Request) -> httpx.Response:
+        def server_callback(request: httpx2.Request) -> httpx2.Response:
             # Check request body content
             body_content = request.content.decode() if request.content else ""
             if "fail" in body_content:
-                return httpx.Response(400, json={"error": {"message": "Item failed", "code": 400}})
+                return httpx2.Response(400, json={"error": {"message": "Item failed", "code": 400}})
             elif "success" in body_content:
-                return httpx.Response(200, json={"items": response_items})
+                return httpx2.Response(200, json={"items": response_items})
             else:
-                return httpx.Response(200, json={"items": []})
+                return httpx2.Response(200, json={"items": []})
 
         rsps.post("https://example.com/api/resource").mock(side_effect=server_callback)
 
@@ -321,7 +321,7 @@ class TestHTTPClientItemRequests2:
 
     def test_timeout_error(self, http_client_one_retry: HTTPClient, rsps: respx.MockRouter) -> None:
         client = http_client_one_retry
-        rsps.post("https://example.com/api/resource").mock(side_effect=httpx.ReadTimeout("Simulated timeout error"))
+        rsps.post("https://example.com/api/resource").mock(side_effect=httpx2.ReadTimeout("Simulated timeout error"))
         with patch("time.sleep"):
             results = client.request_items_retries(
                 ItemsRequest(
@@ -426,21 +426,21 @@ class TestHTTPClientItemRequests2:
     def test_failing_3_items(self, http_client_one_retry: HTTPClient, rsps: respx.MockRouter) -> None:
         client = http_client_one_retry
 
-        def dislike_942_112_and_547(request: httpx.Request) -> httpx.Response:
+        def dislike_942_112_and_547(request: httpx2.Request) -> httpx2.Response:
             # Check request body content
             body_content = request.content.decode() if request.content else ""
             for no in ["942", "112", "547"]:
                 if no in body_content:
-                    return httpx.Response(400, json={"error": {"message": f"Item {no} is not allowed", "code": 400}})
+                    return httpx2.Response(400, json={"error": {"message": f"Item {no} is not allowed", "code": 400}})
 
             # Parse the request body to create response items
             try:
                 body_data = json.loads(body_content)
                 items = body_data.get("items", [])
                 response_items = [{"id": item["id"], "status": "ok"} for item in items]
-                return httpx.Response(200, json={"items": response_items})
+                return httpx2.Response(200, json={"items": response_items})
             except (json.JSONDecodeError, KeyError):
-                return httpx.Response(200, json={"items": []})
+                return httpx2.Response(200, json={"items": []})
 
         rsps.post("https://example.com/api/resource").mock(side_effect=dislike_942_112_and_547)
         with patch("time.sleep"):

--- a/tests/test_unit/test_check_smoke_results.py
+++ b/tests/test_unit/test_check_smoke_results.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import respx
-from httpx import Response
+from httpx2 import Response
 
 from tests_smoke.check_smoke_results import Context, SlackMessage, check_smoke_tests_results
 

--- a/tests_smoke/check_smoke_results.py
+++ b/tests_smoke/check_smoke_results.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal, TypeAlias
 
-import httpx
+import httpx2
 from pydantic import BaseModel, JsonValue
 from rich import print
 
@@ -172,9 +172,9 @@ def _notify_slack(messages: list[SlackMessage], context: Context) -> None:
     for message in messages:
         if context.send_messages:
             try:
-                response = httpx.post(context.slack_webhook_url, content=message.model_dump_json())
+                response = httpx2.post(context.slack_webhook_url, content=message.model_dump_json())
                 response.raise_for_status()
-            except httpx.HTTPError as e:
+            except httpx2.HTTPError as e:
                 print(f"[red]Failed to send message to Slack: {e}[/red]")
         else:
             print(f"[yellow]Dry run: would send message to Slack:[/yellow] {message.model_dump_json()}")

--- a/tests_smoke/test_cruds/test_resource_crud.py
+++ b/tests_smoke/test_cruds/test_resource_crud.py
@@ -1,6 +1,6 @@
 import asyncio
 
-import httpx
+import httpx2
 
 from cognite_toolkit._cdf_tk.client import ToolkitClient
 from cognite_toolkit._cdf_tk.resource_ios import (
@@ -38,19 +38,19 @@ class TestResourceCRUD:
         # Robotics does not have a public doc_url
         crud_classes = [crud_cls for crud_cls in CRUD_LIST if crud_cls not in INTERNAL_DOCS]
 
-        async def check_url(crud_cls: type[Loader], client: httpx.AsyncClient) -> str | None:
+        async def check_url(crud_cls: type[Loader], client: httpx2.AsyncClient) -> str | None:
             crud = crud_cls.create_loader(toolkit_client)
             url = crud.doc_url()
             try:
                 response = await client.get(url, follow_redirects=True)
                 if response.status_code < 200 or response.status_code >= 300:
                     return f"{crud.display_name} doc_url is not accessible ({url}). Status code: {response.status_code}"
-            except httpx.RequestError as e:
+            except httpx2.RequestError as e:
                 return f"{crud.display_name} doc_url request failed ({url}). Error: {e}"
             return None
 
         async def check_all_urls() -> list[str]:
-            async with httpx.AsyncClient() as client:
+            async with httpx2.AsyncClient() as client:
                 results = await asyncio.gather(*[check_url(crud_cls, client) for crud_cls in crud_classes])
             return [error for error in results if error is not None]
 

--- a/uv.lock
+++ b/uv.lock
@@ -376,7 +376,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cognite-sdk" },
     { name = "filelock" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "mixpanel" },
     { name = "packaging" },
     { name = "pip" },
@@ -435,7 +435,7 @@ requires-dist = [
     { name = "cognite-neat", marker = "extra == 'v08'", specifier = ">=1.0.43" },
     { name = "cognite-sdk", specifier = ">=8.6.0,<9.0.0" },
     { name = "filelock", specifier = ">=3.18.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx2", specifier = ">=2.12.0" },
     { name = "mixpanel", specifier = ">=4.10.1" },
     { name = "openpyxl", marker = "extra == 'table'", specifier = ">=3.1.5" },
     { name = "packaging", specifier = ">=25" },
@@ -937,6 +937,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -949,6 +962,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -983,11 +1022,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.16"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -2391,6 +2430,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Bump

- [x] Patch
- [ ] Skip

## Changelog

### Changed

- Replace `httpx` with `httpx2` as `httpx` is no longer maintained while `httpx2` is maintained by the pydantic team. 
