### PR TITLE
[CDF-28594] 🙂Require get dependencies implementation

### DIFF
--- a/cognite_toolkit/_cdf_tk/resource_ios/_base_ios.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_base_ios.py
@@ -274,6 +274,7 @@ class ResourceIO(Loader, ABC, Generic[T_Identifier, T_RequestResource, T_Respons
         return None
 
     @classmethod
+    @abstractmethod
     def get_dependencies(cls, resource: Any) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
         """Returns dependencies for a given resource.
         This is used to determine the order of deployment and to check for missing dependencies.
@@ -282,10 +283,7 @@ class ResourceIO(Loader, ABC, Generic[T_Identifier, T_RequestResource, T_Respons
             resource: The resource to get dependencies for.
 
         """
-        # TODO: Temporary set to return empty dict until all resource CRUDs have implemented this method.
-        # Once all resource CRUDs have implemented this method,
-        # we can remove the default implementation that returns an empty dict.
-        return {}
+        raise NotImplementedError(f"get_dependencies must be implemented for {cls.__name__}.")
 
     @classmethod
     def get_dependent_items(cls, item: dict) -> "Iterable[tuple[type[ResourceIO], Hashable]]":

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/auth.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/auth.py
@@ -563,6 +563,10 @@ class SecurityCategoryIO(ResourceIO[NameId, SecurityCategoryRequest, SecurityCat
                 acl_actions.extend(["CREATE", "UPDATE", "DELETE"])
             yield SecurityCategoriesAcl(actions=acl_actions, scope=scope)
 
+    @classmethod
+    def get_dependencies(cls, resource: SecurityCategoriesYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        return []
+
     def create(self, items: Sequence[SecurityCategoryRequest]) -> list[SecurityCategoryResponse]:
         return self.client.tool.security_categories.create(items)
 

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_organization.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/data_organization.py
@@ -82,6 +82,10 @@ class DataSetsIO(ResourceIO[ExternalId, DataSetRequest, DataSetResponse]):
     def as_str(cls, id: ExternalId) -> str:
         return sanitize_filename(id.external_id)
 
+    @classmethod
+    def get_dependencies(cls, resource: DataSetYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        return []
+
     def load_resource(self, resource: dict[str, Any], is_dry_run: bool = False) -> DataSetRequest:
         if resource.get("metadata"):
             for key, value in list(resource["metadata"].items()):

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/datamodel.py
@@ -188,6 +188,10 @@ class SpaceCRUD(ResourceContainerIO[SpaceId, SpaceRequest, SpaceResponse]):
     def as_str(cls, id: SpaceId) -> str:
         return sanitize_filename(id.space)
 
+    @classmethod
+    def get_dependencies(cls, resource: SpaceYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        return []
+
     def dump_resource(self, resource: SpaceResponse, local: dict[str, Any] | None = None) -> dict[str, Any]:
         dumped = resource.as_request_resource().dump()
         has_local = local is not None

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
@@ -309,6 +309,17 @@ class InFieldLocationConfigIO(ResourceIO[NodeId, InFieldLocationConfigRequest, I
         if isinstance(scope, AllScope | SpaceIDScope):
             yield DataModelInstancesAcl(actions=as_instance_acl_actions(actions), scope=scope)
 
+    @classmethod
+    def get_dependencies(cls, resource: InfieldLocationConfigYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        if resource.access_management:
+            for group_name in resource.access_management.checklist_admins or []:
+                yield GroupResourceScopedCRUD, NameId(name=group_name)
+            for group_name in resource.access_management.template_admins or []:
+                yield GroupAllScopedCRUD, NameId(name=group_name)
+        if resource.app_instance_space:
+            yield SpaceCRUD, SpaceId(space=resource.app_instance_space)
+
+
     def dump_resource(
         self, resource: InFieldLocationConfigResponse, local: dict[str, Any] | None = None
     ) -> dict[str, Any]:

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/fieldops.py
@@ -319,7 +319,6 @@ class InFieldLocationConfigIO(ResourceIO[NodeId, InFieldLocationConfigRequest, I
         if resource.app_instance_space:
             yield SpaceCRUD, SpaceId(space=resource.app_instance_space)
 
-
     def dump_resource(
         self, resource: InFieldLocationConfigResponse, local: dict[str, Any] | None = None
     ) -> dict[str, Any]:

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/hosted_extractors.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/hosted_extractors.py
@@ -94,6 +94,10 @@ class HostedExtractorSourceIO(
         if isinstance(scope, AllScope):
             yield HostedExtractorsAcl(actions=sorted(actions), scope=scope)
 
+    @classmethod
+    def get_dependencies(cls, resource: HostedExtractorSourceYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        return []
+
     def create(self, items: Sequence[HostedExtractorSourceRequestUnion]) -> list[HostedExtractorSourceResponseUnion]:
         return self.client.tool.hosted_extractors.sources.create(list(items))
 
@@ -418,6 +422,10 @@ class HostedExtractorMappingIO(ResourceIO[ExternalId, HostedExtractorMappingRequ
     def create_acl(cls, actions: set[Literal["READ", "WRITE"]], scope: ScopeDefinition) -> Iterable[AclType]:
         if isinstance(scope, AllScope):
             yield HostedExtractorsAcl(actions=sorted(actions), scope=scope)
+
+    @classmethod
+    def get_dependencies(cls, resource: HostedExtractorMappingYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        return []
 
     def create(self, items: Sequence[HostedExtractorMappingRequest]) -> list[HostedExtractorMappingResponse]:
         return self.client.tool.hosted_extractors.mappings.create(list(items))

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/raw.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/raw.py
@@ -83,6 +83,10 @@ class RawDatabaseCRUD(ResourceContainerIO[RawDatabaseId, RAWDatabaseRequest, RAW
         return RawDatabaseId(name=item.name)
 
     @classmethod
+    def get_dependencies(cls, resource: DatabaseYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        return []
+
+    @classmethod
     def dump_id(cls, id: RawDatabaseId) -> dict[str, Any]:
         return {"dbName": id.name}
 

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/robotics.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/robotics.py
@@ -2,6 +2,7 @@ import json
 from collections.abc import Hashable, Iterable, Sequence
 from typing import Any, Literal, final
 
+from cognite_toolkit._cdf_tk.client._resource_base import Identifier
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.group import (
     AclType,
@@ -65,6 +66,11 @@ class RoboticFrameIO(ResourceIO[ExternalId, RobotFrameRequest, RobotFrameRespons
     def create_acl(cls, actions: set[Literal["READ", "WRITE"]], scope: ScopeDefinition) -> Iterable[AclType]:
         if isinstance(scope, AllScope | DataSetScope):
             yield RoboticsAcl(actions=as_read_create_update_delete_actions(actions), scope=scope)
+
+    @classmethod
+    def get_dependencies(cls, resource: RobotFrameYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        if resource.transform and resource.transform.parent_frame_external_id:
+            yield RoboticFrameIO, ExternalId(external_id=resource.transform.parent_frame_external_id)
 
     def dump_resource(self, resource: RobotFrameResponse, local: dict[str, Any] | None = None) -> dict[str, Any]:
         dumped = resource.as_request_resource().dump()
@@ -131,6 +137,10 @@ class RoboticLocationIO(ResourceIO[ExternalId, RobotLocationRequest, RobotLocati
         if isinstance(scope, AllScope | DataSetScope):
             yield RoboticsAcl(actions=as_read_create_update_delete_actions(actions), scope=scope)
 
+    @classmethod
+    def get_dependencies(cls, resource: RobotLocationYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        return []
+
     def create(self, items: Sequence[RobotLocationRequest]) -> list[RobotLocationResponse]:
         return self.client.tool.robotics.locations.create(items)
 
@@ -195,6 +205,10 @@ class RoboticsDataPostProcessingIO(
     def create_acl(cls, actions: set[Literal["READ", "WRITE"]], scope: ScopeDefinition) -> Iterable[AclType]:
         if isinstance(scope, AllScope | DataSetScope):
             yield RoboticsAcl(actions=as_read_create_update_delete_actions(actions), scope=scope)
+
+    @classmethod
+    def get_dependencies(cls, resource: RobotDataPostProcessingYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        return []
 
     def create(self, items: Sequence[RobotDataPostProcessingRequest]) -> list[RobotDataPostProcessingResponse]:
         return self.client.tool.robotics.data_postprocessing.create(items)
@@ -271,6 +285,10 @@ class RobotCapabilityIO(ResourceIO[ExternalId, RobotCapabilityRequest, RobotCapa
     def create_acl(cls, actions: set[Literal["READ", "WRITE"]], scope: ScopeDefinition) -> Iterable[AclType]:
         if isinstance(scope, AllScope | DataSetScope):
             yield RoboticsAcl(actions=as_read_create_update_delete_actions(actions), scope=scope)
+
+    @classmethod
+    def get_dependencies(cls, resource: RobotCapabilityYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        return []
 
     def create(self, items: Sequence[RobotCapabilityRequest]) -> list[RobotCapabilityResponse]:
         return self.client.tool.robotics.capabilities.create(items)
@@ -351,6 +369,13 @@ class RoboticMapIO(ResourceIO[ExternalId, RobotMapRequest, RobotMapResponse]):
     def create_acl(cls, actions: set[Literal["READ", "WRITE"]], scope: ScopeDefinition) -> Iterable[AclType]:
         if isinstance(scope, AllScope | DataSetScope):
             yield RoboticsAcl(actions=as_read_create_update_delete_actions(actions), scope=scope)
+
+    @classmethod
+    def get_dependencies(cls, resource: RobotMapYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        if resource.frame_external_id:
+            yield RoboticFrameIO, ExternalId(external_id=resource.frame_external_id)
+        if resource.location_external_id:
+            yield RoboticLocationIO, ExternalId(external_id=resource.location_external_id)
 
     def dump_resource(self, resource: RobotMapResponse, local: dict[str, Any] | None = None) -> dict[str, Any]:
         dump = resource.as_request_resource().dump()

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/rulesets.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/rulesets.py
@@ -80,6 +80,10 @@ class RuleSetIO(ResourceIO[ExternalId, RuleSetRequest, RuleSetResponse]):
                 scope=scope,
             )
 
+    @classmethod
+    def get_dependencies(cls, resource: RuleSetYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        return []
+
     def create(self, items: Sequence[RuleSetRequest]) -> list[RuleSetResponse]:
         return self.client.tool.rulesets.create(list(items))
 

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/signal_sink.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/signal_sink.py
@@ -48,6 +48,10 @@ class SignalSinkIO(ResourceIO[SignalSinkId, SignalSinkRequest, SignalSinkRespons
         if isinstance(scope, AllScope | CurrentUserScope):
             yield SubscribeSignalsAcl(actions=sorted(actions), scope=scope)
 
+    @classmethod
+    def get_dependencies(cls, resource: SignalSinkYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        return []
+
     def create(self, items: Sequence[SignalSinkRequest]) -> list[SignalSinkResponse]:
         return self.client.tool.signal_sinks.create(list(items))
 

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/signal_sink.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/signal_sink.py
@@ -1,6 +1,7 @@
 from collections.abc import Hashable, Iterable, Sequence
 from typing import Any, Literal, final
 
+from cognite_toolkit._cdf_tk.client._resource_base import Identifier
 from cognite_toolkit._cdf_tk.client.identifiers import SignalSinkId
 from cognite_toolkit._cdf_tk.client.resource_classes.group import (
     AclType,

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/skill.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/skill.py
@@ -4,6 +4,7 @@ from typing import Any, Literal, final
 
 from pydantic import ValidationError
 
+from cognite_toolkit._cdf_tk.client._resource_base import Identifier
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.group import (
     AclType,
@@ -133,6 +134,10 @@ class SkillIO(ResourceIO[ExternalId, SkillRequest, SkillResponse]):
             content=content,
             description="skill instructions",
         )
+
+    @classmethod
+    def get_dependencies(cls, resource: SkillYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        return []
 
     def load_resource_file(
         self, filepath: Path, environment_variables: dict[str, str | None] | None = None

--- a/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/streams.py
+++ b/cognite_toolkit/_cdf_tk/resource_ios/_resource_ios/streams.py
@@ -5,6 +5,7 @@ from typing import Any, Literal, final
 
 from pydantic import TypeAdapter
 
+from cognite_toolkit._cdf_tk.client._resource_base import Identifier
 from cognite_toolkit._cdf_tk.client.identifiers import ExternalId
 from cognite_toolkit._cdf_tk.client.resource_classes.group import (
     AclType,
@@ -16,6 +17,7 @@ from cognite_toolkit._cdf_tk.client.resource_classes.streams import (
     StreamRequest,
     StreamResponse,
 )
+from cognite_toolkit._cdf_tk.resource_ios import ResourceIO
 from cognite_toolkit._cdf_tk.resource_ios._base_ios import ResourceContainerIO
 from cognite_toolkit._cdf_tk.utils.time import time_windows_ms
 from cognite_toolkit._cdf_tk.yaml_classes import StreamYAML
@@ -71,6 +73,10 @@ class StreamIO(ResourceContainerIO[ExternalId, StreamRequest, StreamResponse]):
             if "WRITE" in actions:
                 acl_actions.extend(["CREATE", "DELETE"])
             yield StreamsAcl(actions=acl_actions, scope=scope)
+
+    @classmethod
+    def get_dependencies(cls, resource: StreamYAML) -> "Iterable[tuple[type[ResourceIO], Identifier]]":
+        return []
 
     def create(self, items: Sequence[StreamRequest]) -> list[StreamResponse]:
         return self.client.streams.create(items)


### PR DESCRIPTION
# Description

Make the `get_dependencies` required. This is to ensure that any one implementing a `ResourceIO` class considers the dependencies, if there are none they should only return an empty list. 

Only missing implementations were robots and an old infield config - not worth a release. 

## Bump

- [ ] Patch
- [x] Skip

